### PR TITLE
feat(autocad/rhino): CNX-162 CNX-163 adds color proxies on send and receive

### DIFF
--- a/Connectors/ArcGIS/Speckle.Connectors.ArcGIS3/packages.lock.json
+++ b/Connectors/ArcGIS/Speckle.Connectors.ArcGIS3/packages.lock.json
@@ -170,8 +170,8 @@
       },
       "Speckle.Logging": {
         "type": "Transitive",
-        "resolved": "3.1.0-dev.88",
-        "contentHash": "kD8Xuqbv5lmNQGuv+gx+OnzFt51twc2aIWHEmaG+HBwojR4PZ9IqsaCcMSu4wv/Q1p+Xq5MZldVDkO368JSJRw=="
+        "resolved": "3.1.0-dev.89",
+        "contentHash": "sRiVATMGe8N0LwFRlqxBpRwmI7ZXVKGobSUUCLzzBqIe5UKFJRGi4Jz/6ukF6Tl2li6vrU0qt0CBPOx5nX1jrA=="
       },
       "Speckle.Newtonsoft.Json": {
         "type": "Transitive",
@@ -241,7 +241,7 @@
           "Microsoft.Extensions.Logging.Abstractions": "[7.0.0, )",
           "Speckle.Autofac": "[1.0.0, )",
           "Speckle.Connectors.Utils": "[1.0.0, )",
-          "Speckle.Core": "[3.1.0-dev.88, )",
+          "Speckle.Core": "[3.1.0-dev.89, )",
           "System.Threading.Tasks.Dataflow": "[6.0.0, )"
         }
       },
@@ -257,7 +257,7 @@
         "dependencies": {
           "Serilog.Extensions.Logging": "[7.0.0, )",
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Core": "[3.1.0-dev.88, )"
+          "Speckle.Core": "[3.1.0-dev.89, )"
         }
       },
       "speckle.converters.arcgis3": {
@@ -278,7 +278,7 @@
         "type": "Project",
         "dependencies": {
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.88, )"
+          "Speckle.Objects": "[3.1.0-dev.89, )"
         }
       },
       "speckle.converters.common.dependencyinjection": {
@@ -312,9 +312,9 @@
       },
       "Speckle.Core": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.88, )",
-        "resolved": "3.1.0-dev.88",
-        "contentHash": "1yBzO/JEG9aEGeXwpx1vMZgknmma0QI1cVQ+uwoHc7oyYcAk1bePCa/C6ntyszzV+Y3fpeBZY4HGNALYICgVjg==",
+        "requested": "[3.1.0-dev.89, )",
+        "resolved": "3.1.0-dev.89",
+        "contentHash": "p3KMI7g2D6+nRAFtSQ3zDB6sB7329qyOvn+WCvy1n7YK35atM4ssR9WL4SVgKss/IQifxgDZVVldE3/o31TRTQ==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -323,18 +323,18 @@
           "Polly.Contrib.WaitAndRetry": "1.1.1",
           "Polly.Extensions.Http": "3.0.0",
           "Speckle.DoubleNumerics": "4.0.1",
-          "Speckle.Logging": "3.1.0-dev.88",
+          "Speckle.Logging": "3.1.0-dev.89",
           "Speckle.Newtonsoft.Json": "13.0.2",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.88, )",
-        "resolved": "3.1.0-dev.88",
-        "contentHash": "hzqeIYzvSa3VusEWic8FaVsaEMwHcwnbj2p0JDz2ZTAlf3SpFdxVtA4onIq0l7YyROBIFFn78eIIpm1cCucUIw==",
+        "requested": "[3.1.0-dev.89, )",
+        "resolved": "3.1.0-dev.89",
+        "contentHash": "DA035BwkIG5sdg2Z6SEsi9jo5zuP6UxBFzBW8QtY5hf54be34lzxl/9p3HGkpALUyBMrgaAZvZZnS/INEQRpGw==",
         "dependencies": {
-          "Speckle.Core": "3.1.0-dev.88"
+          "Speckle.Core": "3.1.0-dev.89"
         }
       },
       "System.Threading.Tasks.Dataflow": {

--- a/Connectors/Autocad/Speckle.Connectors.Autocad2023/packages.lock.json
+++ b/Connectors/Autocad/Speckle.Connectors.Autocad2023/packages.lock.json
@@ -183,8 +183,8 @@
       },
       "Speckle.Logging": {
         "type": "Transitive",
-        "resolved": "3.1.0-dev.88",
-        "contentHash": "kD8Xuqbv5lmNQGuv+gx+OnzFt51twc2aIWHEmaG+HBwojR4PZ9IqsaCcMSu4wv/Q1p+Xq5MZldVDkO368JSJRw=="
+        "resolved": "3.1.0-dev.89",
+        "contentHash": "sRiVATMGe8N0LwFRlqxBpRwmI7ZXVKGobSUUCLzzBqIe5UKFJRGi4Jz/6ukF6Tl2li6vrU0qt0CBPOx5nX1jrA=="
       },
       "Speckle.Newtonsoft.Json": {
         "type": "Transitive",
@@ -322,7 +322,7 @@
           "Microsoft.Extensions.Logging.Abstractions": "[7.0.0, )",
           "Speckle.Autofac": "[1.0.0, )",
           "Speckle.Connectors.Utils": "[1.0.0, )",
-          "Speckle.Core": "[3.1.0-dev.88, )",
+          "Speckle.Core": "[3.1.0-dev.89, )",
           "System.Threading.Tasks.Dataflow": "[6.0.0, )"
         }
       },
@@ -338,7 +338,7 @@
         "dependencies": {
           "Serilog.Extensions.Logging": "[7.0.0, )",
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Core": "[3.1.0-dev.88, )"
+          "Speckle.Core": "[3.1.0-dev.89, )"
         }
       },
       "speckle.converters.autocad2023": {
@@ -360,7 +360,7 @@
         "type": "Project",
         "dependencies": {
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.88, )"
+          "Speckle.Objects": "[3.1.0-dev.89, )"
         }
       },
       "speckle.converters.common.dependencyinjection": {
@@ -407,9 +407,9 @@
       },
       "Speckle.Core": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.88, )",
-        "resolved": "3.1.0-dev.88",
-        "contentHash": "1yBzO/JEG9aEGeXwpx1vMZgknmma0QI1cVQ+uwoHc7oyYcAk1bePCa/C6ntyszzV+Y3fpeBZY4HGNALYICgVjg==",
+        "requested": "[3.1.0-dev.89, )",
+        "resolved": "3.1.0-dev.89",
+        "contentHash": "p3KMI7g2D6+nRAFtSQ3zDB6sB7329qyOvn+WCvy1n7YK35atM4ssR9WL4SVgKss/IQifxgDZVVldE3/o31TRTQ==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -418,18 +418,18 @@
           "Polly.Contrib.WaitAndRetry": "1.1.1",
           "Polly.Extensions.Http": "3.0.0",
           "Speckle.DoubleNumerics": "4.0.1",
-          "Speckle.Logging": "3.1.0-dev.88",
+          "Speckle.Logging": "3.1.0-dev.89",
           "Speckle.Newtonsoft.Json": "13.0.2",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.88, )",
-        "resolved": "3.1.0-dev.88",
-        "contentHash": "hzqeIYzvSa3VusEWic8FaVsaEMwHcwnbj2p0JDz2ZTAlf3SpFdxVtA4onIq0l7YyROBIFFn78eIIpm1cCucUIw==",
+        "requested": "[3.1.0-dev.89, )",
+        "resolved": "3.1.0-dev.89",
+        "contentHash": "DA035BwkIG5sdg2Z6SEsi9jo5zuP6UxBFzBW8QtY5hf54be34lzxl/9p3HGkpALUyBMrgaAZvZZnS/INEQRpGw==",
         "dependencies": {
-          "Speckle.Core": "3.1.0-dev.88"
+          "Speckle.Core": "3.1.0-dev.89"
         }
       },
       "System.Threading.Tasks.Dataflow": {

--- a/Connectors/Autocad/Speckle.Connectors.AutocadShared/DependencyInjection/SharedRegistration.cs
+++ b/Connectors/Autocad/Speckle.Connectors.AutocadShared/DependencyInjection/SharedRegistration.cs
@@ -37,6 +37,7 @@ public static class SharedRegistration
     builder.AddSingleton<DocumentModelStore, AutocadDocumentStore>();
     builder.AddSingleton<AutocadContext>();
     builder.AddScoped<AutocadLayerManager>();
+    builder.AddScoped<AutocadColorManager>();
     builder.AddSingleton<IAutocadIdleManager, AutocadIdleManager>();
 
     // Register bindings

--- a/Connectors/Autocad/Speckle.Connectors.AutocadShared/HostApp/AutocadColorManager.cs
+++ b/Connectors/Autocad/Speckle.Connectors.AutocadShared/HostApp/AutocadColorManager.cs
@@ -1,7 +1,6 @@
 using Autodesk.AutoCAD.Colors;
 using Autodesk.AutoCAD.DatabaseServices;
 using Speckle.Connectors.Autocad.Operations.Send;
-using Speckle.Core.Models.Collections;
 using Speckle.Core.Models.Proxies;
 using AutocadColor = Autodesk.AutoCAD.Colors.Color;
 
@@ -17,7 +16,7 @@ public class AutocadColorManager
   // POC: Will be addressed to move it into AutocadContext!
   private Document Doc => Application.DocumentManager.MdiActiveDocument;
 
-  public Dictionary<string, AutocadColor> ObjectColorIdMap { get; }
+  public Dictionary<string, AutocadColor> ObjectColorsIdMap { get; }
 
   public AutocadColorManager(AutocadContext autocadContext)
   {
@@ -110,26 +109,11 @@ public class AutocadColorManager
       {
         AutocadColor convertedColor = ConvertColorProxyToColor(colorProxy);
 
-        if (!ObjectColorIdMap.TryGetValue(objectId, out AutocadColor _))
+        if (!ObjectColorsIdMap.TryGetValue(objectId, out AutocadColor _))
         {
-          ObjectColorIdMap.Add(objectId, convertedColor);
+          ObjectColorsIdMap.Add(objectId, convertedColor);
         }
       }
     }
-  }
-
-  public AutocadColor? GetColorByLayerPath(Collection[] layerPath)
-  {
-    AutocadColor? color = null;
-    for (int j = layerPath.Length - 1; j >= 0; j--)
-    {
-      string id = layerPath[j].applicationId ?? layerPath[j].id;
-      if (ObjectColorIdMap.TryGetValue(id, out color))
-      {
-        break;
-      }
-    }
-
-    return color;
   }
 }

--- a/Connectors/Autocad/Speckle.Connectors.AutocadShared/HostApp/AutocadColorManager.cs
+++ b/Connectors/Autocad/Speckle.Connectors.AutocadShared/HostApp/AutocadColorManager.cs
@@ -1,3 +1,4 @@
+using Autodesk.AutoCAD.Colors;
 using Autodesk.AutoCAD.DatabaseServices;
 using Speckle.Connectors.Autocad.Operations.Send;
 using Speckle.Core.Models.Proxies;
@@ -80,5 +81,14 @@ public class AutocadColorManager
     }
 
     return colorProxies.Values.ToList();
+  }
+
+  public AutocadColor ConvertColorProxyToColor(ColorProxy colorProxy)
+  {
+    AutocadColor color = colorProxy["autocadColorIndex"] is short index
+      ? AutocadColor.FromColorIndex(ColorMethod.ByAci, index)
+      : AutocadColor.FromColor(System.Drawing.Color.FromArgb(colorProxy.value));
+
+    return color;
   }
 }

--- a/Connectors/Autocad/Speckle.Connectors.AutocadShared/HostApp/AutocadColorManager.cs
+++ b/Connectors/Autocad/Speckle.Connectors.AutocadShared/HostApp/AutocadColorManager.cs
@@ -30,6 +30,8 @@ public class AutocadColorManager
 
     ColorProxy colorProxy = new(argb, id, name) { objects = new() };
 
