### PR TITLE
feat(autocad): CNX-23 adds color and transparency as render materials on send and receive

### DIFF
--- a/Connectors/Autocad/Speckle.Connectors.AutocadShared/DependencyInjection/SharedRegistration.cs
+++ b/Connectors/Autocad/Speckle.Connectors.AutocadShared/DependencyInjection/SharedRegistration.cs
@@ -35,6 +35,7 @@ public static class SharedRegistration
     builder.AddSingleton<DocumentModelStore, AutocadDocumentStore>();
     builder.AddSingleton<AutocadContext>();
     builder.AddScoped<AutocadLayerManager>();
+    builder.AddScoped<AutocadMaterialManager>();
     builder.AddSingleton<IAutocadIdleManager, AutocadIdleManager>();
 
     // Register bindings

--- a/Connectors/Autocad/Speckle.Connectors.AutocadShared/HostApp/AutocadGroupUnpacker.cs
+++ b/Connectors/Autocad/Speckle.Connectors.AutocadShared/HostApp/AutocadGroupUnpacker.cs
@@ -15,9 +15,9 @@ public class AutocadGroupUnpacker
 
     using var transaction = Application.DocumentManager.CurrentDocument.Database.TransactionManager.StartTransaction();
 
-    foreach (var (dbObject, applicationId) in autocadObjects)
+    foreach (var (entity, applicationId) in autocadObjects)
     {
-      var persistentReactorIds = dbObject.GetPersistentReactorIds();
+      var persistentReactorIds = entity.GetPersistentReactorIds();
       foreach (ObjectId oReactorId in persistentReactorIds)
       {
         var obj = transaction.GetObject(oReactorId, OpenMode.ForRead);

--- a/Connectors/Autocad/Speckle.Connectors.AutocadShared/HostApp/AutocadInstanceObjectManager.cs
+++ b/Connectors/Autocad/Speckle.Connectors.AutocadShared/HostApp/AutocadInstanceObjectManager.cs
@@ -119,7 +119,7 @@ public class AutocadInstanceObjectManager : IInstanceUnpacker<AutocadRootObject>
     // Go through each definition object
     foreach (ObjectId id in definition)
     {
-      var obj = transaction.GetObject(id, OpenMode.ForRead);
+      DBObject obj = transaction.GetObject(id, OpenMode.ForRead);
       var handleIdString = obj.Handle.Value.ToString();
       definitionProxy.objects.Add(handleIdString);
 
@@ -127,7 +127,7 @@ public class AutocadInstanceObjectManager : IInstanceUnpacker<AutocadRootObject>
       {
         UnpackInstance(blockReference, depth + 1, transaction);
       }
-      _instanceObjectsManager.AddAtomicObject(handleIdString, new(obj, handleIdString));
+      _instanceObjectsManager.AddAtomicObject(handleIdString, new((Entity)obj, handleIdString));
     }
 
     _instanceObjectsManager.AddDefinitionProxy(definitionId.ToString(), definitionProxy);

--- a/Connectors/Autocad/Speckle.Connectors.AutocadShared/HostApp/AutocadMaterialManager.cs
+++ b/Connectors/Autocad/Speckle.Connectors.AutocadShared/HostApp/AutocadMaterialManager.cs
@@ -43,6 +43,22 @@ public class AutocadMaterialManager
     };
   }
 
