### PR TITLE
fix(rhino): checks for null edge trims

### DIFF
--- a/Converters/Rhino/Speckle.Converters.RhinoShared/ToSpeckle/Raw/BrepToSpeckleConverter.cs
+++ b/Converters/Rhino/Speckle.Converters.RhinoShared/ToSpeckle/Raw/BrepToSpeckleConverter.cs
@@ -136,7 +136,7 @@ public class BrepToSpeckleConverter : ITypedConverter<RG.Brep, SOG.Brep>
       {
         var t = new SOG.BrepTrim(
           speckleParent,
-          trim.Edge.EdgeIndex,
+          trim.Edge?.EdgeIndex ?? -1,
           trim.Face.FaceIndex,
           trim.Loop.LoopIndex,
           trim.TrimCurveIndex,


### PR DESCRIPTION
[CNX-117 : Rhino: failing to send brep spheres, cylinders, paraboloids, ellipsoids, & co.](https://linear.app/speckle/issue/CNX-117/rhino-failing-to-send-brep-spheres-cylinders-paraboloids-ellipsoids)