+    // INFO: this index is an Autocad internal index for set rgb values
+    // https://gohtx.com/acadcolors.php
     if (color.IsByAci)
     {
       colorProxy["autocadColorIndex"] = (int)color.ColorIndex;

--- a/Connectors/Autocad/Speckle.Connectors.AutocadShared/HostApp/AutocadColorManager.cs
+++ b/Connectors/Autocad/Speckle.Connectors.AutocadShared/HostApp/AutocadColorManager.cs
@@ -42,19 +42,19 @@ public class AutocadColorManager
   {
     Dictionary<string, ColorProxy> colorProxies = new();
 
-    // Stage 1: unpack materials from objects
+    // Stage 1: unpack colors from objects
     foreach (AutocadRootObject rootObj in rootObjects)
     {
       Entity entity = rootObj.Root;
 
       // skip any objects that inherit their colors
-      if (!entity.Color.IsByAci || !entity.Color.IsByColor)
+      if (!entity.Color.IsByAci && !entity.Color.IsByColor)
       {
         continue;
       }
 
       // assumes color names are unique
-      string colorId = entity.Color.ColorName;
+      string colorId = entity.Color.ColorNameForDisplay;
 
       if (colorProxies.TryGetValue(colorId, out ColorProxy value))
       {
@@ -70,7 +70,7 @@ public class AutocadColorManager
     foreach (LayerTableRecord layer in layers)
     {
       // assumes color names are unique
-      string colorId = layer.Color.ColorName;
+      string colorId = layer.Color.ColorNameForDisplay;
 
       if (colorProxies.TryGetValue(colorId, out ColorProxy value))
       {

--- a/Connectors/Autocad/Speckle.Connectors.AutocadShared/HostApp/AutocadColorManager.cs
+++ b/Connectors/Autocad/Speckle.Connectors.AutocadShared/HostApp/AutocadColorManager.cs
@@ -1,0 +1,84 @@
+using Autodesk.AutoCAD.DatabaseServices;
+using Speckle.Connectors.Autocad.Operations.Send;
+using Speckle.Core.Models.Proxies;
+using AutocadColor = Autodesk.AutoCAD.Colors.Color;
+
+namespace Speckle.Connectors.Autocad.HostApp;
+
+/// <summary>
+/// Expects to be a scoped dependency for a given operation and helps with layer creation and cleanup.
+/// </summary>
+public class AutocadColorManager
+{
+  private readonly AutocadContext _autocadContext;
+
+  // POC: Will be addressed to move it into AutocadContext!
+  private Document Doc => Application.DocumentManager.MdiActiveDocument;
+
+  public AutocadColorManager(AutocadContext autocadContext)
+  {
+    _autocadContext = autocadContext;
+  }
+
+  private ColorProxy ConvertColorToColorProxy(AutocadColor color, string id)
+  {
+    int argb = color.ColorValue.ToArgb();
+    string name = color.ColorNameForDisplay;
+
+    ColorProxy colorProxy = new(argb, id, name);
+
+    if (color.IsByAci)
+    {
+      colorProxy["autocadColorIndex"] = color.ColorIndex;
+    }
+
+    return colorProxy;
+  }
+
+  public List<ColorProxy> UnpackColors(List<AutocadRootObject> rootObjects, List<LayerTableRecord> layers)
+  {
+    Dictionary<string, ColorProxy> colorProxies = new();
+
+    // Stage 1: unpack materials from objects
+    foreach (AutocadRootObject rootObj in rootObjects)
+    {
+      Entity entity = rootObj.Root;
+
+      // skip any objects that inherit their colors
+      if (!entity.Color.IsByAci || !entity.Color.IsByColor)
+      {
+        continue;
+      }
+
+      // assumes color names are unique
+      string colorId = entity.Color.ColorName;
+
+      if (colorProxies.TryGetValue(colorId, out ColorProxy value))
+      {
+        value.objects.Add(rootObj.ApplicationId);
+      }
+      else
+      {
+        colorProxies[colorId] = ConvertColorToColorProxy(entity.Color, colorId);
+      }
+    }
+
+    // Stage 2: make sure we collect layer colors as well
+    foreach (LayerTableRecord layer in layers)
+    {
+      // assumes color names are unique
+      string colorId = layer.Color.ColorName;
+
+      if (colorProxies.TryGetValue(colorId, out ColorProxy value))
+      {
+        value.objects.Add(layer.Id.ToString());
+      }
+      else
+      {
+        colorProxies[colorId] = ConvertColorToColorProxy(layer.Color, colorId);
+      }
+    }
+
+    return colorProxies.Values.ToList();
+  }
+}

--- a/Connectors/Autocad/Speckle.Connectors.AutocadShared/HostApp/AutocadGroupUnpacker.cs
+++ b/Connectors/Autocad/Speckle.Connectors.AutocadShared/HostApp/AutocadGroupUnpacker.cs
@@ -1,6 +1,6 @@
 using Autodesk.AutoCAD.DatabaseServices;
 using Speckle.Connectors.Autocad.Operations.Send;
-using Speckle.Core.Models.Instances;
+using Speckle.Core.Models.Proxies;
 
 namespace Speckle.Connectors.Autocad.HostApp;
 

--- a/Connectors/Autocad/Speckle.Connectors.AutocadShared/HostApp/AutocadInstanceObjectManager.cs
+++ b/Connectors/Autocad/Speckle.Connectors.AutocadShared/HostApp/AutocadInstanceObjectManager.cs
@@ -227,7 +227,7 @@ public class AutocadInstanceObjectManager : IInstanceUnpacker<AutocadRootObject>
           string layerName = _autocadLayerManager.CreateLayerForReceive(
             collectionPath,
             baseLayerName,
-            _autocadColorManager.ObjectColorIdMap
+            _autocadColorManager.ObjectColorsIdMap
           );
 
           var blockRef = new BlockReference(insertionPoint, definitionId)

--- a/Connectors/Autocad/Speckle.Connectors.AutocadShared/HostApp/AutocadInstanceObjectManager.cs
+++ b/Connectors/Autocad/Speckle.Connectors.AutocadShared/HostApp/AutocadInstanceObjectManager.cs
@@ -145,7 +145,7 @@ public class AutocadInstanceObjectManager : IInstanceUnpacker<AutocadRootObject>
       {
         UnpackInstance(blockReference, depth + 1, transaction);
       }
-      _instanceObjectsManager.AddAtomicObject(handleIdString, new(obj, handleIdString));
+      _instanceObjectsManager.AddAtomicObject(handleIdString, new((Entity)obj, handleIdString));
     }
 
     _instanceObjectsManager.AddDefinitionProxy(definitionId.ToString(), definitionProxy);

--- a/Connectors/Autocad/Speckle.Connectors.AutocadShared/HostApp/AutocadLayerManager.cs
+++ b/Connectors/Autocad/Speckle.Connectors.AutocadShared/HostApp/AutocadLayerManager.cs
@@ -14,7 +14,7 @@ public class AutocadLayerManager
 {
   private readonly AutocadContext _autocadContext;
   private readonly string _layerFilterName = "Speckle";
-  public Dictionary<string, Layer> CollectionCache { get; }
+  public Dictionary<string, Layer> CollectionCache { get; } = new();
 
   // POC: Will be addressed to move it into AutocadContext!
   private Document Doc => Application.DocumentManager.MdiActiveDocument;

--- a/Connectors/Autocad/Speckle.Connectors.AutocadShared/HostApp/Extensions/DocumentExtensions.cs
+++ b/Connectors/Autocad/Speckle.Connectors.AutocadShared/HostApp/Extensions/DocumentExtensions.cs
@@ -1,4 +1,4 @@
-﻿using Autodesk.AutoCAD.DatabaseServices;
+using Autodesk.AutoCAD.DatabaseServices;
 using Autodesk.AutoCAD.Runtime;
 using Speckle.Connectors.Autocad.Operations.Send;
 
@@ -25,7 +25,7 @@ public static class DocumentExtensions
             {
               if (tr.GetObject(myObjectId, OpenMode.ForRead) is DBObject dbObject)
               {
-                objects.Add(new(dbObject, objectIdHandle));
+                objects.Add(new((Entity)dbObject, objectIdHandle));
               }
             }
           }

--- a/Connectors/Autocad/Speckle.Connectors.AutocadShared/Operations/Receive/AutocadHostObjectBuilder.cs
+++ b/Connectors/Autocad/Speckle.Connectors.AutocadShared/Operations/Receive/AutocadHostObjectBuilder.cs
@@ -212,7 +212,7 @@ public class AutocadHostObjectBuilder : IHostObjectBuilder
     string layerName = _autocadLayerManager.CreateLayerForReceive(
       layerPath,
       baseLayerNamePrefix,
-      _colorManager.ObjectColorIdMap
+      _colorManager.ObjectColorsIdMap
     );
 
     object converted;
@@ -226,7 +226,7 @@ public class AutocadHostObjectBuilder : IHostObjectBuilder
 
     // get color if any
     string objId = obj.applicationId ?? obj.id;
-    AutocadColor? objColor = _colorManager.ObjectColorIdMap.TryGetValue(objId, out AutocadColor? value) ? value : null;
+    AutocadColor? objColor = _colorManager.ObjectColorsIdMap.TryGetValue(objId, out AutocadColor? value) ? value : null;
 
     foreach (Entity? conversionResult in flattened)
     {

--- a/Connectors/Autocad/Speckle.Connectors.AutocadShared/Operations/Receive/AutocadHostObjectBuilder.cs
+++ b/Connectors/Autocad/Speckle.Connectors.AutocadShared/Operations/Receive/AutocadHostObjectBuilder.cs
@@ -34,7 +34,7 @@ public class AutocadHostObjectBuilder : IHostObjectBuilder
     GraphTraversal traversalFunction,
     AutocadLayerManager autocadLayerManager,
     AutocadInstanceObjectManager instanceObjectsManager,
-    AutocadColorManager colorManager
+    AutocadColorManager colorManager,
     ISyncToThread syncToThread,
     AutocadContext autocadContext
   )
@@ -89,11 +89,11 @@ public class AutocadHostObjectBuilder : IHostObjectBuilder
       }
 
       // POC: get colors
-    List<ColorProxy>? colors = (rootObject["colorProxies"] as List<object>)?.Cast<ColorProxy>().ToList();
-    if (colors != null)
-    {
-      _colorManager.ParseColors(colors, onOperationProgressed);
-    }
+      List<ColorProxy>? colors = (rootObject["colorProxies"] as List<object>)?.Cast<ColorProxy>().ToList();
+      if (colors != null)
+      {
+        _colorManager.ParseColors(colors, onOperationProgressed);
+      }
 
       // POC: get group proxies
       var groupProxies = (rootObject["groupProxies"] as List<object>)?.Cast<GroupProxy>().ToList();
@@ -102,8 +102,8 @@ public class AutocadHostObjectBuilder : IHostObjectBuilder
 
       foreach (TraversalContext tc in objectGraph)
       {
-       // create new speckle layer from layer path
-      Collection[] layerPath = _autocadLayerManager.GetLayerPath(tc);
+        // create new speckle layer from layer path
+        Collection[] layerPath = _autocadLayerManager.GetLayerPath(tc);
         switch (tc.Current)
         {
           case IInstanceComponent instanceComponent:
@@ -128,9 +128,7 @@ public class AutocadHostObjectBuilder : IHostObjectBuilder
         {
           List<Entity> convertedObjects = ConvertObject(atomicObject, layerPath, baseLayerPrefix).ToList();
 
-
-            applicationIdMap[objectId] = convertedObjects;
-          
+          applicationIdMap[objectId] = convertedObjects;
 
           results.AddRange(
             convertedObjects.Select(e => new ReceiveConversionResult(

--- a/Connectors/Autocad/Speckle.Connectors.AutocadShared/Operations/Send/AutocadRootObject.cs
+++ b/Connectors/Autocad/Speckle.Connectors.AutocadShared/Operations/Send/AutocadRootObject.cs
@@ -1,6 +1,6 @@
-﻿using Autodesk.AutoCAD.DatabaseServices;
+using Autodesk.AutoCAD.DatabaseServices;
 
 namespace Speckle.Connectors.Autocad.Operations.Send;
 
 // Note: naming is a bit confusing, Root is similar to base commit object, or root commit object, etc. It might be just in my head (dim)
-public record AutocadRootObject(DBObject Root, string ApplicationId);
+public record AutocadRootObject(Entity Root, string ApplicationId);

--- a/Connectors/Autocad/Speckle.Connectors.AutocadShared/Operations/Send/AutocadRootObjectBuilder.cs
+++ b/Connectors/Autocad/Speckle.Connectors.AutocadShared/Operations/Send/AutocadRootObjectBuilder.cs
@@ -105,7 +105,7 @@ public class AutocadRootObjectBuilder : IRootObjectBuilder<AutocadRootObject>
           {
             if (tr.GetObject(entity.LayerId, OpenMode.ForRead) is LayerTableRecord autocadLayer)
             {
-              speckleLayer = new Layer(layerName);
+              speckleLayer = new Layer(layerName) { applicationId = autocadLayer.Handle.ToString() };
               collectionCache[layerName] = speckleLayer;
               layers.Add(autocadLayer);
               modelWithLayers.elements.Add(collectionCache[layerName]);

--- a/Connectors/Autocad/Speckle.Connectors.AutocadShared/Operations/Send/AutocadRootObjectBuilder.cs
+++ b/Connectors/Autocad/Speckle.Connectors.AutocadShared/Operations/Send/AutocadRootObjectBuilder.cs
@@ -104,11 +104,10 @@ public class AutocadRootObjectBuilder : IRootObjectBuilder<AutocadRootObject>
           if (autocadLayer is not null)
           {
             layers.Add(autocadLayer);
+            modelWithLayers.elements.Add(layer);
           }
 
-          modelWithLayers.elements.Add(layer);
           layer.elements.Add(converted);
-
           results.Add(new(Status.SUCCESS, applicationId, entity.GetType().ToString(), converted));
         }
         catch (Exception ex) when (!ex.IsFatal())

--- a/Connectors/Autocad/Speckle.Connectors.AutocadShared/Operations/Send/AutocadRootObjectBuilder.cs
+++ b/Connectors/Autocad/Speckle.Connectors.AutocadShared/Operations/Send/AutocadRootObjectBuilder.cs
@@ -94,13 +94,13 @@ public class AutocadRootObjectBuilder : IRootObjectBuilder<AutocadRootObject>
           {
             if (tr.GetObject(entity.LayerId, OpenMode.ForRead) is LayerTableRecord autocadLayer)
             {
-              speckleLayer = new Layer(layerName, autocadLayer.Color.ColorValue.ToArgb());
+              speckleLayer = new Layer(layerName);
               collectionCache[layerName] = speckleLayer;
               modelWithLayers.elements.Add(collectionCache[layerName]);
             }
             else
             {
-              speckleLayer = new Layer("Unknown layer", System.Drawing.Color.Black.ToArgb());
+              speckleLayer = new Layer("Unknown layer");
             }
           }
 

--- a/Connectors/Autocad/Speckle.Connectors.AutocadShared/Speckle.Connectors.AutocadShared.projitems
+++ b/Connectors/Autocad/Speckle.Connectors.AutocadShared/Speckle.Connectors.AutocadShared.projitems
@@ -23,6 +23,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)HostApp\AutocadDocumentManager.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HostApp\AutocadDocumentModelStore.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HostApp\AutocadIdleManager.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)HostApp\AutocadColorManager.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HostApp\AutocadLayerManager.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HostApp\AutocadSettings.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HostApp\Extensions\AcadUnitsExtension.cs" />

--- a/Connectors/Autocad/Speckle.Connectors.Civil3d2024/packages.lock.json
+++ b/Connectors/Autocad/Speckle.Connectors.Civil3d2024/packages.lock.json
@@ -192,8 +192,8 @@
       },
       "Speckle.Logging": {
         "type": "Transitive",
-        "resolved": "3.1.0-dev.88",
-        "contentHash": "kD8Xuqbv5lmNQGuv+gx+OnzFt51twc2aIWHEmaG+HBwojR4PZ9IqsaCcMSu4wv/Q1p+Xq5MZldVDkO368JSJRw=="
+        "resolved": "3.1.0-dev.89",
+        "contentHash": "sRiVATMGe8N0LwFRlqxBpRwmI7ZXVKGobSUUCLzzBqIe5UKFJRGi4Jz/6ukF6Tl2li6vrU0qt0CBPOx5nX1jrA=="
       },
       "Speckle.Newtonsoft.Json": {
         "type": "Transitive",
@@ -331,7 +331,7 @@
           "Microsoft.Extensions.Logging.Abstractions": "[7.0.0, )",
           "Speckle.Autofac": "[1.0.0, )",
           "Speckle.Connectors.Utils": "[1.0.0, )",
-          "Speckle.Core": "[3.1.0-dev.88, )",
+          "Speckle.Core": "[3.1.0-dev.89, )",
           "System.Threading.Tasks.Dataflow": "[6.0.0, )"
         }
       },
@@ -347,7 +347,7 @@
         "dependencies": {
           "Serilog.Extensions.Logging": "[7.0.0, )",
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Core": "[3.1.0-dev.88, )"
+          "Speckle.Core": "[3.1.0-dev.89, )"
         }
       },
       "speckle.converters.civil3d2024": {
@@ -370,7 +370,7 @@
         "type": "Project",
         "dependencies": {
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.88, )"
+          "Speckle.Objects": "[3.1.0-dev.89, )"
         }
       },
       "speckle.converters.common.dependencyinjection": {
@@ -417,9 +417,9 @@
       },
       "Speckle.Core": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.88, )",
-        "resolved": "3.1.0-dev.88",
-        "contentHash": "1yBzO/JEG9aEGeXwpx1vMZgknmma0QI1cVQ+uwoHc7oyYcAk1bePCa/C6ntyszzV+Y3fpeBZY4HGNALYICgVjg==",
+        "requested": "[3.1.0-dev.89, )",
+        "resolved": "3.1.0-dev.89",
+        "contentHash": "p3KMI7g2D6+nRAFtSQ3zDB6sB7329qyOvn+WCvy1n7YK35atM4ssR9WL4SVgKss/IQifxgDZVVldE3/o31TRTQ==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -428,18 +428,18 @@
           "Polly.Contrib.WaitAndRetry": "1.1.1",
           "Polly.Extensions.Http": "3.0.0",
           "Speckle.DoubleNumerics": "4.0.1",
-          "Speckle.Logging": "3.1.0-dev.88",
+          "Speckle.Logging": "3.1.0-dev.89",
           "Speckle.Newtonsoft.Json": "13.0.2",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.88, )",
-        "resolved": "3.1.0-dev.88",
-        "contentHash": "hzqeIYzvSa3VusEWic8FaVsaEMwHcwnbj2p0JDz2ZTAlf3SpFdxVtA4onIq0l7YyROBIFFn78eIIpm1cCucUIw==",
+        "requested": "[3.1.0-dev.89, )",
+        "resolved": "3.1.0-dev.89",
+        "contentHash": "DA035BwkIG5sdg2Z6SEsi9jo5zuP6UxBFzBW8QtY5hf54be34lzxl/9p3HGkpALUyBMrgaAZvZZnS/INEQRpGw==",
         "dependencies": {
-          "Speckle.Core": "3.1.0-dev.88"
+          "Speckle.Core": "3.1.0-dev.89"
         }
       },
       "System.Threading.Tasks.Dataflow": {

--- a/Connectors/Revit/Speckle.Connectors.Revit2022/packages.lock.json
+++ b/Connectors/Revit/Speckle.Connectors.Revit2022/packages.lock.json
@@ -211,8 +211,8 @@
       },
       "Speckle.Logging": {
         "type": "Transitive",
-        "resolved": "3.1.0-dev.88",
-        "contentHash": "kD8Xuqbv5lmNQGuv+gx+OnzFt51twc2aIWHEmaG+HBwojR4PZ9IqsaCcMSu4wv/Q1p+Xq5MZldVDkO368JSJRw=="
+        "resolved": "3.1.0-dev.89",
+        "contentHash": "sRiVATMGe8N0LwFRlqxBpRwmI7ZXVKGobSUUCLzzBqIe5UKFJRGi4Jz/6ukF6Tl2li6vrU0qt0CBPOx5nX1jrA=="
       },
       "Speckle.Newtonsoft.Json": {
         "type": "Transitive",
@@ -350,7 +350,7 @@
           "Microsoft.Extensions.Logging.Abstractions": "[7.0.0, )",
           "Speckle.Autofac": "[1.0.0, )",
           "Speckle.Connectors.Utils": "[1.0.0, )",
-          "Speckle.Core": "[3.1.0-dev.88, )",
+          "Speckle.Core": "[3.1.0-dev.89, )",
           "System.Threading.Tasks.Dataflow": "[6.0.0, )"
         }
       },
@@ -359,14 +359,14 @@
         "dependencies": {
           "Serilog.Extensions.Logging": "[7.0.0, )",
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Core": "[3.1.0-dev.88, )"
+          "Speckle.Core": "[3.1.0-dev.89, )"
         }
       },
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.88, )"
+          "Speckle.Objects": "[3.1.0-dev.89, )"
         }
       },
       "speckle.converters.common.dependencyinjection": {
@@ -423,9 +423,9 @@
       },
       "Speckle.Core": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.88, )",
-        "resolved": "3.1.0-dev.88",
-        "contentHash": "1yBzO/JEG9aEGeXwpx1vMZgknmma0QI1cVQ+uwoHc7oyYcAk1bePCa/C6ntyszzV+Y3fpeBZY4HGNALYICgVjg==",
+        "requested": "[3.1.0-dev.89, )",
+        "resolved": "3.1.0-dev.89",
+        "contentHash": "p3KMI7g2D6+nRAFtSQ3zDB6sB7329qyOvn+WCvy1n7YK35atM4ssR9WL4SVgKss/IQifxgDZVVldE3/o31TRTQ==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -434,18 +434,18 @@
           "Polly.Contrib.WaitAndRetry": "1.1.1",
           "Polly.Extensions.Http": "3.0.0",
           "Speckle.DoubleNumerics": "4.0.1",
-          "Speckle.Logging": "3.1.0-dev.88",
+          "Speckle.Logging": "3.1.0-dev.89",
           "Speckle.Newtonsoft.Json": "13.0.2",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.88, )",
-        "resolved": "3.1.0-dev.88",
-        "contentHash": "hzqeIYzvSa3VusEWic8FaVsaEMwHcwnbj2p0JDz2ZTAlf3SpFdxVtA4onIq0l7YyROBIFFn78eIIpm1cCucUIw==",
+        "requested": "[3.1.0-dev.89, )",
+        "resolved": "3.1.0-dev.89",
+        "contentHash": "DA035BwkIG5sdg2Z6SEsi9jo5zuP6UxBFzBW8QtY5hf54be34lzxl/9p3HGkpALUyBMrgaAZvZZnS/INEQRpGw==",
         "dependencies": {
-          "Speckle.Core": "3.1.0-dev.88"
+          "Speckle.Core": "3.1.0-dev.89"
         }
       },
       "Speckle.Revit.API": {

--- a/Connectors/Revit/Speckle.Connectors.Revit2023/packages.lock.json
+++ b/Connectors/Revit/Speckle.Connectors.Revit2023/packages.lock.json
@@ -211,8 +211,8 @@
       },
       "Speckle.Logging": {
         "type": "Transitive",
-        "resolved": "3.1.0-dev.88",
-        "contentHash": "kD8Xuqbv5lmNQGuv+gx+OnzFt51twc2aIWHEmaG+HBwojR4PZ9IqsaCcMSu4wv/Q1p+Xq5MZldVDkO368JSJRw=="
+        "resolved": "3.1.0-dev.89",
+        "contentHash": "sRiVATMGe8N0LwFRlqxBpRwmI7ZXVKGobSUUCLzzBqIe5UKFJRGi4Jz/6ukF6Tl2li6vrU0qt0CBPOx5nX1jrA=="
       },
       "Speckle.Newtonsoft.Json": {
         "type": "Transitive",
@@ -350,7 +350,7 @@
           "Microsoft.Extensions.Logging.Abstractions": "[7.0.0, )",
           "Speckle.Autofac": "[1.0.0, )",
           "Speckle.Connectors.Utils": "[1.0.0, )",
-          "Speckle.Core": "[3.1.0-dev.88, )",
+          "Speckle.Core": "[3.1.0-dev.89, )",
           "System.Threading.Tasks.Dataflow": "[6.0.0, )"
         }
       },
@@ -359,14 +359,14 @@
         "dependencies": {
           "Serilog.Extensions.Logging": "[7.0.0, )",
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Core": "[3.1.0-dev.88, )"
+          "Speckle.Core": "[3.1.0-dev.89, )"
         }
       },
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.88, )"
+          "Speckle.Objects": "[3.1.0-dev.89, )"
         }
       },
       "speckle.converters.common.dependencyinjection": {
@@ -422,9 +422,9 @@
       },
       "Speckle.Core": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.88, )",
-        "resolved": "3.1.0-dev.88",
-        "contentHash": "1yBzO/JEG9aEGeXwpx1vMZgknmma0QI1cVQ+uwoHc7oyYcAk1bePCa/C6ntyszzV+Y3fpeBZY4HGNALYICgVjg==",
+        "requested": "[3.1.0-dev.89, )",
+        "resolved": "3.1.0-dev.89",
+        "contentHash": "p3KMI7g2D6+nRAFtSQ3zDB6sB7329qyOvn+WCvy1n7YK35atM4ssR9WL4SVgKss/IQifxgDZVVldE3/o31TRTQ==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -433,18 +433,18 @@
           "Polly.Contrib.WaitAndRetry": "1.1.1",
           "Polly.Extensions.Http": "3.0.0",
           "Speckle.DoubleNumerics": "4.0.1",
-          "Speckle.Logging": "3.1.0-dev.88",
+          "Speckle.Logging": "3.1.0-dev.89",
           "Speckle.Newtonsoft.Json": "13.0.2",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.88, )",
-        "resolved": "3.1.0-dev.88",
-        "contentHash": "hzqeIYzvSa3VusEWic8FaVsaEMwHcwnbj2p0JDz2ZTAlf3SpFdxVtA4onIq0l7YyROBIFFn78eIIpm1cCucUIw==",
+        "requested": "[3.1.0-dev.89, )",
+        "resolved": "3.1.0-dev.89",
+        "contentHash": "DA035BwkIG5sdg2Z6SEsi9jo5zuP6UxBFzBW8QtY5hf54be34lzxl/9p3HGkpALUyBMrgaAZvZZnS/INEQRpGw==",
         "dependencies": {
-          "Speckle.Core": "3.1.0-dev.88"
+          "Speckle.Core": "3.1.0-dev.89"
         }
       },
       "Speckle.Revit.API": {

--- a/Connectors/Revit/Speckle.Connectors.Revit2024/packages.lock.json
+++ b/Connectors/Revit/Speckle.Connectors.Revit2024/packages.lock.json
@@ -211,8 +211,8 @@
       },
       "Speckle.Logging": {
         "type": "Transitive",
-        "resolved": "3.1.0-dev.88",
-        "contentHash": "kD8Xuqbv5lmNQGuv+gx+OnzFt51twc2aIWHEmaG+HBwojR4PZ9IqsaCcMSu4wv/Q1p+Xq5MZldVDkO368JSJRw=="
+        "resolved": "3.1.0-dev.89",
+        "contentHash": "sRiVATMGe8N0LwFRlqxBpRwmI7ZXVKGobSUUCLzzBqIe5UKFJRGi4Jz/6ukF6Tl2li6vrU0qt0CBPOx5nX1jrA=="
       },
       "Speckle.Newtonsoft.Json": {
         "type": "Transitive",
@@ -350,7 +350,7 @@
           "Microsoft.Extensions.Logging.Abstractions": "[7.0.0, )",
           "Speckle.Autofac": "[1.0.0, )",
           "Speckle.Connectors.Utils": "[1.0.0, )",
-          "Speckle.Core": "[3.1.0-dev.88, )",
+          "Speckle.Core": "[3.1.0-dev.89, )",
           "System.Threading.Tasks.Dataflow": "[6.0.0, )"
         }
       },