+  public (AutocadColor, Transparency?) ConvertRenderMaterialToColorAndTransparency(RenderMaterial material)
+  {
+    System.Drawing.Color systemColor = System.Drawing.Color.FromArgb(material.diffuse);
+    AutocadColor color = AutocadColor.FromColor(systemColor);
+
+    // only create transparency if render material is not opaque
+    Transparency? transparency = null;
+    if (material.opacity != 1)
+    {
+      var alpha = (byte)(material.opacity * 255d);
+      transparency = new Transparency(alpha);
+    }
+
+    return (color, transparency);
+  }
+
   public List<RenderMaterialProxy> UnpackRenderMaterial(
     List<AutocadRootObject> rootObjects,
     List<LayerTableRecord> layers

--- a/Connectors/Autocad/Speckle.Connectors.AutocadShared/HostApp/AutocadMaterialManager.cs
+++ b/Connectors/Autocad/Speckle.Connectors.AutocadShared/HostApp/AutocadMaterialManager.cs
@@ -1,0 +1,96 @@
+using Autodesk.AutoCAD.Colors;
+using Autodesk.AutoCAD.DatabaseServices;
+using Objects.Other;
+using Speckle.Connectors.Autocad.Operations.Send;
+using AutocadColor = Autodesk.AutoCAD.Colors.Color;
+using SpeckleRenderMaterial = Objects.Other.RenderMaterial;
+
+namespace Speckle.Connectors.Autocad.HostApp;
+
+/// <summary>
+/// Utility class managing material creation and/or extraction from autocad. Expects to be a scoped dependency per send or receive operation.
+/// </summary>
+public class AutocadMaterialManager
+{
+  //POC: hack in place to create unique render mateiral app ids since we are faking them from color + transparency
+  private string GetMaterialId(AutocadColor color, Transparency transparency) =>
+    $"{color.ColorIndex}-{Convert.ToDouble(transparency.Alpha)}";
+
+  // converts an autocad color to a render material
+  // more info on autocad colors: https://gohtx.com/acadcolors.php
+  // POC: we will send these as part of display styles in the future, but faking the color as a render material for now
+  private SpeckleRenderMaterial ConvertColorAndTransparencyToRenderMaterial(
+    AutocadColor autocadColor,
+    Transparency transparency
+  )
+  {
+    string renderMaterialName = autocadColor.HasColorName
+      ? autocadColor.ColorName
+      : autocadColor.HasBookName
+        ? autocadColor.BookName
+        : autocadColor.ColorNameForDisplay;
+
+    return new SpeckleRenderMaterial()
+    {
+      diffuse = autocadColor.ColorValue.ToArgb(),
+      opacity = Convert.ToDouble(transparency.Alpha) / 255.0,
+      name = renderMaterialName,
+      applicationId = GetMaterialId(autocadColor, transparency)
+    };
+  }
+
+  public List<RenderMaterialProxy> UnpackRenderMaterial(
+    List<AutocadRootObject> atomicObjects,
+    Dictionary<string, LayerTableRecord> layerCache
+  )
+  {
+    Dictionary<string, RenderMaterialProxy> renderMaterialProxies = new();
+
+    // Stage 1: unpack materials from objects
+    foreach (AutocadRootObject autocadRootObject in atomicObjects)
+    {
+      if (autocadRootObject.Root is Entity entity && entity.EntityColor.IsByColor)
+      {
+        string colorId = entity.Color.ColorIndex.ToString();
+        if (renderMaterialProxies.TryGetValue(colorId, out RenderMaterialProxy value))
+        {
+          value.objects.Add(autocadRootObject.ApplicationId);
+        }
+        else
+        {
+          SpeckleRenderMaterial objMaterial = ConvertColorAndTransparencyToRenderMaterial(
+            entity.Color,
+            entity.Transparency
+          );
+
+          renderMaterialProxies[colorId] = new RenderMaterialProxy()
+          {
+            value = objMaterial,
+            objects = [autocadRootObject.ApplicationId]
+          };
+        }
+      }
+    }
+
+    // Stage 2: make sure we collect layer materials as well
+    foreach (LayerTableRecord layer in layerCache.Values)
+    {
+      string materialId = GetMaterialId(layer.Color, layer.Transparency);
+
+      if (renderMaterialProxies.TryGetValue(materialId, out RenderMaterialProxy value))
+      {
+        value.objects.Add(layer.Id.ToString());
+      }
+      else
+      {
+        renderMaterialProxies[materialId] = new RenderMaterialProxy()
+        {
+          value = ConvertColorAndTransparencyToRenderMaterial(layer.Color, layer.Transparency),
+          objects = [layer.Id.ToString()]
+        };
+      }
+    }
+
+    return renderMaterialProxies.Values.ToList();
+  }
+}

--- a/Connectors/Autocad/Speckle.Connectors.AutocadShared/HostApp/Extensions/DocumentExtensions.cs
+++ b/Connectors/Autocad/Speckle.Connectors.AutocadShared/HostApp/Extensions/DocumentExtensions.cs
@@ -1,4 +1,4 @@
-﻿using Autodesk.AutoCAD.DatabaseServices;
+using Autodesk.AutoCAD.DatabaseServices;
 using Autodesk.AutoCAD.Runtime;
 using Speckle.Connectors.Autocad.Operations.Send;
 
@@ -25,7 +25,7 @@ public static class DocumentExtensions
             {
               if (tr.GetObject(myObjectId, OpenMode.ForRead) is DBObject dbObject)
               {
-                objects.Add(new(dbObject, objectIdHandle));
+                objects.Add(new((Entity)dbObject, objectIdHandle));
               }
             }
           }

