### PR TITLE
Initialize revit async

### DIFF
--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Plugin/RevitWebViewPlugin.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Plugin/RevitWebViewPlugin.cs
@@ -5,6 +5,7 @@ using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using Autodesk.Revit.ApplicationServices;
 using Autodesk.Revit.UI;
+using Revit.Async;
 using Speckle.Connectors.DUI.WebView;
 using Speckle.Converters.RevitShared.Helpers;
 using Speckle.Core.Logging;
@@ -99,7 +100,7 @@ internal sealed class RevitWebViewPlugin : IRevitPlugin
     _revitContext.UIApplication = uiApplication;
 
     // POC: might be worth to interface this out, we shall see...
-    //RevitTask.Initialize(uiApplication);
+    RevitTask.Initialize(uiApplication);
   }
 
   private void RegisterDockablePane()


### PR DESCRIPTION
<!---

Provide a short summary in the Title above. Examples of good PR titles:

* "Feature: adds metrics to component"

* "Fix: resolves duplication in comment thread"

* "Update: apollo v2.34.0"

-->

## Description & motivation

Revit async must be initialized ahead of time in a valid revit context. I had commented this initialization out when upgrading to revit 2025 because revit async was in net framework. I forgot to add this line back after upgrading the package to net standard

<!---

Describe your changes, and why you're making them.  What benefit will this have to others?

Is this linked to an open Github issue, a thread in Speckle community,
or another pull request? Link it here.

If it is related to a Github issue, and resolves it, please link to the issue number, e.g.:
Fixes #85, Fixes #22, Fixes username/repo#123
Connects #123

-->