@@ -359,14 +359,14 @@
         "dependencies": {
           "Serilog.Extensions.Logging": "[7.0.0, )",
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Core": "[3.1.0-dev.88, )"
+          "Speckle.Core": "[3.1.0-dev.89, )"
         }
       },
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.88, )"
+          "Speckle.Objects": "[3.1.0-dev.89, )"
         }
       },
       "speckle.converters.common.dependencyinjection": {
@@ -422,9 +422,9 @@
       },
       "Speckle.Core": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.88, )",
-        "resolved": "3.1.0-dev.88",
-        "contentHash": "1yBzO/JEG9aEGeXwpx1vMZgknmma0QI1cVQ+uwoHc7oyYcAk1bePCa/C6ntyszzV+Y3fpeBZY4HGNALYICgVjg==",
+        "requested": "[3.1.0-dev.89, )",
+        "resolved": "3.1.0-dev.89",
+        "contentHash": "p3KMI7g2D6+nRAFtSQ3zDB6sB7329qyOvn+WCvy1n7YK35atM4ssR9WL4SVgKss/IQifxgDZVVldE3/o31TRTQ==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -433,18 +433,18 @@
           "Polly.Contrib.WaitAndRetry": "1.1.1",
           "Polly.Extensions.Http": "3.0.0",
           "Speckle.DoubleNumerics": "4.0.1",
-          "Speckle.Logging": "3.1.0-dev.88",
+          "Speckle.Logging": "3.1.0-dev.89",
           "Speckle.Newtonsoft.Json": "13.0.2",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.88, )",
-        "resolved": "3.1.0-dev.88",
-        "contentHash": "hzqeIYzvSa3VusEWic8FaVsaEMwHcwnbj2p0JDz2ZTAlf3SpFdxVtA4onIq0l7YyROBIFFn78eIIpm1cCucUIw==",
+        "requested": "[3.1.0-dev.89, )",
+        "resolved": "3.1.0-dev.89",
+        "contentHash": "DA035BwkIG5sdg2Z6SEsi9jo5zuP6UxBFzBW8QtY5hf54be34lzxl/9p3HGkpALUyBMrgaAZvZZnS/INEQRpGw==",
         "dependencies": {
-          "Speckle.Core": "3.1.0-dev.88"
+          "Speckle.Core": "3.1.0-dev.89"
         }
       },
       "Speckle.Revit.API": {

--- a/Connectors/Revit/Speckle.Connectors.Revit2025/packages.lock.json
+++ b/Connectors/Revit/Speckle.Connectors.Revit2025/packages.lock.json
@@ -167,8 +167,8 @@
       },
       "Speckle.Logging": {
         "type": "Transitive",
-        "resolved": "3.1.0-dev.88",
-        "contentHash": "kD8Xuqbv5lmNQGuv+gx+OnzFt51twc2aIWHEmaG+HBwojR4PZ9IqsaCcMSu4wv/Q1p+Xq5MZldVDkO368JSJRw=="
+        "resolved": "3.1.0-dev.89",
+        "contentHash": "sRiVATMGe8N0LwFRlqxBpRwmI7ZXVKGobSUUCLzzBqIe5UKFJRGi4Jz/6ukF6Tl2li6vrU0qt0CBPOx5nX1jrA=="
       },
       "Speckle.Newtonsoft.Json": {
         "type": "Transitive",
@@ -233,7 +233,7 @@
           "Microsoft.Extensions.Logging.Abstractions": "[7.0.0, )",
           "Speckle.Autofac": "[1.0.0, )",
           "Speckle.Connectors.Utils": "[1.0.0, )",
-          "Speckle.Core": "[3.1.0-dev.88, )",
+          "Speckle.Core": "[3.1.0-dev.89, )",
           "System.Threading.Tasks.Dataflow": "[6.0.0, )"
         }
       },
@@ -249,14 +249,14 @@
         "dependencies": {
           "Serilog.Extensions.Logging": "[7.0.0, )",
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Core": "[3.1.0-dev.88, )"
+          "Speckle.Core": "[3.1.0-dev.89, )"
         }
       },
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.88, )"
+          "Speckle.Objects": "[3.1.0-dev.89, )"
         }
       },
       "speckle.converters.common.dependencyinjection": {
@@ -305,9 +305,9 @@
       },
       "Speckle.Core": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.88, )",
-        "resolved": "3.1.0-dev.88",
-        "contentHash": "1yBzO/JEG9aEGeXwpx1vMZgknmma0QI1cVQ+uwoHc7oyYcAk1bePCa/C6ntyszzV+Y3fpeBZY4HGNALYICgVjg==",
+        "requested": "[3.1.0-dev.89, )",
+        "resolved": "3.1.0-dev.89",
+        "contentHash": "p3KMI7g2D6+nRAFtSQ3zDB6sB7329qyOvn+WCvy1n7YK35atM4ssR9WL4SVgKss/IQifxgDZVVldE3/o31TRTQ==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -316,18 +316,18 @@
           "Polly.Contrib.WaitAndRetry": "1.1.1",
           "Polly.Extensions.Http": "3.0.0",
           "Speckle.DoubleNumerics": "4.0.1",
-          "Speckle.Logging": "3.1.0-dev.88",
+          "Speckle.Logging": "3.1.0-dev.89",
           "Speckle.Newtonsoft.Json": "13.0.2",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.88, )",
-        "resolved": "3.1.0-dev.88",
-        "contentHash": "hzqeIYzvSa3VusEWic8FaVsaEMwHcwnbj2p0JDz2ZTAlf3SpFdxVtA4onIq0l7YyROBIFFn78eIIpm1cCucUIw==",
+        "requested": "[3.1.0-dev.89, )",
+        "resolved": "3.1.0-dev.89",
+        "contentHash": "DA035BwkIG5sdg2Z6SEsi9jo5zuP6UxBFzBW8QtY5hf54be34lzxl/9p3HGkpALUyBMrgaAZvZZnS/INEQRpGw==",
         "dependencies": {
-          "Speckle.Core": "3.1.0-dev.88"
+          "Speckle.Core": "3.1.0-dev.89"
         }
       },
       "Speckle.Revit.API": {

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/RevitRootObjectBuilder.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/RevitRootObjectBuilder.cs
@@ -144,7 +144,7 @@ public class RevitRootObjectBuilder : IRootObjectBuilder<ElementId>
       }
       else
       {
-        childCollection = new Collection(pathItem, "layer");
+        childCollection = new Collection(pathItem);
         previousCollection.elements.Add(childCollection);
         _collectionCache[flatPathName] = childCollection;
       }

--- a/Connectors/Rhino/Speckle.Connectors.Rhino7/packages.lock.json
+++ b/Connectors/Rhino/Speckle.Connectors.Rhino7/packages.lock.json
@@ -192,8 +192,8 @@
       },
       "Speckle.Logging": {
         "type": "Transitive",
-        "resolved": "3.1.0-dev.88",
-        "contentHash": "kD8Xuqbv5lmNQGuv+gx+OnzFt51twc2aIWHEmaG+HBwojR4PZ9IqsaCcMSu4wv/Q1p+Xq5MZldVDkO368JSJRw=="
+        "resolved": "3.1.0-dev.89",
+        "contentHash": "sRiVATMGe8N0LwFRlqxBpRwmI7ZXVKGobSUUCLzzBqIe5UKFJRGi4Jz/6ukF6Tl2li6vrU0qt0CBPOx5nX1jrA=="
       },
       "Speckle.Newtonsoft.Json": {
         "type": "Transitive",
@@ -331,7 +331,7 @@
           "Microsoft.Extensions.Logging.Abstractions": "[7.0.0, )",
           "Speckle.Autofac": "[1.0.0, )",
           "Speckle.Connectors.Utils": "[1.0.0, )",
-          "Speckle.Core": "[3.1.0-dev.88, )",
+          "Speckle.Core": "[3.1.0-dev.89, )",
           "System.Threading.Tasks.Dataflow": "[6.0.0, )"
         }
       },
@@ -347,14 +347,14 @@
         "dependencies": {
           "Serilog.Extensions.Logging": "[7.0.0, )",
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Core": "[3.1.0-dev.88, )"
+          "Speckle.Core": "[3.1.0-dev.89, )"
         }
       },
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.88, )"
+          "Speckle.Objects": "[3.1.0-dev.89, )"
         }
       },
       "speckle.converters.common.dependencyinjection": {
@@ -414,9 +414,9 @@
       },
       "Speckle.Core": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.88, )",
-        "resolved": "3.1.0-dev.88",
-        "contentHash": "1yBzO/JEG9aEGeXwpx1vMZgknmma0QI1cVQ+uwoHc7oyYcAk1bePCa/C6ntyszzV+Y3fpeBZY4HGNALYICgVjg==",
+        "requested": "[3.1.0-dev.89, )",
+        "resolved": "3.1.0-dev.89",
+        "contentHash": "p3KMI7g2D6+nRAFtSQ3zDB6sB7329qyOvn+WCvy1n7YK35atM4ssR9WL4SVgKss/IQifxgDZVVldE3/o31TRTQ==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -425,18 +425,18 @@
           "Polly.Contrib.WaitAndRetry": "1.1.1",
           "Polly.Extensions.Http": "3.0.0",
           "Speckle.DoubleNumerics": "4.0.1",
-          "Speckle.Logging": "3.1.0-dev.88",
+          "Speckle.Logging": "3.1.0-dev.89",
           "Speckle.Newtonsoft.Json": "13.0.2",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.88, )",
-        "resolved": "3.1.0-dev.88",
-        "contentHash": "hzqeIYzvSa3VusEWic8FaVsaEMwHcwnbj2p0JDz2ZTAlf3SpFdxVtA4onIq0l7YyROBIFFn78eIIpm1cCucUIw==",
+        "requested": "[3.1.0-dev.89, )",
+        "resolved": "3.1.0-dev.89",
+        "contentHash": "DA035BwkIG5sdg2Z6SEsi9jo5zuP6UxBFzBW8QtY5hf54be34lzxl/9p3HGkpALUyBMrgaAZvZZnS/INEQRpGw==",
         "dependencies": {
-          "Speckle.Core": "3.1.0-dev.88"
+          "Speckle.Core": "3.1.0-dev.89"
         }
       },
       "System.Threading.Tasks.Dataflow": {

--- a/Connectors/Rhino/Speckle.Connectors.Rhino8/packages.lock.json
+++ b/Connectors/Rhino/Speckle.Connectors.Rhino8/packages.lock.json
@@ -192,8 +192,8 @@
       },
       "Speckle.Logging": {
         "type": "Transitive",
-        "resolved": "3.1.0-dev.88",
-        "contentHash": "kD8Xuqbv5lmNQGuv+gx+OnzFt51twc2aIWHEmaG+HBwojR4PZ9IqsaCcMSu4wv/Q1p+Xq5MZldVDkO368JSJRw=="
+        "resolved": "3.1.0-dev.89",
+        "contentHash": "sRiVATMGe8N0LwFRlqxBpRwmI7ZXVKGobSUUCLzzBqIe5UKFJRGi4Jz/6ukF6Tl2li6vrU0qt0CBPOx5nX1jrA=="
       },
       "Speckle.Newtonsoft.Json": {
         "type": "Transitive",
@@ -331,7 +331,7 @@
           "Microsoft.Extensions.Logging.Abstractions": "[7.0.0, )",
           "Speckle.Autofac": "[1.0.0, )",
           "Speckle.Connectors.Utils": "[1.0.0, )",
-          "Speckle.Core": "[3.1.0-dev.88, )",
+          "Speckle.Core": "[3.1.0-dev.89, )",
           "System.Threading.Tasks.Dataflow": "[6.0.0, )"
         }
       },
@@ -347,14 +347,14 @@
         "dependencies": {
           "Serilog.Extensions.Logging": "[7.0.0, )",
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Core": "[3.1.0-dev.88, )"
+          "Speckle.Core": "[3.1.0-dev.89, )"
         }
       },
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.88, )"
+          "Speckle.Objects": "[3.1.0-dev.89, )"
         }
       },
       "speckle.converters.common.dependencyinjection": {
@@ -414,9 +414,9 @@
       },
       "Speckle.Core": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.88, )",
-        "resolved": "3.1.0-dev.88",
-        "contentHash": "1yBzO/JEG9aEGeXwpx1vMZgknmma0QI1cVQ+uwoHc7oyYcAk1bePCa/C6ntyszzV+Y3fpeBZY4HGNALYICgVjg==",
+        "requested": "[3.1.0-dev.89, )",
+        "resolved": "3.1.0-dev.89",
+        "contentHash": "p3KMI7g2D6+nRAFtSQ3zDB6sB7329qyOvn+WCvy1n7YK35atM4ssR9WL4SVgKss/IQifxgDZVVldE3/o31TRTQ==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -425,18 +425,18 @@
           "Polly.Contrib.WaitAndRetry": "1.1.1",
           "Polly.Extensions.Http": "3.0.0",
           "Speckle.DoubleNumerics": "4.0.1",
-          "Speckle.Logging": "3.1.0-dev.88",
+          "Speckle.Logging": "3.1.0-dev.89",
           "Speckle.Newtonsoft.Json": "13.0.2",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.88, )",
-        "resolved": "3.1.0-dev.88",
-        "contentHash": "hzqeIYzvSa3VusEWic8FaVsaEMwHcwnbj2p0JDz2ZTAlf3SpFdxVtA4onIq0l7YyROBIFFn78eIIpm1cCucUIw==",
+        "requested": "[3.1.0-dev.89, )",
+        "resolved": "3.1.0-dev.89",
+        "contentHash": "DA035BwkIG5sdg2Z6SEsi9jo5zuP6UxBFzBW8QtY5hf54be34lzxl/9p3HGkpALUyBMrgaAZvZZnS/INEQRpGw==",
         "dependencies": {
-          "Speckle.Core": "3.1.0-dev.88"
+          "Speckle.Core": "3.1.0-dev.89"
         }
       },
       "System.Threading.Tasks.Dataflow": {

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/DependencyInjection/RhinoConnectorModule.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/DependencyInjection/RhinoConnectorModule.cs
@@ -90,5 +90,6 @@ public class RhinoConnectorModule : ISpeckleModule
     builder.AddScoped<RhinoGroupManager>();
     builder.AddScoped<RhinoLayerManager>();
     builder.AddScoped<RhinoMaterialManager>();
+    builder.AddScoped<RhinoColorManager>();
   }
 }

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/HostApp/RhinoColorManager.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/HostApp/RhinoColorManager.cs
@@ -34,7 +34,7 @@ public class RhinoColorManager
       }
       else
       {
-        ColorProxy newColor = new(atts.ObjectColor.ToArgb(), colorId, colorId);
+        ColorProxy newColor = new(atts.ObjectColor.ToArgb(), colorId, colorId) { objects = new() };
         newColor.objects.Add(objectId);
         colorProxies[colorId] = newColor;
       }

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/HostApp/RhinoColorManager.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/HostApp/RhinoColorManager.cs
@@ -1,0 +1,79 @@
+using Rhino.DocObjects;
+using Speckle.Core.Models.Proxies;
+
+namespace Speckle.Connectors.Rhino.HostApp;
+
+/// <summary>
+/// Utility class managing colors on objects and layers. Expects to be a scoped dependency per send or receive operation.
+/// </summary>
+public class RhinoColorManager
+{
+  public Dictionary<string, Color> ObjectColorsIdMap { get; }
+
+  public List<ColorProxy> UnpackColors(List<RhinoObject> atomicObjects, List<Layer> layers)
+  {
+    Dictionary<string, ColorProxy> colorProxies = new();
+
+    // Stage 1: unpack materials from objects
+    foreach (RhinoObject rhinoObj in atomicObjects)
+    {
+      ObjectAttributes atts = rhinoObj.Attributes;
+
+      // skip any objects that inherit their colors
+      if (atts.ColorSource != ObjectColorSource.ColorFromObject)
+      {
+        continue;
+      }
+
+      // assumes color names are unique
+      string colorId = atts.ObjectColor.Name;
+      if (colorProxies.TryGetValue(colorId, out ColorProxy value))
+      {
+        value.objects.Add(rhinoObj.Id.ToString());
+      }
+      else
+      {
+        colorProxies[colorId] = new(atts.ObjectColor.ToArgb(), colorId, colorId);
+      }
+    }
+
+    // Stage 2: make sure we collect layer colors as well
+    foreach (Layer layer in layers)
+    {
+      // assumes color names are unique
+      string colorId = layer.Color.Name;
+      if (colorProxies.TryGetValue(colorId, out ColorProxy value))
+      {
+        value.objects.Add(layer.Id.ToString());
+      }
+      else
+      {
+        colorProxies[colorId] = new(layer.Color.ToArgb(), colorId, colorId);
+      }
+    }
+
+    return colorProxies.Values.ToList();
+  }
+
+  /// <summary>
+  /// Parse Color Proxies and stores in ObjectColorsIdMap the relationship between object ids and colors
+  /// </summary>
+  /// <param name="colorProxies"></param>
+  /// <param name="onOperationProgressed"></param>
+  public void ParseColors(List<ColorProxy> colorProxies, Action<string, double?>? onOperationProgressed)
+  {
+    var count = 0;
+    foreach (ColorProxy colorProxy in colorProxies)
+    {
+      onOperationProgressed?.Invoke("Converting colors", (double)++count / colorProxies.Count);
+      foreach (string objectId in colorProxy.objects)
+      {
+        Color convertedColor = Color.FromArgb(colorProxy.value);
+        if (!ObjectColorsIdMap.TryGetValue(objectId, out Color _))
+        {
+          ObjectColorsIdMap.Add(objectId, convertedColor);
+        }
+      }
+    }
+  }
+}

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/HostApp/RhinoColorManager.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/HostApp/RhinoColorManager.cs
@@ -8,7 +8,7 @@ namespace Speckle.Connectors.Rhino.HostApp;
 /// </summary>
 public class RhinoColorManager
 {
-  public Dictionary<string, Color> ObjectColorsIdMap { get; }
+  public Dictionary<string, Color> ObjectColorsIdMap { get; } = new();
 
   public List<ColorProxy> UnpackColors(List<RhinoObject> atomicObjects, List<Layer> layers)
   {
@@ -27,13 +27,16 @@ public class RhinoColorManager
 
       // assumes color names are unique
       string colorId = atts.ObjectColor.Name;
+      string objectId = rhinoObj.Id.ToString();
       if (colorProxies.TryGetValue(colorId, out ColorProxy value))
       {
-        value.objects.Add(rhinoObj.Id.ToString());
+        value.objects.Add(objectId);
       }
       else
       {
-        colorProxies[colorId] = new(atts.ObjectColor.ToArgb(), colorId, colorId);
+        ColorProxy newColor = new(atts.ObjectColor.ToArgb(), colorId, colorId);
+        newColor.objects.Add(objectId);
+        colorProxies[colorId] = newColor;
       }
     }
 
@@ -42,13 +45,16 @@ public class RhinoColorManager
     {
       // assumes color names are unique
       string colorId = layer.Color.Name;
+      string layerId = layer.Id.ToString();
       if (colorProxies.TryGetValue(colorId, out ColorProxy value))
       {
-        value.objects.Add(layer.Id.ToString());
+        value.objects.Add(layerId);
       }
       else
       {
-        colorProxies[colorId] = new(layer.Color.ToArgb(), colorId, colorId);
+        ColorProxy newColor = new(layer.Color.ToArgb(), colorId, colorId);
+        newColor.objects.Add(layerId);
+        colorProxies[colorId] = newColor;
       }
     }
 

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/HostApp/RhinoColorManager.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/HostApp/RhinoColorManager.cs
@@ -52,7 +52,7 @@ public class RhinoColorManager
       }
       else
       {
-        ColorProxy newColor = new(layer.Color.ToArgb(), colorId, colorId);
+        ColorProxy newColor = new(layer.Color.ToArgb(), colorId, colorId) { objects = new() };
         newColor.objects.Add(layerId);
         colorProxies[colorId] = newColor;
       }

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/HostApp/RhinoGroupManager.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/HostApp/RhinoGroupManager.cs
@@ -1,6 +1,6 @@
-﻿using Rhino;
+using Rhino;
 using Rhino.DocObjects;
