### PR TITLE
DUI3-350 update dui3 connectors to use new api client functions

### DIFF
--- a/Connectors/ArcGIS/Speckle.Connectors.ArcGIS3/Bindings/ArcGISReceiveBinding.cs
+++ b/Connectors/ArcGIS/Speckle.Connectors.ArcGIS3/Bindings/ArcGISReceiveBinding.cs
@@ -53,7 +53,7 @@ public sealed class ArcGISReceiveBinding : IReceiveBinding
       // Receive host objects
       var receiveOperationResults = await unitOfWork
         .Service.Execute(
-          modelCard.GetReceiveInfo(),
+          modelCard.GetReceiveInfo("ArcGIS"), // POC: get host app name from settings? same for GetSendInfo
           cts.Token,
           (status, progress) =>
             Commands.SetModelProgress(modelCardId, new ModelCardProgress(modelCardId, status, progress), cts)

--- a/Connectors/ArcGIS/Speckle.Connectors.ArcGIS3/Bindings/ArcGISSendBinding.cs
+++ b/Connectors/ArcGIS/Speckle.Connectors.ArcGIS3/Bindings/ArcGISSendBinding.cs
@@ -343,7 +343,7 @@ public sealed class ArcGISSendBinding : ISendBinding
           var result = await unitOfWork
             .Service.Execute(
               mapMembers,
-              modelCard.GetSendInfo("ArcGIS"), // POC: get host app name from settings?
+              modelCard.GetSendInfo("ArcGIS"), // POC: get host app name from settings? same for GetReceiveInfo
               (status, progress) =>
                 Commands.SetModelProgress(modelCardId, new ModelCardProgress(modelCardId, status, progress), cts),
               cts.Token

--- a/Connectors/ArcGIS/Speckle.Connectors.ArcGIS3/packages.lock.json
+++ b/Connectors/ArcGIS/Speckle.Connectors.ArcGIS3/packages.lock.json
@@ -380,7 +380,7 @@
           "Microsoft.Extensions.Logging.Abstractions": "[7.0.0, )",
           "Speckle.Autofac": "[1.0.0, )",
           "Speckle.Connectors.Utils": "[1.0.0, )",
-          "Speckle.Core": "[3.0.1-dev.23, )",
+          "Speckle.Core": "[3.0.1-dev.25, )",
           "System.Threading.Tasks.Dataflow": "[6.0.0, )"
         }
       },
@@ -396,7 +396,7 @@
         "dependencies": {
           "Serilog.Extensions.Logging": "[7.0.0, )",
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Core": "[3.0.1-dev.23, )"
+          "Speckle.Core": "[3.0.1-dev.25, )"
         }
       },
       "speckle.converters.arcgis3": {
@@ -418,7 +418,7 @@
         "type": "Project",
         "dependencies": {
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Objects": "[3.0.1-dev.23, )"
+          "Speckle.Objects": "[3.0.1-dev.25, )"
         }
       },
       "speckle.converters.common.dependencyinjection": {
@@ -452,9 +452,9 @@
       },
       "Speckle.Core": {
         "type": "CentralTransitive",
-        "requested": "[3.0.1-dev.23, )",
-        "resolved": "3.0.1-dev.23",
-        "contentHash": "Mep7zls6FJQ8NR79cL6wNNqEpqNbVNXkKOfvY6oebe2MMnE89FKDr29nb2dRgEhynV1ankVzz+YYCiFGxXZfyQ==",
+        "requested": "[3.0.1-dev.25, )",
+        "resolved": "3.0.1-dev.25",
+        "contentHash": "wcLNocrTfNCmhtJH/Hp/1u18Fp57apIdYvQnfCAAfo0txfNjL5hzx+wtFt5PlHPjF/mPssESuhLa89pvrMFvxw==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -476,11 +476,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.0.1-dev.23, )",
-        "resolved": "3.0.1-dev.23",
-        "contentHash": "UrhwEiRxJAMCgnOfp5IjUXfbQU8OZ1bEd04GoFl5/nA6KMIMQbz01aLyRROuHpliVOH2ae3jLCORDIYy6feU5Q==",
+        "requested": "[3.0.1-dev.25, )",
+        "resolved": "3.0.1-dev.25",
+        "contentHash": "bxYDptn2hnUFdzFOgmEU/YS8ZjcrHCHz4bFwKLDz1rA9ytkBIUvNuTYZpKZz3h9jVJxrgPhh1qDLqUNgK56hdA==",
         "dependencies": {
-          "Speckle.Core": "3.0.1-dev.23"
+          "Speckle.Core": "3.0.1-dev.25"
         }
       },
       "System.Threading.Tasks.Dataflow": {

--- a/Connectors/Autocad/Speckle.Connectors.Autocad2023/packages.lock.json
+++ b/Connectors/Autocad/Speckle.Connectors.Autocad2023/packages.lock.json
@@ -433,7 +433,7 @@
           "Microsoft.Extensions.Logging.Abstractions": "[7.0.0, )",
           "Speckle.Autofac": "[1.0.0, )",
           "Speckle.Connectors.Utils": "[1.0.0, )",
-          "Speckle.Core": "[3.0.1-dev.23, )",
+          "Speckle.Core": "[3.0.1-dev.25, )",
           "System.Threading.Tasks.Dataflow": "[6.0.0, )"
         }
       },
@@ -449,7 +449,7 @@
         "dependencies": {
           "Serilog.Extensions.Logging": "[7.0.0, )",
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Core": "[3.0.1-dev.23, )"
+          "Speckle.Core": "[3.0.1-dev.25, )"
         }
       },
       "speckle.converters.autocad2023": {
@@ -471,7 +471,7 @@
         "type": "Project",
         "dependencies": {
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Objects": "[3.0.1-dev.23, )"
+          "Speckle.Objects": "[3.0.1-dev.25, )"
         }
       },
       "speckle.converters.common.dependencyinjection": {
@@ -508,9 +508,9 @@
       },
       "Speckle.Core": {
         "type": "CentralTransitive",
-        "requested": "[3.0.1-dev.23, )",
-        "resolved": "3.0.1-dev.23",
-        "contentHash": "Mep7zls6FJQ8NR79cL6wNNqEpqNbVNXkKOfvY6oebe2MMnE89FKDr29nb2dRgEhynV1ankVzz+YYCiFGxXZfyQ==",
+        "requested": "[3.0.1-dev.25, )",
+        "resolved": "3.0.1-dev.25",
+        "contentHash": "wcLNocrTfNCmhtJH/Hp/1u18Fp57apIdYvQnfCAAfo0txfNjL5hzx+wtFt5PlHPjF/mPssESuhLa89pvrMFvxw==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -532,11 +532,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.0.1-dev.23, )",
-        "resolved": "3.0.1-dev.23",
-        "contentHash": "UrhwEiRxJAMCgnOfp5IjUXfbQU8OZ1bEd04GoFl5/nA6KMIMQbz01aLyRROuHpliVOH2ae3jLCORDIYy6feU5Q==",
+        "requested": "[3.0.1-dev.25, )",
+        "resolved": "3.0.1-dev.25",
+        "contentHash": "bxYDptn2hnUFdzFOgmEU/YS8ZjcrHCHz4bFwKLDz1rA9ytkBIUvNuTYZpKZz3h9jVJxrgPhh1qDLqUNgK56hdA==",
         "dependencies": {
-          "Speckle.Core": "3.0.1-dev.23"
+          "Speckle.Core": "3.0.1-dev.25"
         }
       },
       "System.Threading.Tasks.Dataflow": {

--- a/Connectors/Autocad/Speckle.Connectors.AutocadShared/Bindings/AutocadReceiveBinding.cs
+++ b/Connectors/Autocad/Speckle.Connectors.AutocadShared/Bindings/AutocadReceiveBinding.cs
@@ -1,4 +1,5 @@
 using Speckle.Autofac.DependencyInjection;
+using Speckle.Connectors.Autocad.HostApp;
 using Speckle.Connectors.DUI.Bindings;
 using Speckle.Connectors.DUI.Bridge;
 using Speckle.Connectors.DUI.Models;
@@ -18,6 +19,7 @@ public sealed class AutocadReceiveBinding : IReceiveBinding
   private readonly DocumentModelStore _store;
   private readonly CancellationManager _cancellationManager;
   private readonly IUnitOfWorkFactory _unitOfWorkFactory;
+  private readonly AutocadSettings _autocadSettings;
 
   public ReceiveBindingUICommands Commands { get; }
 
@@ -25,12 +27,14 @@ public sealed class AutocadReceiveBinding : IReceiveBinding
     DocumentModelStore store,
     IBridge parent,
     CancellationManager cancellationManager,
-    IUnitOfWorkFactory unitOfWorkFactory
+    IUnitOfWorkFactory unitOfWorkFactory,
+    AutocadSettings autocadSettings
   )
   {
     _store = store;
     _cancellationManager = cancellationManager;
     _unitOfWorkFactory = unitOfWorkFactory;
+    _autocadSettings = autocadSettings;
     Parent = parent;
     Commands = new ReceiveBindingUICommands(parent);
   }
