### PR TITLE
Add copying/cleaning if RevitVersion defined and is not a CI build

### DIFF
--- a/Connectors/Revit/Speckle.Connectors.Revit2023/Speckle.Connectors.Revit2023.csproj
+++ b/Connectors/Revit/Speckle.Connectors.Revit2023/Speckle.Connectors.Revit2023.csproj
@@ -2,8 +2,8 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
-    <UseWpf>true</UseWpf>
-    <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
+    <UseWpf>true</UseWpf>    
+    <RevitVersion>2023</RevitVersion>
   </PropertyGroup>
 
   <Import Project="..\Speckle.Connectors.RevitShared\Speckle.Connectors.RevitShared.projitems" Label="Shared" />
@@ -33,22 +33,4 @@
     <PackageReference Include="CefSharp.Wpf" IncludeAssets="compile" NoWarn="NU1903" />
     <PackageReference Include="Revit.Async" />
   </ItemGroup>
-
-  <Target AfterTargets="Clean" Name="CleanAddinFolder">
-    <RemoveDir Directories="$(TargetDir);$(ProjectDir)\..\Release\Release2023;$(AppData)\Autodesk\Revit\Addins\2023\Speckle.Connectors.Revit2023;" />
-    <Delete Files="$(AppData)\Autodesk\Revit\Addins\2023\Speckle.Connectors.Revit2023.addin" />
-  </Target>
-
-  <Target Name="AfterBuildMigrated" AfterTargets="Build" Condition="$([MSBuild]::IsOsPlatform('Windows'))">
-    <CallTarget Condition="'$(IsDesktopBuild)' == true" Targets="AfterBuildDebug" />
-  </Target>
-
-  <Target Name="AfterBuildDebug">
-    <ItemGroup>
-      <RevitDLLs Include="$(TargetDir)\**\*.*" Exclude="$(TargetDir)*.addin" />
-      <SourceManifest Include="$(TargetDir)\Plugin\*.addin" />
-    </ItemGroup>
-    <Copy DestinationFolder="$(AppData)\Autodesk\REVIT\Addins\2023\Speckle.Connectors.Revit2023\%(RecursiveDir)" SourceFiles="@(RevitDLLs)" />
-    <Copy DestinationFolder="$(AppData)\Autodesk\REVIT\Addins\2023\" SourceFiles="@(SourceManifest)" />
-  </Target>
 </Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+  <Target AfterTargets="Clean" Name="CleanAddinsRevit" Condition="'$(RevitVersion)' != '' And '$(ContinuousIntegrationBuild)' != 'true'">
+    <RemoveDir Directories="$(TargetDir);$(ProjectDir)\..\Release\Release$(RevitVersion);$(AppData)\Autodesk\Revit\Addins\$(RevitVersion)\Speckle.Connectors.Revit$(RevitVersion);" />
+    <Delete Files="$(AppData)\Autodesk\Revit\Addins\$(RevitVersion)\Speckle.Connectors.Revit$(RevitVersion).addin" />
+  </Target>
+  <Target AfterTargets="Build"  Name="AfterBuildRevit" Condition="'$(RevitVersion)' != '' And '$(ContinuousIntegrationBuild)' != 'true'">
+    <ItemGroup>
+      <RevitDLLs Include="$(TargetDir)\**\*.*" Exclude="$(TargetDir)*.addin" />
+      <SourceManifest Include="$(TargetDir)\Plugin\Speckle.Connectors.Revit$(RevitVersion).addin" />
+    </ItemGroup>
+    <Message Text="RevitVersion $(RevitVersion)" Importance="high"/>
+    <Copy DestinationFolder="$(AppData)\Autodesk\REVIT\Addins\$(RevitVersion)\Speckle.Connectors.Revit$(RevitVersion)\%(RecursiveDir)" SourceFiles="@(RevitDLLs)" />
+    <Copy DestinationFolder="$(AppData)\Autodesk\REVIT\Addins\$(RevitVersion)\" SourceFiles="@(SourceManifest)" />
+  </Target>
+</Project>


### PR DESCRIPTION
Done originally in https://github.com/specklesystems/speckle-sharp-connectors/pull/13