-using Speckle.Core.Models.Instances;
+using Speckle.Core.Models.Proxies;
 
 namespace Speckle.Connectors.Rhino.HostApp;
 

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/HostApp/RhinoLayerManager.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/HostApp/RhinoLayerManager.cs
@@ -43,7 +43,7 @@ public class RhinoLayerManager
 
     var currentLayerName = baseLayerName;
     var currentDocument = RhinoDoc.ActiveDoc; // POC: too much effort right now to wrap around the interfaced layers
-    var previousLayer = currentDocument.Layers.FindName(currentLayerName);
+    Layer previousLayer = currentDocument.Layers.FindName(currentLayerName);
     foreach (Collection collection in collectionPath)
     {
       currentLayerName = baseLayerName + Layer.PathSeparator + collection.name;
@@ -55,17 +55,9 @@ public class RhinoLayerManager
       }
 
       var cleanNewLayerName = collection.name.Replace("{", "").Replace("}", "");
-      Color layerColor = collection is IHasColor coloredCollection
-        ? Color.FromArgb(coloredCollection.color)
-        : Color.Black;
-      var newLayer = new Layer
-      {
-        Name = cleanNewLayerName,
-        ParentLayerId = previousLayer.Id,
-        Color = layerColor
-      };
+      Layer newLayer = new() { Name = cleanNewLayerName, ParentLayerId = previousLayer.Id };
 
-      var index = currentDocument.Layers.Add(newLayer);
+      int index = currentDocument.Layers.Add(newLayer);
       _hostLayerCache.Add(currentLayerName, index);
       previousLayer = currentDocument.Layers.FindIndex(index); // note we need to get the correct id out, hence why we're double calling this
     }
@@ -101,7 +93,7 @@ public class RhinoLayerManager
       }
       else
       {
-        childCollection = new SpeckleLayer(layerName, rhLayer.Color.ToArgb())
+        childCollection = new SpeckleLayer(layerName)
         {
           applicationId = RhinoDoc.ActiveDoc.Layers[existingLayerIndex].Id.ToString()
         };

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/Operations/Receive/RhinoHostObjectBuilder.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/Operations/Receive/RhinoHostObjectBuilder.cs
@@ -11,6 +11,7 @@ using Speckle.Core.Models;
 using Speckle.Core.Models.Collections;
 using Speckle.Core.Models.GraphTraversal;
 using Speckle.Core.Models.Instances;
+using Speckle.Core.Models.Proxies;
 using RenderMaterialProxy = Objects.Other.RenderMaterialProxy;
 
 namespace Speckle.Connectors.Rhino.Operations.Receive;

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/Operations/Receive/RhinoHostObjectBuilder.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/Operations/Receive/RhinoHostObjectBuilder.cs
@@ -38,7 +38,7 @@ public class RhinoHostObjectBuilder : IHostObjectBuilder
     RhinoLayerManager layerManager,
     RhinoInstanceObjectsManager instanceObjectsManager,
     RhinoMaterialManager materialManager,
-    RhinoColorManager colorManager
+    RhinoColorManager colorManager,
     ISyncToThread syncToThread
   )
   {
@@ -80,20 +80,20 @@ public class RhinoHostObjectBuilder : IHostObjectBuilder
         ?.Cast<RenderMaterialProxy>()
         .ToList();
 
-    List<ColorProxy>? colors = (rootObject["colorProxies"] as List<object>)?.Cast<ColorProxy>().ToList();
-    if (colors != null)
-    {
-      _colorManager.ParseColors(colors, onOperationProgressed);
-    }
+      List<ColorProxy>? colors = (rootObject["colorProxies"] as List<object>)?.Cast<ColorProxy>().ToList();
+      if (colors != null)
+      {
+        _colorManager.ParseColors(colors, onOperationProgressed);
+      }
 
-    var conversionResults = BakeObjects(
-      objectsToConvert,
-      instanceDefinitionProxies,
-      groupProxies,
-      renderMaterials,
-      baseLayerName,
-      onOperationProgressed
-    );
+      var conversionResults = BakeObjects(
+        objectsToConvert,
+        instanceDefinitionProxies,
+        groupProxies,
+        renderMaterials,
+        baseLayerName,
+        onOperationProgressed
+      );
 
       _contextStack.Current.Document.Views.Redraw();
 

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/Operations/Send/RhinoRootObjectBuilder.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/Operations/Send/RhinoRootObjectBuilder.cs
@@ -38,7 +38,7 @@ public class RhinoRootObjectBuilder : IRootObjectBuilder<RhinoObject>
     RhinoGroupManager rhinoGroupManager,
     IRootToSpeckleConverter rootToSpeckleConverter,
     RhinoMaterialManager materialManager,
-    RhinoColorManager colorManager
+    RhinoColorManager colorManager,
     ISyncToThread syncToThread
   )
   {
@@ -124,11 +124,11 @@ public class RhinoRootObjectBuilder : IRootObjectBuilder<RhinoObject>
         // NOTE: useful for testing ui states, pls keep for now so we can easily uncomment
         // Thread.Sleep(550);
       }
-      
+
       // set render materials and colors
       rootObjectCollection["renderMaterialProxies"] = _materialManager.UnpackRenderMaterial(atomicObjects);
-    List<ColorProxy> colorProxies = _colorManager.UnpackColors(atomicObjects, versionLayers.ToList());
-    rootObjectCollection["colorProxies"] = colorProxies;
+      List<ColorProxy> colorProxies = _colorManager.UnpackColors(atomicObjects, versionLayers.ToList());
+      rootObjectCollection["colorProxies"] = colorProxies;
 
       // 5. profit
       return new RootObjectBuilderResult(rootObjectCollection, results);

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/Speckle.Connectors.RhinoShared.projitems
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/Speckle.Connectors.RhinoShared.projitems
@@ -33,6 +33,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)HostApp\RhinoIdleManager.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HostApp\RhinoInstanceObjectsManager.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HostApp\RhinoLayerManager.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)HostApp\RhinoColorManager.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HostApp\RhinoMaterialManager.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HostApp\RhinoSettings.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HostApp\SpeckleRhinoPanelHost.cs" />

--- a/Converters/ArcGIS/Speckle.Converters.ArcGIS3.DependencyInjection/packages.lock.json
+++ b/Converters/ArcGIS/Speckle.Converters.ArcGIS3.DependencyInjection/packages.lock.json
@@ -112,8 +112,8 @@
       },
       "Speckle.Logging": {
         "type": "Transitive",
-        "resolved": "3.1.0-dev.88",
-        "contentHash": "kD8Xuqbv5lmNQGuv+gx+OnzFt51twc2aIWHEmaG+HBwojR4PZ9IqsaCcMSu4wv/Q1p+Xq5MZldVDkO368JSJRw=="
+        "resolved": "3.1.0-dev.89",
+        "contentHash": "sRiVATMGe8N0LwFRlqxBpRwmI7ZXVKGobSUUCLzzBqIe5UKFJRGi4Jz/6ukF6Tl2li6vrU0qt0CBPOx5nX1jrA=="
       },
       "Speckle.Newtonsoft.Json": {
         "type": "Transitive",
@@ -183,7 +183,7 @@
         "type": "Project",
         "dependencies": {
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.88, )"
+          "Speckle.Objects": "[3.1.0-dev.89, )"
         }
       },
       "speckle.converters.common.dependencyinjection": {
@@ -213,9 +213,9 @@
       },
       "Speckle.Core": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.88, )",
-        "resolved": "3.1.0-dev.88",
-        "contentHash": "1yBzO/JEG9aEGeXwpx1vMZgknmma0QI1cVQ+uwoHc7oyYcAk1bePCa/C6ntyszzV+Y3fpeBZY4HGNALYICgVjg==",
+        "requested": "[3.1.0-dev.89, )",
+        "resolved": "3.1.0-dev.89",
+        "contentHash": "p3KMI7g2D6+nRAFtSQ3zDB6sB7329qyOvn+WCvy1n7YK35atM4ssR9WL4SVgKss/IQifxgDZVVldE3/o31TRTQ==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -224,18 +224,18 @@
           "Polly.Contrib.WaitAndRetry": "1.1.1",
           "Polly.Extensions.Http": "3.0.0",
           "Speckle.DoubleNumerics": "4.0.1",
-          "Speckle.Logging": "3.1.0-dev.88",
+          "Speckle.Logging": "3.1.0-dev.89",
           "Speckle.Newtonsoft.Json": "13.0.2",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.88, )",
-        "resolved": "3.1.0-dev.88",
-        "contentHash": "hzqeIYzvSa3VusEWic8FaVsaEMwHcwnbj2p0JDz2ZTAlf3SpFdxVtA4onIq0l7YyROBIFFn78eIIpm1cCucUIw==",
+        "requested": "[3.1.0-dev.89, )",
+        "resolved": "3.1.0-dev.89",
+        "contentHash": "DA035BwkIG5sdg2Z6SEsi9jo5zuP6UxBFzBW8QtY5hf54be34lzxl/9p3HGkpALUyBMrgaAZvZZnS/INEQRpGw==",
         "dependencies": {
-          "Speckle.Core": "3.1.0-dev.88"
+          "Speckle.Core": "3.1.0-dev.89"
         }
       }
     }

--- a/Converters/ArcGIS/Speckle.Converters.ArcGIS3/packages.lock.json
+++ b/Converters/ArcGIS/Speckle.Converters.ArcGIS3/packages.lock.json
@@ -118,8 +118,8 @@
       },
       "Speckle.Logging": {
         "type": "Transitive",
-        "resolved": "3.1.0-dev.88",
-        "contentHash": "kD8Xuqbv5lmNQGuv+gx+OnzFt51twc2aIWHEmaG+HBwojR4PZ9IqsaCcMSu4wv/Q1p+Xq5MZldVDkO368JSJRw=="
+        "resolved": "3.1.0-dev.89",
+        "contentHash": "sRiVATMGe8N0LwFRlqxBpRwmI7ZXVKGobSUUCLzzBqIe5UKFJRGi4Jz/6ukF6Tl2li6vrU0qt0CBPOx5nX1jrA=="
       },
       "Speckle.Newtonsoft.Json": {
         "type": "Transitive",
@@ -182,7 +182,7 @@
         "type": "Project",
         "dependencies": {
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.88, )"
+          "Speckle.Objects": "[3.1.0-dev.89, )"
         }
       },
       "Autofac": {
@@ -199,9 +199,9 @@
       },
       "Speckle.Core": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.88, )",
-        "resolved": "3.1.0-dev.88",
-        "contentHash": "1yBzO/JEG9aEGeXwpx1vMZgknmma0QI1cVQ+uwoHc7oyYcAk1bePCa/C6ntyszzV+Y3fpeBZY4HGNALYICgVjg==",
+        "requested": "[3.1.0-dev.89, )",
+        "resolved": "3.1.0-dev.89",
+        "contentHash": "p3KMI7g2D6+nRAFtSQ3zDB6sB7329qyOvn+WCvy1n7YK35atM4ssR9WL4SVgKss/IQifxgDZVVldE3/o31TRTQ==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -210,18 +210,18 @@
           "Polly.Contrib.WaitAndRetry": "1.1.1",
           "Polly.Extensions.Http": "3.0.0",
           "Speckle.DoubleNumerics": "4.0.1",
-          "Speckle.Logging": "3.1.0-dev.88",
+          "Speckle.Logging": "3.1.0-dev.89",
           "Speckle.Newtonsoft.Json": "13.0.2",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.88, )",
-        "resolved": "3.1.0-dev.88",
-        "contentHash": "hzqeIYzvSa3VusEWic8FaVsaEMwHcwnbj2p0JDz2ZTAlf3SpFdxVtA4onIq0l7YyROBIFFn78eIIpm1cCucUIw==",
+        "requested": "[3.1.0-dev.89, )",
+        "resolved": "3.1.0-dev.89",
+        "contentHash": "DA035BwkIG5sdg2Z6SEsi9jo5zuP6UxBFzBW8QtY5hf54be34lzxl/9p3HGkpALUyBMrgaAZvZZnS/INEQRpGw==",
         "dependencies": {
-          "Speckle.Core": "3.1.0-dev.88"
+          "Speckle.Core": "3.1.0-dev.89"
         }
       }
     }

--- a/Converters/Autocad/Speckle.Converters.Autocad2023.DependencyInjection/packages.lock.json
+++ b/Converters/Autocad/Speckle.Converters.Autocad2023.DependencyInjection/packages.lock.json
@@ -130,8 +130,8 @@
       },
       "Speckle.Logging": {
         "type": "Transitive",
-        "resolved": "3.1.0-dev.88",
-        "contentHash": "kD8Xuqbv5lmNQGuv+gx+OnzFt51twc2aIWHEmaG+HBwojR4PZ9IqsaCcMSu4wv/Q1p+Xq5MZldVDkO368JSJRw=="
+        "resolved": "3.1.0-dev.89",
+        "contentHash": "sRiVATMGe8N0LwFRlqxBpRwmI7ZXVKGobSUUCLzzBqIe5UKFJRGi4Jz/6ukF6Tl2li6vrU0qt0CBPOx5nX1jrA=="
       },
       "Speckle.Newtonsoft.Json": {
         "type": "Transitive",
@@ -265,7 +265,7 @@
         "type": "Project",
         "dependencies": {
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.88, )"
+          "Speckle.Objects": "[3.1.0-dev.89, )"
         }
       },
       "speckle.converters.common.dependencyinjection": {
@@ -293,9 +293,9 @@
       },
       "Speckle.Core": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.88, )",
-        "resolved": "3.1.0-dev.88",
-        "contentHash": "1yBzO/JEG9aEGeXwpx1vMZgknmma0QI1cVQ+uwoHc7oyYcAk1bePCa/C6ntyszzV+Y3fpeBZY4HGNALYICgVjg==",
+        "requested": "[3.1.0-dev.89, )",
+        "resolved": "3.1.0-dev.89",
+        "contentHash": "p3KMI7g2D6+nRAFtSQ3zDB6sB7329qyOvn+WCvy1n7YK35atM4ssR9WL4SVgKss/IQifxgDZVVldE3/o31TRTQ==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -304,18 +304,18 @@
           "Polly.Contrib.WaitAndRetry": "1.1.1",
           "Polly.Extensions.Http": "3.0.0",
           "Speckle.DoubleNumerics": "4.0.1",
-          "Speckle.Logging": "3.1.0-dev.88",
+          "Speckle.Logging": "3.1.0-dev.89",
           "Speckle.Newtonsoft.Json": "13.0.2",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.88, )",
-        "resolved": "3.1.0-dev.88",
-        "contentHash": "hzqeIYzvSa3VusEWic8FaVsaEMwHcwnbj2p0JDz2ZTAlf3SpFdxVtA4onIq0l7YyROBIFFn78eIIpm1cCucUIw==",
+        "requested": "[3.1.0-dev.89, )",
+        "resolved": "3.1.0-dev.89",
+        "contentHash": "DA035BwkIG5sdg2Z6SEsi9jo5zuP6UxBFzBW8QtY5hf54be34lzxl/9p3HGkpALUyBMrgaAZvZZnS/INEQRpGw==",
         "dependencies": {
-          "Speckle.Core": "3.1.0-dev.88"
+          "Speckle.Core": "3.1.0-dev.89"
         }
       }
     }

--- a/Converters/Autocad/Speckle.Converters.Autocad2023/packages.lock.json
+++ b/Converters/Autocad/Speckle.Converters.Autocad2023/packages.lock.json
@@ -127,8 +127,8 @@
       },
       "Speckle.Logging": {
         "type": "Transitive",
-        "resolved": "3.1.0-dev.88",
-        "contentHash": "kD8Xuqbv5lmNQGuv+gx+OnzFt51twc2aIWHEmaG+HBwojR4PZ9IqsaCcMSu4wv/Q1p+Xq5MZldVDkO368JSJRw=="
+        "resolved": "3.1.0-dev.89",
+        "contentHash": "sRiVATMGe8N0LwFRlqxBpRwmI7ZXVKGobSUUCLzzBqIe5UKFJRGi4Jz/6ukF6Tl2li6vrU0qt0CBPOx5nX1jrA=="
       },
       "Speckle.Newtonsoft.Json": {
         "type": "Transitive",
@@ -255,7 +255,7 @@
         "type": "Project",
         "dependencies": {
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.88, )"
+          "Speckle.Objects": "[3.1.0-dev.89, )"
         }
       },
       "Autofac": {
@@ -279,9 +279,9 @@
       },
       "Speckle.Core": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.88, )",
-        "resolved": "3.1.0-dev.88",
-        "contentHash": "1yBzO/JEG9aEGeXwpx1vMZgknmma0QI1cVQ+uwoHc7oyYcAk1bePCa/C6ntyszzV+Y3fpeBZY4HGNALYICgVjg==",
+        "requested": "[3.1.0-dev.89, )",
+        "resolved": "3.1.0-dev.89",
+        "contentHash": "p3KMI7g2D6+nRAFtSQ3zDB6sB7329qyOvn+WCvy1n7YK35atM4ssR9WL4SVgKss/IQifxgDZVVldE3/o31TRTQ==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -290,18 +290,18 @@
           "Polly.Contrib.WaitAndRetry": "1.1.1",
           "Polly.Extensions.Http": "3.0.0",
           "Speckle.DoubleNumerics": "4.0.1",
-          "Speckle.Logging": "3.1.0-dev.88",
+          "Speckle.Logging": "3.1.0-dev.89",
           "Speckle.Newtonsoft.Json": "13.0.2",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.88, )",
-        "resolved": "3.1.0-dev.88",
-        "contentHash": "hzqeIYzvSa3VusEWic8FaVsaEMwHcwnbj2p0JDz2ZTAlf3SpFdxVtA4onIq0l7YyROBIFFn78eIIpm1cCucUIw==",
+        "requested": "[3.1.0-dev.89, )",
+        "resolved": "3.1.0-dev.89",
+        "contentHash": "DA035BwkIG5sdg2Z6SEsi9jo5zuP6UxBFzBW8QtY5hf54be34lzxl/9p3HGkpALUyBMrgaAZvZZnS/INEQRpGw==",
         "dependencies": {
-          "Speckle.Core": "3.1.0-dev.88"
+          "Speckle.Core": "3.1.0-dev.89"
         }
       }
     }

--- a/Converters/Autocad/Speckle.Converters.Autocad2024.DependencyInjection/packages.lock.json
+++ b/Converters/Autocad/Speckle.Converters.Autocad2024.DependencyInjection/packages.lock.json
@@ -130,8 +130,8 @@
       },
       "Speckle.Logging": {
         "type": "Transitive",
-        "resolved": "3.1.0-dev.88",
-        "contentHash": "kD8Xuqbv5lmNQGuv+gx+OnzFt51twc2aIWHEmaG+HBwojR4PZ9IqsaCcMSu4wv/Q1p+Xq5MZldVDkO368JSJRw=="
+        "resolved": "3.1.0-dev.89",
+        "contentHash": "sRiVATMGe8N0LwFRlqxBpRwmI7ZXVKGobSUUCLzzBqIe5UKFJRGi4Jz/6ukF6Tl2li6vrU0qt0CBPOx5nX1jrA=="
       },
       "Speckle.Newtonsoft.Json": {
         "type": "Transitive",
@@ -265,7 +265,7 @@
         "type": "Project",
         "dependencies": {
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.88, )"
+          "Speckle.Objects": "[3.1.0-dev.89, )"
         }
       },
       "speckle.converters.common.dependencyinjection": {
@@ -293,9 +293,9 @@
       },
       "Speckle.Core": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.88, )",