--- a/Connectors/Autocad/Speckle.Connectors.AutocadShared/Operations/Send/AutocadRootObject.cs
+++ b/Connectors/Autocad/Speckle.Connectors.AutocadShared/Operations/Send/AutocadRootObject.cs
@@ -1,6 +1,6 @@
-﻿using Autodesk.AutoCAD.DatabaseServices;
+using Autodesk.AutoCAD.DatabaseServices;
 
 namespace Speckle.Connectors.Autocad.Operations.Send;
 
 // Note: naming is a bit confusing, Root is similar to base commit object, or root commit object, etc. It might be just in my head (dim)
-public record AutocadRootObject(DBObject Root, string ApplicationId);
+public record AutocadRootObject(Entity Root, string ApplicationId);

--- a/Connectors/Autocad/Speckle.Connectors.AutocadShared/Speckle.Connectors.AutocadShared.projitems
+++ b/Connectors/Autocad/Speckle.Connectors.AutocadShared/Speckle.Connectors.AutocadShared.projitems
@@ -30,6 +30,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)HostApp\Extensions\DocumentExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HostApp\Extensions\EditorExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HostApp\Extensions\EntityExtensions.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)HostApp\AutocadMaterialManager.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HostApp\TransactionContext.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Operations\Receive\AutocadHostObjectBuilder.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Operations\Send\AutocadRootObject.cs" />

--- a/Connectors/Rhino/Speckle.Connectors.Rhino7/HostApp/RhinoMaterialManager.cs
+++ b/Connectors/Rhino/Speckle.Connectors.Rhino7/HostApp/RhinoMaterialManager.cs
@@ -13,7 +13,7 @@ using SpeckleRenderMaterial = Objects.Other.RenderMaterial;
 namespace Speckle.Connectors.Rhino7.HostApp;
 
 /// <summary>
-/// Utility class managing layer creation and/or extraction from rhino. Expects to be a scoped dependency per send or receive operation.
+/// Utility class managing material creation and/or extraction from rhino. Expects to be a scoped dependency per send or receive operation.
 /// </summary>
 public class RhinoMaterialManager
 {

--- a/Sdk/Speckle.Connectors.Utils/RenderMaterials/BakeResult.cs
+++ b/Sdk/Speckle.Connectors.Utils/RenderMaterials/BakeResult.cs
@@ -4,5 +4,5 @@ namespace Speckle.Connectors.Utils.RenderMaterials;
 
 public record BakeResult(
   Dictionary<string, int> MaterialIdMap,
-  List<ReceiveConversionResult> InstanceConversionResults
+  List<ReceiveConversionResult> MaterialConversionResults
 );


### PR DESCRIPTION
In autocad, we are sending every object's `color` and `transparency` as a render material (in lieu of not implementing display styles). This currently doesn't apply for layers, which already have a color.

This doesn't take into consideration, on receive, when the converted object is a list of display values, which may have their own render materials different from the parent which was passed to the converter. This will need to be debugged once revit send is polished.