@@ -60,7 +64,7 @@ public sealed class AutocadReceiveBinding : IReceiveBinding
       // Receive host objects
       var operationResults = await unitOfWork
         .Service.Execute(
-          modelCard.GetReceiveInfo(),
+          modelCard.GetReceiveInfo(_autocadSettings.HostAppInfo.Name),
           cts.Token,
           (status, progress) =>
             Commands.SetModelProgress(modelCardId, new ModelCardProgress(modelCardId, status, progress), cts)

--- a/Connectors/Autocad/Speckle.Connectors.Civil3d2024/packages.lock.json
+++ b/Connectors/Autocad/Speckle.Connectors.Civil3d2024/packages.lock.json
@@ -442,7 +442,7 @@
           "Microsoft.Extensions.Logging.Abstractions": "[7.0.0, )",
           "Speckle.Autofac": "[1.0.0, )",
           "Speckle.Connectors.Utils": "[1.0.0, )",
-          "Speckle.Core": "[3.0.1-dev.23, )",
+          "Speckle.Core": "[3.0.1-dev.25, )",
           "System.Threading.Tasks.Dataflow": "[6.0.0, )"
         }
       },
@@ -458,7 +458,7 @@
         "dependencies": {
           "Serilog.Extensions.Logging": "[7.0.0, )",
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Core": "[3.0.1-dev.23, )"
+          "Speckle.Core": "[3.0.1-dev.25, )"
         }
       },
       "speckle.converters.civil3d2024": {
@@ -481,7 +481,7 @@
         "type": "Project",
         "dependencies": {
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Objects": "[3.0.1-dev.23, )"
+          "Speckle.Objects": "[3.0.1-dev.25, )"
         }
       },
       "speckle.converters.common.dependencyinjection": {
@@ -518,9 +518,9 @@
       },
       "Speckle.Core": {
         "type": "CentralTransitive",
-        "requested": "[3.0.1-dev.23, )",
-        "resolved": "3.0.1-dev.23",
-        "contentHash": "Mep7zls6FJQ8NR79cL6wNNqEpqNbVNXkKOfvY6oebe2MMnE89FKDr29nb2dRgEhynV1ankVzz+YYCiFGxXZfyQ==",
+        "requested": "[3.0.1-dev.25, )",
+        "resolved": "3.0.1-dev.25",
+        "contentHash": "wcLNocrTfNCmhtJH/Hp/1u18Fp57apIdYvQnfCAAfo0txfNjL5hzx+wtFt5PlHPjF/mPssESuhLa89pvrMFvxw==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -542,11 +542,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.0.1-dev.23, )",
-        "resolved": "3.0.1-dev.23",
-        "contentHash": "UrhwEiRxJAMCgnOfp5IjUXfbQU8OZ1bEd04GoFl5/nA6KMIMQbz01aLyRROuHpliVOH2ae3jLCORDIYy6feU5Q==",
+        "requested": "[3.0.1-dev.25, )",
+        "resolved": "3.0.1-dev.25",
+        "contentHash": "bxYDptn2hnUFdzFOgmEU/YS8ZjcrHCHz4bFwKLDz1rA9ytkBIUvNuTYZpKZz3h9jVJxrgPhh1qDLqUNgK56hdA==",
         "dependencies": {
-          "Speckle.Core": "3.0.1-dev.23"
+          "Speckle.Core": "3.0.1-dev.25"
         }
       },
       "System.Threading.Tasks.Dataflow": {

--- a/Connectors/Revit/Speckle.Connectors.Revit2023/Properties/launchSettings.json
+++ b/Connectors/Revit/Speckle.Connectors.Revit2023/Properties/launchSettings.json
@@ -1,6 +1,6 @@
 {
   "profiles": {
-    "ConnectorRevit2023": {
+    "Speckle.Connectors.Revit2023": {
       "commandName": "Executable",
       "executablePath": "C:\\Program Files\\Autodesk\\Revit 2023\\Revit.exe"
     }

--- a/Connectors/Revit/Speckle.Connectors.Revit2023/packages.lock.json
+++ b/Connectors/Revit/Speckle.Connectors.Revit2023/packages.lock.json
@@ -451,7 +451,7 @@
           "Microsoft.Extensions.Logging.Abstractions": "[7.0.0, )",
           "Speckle.Autofac": "[1.0.0, )",
           "Speckle.Connectors.Utils": "[1.0.0, )",
-          "Speckle.Core": "[3.0.1-dev.23, )",
+          "Speckle.Core": "[3.0.1-dev.25, )",
           "System.Threading.Tasks.Dataflow": "[6.0.0, )"
         }
       },
@@ -460,14 +460,14 @@
         "dependencies": {
           "Serilog.Extensions.Logging": "[7.0.0, )",
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Core": "[3.0.1-dev.23, )"
+          "Speckle.Core": "[3.0.1-dev.25, )"
         }
       },
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Objects": "[3.0.1-dev.23, )"
+          "Speckle.Objects": "[3.0.1-dev.25, )"
         }
       },
       "speckle.converters.common.dependencyinjection": {
@@ -514,9 +514,9 @@
       },
       "Speckle.Core": {
         "type": "CentralTransitive",
-        "requested": "[3.0.1-dev.23, )",
-        "resolved": "3.0.1-dev.23",
-        "contentHash": "Mep7zls6FJQ8NR79cL6wNNqEpqNbVNXkKOfvY6oebe2MMnE89FKDr29nb2dRgEhynV1ankVzz+YYCiFGxXZfyQ==",
+        "requested": "[3.0.1-dev.25, )",
+        "resolved": "3.0.1-dev.25",
+        "contentHash": "wcLNocrTfNCmhtJH/Hp/1u18Fp57apIdYvQnfCAAfo0txfNjL5hzx+wtFt5PlHPjF/mPssESuhLa89pvrMFvxw==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -538,11 +538,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.0.1-dev.23, )",
-        "resolved": "3.0.1-dev.23",
-        "contentHash": "UrhwEiRxJAMCgnOfp5IjUXfbQU8OZ1bEd04GoFl5/nA6KMIMQbz01aLyRROuHpliVOH2ae3jLCORDIYy6feU5Q==",
+        "requested": "[3.0.1-dev.25, )",
+        "resolved": "3.0.1-dev.25",
+        "contentHash": "bxYDptn2hnUFdzFOgmEU/YS8ZjcrHCHz4bFwKLDz1rA9ytkBIUvNuTYZpKZz3h9jVJxrgPhh1qDLqUNgK56hdA==",
         "dependencies": {
-          "Speckle.Core": "3.0.1-dev.23"
+          "Speckle.Core": "3.0.1-dev.25"
         }
       },
       "Speckle.Revit.API": {

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Bindings/RevitReceiveBinding.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Bindings/RevitReceiveBinding.cs
@@ -3,6 +3,7 @@ using Speckle.Connectors.DUI.Bindings;
 using Speckle.Connectors.DUI.Bridge;
 using Speckle.Connectors.DUI.Models;
 using Speckle.Connectors.DUI.Models.Card;
+using Speckle.Connectors.Revit.Plugin;
 using Speckle.Connectors.Utils;
 using Speckle.Connectors.Utils.Builders;
 using Speckle.Connectors.Utils.Cancellation;
@@ -16,6 +17,7 @@ internal class RevitReceiveBinding : IReceiveBinding
   public string Name => "receiveBinding";
   public IBridge Parent { get; }
 
+  private readonly RevitSettings _revitSettings;
   private readonly CancellationManager _cancellationManager;
   private readonly DocumentModelStore _store;
   private readonly IUnitOfWorkFactory _unitOfWorkFactory;
@@ -25,12 +27,14 @@ internal class RevitReceiveBinding : IReceiveBinding
     DocumentModelStore store,
     CancellationManager cancellationManager,
     IBridge parent,
-    IUnitOfWorkFactory unitOfWorkFactory
+    IUnitOfWorkFactory unitOfWorkFactory,
+    RevitSettings revitSettings
   )
   {
     Parent = parent;
     _store = store;
     _unitOfWorkFactory = unitOfWorkFactory;
+    _revitSettings = revitSettings;
     _cancellationManager = cancellationManager;
     Commands = new ReceiveBindingUICommands(parent);
   }