-        "resolved": "3.1.0-dev.88",
-        "contentHash": "1yBzO/JEG9aEGeXwpx1vMZgknmma0QI1cVQ+uwoHc7oyYcAk1bePCa/C6ntyszzV+Y3fpeBZY4HGNALYICgVjg==",
+        "requested": "[3.1.0-dev.89, )",
+        "resolved": "3.1.0-dev.89",
+        "contentHash": "p3KMI7g2D6+nRAFtSQ3zDB6sB7329qyOvn+WCvy1n7YK35atM4ssR9WL4SVgKss/IQifxgDZVVldE3/o31TRTQ==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -304,18 +304,18 @@
           "Polly.Contrib.WaitAndRetry": "1.1.1",
           "Polly.Extensions.Http": "3.0.0",
           "Speckle.DoubleNumerics": "4.0.1",
-          "Speckle.Logging": "3.1.0-dev.88",
+          "Speckle.Logging": "3.1.0-dev.89",
           "Speckle.Newtonsoft.Json": "13.0.2",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.88, )",
-        "resolved": "3.1.0-dev.88",
-        "contentHash": "hzqeIYzvSa3VusEWic8FaVsaEMwHcwnbj2p0JDz2ZTAlf3SpFdxVtA4onIq0l7YyROBIFFn78eIIpm1cCucUIw==",
+        "requested": "[3.1.0-dev.89, )",
+        "resolved": "3.1.0-dev.89",
+        "contentHash": "DA035BwkIG5sdg2Z6SEsi9jo5zuP6UxBFzBW8QtY5hf54be34lzxl/9p3HGkpALUyBMrgaAZvZZnS/INEQRpGw==",
         "dependencies": {
-          "Speckle.Core": "3.1.0-dev.88"
+          "Speckle.Core": "3.1.0-dev.89"
         }
       }
     }

--- a/Converters/Autocad/Speckle.Converters.Autocad2024/packages.lock.json
+++ b/Converters/Autocad/Speckle.Converters.Autocad2024/packages.lock.json
@@ -127,8 +127,8 @@
       },
       "Speckle.Logging": {
         "type": "Transitive",
-        "resolved": "3.1.0-dev.88",
-        "contentHash": "kD8Xuqbv5lmNQGuv+gx+OnzFt51twc2aIWHEmaG+HBwojR4PZ9IqsaCcMSu4wv/Q1p+Xq5MZldVDkO368JSJRw=="
+        "resolved": "3.1.0-dev.89",
+        "contentHash": "sRiVATMGe8N0LwFRlqxBpRwmI7ZXVKGobSUUCLzzBqIe5UKFJRGi4Jz/6ukF6Tl2li6vrU0qt0CBPOx5nX1jrA=="
       },
       "Speckle.Newtonsoft.Json": {
         "type": "Transitive",
@@ -255,7 +255,7 @@
         "type": "Project",
         "dependencies": {
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.88, )"
+          "Speckle.Objects": "[3.1.0-dev.89, )"
         }
       },
       "Autofac": {
@@ -279,9 +279,9 @@
       },
       "Speckle.Core": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.88, )",
-        "resolved": "3.1.0-dev.88",
-        "contentHash": "1yBzO/JEG9aEGeXwpx1vMZgknmma0QI1cVQ+uwoHc7oyYcAk1bePCa/C6ntyszzV+Y3fpeBZY4HGNALYICgVjg==",
+        "requested": "[3.1.0-dev.89, )",
+        "resolved": "3.1.0-dev.89",
+        "contentHash": "p3KMI7g2D6+nRAFtSQ3zDB6sB7329qyOvn+WCvy1n7YK35atM4ssR9WL4SVgKss/IQifxgDZVVldE3/o31TRTQ==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -290,18 +290,18 @@
           "Polly.Contrib.WaitAndRetry": "1.1.1",
           "Polly.Extensions.Http": "3.0.0",
           "Speckle.DoubleNumerics": "4.0.1",
-          "Speckle.Logging": "3.1.0-dev.88",
+          "Speckle.Logging": "3.1.0-dev.89",
           "Speckle.Newtonsoft.Json": "13.0.2",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.88, )",
-        "resolved": "3.1.0-dev.88",
-        "contentHash": "hzqeIYzvSa3VusEWic8FaVsaEMwHcwnbj2p0JDz2ZTAlf3SpFdxVtA4onIq0l7YyROBIFFn78eIIpm1cCucUIw==",
+        "requested": "[3.1.0-dev.89, )",
+        "resolved": "3.1.0-dev.89",
+        "contentHash": "DA035BwkIG5sdg2Z6SEsi9jo5zuP6UxBFzBW8QtY5hf54be34lzxl/9p3HGkpALUyBMrgaAZvZZnS/INEQRpGw==",
         "dependencies": {
-          "Speckle.Core": "3.1.0-dev.88"
+          "Speckle.Core": "3.1.0-dev.89"
         }
       }
     }

--- a/Converters/Civil3d/Speckle.Converters.Civil3d2024.DependencyInjection/packages.lock.json
+++ b/Converters/Civil3d/Speckle.Converters.Civil3d2024.DependencyInjection/packages.lock.json
@@ -130,8 +130,8 @@
       },
       "Speckle.Logging": {
         "type": "Transitive",
-        "resolved": "3.1.0-dev.88",
-        "contentHash": "kD8Xuqbv5lmNQGuv+gx+OnzFt51twc2aIWHEmaG+HBwojR4PZ9IqsaCcMSu4wv/Q1p+Xq5MZldVDkO368JSJRw=="
+        "resolved": "3.1.0-dev.89",
+        "contentHash": "sRiVATMGe8N0LwFRlqxBpRwmI7ZXVKGobSUUCLzzBqIe5UKFJRGi4Jz/6ukF6Tl2li6vrU0qt0CBPOx5nX1jrA=="
       },
       "Speckle.Newtonsoft.Json": {
         "type": "Transitive",
@@ -266,7 +266,7 @@
         "type": "Project",
         "dependencies": {
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.88, )"
+          "Speckle.Objects": "[3.1.0-dev.89, )"
         }
       },
       "speckle.converters.common.dependencyinjection": {
@@ -303,9 +303,9 @@
       },
       "Speckle.Core": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.88, )",
-        "resolved": "3.1.0-dev.88",
-        "contentHash": "1yBzO/JEG9aEGeXwpx1vMZgknmma0QI1cVQ+uwoHc7oyYcAk1bePCa/C6ntyszzV+Y3fpeBZY4HGNALYICgVjg==",
+        "requested": "[3.1.0-dev.89, )",
+        "resolved": "3.1.0-dev.89",
+        "contentHash": "p3KMI7g2D6+nRAFtSQ3zDB6sB7329qyOvn+WCvy1n7YK35atM4ssR9WL4SVgKss/IQifxgDZVVldE3/o31TRTQ==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -314,18 +314,18 @@
           "Polly.Contrib.WaitAndRetry": "1.1.1",
           "Polly.Extensions.Http": "3.0.0",
           "Speckle.DoubleNumerics": "4.0.1",
-          "Speckle.Logging": "3.1.0-dev.88",
+          "Speckle.Logging": "3.1.0-dev.89",
           "Speckle.Newtonsoft.Json": "13.0.2",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.88, )",
-        "resolved": "3.1.0-dev.88",
-        "contentHash": "hzqeIYzvSa3VusEWic8FaVsaEMwHcwnbj2p0JDz2ZTAlf3SpFdxVtA4onIq0l7YyROBIFFn78eIIpm1cCucUIw==",
+        "requested": "[3.1.0-dev.89, )",
+        "resolved": "3.1.0-dev.89",
+        "contentHash": "DA035BwkIG5sdg2Z6SEsi9jo5zuP6UxBFzBW8QtY5hf54be34lzxl/9p3HGkpALUyBMrgaAZvZZnS/INEQRpGw==",
         "dependencies": {
-          "Speckle.Core": "3.1.0-dev.88"
+          "Speckle.Core": "3.1.0-dev.89"
         }
       }
     }

--- a/Converters/Civil3d/Speckle.Converters.Civil3d2024/packages.lock.json
+++ b/Converters/Civil3d/Speckle.Converters.Civil3d2024/packages.lock.json
@@ -136,8 +136,8 @@
       },
       "Speckle.Logging": {
         "type": "Transitive",
-        "resolved": "3.1.0-dev.88",
-        "contentHash": "kD8Xuqbv5lmNQGuv+gx+OnzFt51twc2aIWHEmaG+HBwojR4PZ9IqsaCcMSu4wv/Q1p+Xq5MZldVDkO368JSJRw=="
+        "resolved": "3.1.0-dev.89",
+        "contentHash": "sRiVATMGe8N0LwFRlqxBpRwmI7ZXVKGobSUUCLzzBqIe5UKFJRGi4Jz/6ukF6Tl2li6vrU0qt0CBPOx5nX1jrA=="
       },
       "Speckle.Newtonsoft.Json": {
         "type": "Transitive",
@@ -264,7 +264,7 @@
         "type": "Project",
         "dependencies": {
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.88, )"
+          "Speckle.Objects": "[3.1.0-dev.89, )"
         }
       },
       "Autofac": {
@@ -288,9 +288,9 @@
       },
       "Speckle.Core": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.88, )",
-        "resolved": "3.1.0-dev.88",
-        "contentHash": "1yBzO/JEG9aEGeXwpx1vMZgknmma0QI1cVQ+uwoHc7oyYcAk1bePCa/C6ntyszzV+Y3fpeBZY4HGNALYICgVjg==",
+        "requested": "[3.1.0-dev.89, )",
+        "resolved": "3.1.0-dev.89",
+        "contentHash": "p3KMI7g2D6+nRAFtSQ3zDB6sB7329qyOvn+WCvy1n7YK35atM4ssR9WL4SVgKss/IQifxgDZVVldE3/o31TRTQ==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -299,18 +299,18 @@
           "Polly.Contrib.WaitAndRetry": "1.1.1",
           "Polly.Extensions.Http": "3.0.0",
           "Speckle.DoubleNumerics": "4.0.1",
-          "Speckle.Logging": "3.1.0-dev.88",
+          "Speckle.Logging": "3.1.0-dev.89",
           "Speckle.Newtonsoft.Json": "13.0.2",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.88, )",
-        "resolved": "3.1.0-dev.88",
-        "contentHash": "hzqeIYzvSa3VusEWic8FaVsaEMwHcwnbj2p0JDz2ZTAlf3SpFdxVtA4onIq0l7YyROBIFFn78eIIpm1cCucUIw==",
+        "requested": "[3.1.0-dev.89, )",
+        "resolved": "3.1.0-dev.89",
+        "contentHash": "DA035BwkIG5sdg2Z6SEsi9jo5zuP6UxBFzBW8QtY5hf54be34lzxl/9p3HGkpALUyBMrgaAZvZZnS/INEQRpGw==",
         "dependencies": {
-          "Speckle.Core": "3.1.0-dev.88"
+          "Speckle.Core": "3.1.0-dev.89"
         }
       }
     }

--- a/Converters/Revit/Speckle.Converters.Revit2022.DependencyInjection/packages.lock.json
+++ b/Converters/Revit/Speckle.Converters.Revit2022.DependencyInjection/packages.lock.json
@@ -121,8 +121,8 @@
       },
       "Speckle.Logging": {
         "type": "Transitive",
-        "resolved": "3.1.0-dev.88",
-        "contentHash": "kD8Xuqbv5lmNQGuv+gx+OnzFt51twc2aIWHEmaG+HBwojR4PZ9IqsaCcMSu4wv/Q1p+Xq5MZldVDkO368JSJRw=="
+        "resolved": "3.1.0-dev.89",
+        "contentHash": "sRiVATMGe8N0LwFRlqxBpRwmI7ZXVKGobSUUCLzzBqIe5UKFJRGi4Jz/6ukF6Tl2li6vrU0qt0CBPOx5nX1jrA=="
       },
       "Speckle.Newtonsoft.Json": {
         "type": "Transitive",
@@ -249,7 +249,7 @@
         "type": "Project",
         "dependencies": {
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.88, )"
+          "Speckle.Objects": "[3.1.0-dev.89, )"
         }
       },
       "speckle.converters.common.dependencyinjection": {
@@ -288,9 +288,9 @@
       },
       "Speckle.Core": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.88, )",
-        "resolved": "3.1.0-dev.88",
-        "contentHash": "1yBzO/JEG9aEGeXwpx1vMZgknmma0QI1cVQ+uwoHc7oyYcAk1bePCa/C6ntyszzV+Y3fpeBZY4HGNALYICgVjg==",
+        "requested": "[3.1.0-dev.89, )",
+        "resolved": "3.1.0-dev.89",
+        "contentHash": "p3KMI7g2D6+nRAFtSQ3zDB6sB7329qyOvn+WCvy1n7YK35atM4ssR9WL4SVgKss/IQifxgDZVVldE3/o31TRTQ==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -299,18 +299,18 @@
           "Polly.Contrib.WaitAndRetry": "1.1.1",
           "Polly.Extensions.Http": "3.0.0",
           "Speckle.DoubleNumerics": "4.0.1",
-          "Speckle.Logging": "3.1.0-dev.88",
+          "Speckle.Logging": "3.1.0-dev.89",
           "Speckle.Newtonsoft.Json": "13.0.2",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.88, )",
-        "resolved": "3.1.0-dev.88",
-        "contentHash": "hzqeIYzvSa3VusEWic8FaVsaEMwHcwnbj2p0JDz2ZTAlf3SpFdxVtA4onIq0l7YyROBIFFn78eIIpm1cCucUIw==",
+        "requested": "[3.1.0-dev.89, )",
+        "resolved": "3.1.0-dev.89",
+        "contentHash": "DA035BwkIG5sdg2Z6SEsi9jo5zuP6UxBFzBW8QtY5hf54be34lzxl/9p3HGkpALUyBMrgaAZvZZnS/INEQRpGw==",
         "dependencies": {
-          "Speckle.Core": "3.1.0-dev.88"
+          "Speckle.Core": "3.1.0-dev.89"
         }
       },
       "Speckle.Revit.API": {

--- a/Converters/Revit/Speckle.Converters.Revit2022.Tests/packages.lock.json
+++ b/Converters/Revit/Speckle.Converters.Revit2022.Tests/packages.lock.json
@@ -213,8 +213,8 @@
       },
       "Speckle.Logging": {
         "type": "Transitive",
-        "resolved": "3.1.0-dev.88",
-        "contentHash": "kD8Xuqbv5lmNQGuv+gx+OnzFt51twc2aIWHEmaG+HBwojR4PZ9IqsaCcMSu4wv/Q1p+Xq5MZldVDkO368JSJRw=="
+        "resolved": "3.1.0-dev.89",
+        "contentHash": "sRiVATMGe8N0LwFRlqxBpRwmI7ZXVKGobSUUCLzzBqIe5UKFJRGi4Jz/6ukF6Tl2li6vrU0qt0CBPOx5nX1jrA=="
       },
       "Speckle.Newtonsoft.Json": {
         "type": "Transitive",
@@ -308,7 +308,7 @@
         "type": "Project",
         "dependencies": {
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.88, )"
+          "Speckle.Objects": "[3.1.0-dev.89, )"
         }
       },
       "speckle.testing": {
@@ -332,9 +332,9 @@
       },
       "Speckle.Core": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.88, )",
-        "resolved": "3.1.0-dev.88",
-        "contentHash": "1yBzO/JEG9aEGeXwpx1vMZgknmma0QI1cVQ+uwoHc7oyYcAk1bePCa/C6ntyszzV+Y3fpeBZY4HGNALYICgVjg==",
+        "requested": "[3.1.0-dev.89, )",
+        "resolved": "3.1.0-dev.89",
+        "contentHash": "p3KMI7g2D6+nRAFtSQ3zDB6sB7329qyOvn+WCvy1n7YK35atM4ssR9WL4SVgKss/IQifxgDZVVldE3/o31TRTQ==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -343,18 +343,18 @@
           "Polly.Contrib.WaitAndRetry": "1.1.1",
           "Polly.Extensions.Http": "3.0.0",
           "Speckle.DoubleNumerics": "4.0.1",
-          "Speckle.Logging": "3.1.0-dev.88",
+          "Speckle.Logging": "3.1.0-dev.89",
           "Speckle.Newtonsoft.Json": "13.0.2",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.88, )",
-        "resolved": "3.1.0-dev.88",
-        "contentHash": "hzqeIYzvSa3VusEWic8FaVsaEMwHcwnbj2p0JDz2ZTAlf3SpFdxVtA4onIq0l7YyROBIFFn78eIIpm1cCucUIw==",
+        "requested": "[3.1.0-dev.89, )",
+        "resolved": "3.1.0-dev.89",
+        "contentHash": "DA035BwkIG5sdg2Z6SEsi9jo5zuP6UxBFzBW8QtY5hf54be34lzxl/9p3HGkpALUyBMrgaAZvZZnS/INEQRpGw==",
         "dependencies": {
-          "Speckle.Core": "3.1.0-dev.88"
+          "Speckle.Core": "3.1.0-dev.89"
         }
       }
     }

--- a/Converters/Revit/Speckle.Converters.Revit2022/packages.lock.json
+++ b/Converters/Revit/Speckle.Converters.Revit2022/packages.lock.json
@@ -127,8 +127,8 @@
       },
       "Speckle.Logging": {
         "type": "Transitive",
-        "resolved": "3.1.0-dev.88",
-        "contentHash": "kD8Xuqbv5lmNQGuv+gx+OnzFt51twc2aIWHEmaG+HBwojR4PZ9IqsaCcMSu4wv/Q1p+Xq5MZldVDkO368JSJRw=="
+        "resolved": "3.1.0-dev.89",
+        "contentHash": "sRiVATMGe8N0LwFRlqxBpRwmI7ZXVKGobSUUCLzzBqIe5UKFJRGi4Jz/6ukF6Tl2li6vrU0qt0CBPOx5nX1jrA=="
       },
       "Speckle.Newtonsoft.Json": {
         "type": "Transitive",
@@ -255,7 +255,7 @@
         "type": "Project",
         "dependencies": {
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.88, )"
+          "Speckle.Objects": "[3.1.0-dev.89, )"
         }
       },
       "speckle.converters.common.dependencyinjection": {
@@ -286,9 +286,9 @@
       },
       "Speckle.Core": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.88, )",
-        "resolved": "3.1.0-dev.88",
-        "contentHash": "1yBzO/JEG9aEGeXwpx1vMZgknmma0QI1cVQ+uwoHc7oyYcAk1bePCa/C6ntyszzV+Y3fpeBZY4HGNALYICgVjg==",
+        "requested": "[3.1.0-dev.89, )",
+        "resolved": "3.1.0-dev.89",
+        "contentHash": "p3KMI7g2D6+nRAFtSQ3zDB6sB7329qyOvn+WCvy1n7YK35atM4ssR9WL4SVgKss/IQifxgDZVVldE3/o31TRTQ==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -297,18 +297,18 @@
           "Polly.Contrib.WaitAndRetry": "1.1.1",
           "Polly.Extensions.Http": "3.0.0",
           "Speckle.DoubleNumerics": "4.0.1",
-          "Speckle.Logging": "3.1.0-dev.88",
+          "Speckle.Logging": "3.1.0-dev.89",
           "Speckle.Newtonsoft.Json": "13.0.2",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.88, )",
-        "resolved": "3.1.0-dev.88",
-        "contentHash": "hzqeIYzvSa3VusEWic8FaVsaEMwHcwnbj2p0JDz2ZTAlf3SpFdxVtA4onIq0l7YyROBIFFn78eIIpm1cCucUIw==",
+        "requested": "[3.1.0-dev.89, )",
+        "resolved": "3.1.0-dev.89",
+        "contentHash": "DA035BwkIG5sdg2Z6SEsi9jo5zuP6UxBFzBW8QtY5hf54be34lzxl/9p3HGkpALUyBMrgaAZvZZnS/INEQRpGw==",
         "dependencies": {
-          "Speckle.Core": "3.1.0-dev.88"
+          "Speckle.Core": "3.1.0-dev.89"
         }
       }
     }

