### PR TITLE
fix(dui3): cleans up base layer prefix from invalid chars - fixes second receive cleanup issues

### DIFF
--- a/Connectors/Autocad/Speckle.Connectors.AutocadShared/HostApp/AutocadLayerManager.cs
+++ b/Connectors/Autocad/Speckle.Connectors.AutocadShared/HostApp/AutocadLayerManager.cs
@@ -94,7 +94,7 @@ public class AutocadLayerManager
         SelectionSet selectionResult = Doc.Editor.SelectAll(selectionFilter).Value;
         if (selectionResult == null)
         {
-          return;
+          continue;
         }
         foreach (SelectedObject selectedObject in selectionResult)
         {

--- a/Connectors/Autocad/Speckle.Connectors.AutocadShared/HostApp/AutocadLayerManager.cs
+++ b/Connectors/Autocad/Speckle.Connectors.AutocadShared/HostApp/AutocadLayerManager.cs
@@ -29,7 +29,7 @@ public class AutocadLayerManager
   /// </summary>
   public void CreateLayerForReceive(Collection layerCollection)
   {
-    string layerName = layerCollection.name;
+    string layerName = _autocadContext.RemoveInvalidChars(layerCollection.name);
     if (!_uniqueLayerNames.Add(layerName))
     {
       return;

--- a/Connectors/Autocad/Speckle.Connectors.AutocadShared/Operations/Receive/AutocadHostObjectBuilder.cs
+++ b/Connectors/Autocad/Speckle.Connectors.AutocadShared/Operations/Receive/AutocadHostObjectBuilder.cs
@@ -25,13 +25,15 @@ public class AutocadHostObjectBuilder : IHostObjectBuilder
 
   // private readonly HashSet<string> _uniqueLayerNames = new();
   private readonly AutocadInstanceObjectManager _instanceObjectsManager;
+  private readonly AutocadContext _autocadContext;
 
   public AutocadHostObjectBuilder(
     IRootToHostConverter converter,
     GraphTraversal traversalFunction,
     AutocadLayerManager autocadLayerManager,
     AutocadInstanceObjectManager instanceObjectsManager,
-    ISyncToThread syncToThread
+    ISyncToThread syncToThread,
+    AutocadContext autocadContext
   )
   {
     _converter = converter;
@@ -39,6 +41,7 @@ public class AutocadHostObjectBuilder : IHostObjectBuilder
     _autocadLayerManager = autocadLayerManager;
     _instanceObjectsManager = instanceObjectsManager;
     _syncToThread = syncToThread;
+    _autocadContext = autocadContext;
   }
 
   public Task<HostObjectBuilderResult> Build(
@@ -57,8 +60,7 @@ public class AutocadHostObjectBuilder : IHostObjectBuilder
       // Layer filter for received commit with project and model name
       _autocadLayerManager.CreateLayerFilter(projectName, modelName);
 
-      //TODO: make the layerManager handle \/ ?
-      string baseLayerPrefix = $"SPK-{projectName}-{modelName}-";
+      string baseLayerPrefix = _autocadContext.RemoveInvalidChars($"SPK-{projectName}-{modelName}-");
 
       PreReceiveDeepClean(baseLayerPrefix);
 


### PR DESCRIPTION
and adds extra defensibility around layer naming in acad. 

The issue was that we were not consistently cleaning up the base layer prefix: 
- layer creation would remove `/` chars
- base layer prefix would still contain `/` chars

resulting in all second receives from nested models being borked. 

Also fixes another acad second receive bug, where we would stop purging object layers if we would encounter one with no objects on it. 