@@ -55,7 +59,7 @@ internal class RevitReceiveBinding : IReceiveBinding
       // Receive host objects
       HostObjectBuilderResult conversionResults = await unitOfWork
         .Service.Execute(
-          modelCard.GetReceiveInfo(),
+          modelCard.GetReceiveInfo(_revitSettings.HostSlug.NotNull()),
           cts.Token,
           (status, progress) =>
             Commands.SetModelProgress(modelCardId, new ModelCardProgress(modelCardId, status, progress), cts)

--- a/Connectors/Rhino/Speckle.Connectors.Rhino7/Bindings/RhinoReceiveBinding.cs
+++ b/Connectors/Rhino/Speckle.Connectors.Rhino7/Bindings/RhinoReceiveBinding.cs
@@ -3,6 +3,7 @@ using Speckle.Connectors.DUI.Bindings;
 using Speckle.Connectors.DUI.Bridge;
 using Speckle.Connectors.DUI.Models;
 using Speckle.Connectors.DUI.Models.Card;
+using Speckle.Connectors.Rhino7.HostApp;
 using Speckle.Connectors.Utils;
 using Speckle.Connectors.Utils.Builders;
 using Speckle.Connectors.Utils.Cancellation;
@@ -19,18 +20,21 @@ public class RhinoReceiveBinding : IReceiveBinding
   private readonly CancellationManager _cancellationManager;
   private readonly DocumentModelStore _store;
   private readonly IUnitOfWorkFactory _unitOfWorkFactory;
+  private readonly RhinoSettings _rhinoSettings;
   public ReceiveBindingUICommands Commands { get; }
 
   public RhinoReceiveBinding(
     DocumentModelStore store,
     CancellationManager cancellationManager,
     IBridge parent,
-    IUnitOfWorkFactory unitOfWorkFactory
+    IUnitOfWorkFactory unitOfWorkFactory,
+    RhinoSettings rhinoSettings
   )
   {
     Parent = parent;
     _store = store;
     _unitOfWorkFactory = unitOfWorkFactory;
+    _rhinoSettings = rhinoSettings;
     _cancellationManager = cancellationManager;
     Commands = new ReceiveBindingUICommands(parent);
   }
@@ -55,7 +59,7 @@ public class RhinoReceiveBinding : IReceiveBinding
       // Receive host objects
       HostObjectBuilderResult conversionResults = await unitOfWork
         .Service.Execute(
-          modelCard.GetReceiveInfo(),
+          modelCard.GetReceiveInfo(_rhinoSettings.HostAppInfo.Name),
           cts.Token,
           (status, progress) =>
             Commands.SetModelProgress(modelCardId, new ModelCardProgress(modelCardId, status, progress), cts)

--- a/Connectors/Rhino/Speckle.Connectors.Rhino7/packages.lock.json
+++ b/Connectors/Rhino/Speckle.Connectors.Rhino7/packages.lock.json
@@ -441,7 +441,7 @@
           "Microsoft.Extensions.Logging.Abstractions": "[7.0.0, )",
           "Speckle.Autofac": "[1.0.0, )",
           "Speckle.Connectors.Utils": "[1.0.0, )",
-          "Speckle.Core": "[3.0.1-dev.23, )",
+          "Speckle.Core": "[3.0.1-dev.25, )",
           "System.Threading.Tasks.Dataflow": "[6.0.0, )"
         }
       },
@@ -457,14 +457,14 @@
         "dependencies": {
           "Serilog.Extensions.Logging": "[7.0.0, )",
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Core": "[3.0.1-dev.23, )"
+          "Speckle.Core": "[3.0.1-dev.25, )"
         }
       },
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Objects": "[3.0.1-dev.23, )"
+          "Speckle.Objects": "[3.0.1-dev.25, )"
         }
       },
       "speckle.converters.common.dependencyinjection": {
@@ -515,9 +515,9 @@
       },
       "Speckle.Core": {
         "type": "CentralTransitive",
-        "requested": "[3.0.1-dev.23, )",
-        "resolved": "3.0.1-dev.23",
-        "contentHash": "Mep7zls6FJQ8NR79cL6wNNqEpqNbVNXkKOfvY6oebe2MMnE89FKDr29nb2dRgEhynV1ankVzz+YYCiFGxXZfyQ==",
+        "requested": "[3.0.1-dev.25, )",
+        "resolved": "3.0.1-dev.25",
+        "contentHash": "wcLNocrTfNCmhtJH/Hp/1u18Fp57apIdYvQnfCAAfo0txfNjL5hzx+wtFt5PlHPjF/mPssESuhLa89pvrMFvxw==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -539,11 +539,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.0.1-dev.23, )",
-        "resolved": "3.0.1-dev.23",
-        "contentHash": "UrhwEiRxJAMCgnOfp5IjUXfbQU8OZ1bEd04GoFl5/nA6KMIMQbz01aLyRROuHpliVOH2ae3jLCORDIYy6feU5Q==",
+        "requested": "[3.0.1-dev.25, )",
+        "resolved": "3.0.1-dev.25",
+        "contentHash": "bxYDptn2hnUFdzFOgmEU/YS8ZjcrHCHz4bFwKLDz1rA9ytkBIUvNuTYZpKZz3h9jVJxrgPhh1qDLqUNgK56hdA==",
         "dependencies": {
-          "Speckle.Core": "3.0.1-dev.23"
+          "Speckle.Core": "3.0.1-dev.25"
         }
       },
       "System.Threading.Tasks.Dataflow": {

--- a/Converters/ArcGIS/Speckle.Converters.ArcGIS3.DependencyInjection/packages.lock.json
+++ b/Converters/ArcGIS/Speckle.Converters.ArcGIS3.DependencyInjection/packages.lock.json
@@ -367,7 +367,7 @@
         "type": "Project",
         "dependencies": {
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Objects": "[3.0.1-dev.23, )"
+          "Speckle.Objects": "[3.0.1-dev.25, )"
         }
       },
       "speckle.converters.common.dependencyinjection": {
@@ -391,9 +391,9 @@
       },
       "Speckle.Core": {
         "type": "CentralTransitive",
-        "requested": "[3.0.1-dev.23, )",
-        "resolved": "3.0.1-dev.23",
-        "contentHash": "Mep7zls6FJQ8NR79cL6wNNqEpqNbVNXkKOfvY6oebe2MMnE89FKDr29nb2dRgEhynV1ankVzz+YYCiFGxXZfyQ==",
+        "requested": "[3.0.1-dev.25, )",
+        "resolved": "3.0.1-dev.25",
+        "contentHash": "wcLNocrTfNCmhtJH/Hp/1u18Fp57apIdYvQnfCAAfo0txfNjL5hzx+wtFt5PlHPjF/mPssESuhLa89pvrMFvxw==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -415,11 +415,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.0.1-dev.23, )",
-        "resolved": "3.0.1-dev.23",
-        "contentHash": "UrhwEiRxJAMCgnOfp5IjUXfbQU8OZ1bEd04GoFl5/nA6KMIMQbz01aLyRROuHpliVOH2ae3jLCORDIYy6feU5Q==",
+        "requested": "[3.0.1-dev.25, )",
+        "resolved": "3.0.1-dev.25",
+        "contentHash": "bxYDptn2hnUFdzFOgmEU/YS8ZjcrHCHz4bFwKLDz1rA9ytkBIUvNuTYZpKZz3h9jVJxrgPhh1qDLqUNgK56hdA==",
         "dependencies": {
-          "Speckle.Core": "3.0.1-dev.23"
+          "Speckle.Core": "3.0.1-dev.25"
         }
       }
     }