--- a/Converters/Revit/Speckle.Converters.Revit2023.DependencyInjection/packages.lock.json
+++ b/Converters/Revit/Speckle.Converters.Revit2023.DependencyInjection/packages.lock.json
@@ -121,8 +121,8 @@
       },
       "Speckle.Logging": {
         "type": "Transitive",
-        "resolved": "3.1.0-dev.88",
-        "contentHash": "kD8Xuqbv5lmNQGuv+gx+OnzFt51twc2aIWHEmaG+HBwojR4PZ9IqsaCcMSu4wv/Q1p+Xq5MZldVDkO368JSJRw=="
+        "resolved": "3.1.0-dev.89",
+        "contentHash": "sRiVATMGe8N0LwFRlqxBpRwmI7ZXVKGobSUUCLzzBqIe5UKFJRGi4Jz/6ukF6Tl2li6vrU0qt0CBPOx5nX1jrA=="
       },
       "Speckle.Newtonsoft.Json": {
         "type": "Transitive",
@@ -249,7 +249,7 @@
         "type": "Project",
         "dependencies": {
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.88, )"
+          "Speckle.Objects": "[3.1.0-dev.89, )"
         }
       },
       "speckle.converters.common.dependencyinjection": {
@@ -287,9 +287,9 @@
       },
       "Speckle.Core": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.88, )",
-        "resolved": "3.1.0-dev.88",
-        "contentHash": "1yBzO/JEG9aEGeXwpx1vMZgknmma0QI1cVQ+uwoHc7oyYcAk1bePCa/C6ntyszzV+Y3fpeBZY4HGNALYICgVjg==",
+        "requested": "[3.1.0-dev.89, )",
+        "resolved": "3.1.0-dev.89",
+        "contentHash": "p3KMI7g2D6+nRAFtSQ3zDB6sB7329qyOvn+WCvy1n7YK35atM4ssR9WL4SVgKss/IQifxgDZVVldE3/o31TRTQ==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -298,18 +298,18 @@
           "Polly.Contrib.WaitAndRetry": "1.1.1",
           "Polly.Extensions.Http": "3.0.0",
           "Speckle.DoubleNumerics": "4.0.1",
-          "Speckle.Logging": "3.1.0-dev.88",
+          "Speckle.Logging": "3.1.0-dev.89",
           "Speckle.Newtonsoft.Json": "13.0.2",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.88, )",
-        "resolved": "3.1.0-dev.88",
-        "contentHash": "hzqeIYzvSa3VusEWic8FaVsaEMwHcwnbj2p0JDz2ZTAlf3SpFdxVtA4onIq0l7YyROBIFFn78eIIpm1cCucUIw==",
+        "requested": "[3.1.0-dev.89, )",
+        "resolved": "3.1.0-dev.89",
+        "contentHash": "DA035BwkIG5sdg2Z6SEsi9jo5zuP6UxBFzBW8QtY5hf54be34lzxl/9p3HGkpALUyBMrgaAZvZZnS/INEQRpGw==",
         "dependencies": {
-          "Speckle.Core": "3.1.0-dev.88"
+          "Speckle.Core": "3.1.0-dev.89"
         }
       },
       "Speckle.Revit.API": {

--- a/Converters/Revit/Speckle.Converters.Revit2023.Tests/packages.lock.json
+++ b/Converters/Revit/Speckle.Converters.Revit2023.Tests/packages.lock.json
@@ -213,8 +213,8 @@
       },
       "Speckle.Logging": {
         "type": "Transitive",
-        "resolved": "3.1.0-dev.88",
-        "contentHash": "kD8Xuqbv5lmNQGuv+gx+OnzFt51twc2aIWHEmaG+HBwojR4PZ9IqsaCcMSu4wv/Q1p+Xq5MZldVDkO368JSJRw=="
+        "resolved": "3.1.0-dev.89",
+        "contentHash": "sRiVATMGe8N0LwFRlqxBpRwmI7ZXVKGobSUUCLzzBqIe5UKFJRGi4Jz/6ukF6Tl2li6vrU0qt0CBPOx5nX1jrA=="
       },
       "Speckle.Newtonsoft.Json": {
         "type": "Transitive",
@@ -308,7 +308,7 @@
         "type": "Project",
         "dependencies": {
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.88, )"
+          "Speckle.Objects": "[3.1.0-dev.89, )"
         }
       },
       "speckle.testing": {
@@ -332,9 +332,9 @@
       },
       "Speckle.Core": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.88, )",
-        "resolved": "3.1.0-dev.88",
-        "contentHash": "1yBzO/JEG9aEGeXwpx1vMZgknmma0QI1cVQ+uwoHc7oyYcAk1bePCa/C6ntyszzV+Y3fpeBZY4HGNALYICgVjg==",
+        "requested": "[3.1.0-dev.89, )",
+        "resolved": "3.1.0-dev.89",
+        "contentHash": "p3KMI7g2D6+nRAFtSQ3zDB6sB7329qyOvn+WCvy1n7YK35atM4ssR9WL4SVgKss/IQifxgDZVVldE3/o31TRTQ==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -343,18 +343,18 @@
           "Polly.Contrib.WaitAndRetry": "1.1.1",
           "Polly.Extensions.Http": "3.0.0",
           "Speckle.DoubleNumerics": "4.0.1",
-          "Speckle.Logging": "3.1.0-dev.88",
+          "Speckle.Logging": "3.1.0-dev.89",
           "Speckle.Newtonsoft.Json": "13.0.2",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.88, )",
-        "resolved": "3.1.0-dev.88",
-        "contentHash": "hzqeIYzvSa3VusEWic8FaVsaEMwHcwnbj2p0JDz2ZTAlf3SpFdxVtA4onIq0l7YyROBIFFn78eIIpm1cCucUIw==",
+        "requested": "[3.1.0-dev.89, )",
+        "resolved": "3.1.0-dev.89",
+        "contentHash": "DA035BwkIG5sdg2Z6SEsi9jo5zuP6UxBFzBW8QtY5hf54be34lzxl/9p3HGkpALUyBMrgaAZvZZnS/INEQRpGw==",
         "dependencies": {
-          "Speckle.Core": "3.1.0-dev.88"
+          "Speckle.Core": "3.1.0-dev.89"
         }
       }
     }

--- a/Converters/Revit/Speckle.Converters.Revit2023/packages.lock.json
+++ b/Converters/Revit/Speckle.Converters.Revit2023/packages.lock.json
@@ -127,8 +127,8 @@
       },
       "Speckle.Logging": {
         "type": "Transitive",
-        "resolved": "3.1.0-dev.88",
-        "contentHash": "kD8Xuqbv5lmNQGuv+gx+OnzFt51twc2aIWHEmaG+HBwojR4PZ9IqsaCcMSu4wv/Q1p+Xq5MZldVDkO368JSJRw=="
+        "resolved": "3.1.0-dev.89",
+        "contentHash": "sRiVATMGe8N0LwFRlqxBpRwmI7ZXVKGobSUUCLzzBqIe5UKFJRGi4Jz/6ukF6Tl2li6vrU0qt0CBPOx5nX1jrA=="
       },
       "Speckle.Newtonsoft.Json": {
         "type": "Transitive",
@@ -255,7 +255,7 @@
         "type": "Project",
         "dependencies": {
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.88, )"
+          "Speckle.Objects": "[3.1.0-dev.89, )"
         }
       },
       "Autofac": {
@@ -279,9 +279,9 @@
       },
       "Speckle.Core": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.88, )",
-        "resolved": "3.1.0-dev.88",
-        "contentHash": "1yBzO/JEG9aEGeXwpx1vMZgknmma0QI1cVQ+uwoHc7oyYcAk1bePCa/C6ntyszzV+Y3fpeBZY4HGNALYICgVjg==",
+        "requested": "[3.1.0-dev.89, )",
+        "resolved": "3.1.0-dev.89",
+        "contentHash": "p3KMI7g2D6+nRAFtSQ3zDB6sB7329qyOvn+WCvy1n7YK35atM4ssR9WL4SVgKss/IQifxgDZVVldE3/o31TRTQ==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -290,18 +290,18 @@
           "Polly.Contrib.WaitAndRetry": "1.1.1",
           "Polly.Extensions.Http": "3.0.0",
           "Speckle.DoubleNumerics": "4.0.1",
-          "Speckle.Logging": "3.1.0-dev.88",
+          "Speckle.Logging": "3.1.0-dev.89",
           "Speckle.Newtonsoft.Json": "13.0.2",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.88, )",
-        "resolved": "3.1.0-dev.88",
-        "contentHash": "hzqeIYzvSa3VusEWic8FaVsaEMwHcwnbj2p0JDz2ZTAlf3SpFdxVtA4onIq0l7YyROBIFFn78eIIpm1cCucUIw==",
+        "requested": "[3.1.0-dev.89, )",
+        "resolved": "3.1.0-dev.89",
+        "contentHash": "DA035BwkIG5sdg2Z6SEsi9jo5zuP6UxBFzBW8QtY5hf54be34lzxl/9p3HGkpALUyBMrgaAZvZZnS/INEQRpGw==",
         "dependencies": {
-          "Speckle.Core": "3.1.0-dev.88"
+          "Speckle.Core": "3.1.0-dev.89"
         }
       }
     }

--- a/Converters/Revit/Speckle.Converters.Revit2024.DependencyInjection/packages.lock.json
+++ b/Converters/Revit/Speckle.Converters.Revit2024.DependencyInjection/packages.lock.json
@@ -121,8 +121,8 @@
       },
       "Speckle.Logging": {
         "type": "Transitive",
-        "resolved": "3.1.0-dev.88",
-        "contentHash": "kD8Xuqbv5lmNQGuv+gx+OnzFt51twc2aIWHEmaG+HBwojR4PZ9IqsaCcMSu4wv/Q1p+Xq5MZldVDkO368JSJRw=="
+        "resolved": "3.1.0-dev.89",
+        "contentHash": "sRiVATMGe8N0LwFRlqxBpRwmI7ZXVKGobSUUCLzzBqIe5UKFJRGi4Jz/6ukF6Tl2li6vrU0qt0CBPOx5nX1jrA=="
       },
       "Speckle.Newtonsoft.Json": {
         "type": "Transitive",
@@ -249,7 +249,7 @@
         "type": "Project",
         "dependencies": {
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.88, )"
+          "Speckle.Objects": "[3.1.0-dev.89, )"
         }
       },
       "speckle.converters.common.dependencyinjection": {
@@ -287,9 +287,9 @@
       },
       "Speckle.Core": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.88, )",
-        "resolved": "3.1.0-dev.88",
-        "contentHash": "1yBzO/JEG9aEGeXwpx1vMZgknmma0QI1cVQ+uwoHc7oyYcAk1bePCa/C6ntyszzV+Y3fpeBZY4HGNALYICgVjg==",
+        "requested": "[3.1.0-dev.89, )",
+        "resolved": "3.1.0-dev.89",
+        "contentHash": "p3KMI7g2D6+nRAFtSQ3zDB6sB7329qyOvn+WCvy1n7YK35atM4ssR9WL4SVgKss/IQifxgDZVVldE3/o31TRTQ==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -298,18 +298,18 @@
           "Polly.Contrib.WaitAndRetry": "1.1.1",
           "Polly.Extensions.Http": "3.0.0",
           "Speckle.DoubleNumerics": "4.0.1",
-          "Speckle.Logging": "3.1.0-dev.88",
+          "Speckle.Logging": "3.1.0-dev.89",
           "Speckle.Newtonsoft.Json": "13.0.2",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.88, )",
-        "resolved": "3.1.0-dev.88",
-        "contentHash": "hzqeIYzvSa3VusEWic8FaVsaEMwHcwnbj2p0JDz2ZTAlf3SpFdxVtA4onIq0l7YyROBIFFn78eIIpm1cCucUIw==",
+        "requested": "[3.1.0-dev.89, )",
+        "resolved": "3.1.0-dev.89",
+        "contentHash": "DA035BwkIG5sdg2Z6SEsi9jo5zuP6UxBFzBW8QtY5hf54be34lzxl/9p3HGkpALUyBMrgaAZvZZnS/INEQRpGw==",
         "dependencies": {
-          "Speckle.Core": "3.1.0-dev.88"
+          "Speckle.Core": "3.1.0-dev.89"
         }
       },
       "Speckle.Revit.API": {

--- a/Converters/Revit/Speckle.Converters.Revit2024.Tests/packages.lock.json
+++ b/Converters/Revit/Speckle.Converters.Revit2024.Tests/packages.lock.json
@@ -213,8 +213,8 @@
       },
       "Speckle.Logging": {
         "type": "Transitive",
-        "resolved": "3.1.0-dev.88",
-        "contentHash": "kD8Xuqbv5lmNQGuv+gx+OnzFt51twc2aIWHEmaG+HBwojR4PZ9IqsaCcMSu4wv/Q1p+Xq5MZldVDkO368JSJRw=="
+        "resolved": "3.1.0-dev.89",
+        "contentHash": "sRiVATMGe8N0LwFRlqxBpRwmI7ZXVKGobSUUCLzzBqIe5UKFJRGi4Jz/6ukF6Tl2li6vrU0qt0CBPOx5nX1jrA=="
       },
       "Speckle.Newtonsoft.Json": {
         "type": "Transitive",
@@ -308,7 +308,7 @@
         "type": "Project",
         "dependencies": {
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.88, )"
+          "Speckle.Objects": "[3.1.0-dev.89, )"
         }
       },
       "speckle.testing": {
@@ -332,9 +332,9 @@
       },
       "Speckle.Core": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.88, )",
-        "resolved": "3.1.0-dev.88",
-        "contentHash": "1yBzO/JEG9aEGeXwpx1vMZgknmma0QI1cVQ+uwoHc7oyYcAk1bePCa/C6ntyszzV+Y3fpeBZY4HGNALYICgVjg==",
+        "requested": "[3.1.0-dev.89, )",
+        "resolved": "3.1.0-dev.89",
+        "contentHash": "p3KMI7g2D6+nRAFtSQ3zDB6sB7329qyOvn+WCvy1n7YK35atM4ssR9WL4SVgKss/IQifxgDZVVldE3/o31TRTQ==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -343,18 +343,18 @@
           "Polly.Contrib.WaitAndRetry": "1.1.1",
           "Polly.Extensions.Http": "3.0.0",
           "Speckle.DoubleNumerics": "4.0.1",
-          "Speckle.Logging": "3.1.0-dev.88",
+          "Speckle.Logging": "3.1.0-dev.89",
           "Speckle.Newtonsoft.Json": "13.0.2",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.88, )",
-        "resolved": "3.1.0-dev.88",
-        "contentHash": "hzqeIYzvSa3VusEWic8FaVsaEMwHcwnbj2p0JDz2ZTAlf3SpFdxVtA4onIq0l7YyROBIFFn78eIIpm1cCucUIw==",
+        "requested": "[3.1.0-dev.89, )",
+        "resolved": "3.1.0-dev.89",
+        "contentHash": "DA035BwkIG5sdg2Z6SEsi9jo5zuP6UxBFzBW8QtY5hf54be34lzxl/9p3HGkpALUyBMrgaAZvZZnS/INEQRpGw==",
         "dependencies": {
-          "Speckle.Core": "3.1.0-dev.88"
+          "Speckle.Core": "3.1.0-dev.89"
         }
       }
     }

--- a/Converters/Revit/Speckle.Converters.Revit2024/packages.lock.json
+++ b/Converters/Revit/Speckle.Converters.Revit2024/packages.lock.json
@@ -127,8 +127,8 @@
       },
       "Speckle.Logging": {
         "type": "Transitive",
-        "resolved": "3.1.0-dev.88",
-        "contentHash": "kD8Xuqbv5lmNQGuv+gx+OnzFt51twc2aIWHEmaG+HBwojR4PZ9IqsaCcMSu4wv/Q1p+Xq5MZldVDkO368JSJRw=="
+        "resolved": "3.1.0-dev.89",
+        "contentHash": "sRiVATMGe8N0LwFRlqxBpRwmI7ZXVKGobSUUCLzzBqIe5UKFJRGi4Jz/6ukF6Tl2li6vrU0qt0CBPOx5nX1jrA=="
       },
       "Speckle.Newtonsoft.Json": {
         "type": "Transitive",
@@ -255,7 +255,7 @@
         "type": "Project",
         "dependencies": {
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.88, )"
+          "Speckle.Objects": "[3.1.0-dev.89, )"
         }
       },
       "Autofac": {
@@ -279,9 +279,9 @@
       },
       "Speckle.Core": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.88, )",
-        "resolved": "3.1.0-dev.88",
-        "contentHash": "1yBzO/JEG9aEGeXwpx1vMZgknmma0QI1cVQ+uwoHc7oyYcAk1bePCa/C6ntyszzV+Y3fpeBZY4HGNALYICgVjg==",
+        "requested": "[3.1.0-dev.89, )",
+        "resolved": "3.1.0-dev.89",
+        "contentHash": "p3KMI7g2D6+nRAFtSQ3zDB6sB7329qyOvn+WCvy1n7YK35atM4ssR9WL4SVgKss/IQifxgDZVVldE3/o31TRTQ==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -290,18 +290,18 @@
           "Polly.Contrib.WaitAndRetry": "1.1.1",
           "Polly.Extensions.Http": "3.0.0",
           "Speckle.DoubleNumerics": "4.0.1",
-          "Speckle.Logging": "3.1.0-dev.88",
+          "Speckle.Logging": "3.1.0-dev.89",
           "Speckle.Newtonsoft.Json": "13.0.2",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.88, )",
-        "resolved": "3.1.0-dev.88",
-        "contentHash": "hzqeIYzvSa3VusEWic8FaVsaEMwHcwnbj2p0JDz2ZTAlf3SpFdxVtA4onIq0l7YyROBIFFn78eIIpm1cCucUIw==",
+        "requested": "[3.1.0-dev.89, )",
+        "resolved": "3.1.0-dev.89",
+        "contentHash": "DA035BwkIG5sdg2Z6SEsi9jo5zuP6UxBFzBW8QtY5hf54be34lzxl/9p3HGkpALUyBMrgaAZvZZnS/INEQRpGw==",
         "dependencies": {
-          "Speckle.Core": "3.1.0-dev.88"
+          "Speckle.Core": "3.1.0-dev.89"
         }
       }
     }

--- a/Converters/Revit/Speckle.Converters.Revit2025.DependencyInjection/packages.lock.json
+++ b/Converters/Revit/Speckle.Converters.Revit2025.DependencyInjection/packages.lock.json
@@ -112,8 +112,8 @@
       },
       "Speckle.Logging": {
         "type": "Transitive",
-        "resolved": "3.1.0-dev.88",
-        "contentHash": "kD8Xuqbv5lmNQGuv+gx+OnzFt51twc2aIWHEmaG+HBwojR4PZ9IqsaCcMSu4wv/Q1p+Xq5MZldVDkO368JSJRw=="
+        "resolved": "3.1.0-dev.89",
+        "contentHash": "sRiVATMGe8N0LwFRlqxBpRwmI7ZXVKGobSUUCLzzBqIe5UKFJRGi4Jz/6ukF6Tl2li6vrU0qt0CBPOx5nX1jrA=="
       },
       "Speckle.Newtonsoft.Json": {
         "type": "Transitive",
@@ -176,7 +176,7 @@
         "type": "Project",
         "dependencies": {
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.88, )"
+          "Speckle.Objects": "[3.1.0-dev.89, )"
         }
       },
       "speckle.converters.common.dependencyinjection": {
@@ -207,9 +207,9 @@
       },
       "Speckle.Core": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.88, )",
