### PR TITLE
Dimitrie/cnx 14 send dynamic blocks from acad as exploded groupsstatic

### DIFF
--- a/Connectors/Autocad/Speckle.Connectors.AutocadShared/Bindings/AutocadBasicConnectorBinding.cs
+++ b/Connectors/Autocad/Speckle.Connectors.AutocadShared/Bindings/AutocadBasicConnectorBinding.cs
@@ -116,6 +116,7 @@ public class AutocadBasicConnectorBinding : IBasicConnectorBinding
   {
     var doc = Application.DocumentManager.MdiActiveDocument;
 
+    // TODO: wrap in top level exception handler once the PR is in
     Parent.RunOnMainThread(() =>
     {
       try
@@ -148,8 +149,9 @@ public class AutocadBasicConnectorBinding : IBasicConnectorBinding
         }
         else
         {
-          // This will happen, in some cases, where we highlight individual objects.
-          throw;
+          // This will happen, in some cases, where we highlight individual objects. Should be caught by the top level handler and not
+          // crash the host app.
+          // throw;
         }
       }
     });

--- a/Connectors/Autocad/Speckle.Connectors.AutocadShared/Bindings/AutocadBasicConnectorBinding.cs
+++ b/Connectors/Autocad/Speckle.Connectors.AutocadShared/Bindings/AutocadBasicConnectorBinding.cs
@@ -116,7 +116,6 @@ public class AutocadBasicConnectorBinding : IBasicConnectorBinding
   {
     var doc = Application.DocumentManager.MdiActiveDocument;
 
-    // TODO: wrap in top level exception handler once the PR is in
     Parent.RunOnMainThread(
       () =>
         Parent.TopLevelExceptionHandler.CatchUnhandled(() =>

--- a/Connectors/Autocad/Speckle.Connectors.AutocadShared/HostApp/AutocadInstanceObjectManager.cs
+++ b/Connectors/Autocad/Speckle.Connectors.AutocadShared/HostApp/AutocadInstanceObjectManager.cs
@@ -187,7 +187,6 @@ public class AutocadInstanceObjectManager : IInstanceUnpacker<AutocadRootObject>
 
           foreach (var entity in constituentEntities)
           {
-            // record.AppendEntity(entity);
             objectIds.Add(entity.ObjectId);
           }
 

--- a/Connectors/Autocad/Speckle.Connectors.AutocadShared/Operations/Receive/AutocadHostObjectBuilder.cs
+++ b/Connectors/Autocad/Speckle.Connectors.AutocadShared/Operations/Receive/AutocadHostObjectBuilder.cs
@@ -145,7 +145,6 @@ public class AutocadHostObjectBuilder : IHostObjectBuilder
     // Stage 3: Create group
     // using var transactionContext = TransactionContext.StartTransaction(Application.DocumentManager.MdiActiveDocument);
 
-
     if (groupProxies != null)
     {
       using var groupCreationTransaction =


### PR DESCRIPTION
Closes [CNX-14 : Send dynamic blocks from acad as exploded groups/static blocks](https://linear.app/speckle/issue/CNX-14/send-dynamic-blocks-from-acad-as-exploded-groupsstatic-blocks) and [CNX-116 : Invalid block names for all instances coming from nested models (containing '/')](https://linear.app/speckle/issue/CNX-116/invalid-block-names-for-all-instances-coming-from-nested-models)

Test file: 
[funky-instances.zip](https://github.com/user-attachments/files/16401176/funky-instances.zip)

Tested acad <> acad, acad > rhino