--- a/Converters/ArcGIS/Speckle.Converters.ArcGIS3/packages.lock.json
+++ b/Converters/ArcGIS/Speckle.Converters.ArcGIS3/packages.lock.json
@@ -360,7 +360,7 @@
         "type": "Project",
         "dependencies": {
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Objects": "[3.0.1-dev.23, )"
+          "Speckle.Objects": "[3.0.1-dev.25, )"
         }
       },
       "Microsoft.Extensions.Logging.Abstractions": {
@@ -371,9 +371,9 @@
       },
       "Speckle.Core": {
         "type": "CentralTransitive",
-        "requested": "[3.0.1-dev.23, )",
-        "resolved": "3.0.1-dev.23",
-        "contentHash": "Mep7zls6FJQ8NR79cL6wNNqEpqNbVNXkKOfvY6oebe2MMnE89FKDr29nb2dRgEhynV1ankVzz+YYCiFGxXZfyQ==",
+        "requested": "[3.0.1-dev.25, )",
+        "resolved": "3.0.1-dev.25",
+        "contentHash": "wcLNocrTfNCmhtJH/Hp/1u18Fp57apIdYvQnfCAAfo0txfNjL5hzx+wtFt5PlHPjF/mPssESuhLa89pvrMFvxw==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -395,11 +395,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.0.1-dev.23, )",
-        "resolved": "3.0.1-dev.23",
-        "contentHash": "UrhwEiRxJAMCgnOfp5IjUXfbQU8OZ1bEd04GoFl5/nA6KMIMQbz01aLyRROuHpliVOH2ae3jLCORDIYy6feU5Q==",
+        "requested": "[3.0.1-dev.25, )",
+        "resolved": "3.0.1-dev.25",
+        "contentHash": "bxYDptn2hnUFdzFOgmEU/YS8ZjcrHCHz4bFwKLDz1rA9ytkBIUvNuTYZpKZz3h9jVJxrgPhh1qDLqUNgK56hdA==",
         "dependencies": {
-          "Speckle.Core": "3.0.1-dev.23"
+          "Speckle.Core": "3.0.1-dev.25"
         }
       }
     }

--- a/Converters/Autocad/Speckle.Converters.Autocad2023.DependencyInjection/packages.lock.json
+++ b/Converters/Autocad/Speckle.Converters.Autocad2023.DependencyInjection/packages.lock.json
@@ -371,7 +371,7 @@
         "type": "Project",
         "dependencies": {
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Objects": "[3.0.1-dev.23, )"
+          "Speckle.Objects": "[3.0.1-dev.25, )"
         }
       },
       "speckle.converters.common.dependencyinjection": {
@@ -399,9 +399,9 @@
       },
       "Speckle.Core": {
         "type": "CentralTransitive",
-        "requested": "[3.0.1-dev.23, )",
-        "resolved": "3.0.1-dev.23",
-        "contentHash": "Mep7zls6FJQ8NR79cL6wNNqEpqNbVNXkKOfvY6oebe2MMnE89FKDr29nb2dRgEhynV1ankVzz+YYCiFGxXZfyQ==",
+        "requested": "[3.0.1-dev.25, )",
+        "resolved": "3.0.1-dev.25",
+        "contentHash": "wcLNocrTfNCmhtJH/Hp/1u18Fp57apIdYvQnfCAAfo0txfNjL5hzx+wtFt5PlHPjF/mPssESuhLa89pvrMFvxw==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -423,11 +423,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.0.1-dev.23, )",
-        "resolved": "3.0.1-dev.23",
-        "contentHash": "UrhwEiRxJAMCgnOfp5IjUXfbQU8OZ1bEd04GoFl5/nA6KMIMQbz01aLyRROuHpliVOH2ae3jLCORDIYy6feU5Q==",
+        "requested": "[3.0.1-dev.25, )",
+        "resolved": "3.0.1-dev.25",
+        "contentHash": "bxYDptn2hnUFdzFOgmEU/YS8ZjcrHCHz4bFwKLDz1rA9ytkBIUvNuTYZpKZz3h9jVJxrgPhh1qDLqUNgK56hdA==",
         "dependencies": {
-          "Speckle.Core": "3.0.1-dev.23"
+          "Speckle.Core": "3.0.1-dev.25"
         }
       }
     }

--- a/Converters/Autocad/Speckle.Converters.Autocad2023/packages.lock.json
+++ b/Converters/Autocad/Speckle.Converters.Autocad2023/packages.lock.json
@@ -361,7 +361,7 @@
         "type": "Project",
         "dependencies": {
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Objects": "[3.0.1-dev.23, )"
+          "Speckle.Objects": "[3.0.1-dev.25, )"
         }
       },
       "Microsoft.Extensions.Logging.Abstractions": {
@@ -376,9 +376,9 @@
       },
       "Speckle.Core": {
         "type": "CentralTransitive",
-        "requested": "[3.0.1-dev.23, )",
-        "resolved": "3.0.1-dev.23",
-        "contentHash": "Mep7zls6FJQ8NR79cL6wNNqEpqNbVNXkKOfvY6oebe2MMnE89FKDr29nb2dRgEhynV1ankVzz+YYCiFGxXZfyQ==",
+        "requested": "[3.0.1-dev.25, )",
+        "resolved": "3.0.1-dev.25",
+        "contentHash": "wcLNocrTfNCmhtJH/Hp/1u18Fp57apIdYvQnfCAAfo0txfNjL5hzx+wtFt5PlHPjF/mPssESuhLa89pvrMFvxw==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -400,11 +400,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.0.1-dev.23, )",
-        "resolved": "3.0.1-dev.23",
-        "contentHash": "UrhwEiRxJAMCgnOfp5IjUXfbQU8OZ1bEd04GoFl5/nA6KMIMQbz01aLyRROuHpliVOH2ae3jLCORDIYy6feU5Q==",
+        "requested": "[3.0.1-dev.25, )",
+        "resolved": "3.0.1-dev.25",
+        "contentHash": "bxYDptn2hnUFdzFOgmEU/YS8ZjcrHCHz4bFwKLDz1rA9ytkBIUvNuTYZpKZz3h9jVJxrgPhh1qDLqUNgK56hdA==",
         "dependencies": {
-          "Speckle.Core": "3.0.1-dev.23"
+          "Speckle.Core": "3.0.1-dev.25"
         }
       }
     }

--- a/Converters/Autocad/Speckle.Converters.Autocad2024.DependencyInjection/packages.lock.json
+++ b/Converters/Autocad/Speckle.Converters.Autocad2024.DependencyInjection/packages.lock.json
@@ -371,7 +371,7 @@
         "type": "Project",
         "dependencies": {
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Objects": "[3.0.1-dev.23, )"
+          "Speckle.Objects": "[3.0.1-dev.25, )"
         }
       },
       "speckle.converters.common.dependencyinjection": {
@@ -399,9 +399,9 @@
       },
       "Speckle.Core": {
         "type": "CentralTransitive",
-        "requested": "[3.0.1-dev.23, )",
-        "resolved": "3.0.1-dev.23",
-        "contentHash": "Mep7zls6FJQ8NR79cL6wNNqEpqNbVNXkKOfvY6oebe2MMnE89FKDr29nb2dRgEhynV1ankVzz+YYCiFGxXZfyQ==",
+        "requested": "[3.0.1-dev.25, )",
+        "resolved": "3.0.1-dev.25",
+        "contentHash": "wcLNocrTfNCmhtJH/Hp/1u18Fp57apIdYvQnfCAAfo0txfNjL5hzx+wtFt5PlHPjF/mPssESuhLa89pvrMFvxw==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -423,11 +423,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.0.1-dev.23, )",
-        "resolved": "3.0.1-dev.23",
-        "contentHash": "UrhwEiRxJAMCgnOfp5IjUXfbQU8OZ1bEd04GoFl5/nA6KMIMQbz01aLyRROuHpliVOH2ae3jLCORDIYy6feU5Q==",
+        "requested": "[3.0.1-dev.25, )",
+        "resolved": "3.0.1-dev.25",
+        "contentHash": "bxYDptn2hnUFdzFOgmEU/YS8ZjcrHCHz4bFwKLDz1rA9ytkBIUvNuTYZpKZz3h9jVJxrgPhh1qDLqUNgK56hdA==",
         "dependencies": {
-          "Speckle.Core": "3.0.1-dev.23"
+          "Speckle.Core": "3.0.1-dev.25"
         }
       }
     }