-        "resolved": "3.1.0-dev.88",
-        "contentHash": "1yBzO/JEG9aEGeXwpx1vMZgknmma0QI1cVQ+uwoHc7oyYcAk1bePCa/C6ntyszzV+Y3fpeBZY4HGNALYICgVjg==",
+        "requested": "[3.1.0-dev.89, )",
+        "resolved": "3.1.0-dev.89",
+        "contentHash": "p3KMI7g2D6+nRAFtSQ3zDB6sB7329qyOvn+WCvy1n7YK35atM4ssR9WL4SVgKss/IQifxgDZVVldE3/o31TRTQ==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -218,18 +218,18 @@
           "Polly.Contrib.WaitAndRetry": "1.1.1",
           "Polly.Extensions.Http": "3.0.0",
           "Speckle.DoubleNumerics": "4.0.1",
-          "Speckle.Logging": "3.1.0-dev.88",
+          "Speckle.Logging": "3.1.0-dev.89",
           "Speckle.Newtonsoft.Json": "13.0.2",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.88, )",
-        "resolved": "3.1.0-dev.88",
-        "contentHash": "hzqeIYzvSa3VusEWic8FaVsaEMwHcwnbj2p0JDz2ZTAlf3SpFdxVtA4onIq0l7YyROBIFFn78eIIpm1cCucUIw==",
+        "requested": "[3.1.0-dev.89, )",
+        "resolved": "3.1.0-dev.89",
+        "contentHash": "DA035BwkIG5sdg2Z6SEsi9jo5zuP6UxBFzBW8QtY5hf54be34lzxl/9p3HGkpALUyBMrgaAZvZZnS/INEQRpGw==",
         "dependencies": {
-          "Speckle.Core": "3.1.0-dev.88"
+          "Speckle.Core": "3.1.0-dev.89"
         }
       },
       "Speckle.Revit.API": {

--- a/Converters/Revit/Speckle.Converters.Revit2025/packages.lock.json
+++ b/Converters/Revit/Speckle.Converters.Revit2025/packages.lock.json
@@ -118,8 +118,8 @@
       },
       "Speckle.Logging": {
         "type": "Transitive",
-        "resolved": "3.1.0-dev.88",
-        "contentHash": "kD8Xuqbv5lmNQGuv+gx+OnzFt51twc2aIWHEmaG+HBwojR4PZ9IqsaCcMSu4wv/Q1p+Xq5MZldVDkO368JSJRw=="
+        "resolved": "3.1.0-dev.89",
+        "contentHash": "sRiVATMGe8N0LwFRlqxBpRwmI7ZXVKGobSUUCLzzBqIe5UKFJRGi4Jz/6ukF6Tl2li6vrU0qt0CBPOx5nX1jrA=="
       },
       "Speckle.Newtonsoft.Json": {
         "type": "Transitive",
@@ -182,7 +182,7 @@
         "type": "Project",
         "dependencies": {
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.88, )"
+          "Speckle.Objects": "[3.1.0-dev.89, )"
         }
       },
       "Autofac": {
@@ -199,9 +199,9 @@
       },
       "Speckle.Core": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.88, )",
-        "resolved": "3.1.0-dev.88",
-        "contentHash": "1yBzO/JEG9aEGeXwpx1vMZgknmma0QI1cVQ+uwoHc7oyYcAk1bePCa/C6ntyszzV+Y3fpeBZY4HGNALYICgVjg==",
+        "requested": "[3.1.0-dev.89, )",
+        "resolved": "3.1.0-dev.89",
+        "contentHash": "p3KMI7g2D6+nRAFtSQ3zDB6sB7329qyOvn+WCvy1n7YK35atM4ssR9WL4SVgKss/IQifxgDZVVldE3/o31TRTQ==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -210,18 +210,18 @@
           "Polly.Contrib.WaitAndRetry": "1.1.1",
           "Polly.Extensions.Http": "3.0.0",
           "Speckle.DoubleNumerics": "4.0.1",
-          "Speckle.Logging": "3.1.0-dev.88",
+          "Speckle.Logging": "3.1.0-dev.89",
           "Speckle.Newtonsoft.Json": "13.0.2",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.88, )",
-        "resolved": "3.1.0-dev.88",
-        "contentHash": "hzqeIYzvSa3VusEWic8FaVsaEMwHcwnbj2p0JDz2ZTAlf3SpFdxVtA4onIq0l7YyROBIFFn78eIIpm1cCucUIw==",
+        "requested": "[3.1.0-dev.89, )",
+        "resolved": "3.1.0-dev.89",
+        "contentHash": "DA035BwkIG5sdg2Z6SEsi9jo5zuP6UxBFzBW8QtY5hf54be34lzxl/9p3HGkpALUyBMrgaAZvZZnS/INEQRpGw==",
         "dependencies": {
-          "Speckle.Core": "3.1.0-dev.88"
+          "Speckle.Core": "3.1.0-dev.89"
         }
       }
     }

--- a/Converters/Rhino/Speckle.Converters.Rhino7.DependencyInjection/packages.lock.json
+++ b/Converters/Rhino/Speckle.Converters.Rhino7.DependencyInjection/packages.lock.json
@@ -121,8 +121,8 @@
       },
       "Speckle.Logging": {
         "type": "Transitive",
-        "resolved": "3.1.0-dev.88",
-        "contentHash": "kD8Xuqbv5lmNQGuv+gx+OnzFt51twc2aIWHEmaG+HBwojR4PZ9IqsaCcMSu4wv/Q1p+Xq5MZldVDkO368JSJRw=="
+        "resolved": "3.1.0-dev.89",
+        "contentHash": "sRiVATMGe8N0LwFRlqxBpRwmI7ZXVKGobSUUCLzzBqIe5UKFJRGi4Jz/6ukF6Tl2li6vrU0qt0CBPOx5nX1jrA=="
       },
       "Speckle.Newtonsoft.Json": {
         "type": "Transitive",
@@ -249,7 +249,7 @@
         "type": "Project",
         "dependencies": {
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.88, )"
+          "Speckle.Objects": "[3.1.0-dev.89, )"
         }
       },
       "speckle.converters.common.dependencyinjection": {
@@ -293,9 +293,9 @@
       },
       "Speckle.Core": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.88, )",
-        "resolved": "3.1.0-dev.88",
-        "contentHash": "1yBzO/JEG9aEGeXwpx1vMZgknmma0QI1cVQ+uwoHc7oyYcAk1bePCa/C6ntyszzV+Y3fpeBZY4HGNALYICgVjg==",
+        "requested": "[3.1.0-dev.89, )",
+        "resolved": "3.1.0-dev.89",
+        "contentHash": "p3KMI7g2D6+nRAFtSQ3zDB6sB7329qyOvn+WCvy1n7YK35atM4ssR9WL4SVgKss/IQifxgDZVVldE3/o31TRTQ==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -304,18 +304,18 @@
           "Polly.Contrib.WaitAndRetry": "1.1.1",
           "Polly.Extensions.Http": "3.0.0",
           "Speckle.DoubleNumerics": "4.0.1",
-          "Speckle.Logging": "3.1.0-dev.88",
+          "Speckle.Logging": "3.1.0-dev.89",
           "Speckle.Newtonsoft.Json": "13.0.2",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.88, )",
-        "resolved": "3.1.0-dev.88",
-        "contentHash": "hzqeIYzvSa3VusEWic8FaVsaEMwHcwnbj2p0JDz2ZTAlf3SpFdxVtA4onIq0l7YyROBIFFn78eIIpm1cCucUIw==",
+        "requested": "[3.1.0-dev.89, )",
+        "resolved": "3.1.0-dev.89",
+        "contentHash": "DA035BwkIG5sdg2Z6SEsi9jo5zuP6UxBFzBW8QtY5hf54be34lzxl/9p3HGkpALUyBMrgaAZvZZnS/INEQRpGw==",
         "dependencies": {
-          "Speckle.Core": "3.1.0-dev.88"
+          "Speckle.Core": "3.1.0-dev.89"
         }
       }
     }

--- a/Converters/Rhino/Speckle.Converters.Rhino7.Tests/packages.lock.json
+++ b/Converters/Rhino/Speckle.Converters.Rhino7.Tests/packages.lock.json
@@ -213,8 +213,8 @@
       },
       "Speckle.Logging": {
         "type": "Transitive",
-        "resolved": "3.1.0-dev.88",
-        "contentHash": "kD8Xuqbv5lmNQGuv+gx+OnzFt51twc2aIWHEmaG+HBwojR4PZ9IqsaCcMSu4wv/Q1p+Xq5MZldVDkO368JSJRw=="
+        "resolved": "3.1.0-dev.89",
+        "contentHash": "sRiVATMGe8N0LwFRlqxBpRwmI7ZXVKGobSUUCLzzBqIe5UKFJRGi4Jz/6ukF6Tl2li6vrU0qt0CBPOx5nX1jrA=="
       },
       "Speckle.Newtonsoft.Json": {
         "type": "Transitive",
@@ -308,7 +308,7 @@
         "type": "Project",
         "dependencies": {
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.88, )"
+          "Speckle.Objects": "[3.1.0-dev.89, )"
         }
       },
       "speckle.testing": {
@@ -332,9 +332,9 @@
       },
       "Speckle.Core": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.88, )",
-        "resolved": "3.1.0-dev.88",
-        "contentHash": "1yBzO/JEG9aEGeXwpx1vMZgknmma0QI1cVQ+uwoHc7oyYcAk1bePCa/C6ntyszzV+Y3fpeBZY4HGNALYICgVjg==",
+        "requested": "[3.1.0-dev.89, )",
+        "resolved": "3.1.0-dev.89",
+        "contentHash": "p3KMI7g2D6+nRAFtSQ3zDB6sB7329qyOvn+WCvy1n7YK35atM4ssR9WL4SVgKss/IQifxgDZVVldE3/o31TRTQ==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -343,18 +343,18 @@
           "Polly.Contrib.WaitAndRetry": "1.1.1",
           "Polly.Extensions.Http": "3.0.0",
           "Speckle.DoubleNumerics": "4.0.1",
-          "Speckle.Logging": "3.1.0-dev.88",
+          "Speckle.Logging": "3.1.0-dev.89",
           "Speckle.Newtonsoft.Json": "13.0.2",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.88, )",
-        "resolved": "3.1.0-dev.88",
-        "contentHash": "hzqeIYzvSa3VusEWic8FaVsaEMwHcwnbj2p0JDz2ZTAlf3SpFdxVtA4onIq0l7YyROBIFFn78eIIpm1cCucUIw==",
+        "requested": "[3.1.0-dev.89, )",
+        "resolved": "3.1.0-dev.89",
+        "contentHash": "DA035BwkIG5sdg2Z6SEsi9jo5zuP6UxBFzBW8QtY5hf54be34lzxl/9p3HGkpALUyBMrgaAZvZZnS/INEQRpGw==",
         "dependencies": {
-          "Speckle.Core": "3.1.0-dev.88"
+          "Speckle.Core": "3.1.0-dev.89"
         }
       }
     }

--- a/Converters/Rhino/Speckle.Converters.Rhino7/packages.lock.json
+++ b/Converters/Rhino/Speckle.Converters.Rhino7/packages.lock.json
@@ -127,8 +127,8 @@
       },
       "Speckle.Logging": {
         "type": "Transitive",
-        "resolved": "3.1.0-dev.88",
-        "contentHash": "kD8Xuqbv5lmNQGuv+gx+OnzFt51twc2aIWHEmaG+HBwojR4PZ9IqsaCcMSu4wv/Q1p+Xq5MZldVDkO368JSJRw=="
+        "resolved": "3.1.0-dev.89",
+        "contentHash": "sRiVATMGe8N0LwFRlqxBpRwmI7ZXVKGobSUUCLzzBqIe5UKFJRGi4Jz/6ukF6Tl2li6vrU0qt0CBPOx5nX1jrA=="
       },
       "Speckle.Newtonsoft.Json": {
         "type": "Transitive",
@@ -255,7 +255,7 @@
         "type": "Project",
         "dependencies": {
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.88, )"
+          "Speckle.Objects": "[3.1.0-dev.89, )"
         }
       },
       "Autofac": {
@@ -279,9 +279,9 @@
       },
       "Speckle.Core": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.88, )",
-        "resolved": "3.1.0-dev.88",
-        "contentHash": "1yBzO/JEG9aEGeXwpx1vMZgknmma0QI1cVQ+uwoHc7oyYcAk1bePCa/C6ntyszzV+Y3fpeBZY4HGNALYICgVjg==",
+        "requested": "[3.1.0-dev.89, )",
+        "resolved": "3.1.0-dev.89",
+        "contentHash": "p3KMI7g2D6+nRAFtSQ3zDB6sB7329qyOvn+WCvy1n7YK35atM4ssR9WL4SVgKss/IQifxgDZVVldE3/o31TRTQ==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -290,18 +290,18 @@
           "Polly.Contrib.WaitAndRetry": "1.1.1",
           "Polly.Extensions.Http": "3.0.0",
           "Speckle.DoubleNumerics": "4.0.1",
-          "Speckle.Logging": "3.1.0-dev.88",
+          "Speckle.Logging": "3.1.0-dev.89",
           "Speckle.Newtonsoft.Json": "13.0.2",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.88, )",
-        "resolved": "3.1.0-dev.88",
-        "contentHash": "hzqeIYzvSa3VusEWic8FaVsaEMwHcwnbj2p0JDz2ZTAlf3SpFdxVtA4onIq0l7YyROBIFFn78eIIpm1cCucUIw==",
+        "requested": "[3.1.0-dev.89, )",
+        "resolved": "3.1.0-dev.89",
+        "contentHash": "DA035BwkIG5sdg2Z6SEsi9jo5zuP6UxBFzBW8QtY5hf54be34lzxl/9p3HGkpALUyBMrgaAZvZZnS/INEQRpGw==",
         "dependencies": {
-          "Speckle.Core": "3.1.0-dev.88"
+          "Speckle.Core": "3.1.0-dev.89"
         }
       }
     }

--- a/Converters/Rhino/Speckle.Converters.Rhino8.DependencyInjection/packages.lock.json
+++ b/Converters/Rhino/Speckle.Converters.Rhino8.DependencyInjection/packages.lock.json
@@ -121,8 +121,8 @@
       },
       "Speckle.Logging": {
         "type": "Transitive",
-        "resolved": "3.1.0-dev.88",
-        "contentHash": "kD8Xuqbv5lmNQGuv+gx+OnzFt51twc2aIWHEmaG+HBwojR4PZ9IqsaCcMSu4wv/Q1p+Xq5MZldVDkO368JSJRw=="
+        "resolved": "3.1.0-dev.89",
+        "contentHash": "sRiVATMGe8N0LwFRlqxBpRwmI7ZXVKGobSUUCLzzBqIe5UKFJRGi4Jz/6ukF6Tl2li6vrU0qt0CBPOx5nX1jrA=="
       },
       "Speckle.Newtonsoft.Json": {
         "type": "Transitive",
@@ -249,7 +249,7 @@
         "type": "Project",
         "dependencies": {
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.88, )"
+          "Speckle.Objects": "[3.1.0-dev.89, )"
         }
       },
       "speckle.converters.common.dependencyinjection": {
@@ -293,9 +293,9 @@
       },
       "Speckle.Core": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.88, )",
-        "resolved": "3.1.0-dev.88",
-        "contentHash": "1yBzO/JEG9aEGeXwpx1vMZgknmma0QI1cVQ+uwoHc7oyYcAk1bePCa/C6ntyszzV+Y3fpeBZY4HGNALYICgVjg==",
+        "requested": "[3.1.0-dev.89, )",
+        "resolved": "3.1.0-dev.89",
+        "contentHash": "p3KMI7g2D6+nRAFtSQ3zDB6sB7329qyOvn+WCvy1n7YK35atM4ssR9WL4SVgKss/IQifxgDZVVldE3/o31TRTQ==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -304,18 +304,18 @@
           "Polly.Contrib.WaitAndRetry": "1.1.1",
           "Polly.Extensions.Http": "3.0.0",
           "Speckle.DoubleNumerics": "4.0.1",
-          "Speckle.Logging": "3.1.0-dev.88",
+          "Speckle.Logging": "3.1.0-dev.89",
           "Speckle.Newtonsoft.Json": "13.0.2",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.88, )",
-        "resolved": "3.1.0-dev.88",
-        "contentHash": "hzqeIYzvSa3VusEWic8FaVsaEMwHcwnbj2p0JDz2ZTAlf3SpFdxVtA4onIq0l7YyROBIFFn78eIIpm1cCucUIw==",
+        "requested": "[3.1.0-dev.89, )",
+        "resolved": "3.1.0-dev.89",
+        "contentHash": "DA035BwkIG5sdg2Z6SEsi9jo5zuP6UxBFzBW8QtY5hf54be34lzxl/9p3HGkpALUyBMrgaAZvZZnS/INEQRpGw==",
         "dependencies": {
-          "Speckle.Core": "3.1.0-dev.88"
+          "Speckle.Core": "3.1.0-dev.89"
         }
       }
     }

--- a/Converters/Rhino/Speckle.Converters.Rhino8/packages.lock.json
+++ b/Converters/Rhino/Speckle.Converters.Rhino8/packages.lock.json
@@ -127,8 +127,8 @@
       },
       "Speckle.Logging": {
         "type": "Transitive",
-        "resolved": "3.1.0-dev.88",
-        "contentHash": "kD8Xuqbv5lmNQGuv+gx+OnzFt51twc2aIWHEmaG+HBwojR4PZ9IqsaCcMSu4wv/Q1p+Xq5MZldVDkO368JSJRw=="
+        "resolved": "3.1.0-dev.89",
+        "contentHash": "sRiVATMGe8N0LwFRlqxBpRwmI7ZXVKGobSUUCLzzBqIe5UKFJRGi4Jz/6ukF6Tl2li6vrU0qt0CBPOx5nX1jrA=="
       },
       "Speckle.Newtonsoft.Json": {
         "type": "Transitive",
@@ -255,7 +255,7 @@
         "type": "Project",
         "dependencies": {
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.88, )"
+          "Speckle.Objects": "[3.1.0-dev.89, )"
         }
       },
       "Autofac": {
@@ -279,9 +279,9 @@
       },
       "Speckle.Core": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.88, )",
-        "resolved": "3.1.0-dev.88",
-        "contentHash": "1yBzO/JEG9aEGeXwpx1vMZgknmma0QI1cVQ+uwoHc7oyYcAk1bePCa/C6ntyszzV+Y3fpeBZY4HGNALYICgVjg==",
+        "requested": "[3.1.0-dev.89, )",
+        "resolved": "3.1.0-dev.89",
+        "contentHash": "p3KMI7g2D6+nRAFtSQ3zDB6sB7329qyOvn+WCvy1n7YK35atM4ssR9WL4SVgKss/IQifxgDZVVldE3/o31TRTQ==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -290,18 +290,18 @@
           "Polly.Contrib.WaitAndRetry": "1.1.1",
           "Polly.Extensions.Http": "3.0.0",
           "Speckle.DoubleNumerics": "4.0.1",
-          "Speckle.Logging": "3.1.0-dev.88",
+          "Speckle.Logging": "3.1.0-dev.89",
           "Speckle.Newtonsoft.Json": "13.0.2",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.88, )",
-        "resolved": "3.1.0-dev.88",
-        "contentHash": "hzqeIYzvSa3VusEWic8FaVsaEMwHcwnbj2p0JDz2ZTAlf3SpFdxVtA4onIq0l7YyROBIFFn78eIIpm1cCucUIw==",
+        "requested": "[3.1.0-dev.89, )",
+        "resolved": "3.1.0-dev.89",
+        "contentHash": "DA035BwkIG5sdg2Z6SEsi9jo5zuP6UxBFzBW8QtY5hf54be34lzxl/9p3HGkpALUyBMrgaAZvZZnS/INEQRpGw==",
         "dependencies": {
-          "Speckle.Core": "3.1.0-dev.88"
+          "Speckle.Core": "3.1.0-dev.89"
         }
       }
     }

--- a/DUI3/Speckle.Connectors.DUI.Tests/packages.lock.json
+++ b/DUI3/Speckle.Connectors.DUI.Tests/packages.lock.json
@@ -242,8 +242,8 @@
       },
       "Speckle.Logging": {
         "type": "Transitive",
-        "resolved": "3.1.0-dev.88",
-        "contentHash": "kD8Xuqbv5lmNQGuv+gx+OnzFt51twc2aIWHEmaG+HBwojR4PZ9IqsaCcMSu4wv/Q1p+Xq5MZldVDkO368JSJRw=="
+        "resolved": "3.1.0-dev.89",
+        "contentHash": "sRiVATMGe8N0LwFRlqxBpRwmI7ZXVKGobSUUCLzzBqIe5UKFJRGi4Jz/6ukF6Tl2li6vrU0qt0CBPOx5nX1jrA=="
       },
       "Speckle.Newtonsoft.Json": {
         "type": "Transitive",
@@ -331,7 +331,7 @@
           "Microsoft.Extensions.Logging.Abstractions": "[7.0.0, )",
           "Speckle.Autofac": "[1.0.0, )",
           "Speckle.Connectors.Utils": "[1.0.0, )",
-          "Speckle.Core": "[3.1.0-dev.88, )",
+          "Speckle.Core": "[3.1.0-dev.89, )",
           "System.Threading.Tasks.Dataflow": "[6.0.0, )"
         }
       },
@@ -340,7 +340,7 @@
         "dependencies": {
           "Serilog.Extensions.Logging": "[7.0.0, )",
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Core": "[3.1.0-dev.88, )"
+          "Speckle.Core": "[3.1.0-dev.89, )"
         }
       },
       "speckle.testing": {
@@ -374,9 +374,9 @@
       },
       "Speckle.Core": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.88, )",
-        "resolved": "3.1.0-dev.88",
-        "contentHash": "1yBzO/JEG9aEGeXwpx1vMZgknmma0QI1cVQ+uwoHc7oyYcAk1bePCa/C6ntyszzV+Y3fpeBZY4HGNALYICgVjg==",
+        "requested": "[3.1.0-dev.89, )",
+        "resolved": "3.1.0-dev.89",
+        "contentHash": "p3KMI7g2D6+nRAFtSQ3zDB6sB7329qyOvn+WCvy1n7YK35atM4ssR9WL4SVgKss/IQifxgDZVVldE3/o31TRTQ==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -385,7 +385,7 @@
           "Polly.Contrib.WaitAndRetry": "1.1.1",
           "Polly.Extensions.Http": "3.0.0",
           "Speckle.DoubleNumerics": "4.0.1",
-          "Speckle.Logging": "3.1.0-dev.88",
+          "Speckle.Logging": "3.1.0-dev.89",
           "Speckle.Newtonsoft.Json": "13.0.2",
           "System.Text.Json": "5.0.2"
         }

--- a/DUI3/Speckle.Connectors.DUI.WebView/packages.lock.json
+++ b/DUI3/Speckle.Connectors.DUI.WebView/packages.lock.json
@@ -183,8 +183,8 @@
       },
       "Speckle.Logging": {
         "type": "Transitive",
-        "resolved": "3.1.0-dev.88",
-        "contentHash": "kD8Xuqbv5lmNQGuv+gx+OnzFt51twc2aIWHEmaG+HBwojR4PZ9IqsaCcMSu4wv/Q1p+Xq5MZldVDkO368JSJRw=="
+        "resolved": "3.1.0-dev.89",
+        "contentHash": "sRiVATMGe8N0LwFRlqxBpRwmI7ZXVKGobSUUCLzzBqIe5UKFJRGi4Jz/6ukF6Tl2li6vrU0qt0CBPOx5nX1jrA=="
       },
       "Speckle.Newtonsoft.Json": {
         "type": "Transitive",
@@ -322,7 +322,7 @@
           "Microsoft.Extensions.Logging.Abstractions": "[7.0.0, )",
           "Speckle.Autofac": "[1.0.0, )",
           "Speckle.Connectors.Utils": "[1.0.0, )",
-          "Speckle.Core": "[3.1.0-dev.88, )",
+          "Speckle.Core": "[3.1.0-dev.89, )",
           "System.Threading.Tasks.Dataflow": "[6.0.0, )"
         }
       },
@@ -331,7 +331,7 @@
         "dependencies": {
           "Serilog.Extensions.Logging": "[7.0.0, )",
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Core": "[3.1.0-dev.88, )"
+          "Speckle.Core": "[3.1.0-dev.89, )"
         }
       },
       "Autofac": {
@@ -365,9 +365,9 @@
       },
       "Speckle.Core": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.88, )",
-        "resolved": "3.1.0-dev.88",
-        "contentHash": "1yBzO/JEG9aEGeXwpx1vMZgknmma0QI1cVQ+uwoHc7oyYcAk1bePCa/C6ntyszzV+Y3fpeBZY4HGNALYICgVjg==",
+        "requested": "[3.1.0-dev.89, )",
+        "resolved": "3.1.0-dev.89",
+        "contentHash": "p3KMI7g2D6+nRAFtSQ3zDB6sB7329qyOvn+WCvy1n7YK35atM4ssR9WL4SVgKss/IQifxgDZVVldE3/o31TRTQ==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -376,7 +376,7 @@
           "Polly.Contrib.WaitAndRetry": "1.1.1",
           "Polly.Extensions.Http": "3.0.0",
           "Speckle.DoubleNumerics": "4.0.1",
-          "Speckle.Logging": "3.1.0-dev.88",
+          "Speckle.Logging": "3.1.0-dev.89",
           "Speckle.Newtonsoft.Json": "13.0.2",
           "System.Text.Json": "5.0.2"
         }
@@ -551,8 +551,8 @@
       },
       "Speckle.Logging": {
         "type": "Transitive",
-        "resolved": "3.1.0-dev.88",
-        "contentHash": "kD8Xuqbv5lmNQGuv+gx+OnzFt51twc2aIWHEmaG+HBwojR4PZ9IqsaCcMSu4wv/Q1p+Xq5MZldVDkO368JSJRw=="
+        "resolved": "3.1.0-dev.89",
+        "contentHash": "sRiVATMGe8N0LwFRlqxBpRwmI7ZXVKGobSUUCLzzBqIe5UKFJRGi4Jz/6ukF6Tl2li6vrU0qt0CBPOx5nX1jrA=="
       },
       "Speckle.Newtonsoft.Json": {
         "type": "Transitive",
@@ -622,7 +622,7 @@
           "Microsoft.Extensions.Logging.Abstractions": "[7.0.0, )",
           "Speckle.Autofac": "[1.0.0, )",
           "Speckle.Connectors.Utils": "[1.0.0, )",
-          "Speckle.Core": "[3.1.0-dev.88, )",
+          "Speckle.Core": "[3.1.0-dev.89, )",
           "System.Threading.Tasks.Dataflow": "[6.0.0, )"
         }
       },
@@ -631,7 +631,7 @@
         "dependencies": {
           "Serilog.Extensions.Logging": "[7.0.0, )",
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Core": "[3.1.0-dev.88, )"
+          "Speckle.Core": "[3.1.0-dev.89, )"
         }
       },
       "Autofac": {
@@ -658,9 +658,9 @@
       },
       "Speckle.Core": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.88, )",
-        "resolved": "3.1.0-dev.88",
-        "contentHash": "1yBzO/JEG9aEGeXwpx1vMZgknmma0QI1cVQ+uwoHc7oyYcAk1bePCa/C6ntyszzV+Y3fpeBZY4HGNALYICgVjg==",
+        "requested": "[3.1.0-dev.89, )",
+        "resolved": "3.1.0-dev.89",
+        "contentHash": "p3KMI7g2D6+nRAFtSQ3zDB6sB7329qyOvn+WCvy1n7YK35atM4ssR9WL4SVgKss/IQifxgDZVVldE3/o31TRTQ==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -669,7 +669,7 @@
           "Polly.Contrib.WaitAndRetry": "1.1.1",
           "Polly.Extensions.Http": "3.0.0",
           "Speckle.DoubleNumerics": "4.0.1",
-          "Speckle.Logging": "3.1.0-dev.88",
+          "Speckle.Logging": "3.1.0-dev.89",
           "Speckle.Newtonsoft.Json": "13.0.2",
           "System.Text.Json": "5.0.2"
         }

--- a/DUI3/Speckle.Connectors.DUI/packages.lock.json
+++ b/DUI3/Speckle.Connectors.DUI/packages.lock.json
@@ -39,9 +39,9 @@
       },
       "Speckle.Core": {
         "type": "Direct",
-        "requested": "[3.1.0-dev.88, )",
-        "resolved": "3.1.0-dev.88",
-        "contentHash": "1yBzO/JEG9aEGeXwpx1vMZgknmma0QI1cVQ+uwoHc7oyYcAk1bePCa/C6ntyszzV+Y3fpeBZY4HGNALYICgVjg==",
+        "requested": "[3.1.0-dev.89, )",
+        "resolved": "3.1.0-dev.89",
+        "contentHash": "p3KMI7g2D6+nRAFtSQ3zDB6sB7329qyOvn+WCvy1n7YK35atM4ssR9WL4SVgKss/IQifxgDZVVldE3/o31TRTQ==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -50,7 +50,7 @@
           "Polly.Contrib.WaitAndRetry": "1.1.1",
           "Polly.Extensions.Http": "3.0.0",
           "Speckle.DoubleNumerics": "4.0.1",
-          "Speckle.Logging": "3.1.0-dev.88",
+          "Speckle.Logging": "3.1.0-dev.89",
           "Speckle.Newtonsoft.Json": "13.0.2",
           "System.Text.Json": "5.0.2"
         }
@@ -229,8 +229,8 @@
       },
       "Speckle.Logging": {
         "type": "Transitive",
-        "resolved": "3.1.0-dev.88",
-        "contentHash": "kD8Xuqbv5lmNQGuv+gx+OnzFt51twc2aIWHEmaG+HBwojR4PZ9IqsaCcMSu4wv/Q1p+Xq5MZldVDkO368JSJRw=="
+        "resolved": "3.1.0-dev.89",
+        "contentHash": "sRiVATMGe8N0LwFRlqxBpRwmI7ZXVKGobSUUCLzzBqIe5UKFJRGi4Jz/6ukF6Tl2li6vrU0qt0CBPOx5nX1jrA=="
       },
       "Speckle.Newtonsoft.Json": {
         "type": "Transitive",
@@ -375,7 +375,7 @@
         "dependencies": {
           "Serilog.Extensions.Logging": "[7.0.0, )",
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Core": "[3.1.0-dev.88, )"
+          "Speckle.Core": "[3.1.0-dev.89, )"
         }
       },
       "Autofac": {

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -18,8 +18,8 @@
     <PackageVersion Include="RhinoCommon" Version="8.9.24194.18121" />
     <PackageVersion Include="RhinoWindows" Version="8.9.24194.18121" />
     <PackageVersion Include="Serilog.Extensions.Logging" Version="7.0.0" />
-    <PackageVersion Include="Speckle.Core" Version="3.1.0-dev.88" />
-    <PackageVersion Include="Speckle.Objects" Version="3.1.0-dev.88" />
+    <PackageVersion Include="Speckle.Core" Version="3.1.0-dev.89" />
+    <PackageVersion Include="Speckle.Objects" Version="3.1.0-dev.89" />
     <PackageVersion Include="Speckle.AutoCAD.API" Version="2023.0.0" />
     <PackageVersion Include="Speckle.Civil3D.API" Version="2024.0.0" />
     <PackageVersion Include="Speckle.Revit.API" Version="2023.0.0" />

--- a/Sdk/Speckle.Connectors.Utils/packages.lock.json
+++ b/Sdk/Speckle.Connectors.Utils/packages.lock.json
@@ -48,9 +48,9 @@
       },
       "Speckle.Core": {
         "type": "Direct",
-        "requested": "[3.1.0-dev.88, )",
-        "resolved": "3.1.0-dev.88",
-        "contentHash": "1yBzO/JEG9aEGeXwpx1vMZgknmma0QI1cVQ+uwoHc7oyYcAk1bePCa/C6ntyszzV+Y3fpeBZY4HGNALYICgVjg==",
+        "requested": "[3.1.0-dev.89, )",
+        "resolved": "3.1.0-dev.89",
+        "contentHash": "p3KMI7g2D6+nRAFtSQ3zDB6sB7329qyOvn+WCvy1n7YK35atM4ssR9WL4SVgKss/IQifxgDZVVldE3/o31TRTQ==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -59,7 +59,7 @@
           "Polly.Contrib.WaitAndRetry": "1.1.1",
           "Polly.Extensions.Http": "3.0.0",
           "Speckle.DoubleNumerics": "4.0.1",
-          "Speckle.Logging": "3.1.0-dev.88",
+          "Speckle.Logging": "3.1.0-dev.89",
           "Speckle.Newtonsoft.Json": "13.0.2",
           "System.Text.Json": "5.0.2"
         }
@@ -232,8 +232,8 @@
       },
       "Speckle.Logging": {
         "type": "Transitive",
-        "resolved": "3.1.0-dev.88",
-        "contentHash": "kD8Xuqbv5lmNQGuv+gx+OnzFt51twc2aIWHEmaG+HBwojR4PZ9IqsaCcMSu4wv/Q1p+Xq5MZldVDkO368JSJRw=="
+        "resolved": "3.1.0-dev.89",
+        "contentHash": "sRiVATMGe8N0LwFRlqxBpRwmI7ZXVKGobSUUCLzzBqIe5UKFJRGi4Jz/6ukF6Tl2li6vrU0qt0CBPOx5nX1jrA=="
       },
       "Speckle.Newtonsoft.Json": {
         "type": "Transitive",

--- a/Sdk/Speckle.Converters.Common.DependencyInjection/packages.lock.json
+++ b/Sdk/Speckle.Converters.Common.DependencyInjection/packages.lock.json
@@ -148,8 +148,8 @@
       },
       "Speckle.Logging": {
         "type": "Transitive",
-        "resolved": "3.1.0-dev.88",
-        "contentHash": "kD8Xuqbv5lmNQGuv+gx+OnzFt51twc2aIWHEmaG+HBwojR4PZ9IqsaCcMSu4wv/Q1p+Xq5MZldVDkO368JSJRw=="
+        "resolved": "3.1.0-dev.89",
+        "contentHash": "sRiVATMGe8N0LwFRlqxBpRwmI7ZXVKGobSUUCLzzBqIe5UKFJRGi4Jz/6ukF6Tl2li6vrU0qt0CBPOx5nX1jrA=="
       },
       "Speckle.Newtonsoft.Json": {
         "type": "Transitive",
@@ -279,7 +279,7 @@
         "type": "Project",
         "dependencies": {
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.88, )"
+          "Speckle.Objects": "[3.1.0-dev.89, )"
         }
       },
       "Microsoft.Extensions.Logging.Abstractions": {
@@ -294,9 +294,9 @@
       },
       "Speckle.Core": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.88, )",
-        "resolved": "3.1.0-dev.88",
-        "contentHash": "1yBzO/JEG9aEGeXwpx1vMZgknmma0QI1cVQ+uwoHc7oyYcAk1bePCa/C6ntyszzV+Y3fpeBZY4HGNALYICgVjg==",
+        "requested": "[3.1.0-dev.89, )",
+        "resolved": "3.1.0-dev.89",
+        "contentHash": "p3KMI7g2D6+nRAFtSQ3zDB6sB7329qyOvn+WCvy1n7YK35atM4ssR9WL4SVgKss/IQifxgDZVVldE3/o31TRTQ==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -305,18 +305,18 @@
           "Polly.Contrib.WaitAndRetry": "1.1.1",
           "Polly.Extensions.Http": "3.0.0",
           "Speckle.DoubleNumerics": "4.0.1",
-          "Speckle.Logging": "3.1.0-dev.88",
+          "Speckle.Logging": "3.1.0-dev.89",
           "Speckle.Newtonsoft.Json": "13.0.2",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.88, )",
-        "resolved": "3.1.0-dev.88",
-        "contentHash": "hzqeIYzvSa3VusEWic8FaVsaEMwHcwnbj2p0JDz2ZTAlf3SpFdxVtA4onIq0l7YyROBIFFn78eIIpm1cCucUIw==",
+        "requested": "[3.1.0-dev.89, )",
+        "resolved": "3.1.0-dev.89",
+        "contentHash": "DA035BwkIG5sdg2Z6SEsi9jo5zuP6UxBFzBW8QtY5hf54be34lzxl/9p3HGkpALUyBMrgaAZvZZnS/INEQRpGw==",
         "dependencies": {
-          "Speckle.Core": "3.1.0-dev.88"
+          "Speckle.Core": "3.1.0-dev.89"
         }
       }
     }

--- a/Sdk/Speckle.Converters.Common/packages.lock.json
+++ b/Sdk/Speckle.Converters.Common/packages.lock.json
@@ -35,11 +35,11 @@
       },
       "Speckle.Objects": {
         "type": "Direct",
-        "requested": "[3.1.0-dev.88, )",
-        "resolved": "3.1.0-dev.88",
-        "contentHash": "hzqeIYzvSa3VusEWic8FaVsaEMwHcwnbj2p0JDz2ZTAlf3SpFdxVtA4onIq0l7YyROBIFFn78eIIpm1cCucUIw==",
+        "requested": "[3.1.0-dev.89, )",
+        "resolved": "3.1.0-dev.89",
+        "contentHash": "DA035BwkIG5sdg2Z6SEsi9jo5zuP6UxBFzBW8QtY5hf54be34lzxl/9p3HGkpALUyBMrgaAZvZZnS/INEQRpGw==",
         "dependencies": {
-          "Speckle.Core": "3.1.0-dev.88"
+          "Speckle.Core": "3.1.0-dev.89"
         }
       },
       "GraphQL.Client": {
@@ -148,8 +148,8 @@
       },
       "Speckle.Logging": {
         "type": "Transitive",
-        "resolved": "3.1.0-dev.88",
-        "contentHash": "kD8Xuqbv5lmNQGuv+gx+OnzFt51twc2aIWHEmaG+HBwojR4PZ9IqsaCcMSu4wv/Q1p+Xq5MZldVDkO368JSJRw=="
+        "resolved": "3.1.0-dev.89",
+        "contentHash": "sRiVATMGe8N0LwFRlqxBpRwmI7ZXVKGobSUUCLzzBqIe5UKFJRGi4Jz/6ukF6Tl2li6vrU0qt0CBPOx5nX1jrA=="
       },
       "Speckle.Newtonsoft.Json": {
         "type": "Transitive",
@@ -296,9 +296,9 @@
       },
       "Speckle.Core": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.88, )",
-        "resolved": "3.1.0-dev.88",
-        "contentHash": "1yBzO/JEG9aEGeXwpx1vMZgknmma0QI1cVQ+uwoHc7oyYcAk1bePCa/C6ntyszzV+Y3fpeBZY4HGNALYICgVjg==",
+        "requested": "[3.1.0-dev.89, )",
+        "resolved": "3.1.0-dev.89",
+        "contentHash": "p3KMI7g2D6+nRAFtSQ3zDB6sB7329qyOvn+WCvy1n7YK35atM4ssR9WL4SVgKss/IQifxgDZVVldE3/o31TRTQ==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -307,7 +307,7 @@
           "Polly.Contrib.WaitAndRetry": "1.1.1",
           "Polly.Extensions.Http": "3.0.0",
           "Speckle.DoubleNumerics": "4.0.1",
-          "Speckle.Logging": "3.1.0-dev.88",
+          "Speckle.Logging": "3.1.0-dev.89",
           "Speckle.Newtonsoft.Json": "13.0.2",
           "System.Text.Json": "5.0.2"
         }


### PR DESCRIPTION
Adds color proxies on send and receive to objects and layer in rhino and autocad.
Key changes:
- `ColorProxy` now replaces the functionality of the Layer.color property
- `ColorManager` introduced in autocad and rhino
- improvements on color conversions in autocad<>autocad: `ColorMethod.ByAci` is now preserved compared to DUI2
- color inheritance (by object/by layer) should be almost perfect between autocad/rhino: just missing "color by material" option

Tested autocad<> autocad, rhino<>rhino, autocad<>rhino.