--- a/Converters/Autocad/Speckle.Converters.Autocad2024/packages.lock.json
+++ b/Converters/Autocad/Speckle.Converters.Autocad2024/packages.lock.json
@@ -361,7 +361,7 @@
         "type": "Project",
         "dependencies": {
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Objects": "[3.0.1-dev.23, )"
+          "Speckle.Objects": "[3.0.1-dev.25, )"
         }
       },
       "Microsoft.Extensions.Logging.Abstractions": {
@@ -376,9 +376,9 @@
       },
       "Speckle.Core": {
         "type": "CentralTransitive",
-        "requested": "[3.0.1-dev.23, )",
-        "resolved": "3.0.1-dev.23",
-        "contentHash": "Mep7zls6FJQ8NR79cL6wNNqEpqNbVNXkKOfvY6oebe2MMnE89FKDr29nb2dRgEhynV1ankVzz+YYCiFGxXZfyQ==",
+        "requested": "[3.0.1-dev.25, )",
+        "resolved": "3.0.1-dev.25",
+        "contentHash": "wcLNocrTfNCmhtJH/Hp/1u18Fp57apIdYvQnfCAAfo0txfNjL5hzx+wtFt5PlHPjF/mPssESuhLa89pvrMFvxw==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -400,11 +400,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.0.1-dev.23, )",
-        "resolved": "3.0.1-dev.23",
-        "contentHash": "UrhwEiRxJAMCgnOfp5IjUXfbQU8OZ1bEd04GoFl5/nA6KMIMQbz01aLyRROuHpliVOH2ae3jLCORDIYy6feU5Q==",
+        "requested": "[3.0.1-dev.25, )",
+        "resolved": "3.0.1-dev.25",
+        "contentHash": "bxYDptn2hnUFdzFOgmEU/YS8ZjcrHCHz4bFwKLDz1rA9ytkBIUvNuTYZpKZz3h9jVJxrgPhh1qDLqUNgK56hdA==",
         "dependencies": {
-          "Speckle.Core": "3.0.1-dev.23"
+          "Speckle.Core": "3.0.1-dev.25"
         }
       }
     }

--- a/Converters/Civil3d/Speckle.Converters.Civil3d2024.DependencyInjection/packages.lock.json
+++ b/Converters/Civil3d/Speckle.Converters.Civil3d2024.DependencyInjection/packages.lock.json
@@ -372,7 +372,7 @@
         "type": "Project",
         "dependencies": {
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Objects": "[3.0.1-dev.23, )"
+          "Speckle.Objects": "[3.0.1-dev.25, )"
         }
       },
       "speckle.converters.common.dependencyinjection": {
@@ -409,9 +409,9 @@
       },
       "Speckle.Core": {
         "type": "CentralTransitive",
-        "requested": "[3.0.1-dev.23, )",
-        "resolved": "3.0.1-dev.23",
-        "contentHash": "Mep7zls6FJQ8NR79cL6wNNqEpqNbVNXkKOfvY6oebe2MMnE89FKDr29nb2dRgEhynV1ankVzz+YYCiFGxXZfyQ==",
+        "requested": "[3.0.1-dev.25, )",
+        "resolved": "3.0.1-dev.25",
+        "contentHash": "wcLNocrTfNCmhtJH/Hp/1u18Fp57apIdYvQnfCAAfo0txfNjL5hzx+wtFt5PlHPjF/mPssESuhLa89pvrMFvxw==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -433,11 +433,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.0.1-dev.23, )",
-        "resolved": "3.0.1-dev.23",
-        "contentHash": "UrhwEiRxJAMCgnOfp5IjUXfbQU8OZ1bEd04GoFl5/nA6KMIMQbz01aLyRROuHpliVOH2ae3jLCORDIYy6feU5Q==",
+        "requested": "[3.0.1-dev.25, )",
+        "resolved": "3.0.1-dev.25",
+        "contentHash": "bxYDptn2hnUFdzFOgmEU/YS8ZjcrHCHz4bFwKLDz1rA9ytkBIUvNuTYZpKZz3h9jVJxrgPhh1qDLqUNgK56hdA==",
         "dependencies": {
-          "Speckle.Core": "3.0.1-dev.23"
+          "Speckle.Core": "3.0.1-dev.25"
         }
       }
     }

--- a/Converters/Civil3d/Speckle.Converters.Civil3d2024/packages.lock.json
+++ b/Converters/Civil3d/Speckle.Converters.Civil3d2024/packages.lock.json
@@ -370,7 +370,7 @@
         "type": "Project",
         "dependencies": {
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Objects": "[3.0.1-dev.23, )"
+          "Speckle.Objects": "[3.0.1-dev.25, )"
         }
       },
       "Microsoft.Extensions.Logging.Abstractions": {
@@ -385,9 +385,9 @@
       },
       "Speckle.Core": {
         "type": "CentralTransitive",
-        "requested": "[3.0.1-dev.23, )",
-        "resolved": "3.0.1-dev.23",
-        "contentHash": "Mep7zls6FJQ8NR79cL6wNNqEpqNbVNXkKOfvY6oebe2MMnE89FKDr29nb2dRgEhynV1ankVzz+YYCiFGxXZfyQ==",
+        "requested": "[3.0.1-dev.25, )",
+        "resolved": "3.0.1-dev.25",
+        "contentHash": "wcLNocrTfNCmhtJH/Hp/1u18Fp57apIdYvQnfCAAfo0txfNjL5hzx+wtFt5PlHPjF/mPssESuhLa89pvrMFvxw==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -409,11 +409,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.0.1-dev.23, )",
-        "resolved": "3.0.1-dev.23",
-        "contentHash": "UrhwEiRxJAMCgnOfp5IjUXfbQU8OZ1bEd04GoFl5/nA6KMIMQbz01aLyRROuHpliVOH2ae3jLCORDIYy6feU5Q==",
+        "requested": "[3.0.1-dev.25, )",
+        "resolved": "3.0.1-dev.25",
+        "contentHash": "bxYDptn2hnUFdzFOgmEU/YS8ZjcrHCHz4bFwKLDz1rA9ytkBIUvNuTYZpKZz3h9jVJxrgPhh1qDLqUNgK56hdA==",
         "dependencies": {
-          "Speckle.Core": "3.0.1-dev.23"
+          "Speckle.Core": "3.0.1-dev.25"
         }
       }
     }

--- a/Converters/Revit/Speckle.Converters.Revit2023.DependencyInjection/packages.lock.json
+++ b/Converters/Revit/Speckle.Converters.Revit2023.DependencyInjection/packages.lock.json
@@ -355,7 +355,7 @@
         "type": "Project",
         "dependencies": {
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Objects": "[3.0.1-dev.23, )"
+          "Speckle.Objects": "[3.0.1-dev.25, )"
         }
       },
       "speckle.converters.common.dependencyinjection": {
@@ -384,9 +384,9 @@
       },
       "Speckle.Core": {
         "type": "CentralTransitive",
-        "requested": "[3.0.1-dev.23, )",
-        "resolved": "3.0.1-dev.23",
-        "contentHash": "Mep7zls6FJQ8NR79cL6wNNqEpqNbVNXkKOfvY6oebe2MMnE89FKDr29nb2dRgEhynV1ankVzz+YYCiFGxXZfyQ==",
+        "requested": "[3.0.1-dev.25, )",
+        "resolved": "3.0.1-dev.25",
+        "contentHash": "wcLNocrTfNCmhtJH/Hp/1u18Fp57apIdYvQnfCAAfo0txfNjL5hzx+wtFt5PlHPjF/mPssESuhLa89pvrMFvxw==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -408,11 +408,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.0.1-dev.23, )",
-        "resolved": "3.0.1-dev.23",
-        "contentHash": "UrhwEiRxJAMCgnOfp5IjUXfbQU8OZ1bEd04GoFl5/nA6KMIMQbz01aLyRROuHpliVOH2ae3jLCORDIYy6feU5Q==",
+        "requested": "[3.0.1-dev.25, )",
+        "resolved": "3.0.1-dev.25",
+        "contentHash": "bxYDptn2hnUFdzFOgmEU/YS8ZjcrHCHz4bFwKLDz1rA9ytkBIUvNuTYZpKZz3h9jVJxrgPhh1qDLqUNgK56hdA==",
         "dependencies": {
-          "Speckle.Core": "3.0.1-dev.23"
+          "Speckle.Core": "3.0.1-dev.25"
         }
       },
       "Speckle.Revit.API": {

--- a/Converters/Revit/Speckle.Converters.Revit2023.Tests/packages.lock.json
+++ b/Converters/Revit/Speckle.Converters.Revit2023.Tests/packages.lock.json
@@ -480,7 +480,7 @@
         "type": "Project",
         "dependencies": {
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Objects": "[3.0.1-dev.23, )"
+          "Speckle.Objects": "[3.0.1-dev.25, )"
         }
       },
       "speckle.testing": {
@@ -498,9 +498,9 @@
       },
       "Speckle.Core": {
         "type": "CentralTransitive",
-        "requested": "[3.0.1-dev.23, )",
-        "resolved": "3.0.1-dev.23",
-        "contentHash": "Mep7zls6FJQ8NR79cL6wNNqEpqNbVNXkKOfvY6oebe2MMnE89FKDr29nb2dRgEhynV1ankVzz+YYCiFGxXZfyQ==",
+        "requested": "[3.0.1-dev.25, )",
+        "resolved": "3.0.1-dev.25",
+        "contentHash": "wcLNocrTfNCmhtJH/Hp/1u18Fp57apIdYvQnfCAAfo0txfNjL5hzx+wtFt5PlHPjF/mPssESuhLa89pvrMFvxw==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -522,11 +522,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.0.1-dev.23, )",
-        "resolved": "3.0.1-dev.23",
-        "contentHash": "UrhwEiRxJAMCgnOfp5IjUXfbQU8OZ1bEd04GoFl5/nA6KMIMQbz01aLyRROuHpliVOH2ae3jLCORDIYy6feU5Q==",
+        "requested": "[3.0.1-dev.25, )",
+        "resolved": "3.0.1-dev.25",
+        "contentHash": "bxYDptn2hnUFdzFOgmEU/YS8ZjcrHCHz4bFwKLDz1rA9ytkBIUvNuTYZpKZz3h9jVJxrgPhh1qDLqUNgK56hdA==",
         "dependencies": {
-          "Speckle.Core": "3.0.1-dev.23"
+          "Speckle.Core": "3.0.1-dev.25"
         }
       }
     }

--- a/Converters/Revit/Speckle.Converters.Revit2023/packages.lock.json
+++ b/Converters/Revit/Speckle.Converters.Revit2023/packages.lock.json
@@ -361,7 +361,7 @@
         "type": "Project",
         "dependencies": {
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Objects": "[3.0.1-dev.23, )"
+          "Speckle.Objects": "[3.0.1-dev.25, )"
         }
       },
       "Microsoft.Extensions.Logging.Abstractions": {
@@ -376,9 +376,9 @@
       },
       "Speckle.Core": {
         "type": "CentralTransitive",
-        "requested": "[3.0.1-dev.23, )",
-        "resolved": "3.0.1-dev.23",
-        "contentHash": "Mep7zls6FJQ8NR79cL6wNNqEpqNbVNXkKOfvY6oebe2MMnE89FKDr29nb2dRgEhynV1ankVzz+YYCiFGxXZfyQ==",
+        "requested": "[3.0.1-dev.25, )",
+        "resolved": "3.0.1-dev.25",
+        "contentHash": "wcLNocrTfNCmhtJH/Hp/1u18Fp57apIdYvQnfCAAfo0txfNjL5hzx+wtFt5PlHPjF/mPssESuhLa89pvrMFvxw==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -400,11 +400,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.0.1-dev.23, )",
-        "resolved": "3.0.1-dev.23",
-        "contentHash": "UrhwEiRxJAMCgnOfp5IjUXfbQU8OZ1bEd04GoFl5/nA6KMIMQbz01aLyRROuHpliVOH2ae3jLCORDIYy6feU5Q==",
+        "requested": "[3.0.1-dev.25, )",
+        "resolved": "3.0.1-dev.25",
+        "contentHash": "bxYDptn2hnUFdzFOgmEU/YS8ZjcrHCHz4bFwKLDz1rA9ytkBIUvNuTYZpKZz3h9jVJxrgPhh1qDLqUNgK56hdA==",
         "dependencies": {
-          "Speckle.Core": "3.0.1-dev.23"
+          "Speckle.Core": "3.0.1-dev.25"
         }
       }
     }

--- a/Converters/Rhino/Speckle.Converters.Rhino7.DependencyInjection/packages.lock.json
+++ b/Converters/Rhino/Speckle.Converters.Rhino7.DependencyInjection/packages.lock.json
@@ -355,7 +355,7 @@
         "type": "Project",
         "dependencies": {
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Objects": "[3.0.1-dev.23, )"
+          "Speckle.Objects": "[3.0.1-dev.25, )"
         }
       },
       "speckle.converters.common.dependencyinjection": {
@@ -390,9 +390,9 @@
       },
       "Speckle.Core": {
         "type": "CentralTransitive",
-        "requested": "[3.0.1-dev.23, )",
-        "resolved": "3.0.1-dev.23",
-        "contentHash": "Mep7zls6FJQ8NR79cL6wNNqEpqNbVNXkKOfvY6oebe2MMnE89FKDr29nb2dRgEhynV1ankVzz+YYCiFGxXZfyQ==",
+        "requested": "[3.0.1-dev.25, )",
+        "resolved": "3.0.1-dev.25",
+        "contentHash": "wcLNocrTfNCmhtJH/Hp/1u18Fp57apIdYvQnfCAAfo0txfNjL5hzx+wtFt5PlHPjF/mPssESuhLa89pvrMFvxw==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -414,11 +414,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.0.1-dev.23, )",
-        "resolved": "3.0.1-dev.23",
-        "contentHash": "UrhwEiRxJAMCgnOfp5IjUXfbQU8OZ1bEd04GoFl5/nA6KMIMQbz01aLyRROuHpliVOH2ae3jLCORDIYy6feU5Q==",
+        "requested": "[3.0.1-dev.25, )",
+        "resolved": "3.0.1-dev.25",
+        "contentHash": "bxYDptn2hnUFdzFOgmEU/YS8ZjcrHCHz4bFwKLDz1rA9ytkBIUvNuTYZpKZz3h9jVJxrgPhh1qDLqUNgK56hdA==",
         "dependencies": {
-          "Speckle.Core": "3.0.1-dev.23"
+          "Speckle.Core": "3.0.1-dev.25"
         }
       }
     }

--- a/Converters/Rhino/Speckle.Converters.Rhino7.Tests/packages.lock.json
+++ b/Converters/Rhino/Speckle.Converters.Rhino7.Tests/packages.lock.json
@@ -480,7 +480,7 @@
         "type": "Project",
         "dependencies": {
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Objects": "[3.0.1-dev.23, )"
+          "Speckle.Objects": "[3.0.1-dev.25, )"
         }
       },
       "speckle.testing": {
@@ -498,9 +498,9 @@
       },
       "Speckle.Core": {
         "type": "CentralTransitive",
-        "requested": "[3.0.1-dev.23, )",
-        "resolved": "3.0.1-dev.23",
-        "contentHash": "Mep7zls6FJQ8NR79cL6wNNqEpqNbVNXkKOfvY6oebe2MMnE89FKDr29nb2dRgEhynV1ankVzz+YYCiFGxXZfyQ==",
+        "requested": "[3.0.1-dev.25, )",
+        "resolved": "3.0.1-dev.25",
+        "contentHash": "wcLNocrTfNCmhtJH/Hp/1u18Fp57apIdYvQnfCAAfo0txfNjL5hzx+wtFt5PlHPjF/mPssESuhLa89pvrMFvxw==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -522,11 +522,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.0.1-dev.23, )",
-        "resolved": "3.0.1-dev.23",
-        "contentHash": "UrhwEiRxJAMCgnOfp5IjUXfbQU8OZ1bEd04GoFl5/nA6KMIMQbz01aLyRROuHpliVOH2ae3jLCORDIYy6feU5Q==",
+        "requested": "[3.0.1-dev.25, )",
+        "resolved": "3.0.1-dev.25",
+        "contentHash": "bxYDptn2hnUFdzFOgmEU/YS8ZjcrHCHz4bFwKLDz1rA9ytkBIUvNuTYZpKZz3h9jVJxrgPhh1qDLqUNgK56hdA==",
         "dependencies": {
-          "Speckle.Core": "3.0.1-dev.23"
+          "Speckle.Core": "3.0.1-dev.25"
         }
       }
     }

--- a/Converters/Rhino/Speckle.Converters.Rhino7/packages.lock.json
+++ b/Converters/Rhino/Speckle.Converters.Rhino7/packages.lock.json
@@ -361,7 +361,7 @@
         "type": "Project",
         "dependencies": {
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Objects": "[3.0.1-dev.23, )"
+          "Speckle.Objects": "[3.0.1-dev.25, )"
         }
       },
       "Microsoft.Extensions.Logging.Abstractions": {
@@ -376,9 +376,9 @@
       },
       "Speckle.Core": {
         "type": "CentralTransitive",
-        "requested": "[3.0.1-dev.23, )",
-        "resolved": "3.0.1-dev.23",
-        "contentHash": "Mep7zls6FJQ8NR79cL6wNNqEpqNbVNXkKOfvY6oebe2MMnE89FKDr29nb2dRgEhynV1ankVzz+YYCiFGxXZfyQ==",
+        "requested": "[3.0.1-dev.25, )",
+        "resolved": "3.0.1-dev.25",
+        "contentHash": "wcLNocrTfNCmhtJH/Hp/1u18Fp57apIdYvQnfCAAfo0txfNjL5hzx+wtFt5PlHPjF/mPssESuhLa89pvrMFvxw==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -400,11 +400,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.0.1-dev.23, )",
-        "resolved": "3.0.1-dev.23",
-        "contentHash": "UrhwEiRxJAMCgnOfp5IjUXfbQU8OZ1bEd04GoFl5/nA6KMIMQbz01aLyRROuHpliVOH2ae3jLCORDIYy6feU5Q==",
+        "requested": "[3.0.1-dev.25, )",
+        "resolved": "3.0.1-dev.25",
+        "contentHash": "bxYDptn2hnUFdzFOgmEU/YS8ZjcrHCHz4bFwKLDz1rA9ytkBIUvNuTYZpKZz3h9jVJxrgPhh1qDLqUNgK56hdA==",
         "dependencies": {
-          "Speckle.Core": "3.0.1-dev.23"
+          "Speckle.Core": "3.0.1-dev.25"
         }
       }
     }

--- a/DUI3/Speckle.Connectors.DUI.WebView/packages.lock.json
+++ b/DUI3/Speckle.Connectors.DUI.WebView/packages.lock.json
@@ -423,7 +423,7 @@
           "Microsoft.Extensions.Logging.Abstractions": "[7.0.0, )",
           "Speckle.Autofac": "[1.0.0, )",
           "Speckle.Connectors.Utils": "[1.0.0, )",
-          "Speckle.Core": "[3.0.1-dev.23, )",
+          "Speckle.Core": "[3.0.1-dev.25, )",
           "System.Threading.Tasks.Dataflow": "[6.0.0, )"
         }
       },
@@ -432,7 +432,7 @@
         "dependencies": {
           "Serilog.Extensions.Logging": "[7.0.0, )",
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Core": "[3.0.1-dev.23, )"
+          "Speckle.Core": "[3.0.1-dev.25, )"
         }
       },
       "Microsoft.Extensions.Logging.Abstractions": {
@@ -457,9 +457,9 @@
       },
       "Speckle.Core": {
         "type": "CentralTransitive",
-        "requested": "[3.0.1-dev.23, )",
-        "resolved": "3.0.1-dev.23",
-        "contentHash": "Mep7zls6FJQ8NR79cL6wNNqEpqNbVNXkKOfvY6oebe2MMnE89FKDr29nb2dRgEhynV1ankVzz+YYCiFGxXZfyQ==",
+        "requested": "[3.0.1-dev.25, )",
+        "resolved": "3.0.1-dev.25",
+        "contentHash": "wcLNocrTfNCmhtJH/Hp/1u18Fp57apIdYvQnfCAAfo0txfNjL5hzx+wtFt5PlHPjF/mPssESuhLa89pvrMFvxw==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -859,7 +859,7 @@
           "Microsoft.Extensions.Logging.Abstractions": "[7.0.0, )",
           "Speckle.Autofac": "[1.0.0, )",
           "Speckle.Connectors.Utils": "[1.0.0, )",
-          "Speckle.Core": "[3.0.1-dev.23, )",
+          "Speckle.Core": "[3.0.1-dev.25, )",
           "System.Threading.Tasks.Dataflow": "[6.0.0, )"
         }
       },
@@ -868,7 +868,7 @@
         "dependencies": {
           "Serilog.Extensions.Logging": "[7.0.0, )",
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Core": "[3.0.1-dev.23, )"
+          "Speckle.Core": "[3.0.1-dev.25, )"
         }
       },
       "Microsoft.Extensions.Logging.Abstractions": {
@@ -889,9 +889,9 @@
       },
       "Speckle.Core": {
         "type": "CentralTransitive",
-        "requested": "[3.0.1-dev.23, )",
-        "resolved": "3.0.1-dev.23",
-        "contentHash": "Mep7zls6FJQ8NR79cL6wNNqEpqNbVNXkKOfvY6oebe2MMnE89FKDr29nb2dRgEhynV1ankVzz+YYCiFGxXZfyQ==",
+        "requested": "[3.0.1-dev.25, )",
+        "resolved": "3.0.1-dev.25",
+        "contentHash": "wcLNocrTfNCmhtJH/Hp/1u18Fp57apIdYvQnfCAAfo0txfNjL5hzx+wtFt5PlHPjF/mPssESuhLa89pvrMFvxw==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",

--- a/DUI3/Speckle.Connectors.DUI/Models/Card/ReceiverModelCard.cs
+++ b/DUI3/Speckle.Connectors.DUI/Models/Card/ReceiverModelCard.cs
@@ -12,13 +12,15 @@ public class ReceiverModelCard : ModelCard
   public bool HasDismissedUpdateWarning { get; set; }
   public List<string>? BakedObjectIds { get; set; }
 
-  public ReceiveInfo GetReceiveInfo() =>
+  public ReceiveInfo GetReceiveInfo(string sourceApplication) =>
     new(
       AccountId.NotNull(),
       new Uri(ServerUrl.NotNull()),
       ProjectId.NotNull(),
       ProjectName.NotNull(),
+      ModelId.NotNull(),
       ModelName.NotNull(),
-      SelectedVersionId.NotNull()
+      SelectedVersionId.NotNull(),
+      sourceApplication
     );
 }

--- a/DUI3/Speckle.Connectors.DUI/packages.lock.json
+++ b/DUI3/Speckle.Connectors.DUI/packages.lock.json
@@ -39,9 +39,9 @@
       },
       "Speckle.Core": {
         "type": "Direct",
-        "requested": "[3.0.1-dev.23, )",
-        "resolved": "3.0.1-dev.23",
-        "contentHash": "Mep7zls6FJQ8NR79cL6wNNqEpqNbVNXkKOfvY6oebe2MMnE89FKDr29nb2dRgEhynV1ankVzz+YYCiFGxXZfyQ==",
+        "requested": "[3.0.1-dev.25, )",
+        "resolved": "3.0.1-dev.25",
+        "contentHash": "wcLNocrTfNCmhtJH/Hp/1u18Fp57apIdYvQnfCAAfo0txfNjL5hzx+wtFt5PlHPjF/mPssESuhLa89pvrMFvxw==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -535,7 +535,7 @@
         "dependencies": {
           "Serilog.Extensions.Logging": "[7.0.0, )",
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Core": "[3.0.1-dev.23, )"
+          "Speckle.Core": "[3.0.1-dev.25, )"
         }
       },
       "Serilog.Extensions.Logging": {

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,6 +9,7 @@
     <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageVersionOverrideEnabled>true</CentralPackageVersionOverrideEnabled>
+    <WarningsAsErrors>$(WarningsAsErrors);CS0618</WarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,6 @@
     <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageVersionOverrideEnabled>true</CentralPackageVersionOverrideEnabled>
-    <WarningsAsErrors>$(WarningsAsErrors);CS0618</WarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,8 +14,8 @@
     <PackageVersion Include="Esri.ArcGISPro.Extensions30" Version="3.2.0.49743" />
     <PackageVersion Include="CefSharp.Wpf" Version="92.0.260"/>
     <PackageVersion Include="Revit.Async" Version="2.0.1" />   
-    <PackageVersion Include="Speckle.Core" Version="3.0.1-dev.23" />
-    <PackageVersion Include="Speckle.Objects" Version="3.0.1-dev.23" />
+    <PackageVersion Include="Speckle.Core" Version="3.0.1-dev.25" />
+    <PackageVersion Include="Speckle.Objects" Version="3.0.1-dev.25" />
     <PackageVersion Include="Speckle.AutoCAD.API" Version="2023.0.0" />
     <PackageVersion Include="Speckle.Civil3D.API" Version="2024.0.0" />
     <PackageVersion Include="Speckle.Revit.API" Version="2023.0.0" />

--- a/Sdk/Speckle.Connectors.Utils/Operations/ReceiveInfo.cs
+++ b/Sdk/Speckle.Connectors.Utils/Operations/ReceiveInfo.cs
@@ -5,6 +5,8 @@ public record ReceiveInfo(
   Uri ServerUrl,
   string ProjectId,
   string ProjectName,
+  string ModelId,
   string ModelName,
-  string SelectedVersionId
+  string SelectedVersionId,
+  string SourceApplication
 );

--- a/Sdk/Speckle.Connectors.Utils/Operations/RootObjectSender.cs
+++ b/Sdk/Speckle.Connectors.Utils/Operations/RootObjectSender.cs
@@ -1,5 +1,6 @@
 using Speckle.Connectors.Utils.Caching;
 using Speckle.Core.Api;
+using Speckle.Core.Api.GraphQL.Inputs;
 using Speckle.Core.Credentials;
 using Speckle.Core.Models;
 using Speckle.Core.Transports;
@@ -55,14 +56,13 @@ public sealed class RootObjectSender : IRootObjectSender
     // 8 - Create the version (commit)
     using var apiClient = new Client(account);
     _ = await apiClient
-      .CommitCreate(
-        new CommitCreateInput
-        {
-          streamId = sendInfo.ProjectId,
-          branchName = sendInfo.ModelId,
-          sourceApplication = sendInfo.SourceApplication,
-          objectId = sendResult.rootObjId
-        },
+      .Version.Create(
+        new CreateVersionInput(
+          sendResult.rootObjId,
+          sendInfo.ModelId,
+          sendInfo.ProjectId,
+          sourceApplication: sendInfo.SourceApplication
+        ),
         ct
       )
       .ConfigureAwait(true);

--- a/Sdk/Speckle.Connectors.Utils/packages.lock.json
+++ b/Sdk/Speckle.Connectors.Utils/packages.lock.json
@@ -48,9 +48,9 @@
       },
       "Speckle.Core": {
         "type": "Direct",
-        "requested": "[3.0.1-dev.23, )",
-        "resolved": "3.0.1-dev.23",
-        "contentHash": "Mep7zls6FJQ8NR79cL6wNNqEpqNbVNXkKOfvY6oebe2MMnE89FKDr29nb2dRgEhynV1ankVzz+YYCiFGxXZfyQ==",
+        "requested": "[3.0.1-dev.25, )",
+        "resolved": "3.0.1-dev.25",
+        "contentHash": "wcLNocrTfNCmhtJH/Hp/1u18Fp57apIdYvQnfCAAfo0txfNjL5hzx+wtFt5PlHPjF/mPssESuhLa89pvrMFvxw==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",

--- a/Sdk/Speckle.Converters.Common.DependencyInjection/packages.lock.json
+++ b/Sdk/Speckle.Converters.Common.DependencyInjection/packages.lock.json
@@ -461,7 +461,7 @@
         "type": "Project",
         "dependencies": {
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Objects": "[3.0.1-dev.23, )"
+          "Speckle.Objects": "[3.0.1-dev.25, )"
         }
       },
       "Microsoft.Extensions.Logging.Abstractions": {
@@ -476,9 +476,9 @@
       },
       "Speckle.Core": {
         "type": "CentralTransitive",
-        "requested": "[3.0.1-dev.23, )",
-        "resolved": "3.0.1-dev.23",
-        "contentHash": "Mep7zls6FJQ8NR79cL6wNNqEpqNbVNXkKOfvY6oebe2MMnE89FKDr29nb2dRgEhynV1ankVzz+YYCiFGxXZfyQ==",
+        "requested": "[3.0.1-dev.25, )",
+        "resolved": "3.0.1-dev.25",
+        "contentHash": "wcLNocrTfNCmhtJH/Hp/1u18Fp57apIdYvQnfCAAfo0txfNjL5hzx+wtFt5PlHPjF/mPssESuhLa89pvrMFvxw==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -500,11 +500,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.0.1-dev.23, )",
-        "resolved": "3.0.1-dev.23",
-        "contentHash": "UrhwEiRxJAMCgnOfp5IjUXfbQU8OZ1bEd04GoFl5/nA6KMIMQbz01aLyRROuHpliVOH2ae3jLCORDIYy6feU5Q==",
+        "requested": "[3.0.1-dev.25, )",
+        "resolved": "3.0.1-dev.25",
+        "contentHash": "bxYDptn2hnUFdzFOgmEU/YS8ZjcrHCHz4bFwKLDz1rA9ytkBIUvNuTYZpKZz3h9jVJxrgPhh1qDLqUNgK56hdA==",
         "dependencies": {
-          "Speckle.Core": "3.0.1-dev.23"
+          "Speckle.Core": "3.0.1-dev.25"
         }
       }
     }

--- a/Sdk/Speckle.Converters.Common/packages.lock.json
+++ b/Sdk/Speckle.Converters.Common/packages.lock.json
@@ -35,11 +35,11 @@
       },
       "Speckle.Objects": {
         "type": "Direct",
-        "requested": "[3.0.1-dev.23, )",
-        "resolved": "3.0.1-dev.23",
-        "contentHash": "UrhwEiRxJAMCgnOfp5IjUXfbQU8OZ1bEd04GoFl5/nA6KMIMQbz01aLyRROuHpliVOH2ae3jLCORDIYy6feU5Q==",
+        "requested": "[3.0.1-dev.25, )",
+        "resolved": "3.0.1-dev.25",
+        "contentHash": "bxYDptn2hnUFdzFOgmEU/YS8ZjcrHCHz4bFwKLDz1rA9ytkBIUvNuTYZpKZz3h9jVJxrgPhh1qDLqUNgK56hdA==",
         "dependencies": {
-          "Speckle.Core": "3.0.1-dev.23"
+          "Speckle.Core": "3.0.1-dev.25"
         }
       },
       "GraphQL.Client": {
@@ -469,9 +469,9 @@
       },
       "Speckle.Core": {
         "type": "CentralTransitive",
-        "requested": "[3.0.1-dev.23, )",
-        "resolved": "3.0.1-dev.23",
-        "contentHash": "Mep7zls6FJQ8NR79cL6wNNqEpqNbVNXkKOfvY6oebe2MMnE89FKDr29nb2dRgEhynV1ankVzz+YYCiFGxXZfyQ==",
+        "requested": "[3.0.1-dev.25, )",
+        "resolved": "3.0.1-dev.25",
+        "contentHash": "wcLNocrTfNCmhtJH/Hp/1u18Fp57apIdYvQnfCAAfo0txfNjL5hzx+wtFt5PlHPjF/mPssESuhLa89pvrMFvxw==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",


### PR DESCRIPTION
Updated DUI3 to call new Client function
This meant changing the ReceoveInfo to take a few extra props (the modelId and the sourceApplication slug)