### PR TITLE
Feat(dui3) Debouncing progress updates

### DIFF
--- a/Connectors/ArcGIS/Speckle.Connectors.ArcGIS3/Bindings/ArcGISReceiveBinding.cs
+++ b/Connectors/ArcGIS/Speckle.Connectors.ArcGIS3/Bindings/ArcGISReceiveBinding.cs
@@ -15,8 +15,9 @@ public sealed class ArcGISReceiveBinding : IReceiveBinding
   private readonly CancellationManager _cancellationManager;
   private readonly DocumentModelStore _store;
   private readonly IUnitOfWorkFactory _unitOfWorkFactory;
+  private OperationProgressManager OperationProgressManager { get; }
 
-  public ReceiveBindingUICommands Commands { get; }
+  private ReceiveBindingUICommands Commands { get; }
   public IBridge Parent { get; }
 
   public ArcGISReceiveBinding(
@@ -30,6 +31,7 @@ public sealed class ArcGISReceiveBinding : IReceiveBinding
     _cancellationManager = cancellationManager;
     Parent = parent;
     Commands = new ReceiveBindingUICommands(parent);
+    OperationProgressManager = new OperationProgressManager(parent);
     _unitOfWorkFactory = unitOfWorkFactory;
   }
 
@@ -55,7 +57,11 @@ public sealed class ArcGISReceiveBinding : IReceiveBinding
           modelCard.GetReceiveInfo("ArcGIS"), // POC: get host app name from settings? same for GetSendInfo
           cts.Token,
           (status, progress) =>
-            Commands.SetModelProgress(modelCardId, new ModelCardProgress(modelCardId, status, progress), cts)
+            OperationProgressManager.SetModelProgress(
+              modelCardId,
+              new ModelCardProgress(modelCardId, status, progress),
+              cts
+            )
         )
         .ConfigureAwait(false);
 

--- a/Connectors/ArcGIS/Speckle.Connectors.ArcGIS3/Bindings/ArcGISReceiveBinding.cs
+++ b/Connectors/ArcGIS/Speckle.Connectors.ArcGIS3/Bindings/ArcGISReceiveBinding.cs
@@ -15,7 +15,7 @@ public sealed class ArcGISReceiveBinding : IReceiveBinding
   private readonly CancellationManager _cancellationManager;
   private readonly DocumentModelStore _store;
   private readonly IUnitOfWorkFactory _unitOfWorkFactory;
-  private OperationProgressManager OperationProgressManager { get; }
+  private readonly IOperationProgressManager _operationProgressManager;
 
   private ReceiveBindingUICommands Commands { get; }
   public IBridge Parent { get; }
@@ -24,15 +24,16 @@ public sealed class ArcGISReceiveBinding : IReceiveBinding
     DocumentModelStore store,
     IBridge parent,
     CancellationManager cancellationManager,
-    IUnitOfWorkFactory unitOfWorkFactory
+    IUnitOfWorkFactory unitOfWorkFactory,
+    IOperationProgressManager operationProgressManager
   )
   {
     _store = store;
     _cancellationManager = cancellationManager;
     Parent = parent;
     Commands = new ReceiveBindingUICommands(parent);
-    OperationProgressManager = new OperationProgressManager(parent);
     _unitOfWorkFactory = unitOfWorkFactory;
+    _operationProgressManager = operationProgressManager;
   }
 
   public async Task Receive(string modelCardId)
@@ -57,7 +58,8 @@ public sealed class ArcGISReceiveBinding : IReceiveBinding
           modelCard.GetReceiveInfo("ArcGIS"), // POC: get host app name from settings? same for GetSendInfo
           cts.Token,
           (status, progress) =>
-            OperationProgressManager.SetModelProgress(
+            _operationProgressManager.SetModelProgress(
+              Parent,
               modelCardId,
               new ModelCardProgress(modelCardId, status, progress),
               cts

--- a/Connectors/ArcGIS/Speckle.Connectors.ArcGIS3/Bindings/ArcGISSendBinding.cs
+++ b/Connectors/ArcGIS/Speckle.Connectors.ArcGIS3/Bindings/ArcGISSendBinding.cs
@@ -25,6 +25,7 @@ public sealed class ArcGISSendBinding : ISendBinding
 {
   public string Name => "sendBinding";
   public SendBindingUICommands Commands { get; }
+  private OperationProgressManager OperationProgressManager { get; }
   public IBridge Parent { get; }
 
   private readonly DocumentModelStore _store;
@@ -58,6 +59,7 @@ public sealed class ArcGISSendBinding : ISendBinding
     _topLevelExceptionHandler = parent.TopLevelExceptionHandler;
     Parent = parent;
     Commands = new SendBindingUICommands(parent);
+    OperationProgressManager = new OperationProgressManager(parent);
     SubscribeToArcGISEvents();
   }
 
@@ -382,7 +384,11 @@ public sealed class ArcGISSendBinding : ISendBinding
               mapMembers,
               modelCard.GetSendInfo("ArcGIS"), // POC: get host app name from settings? same for GetReceiveInfo
               (status, progress) =>
-                Commands.SetModelProgress(modelCardId, new ModelCardProgress(modelCardId, status, progress), cts),
+                OperationProgressManager.SetModelProgress(
+                  modelCardId,
+                  new ModelCardProgress(modelCardId, status, progress),
+                  cts
+                ),
               cts.Token
             )
             .ConfigureAwait(false);

--- a/Connectors/ArcGIS/Speckle.Connectors.ArcGIS3/DependencyInjection/ArcGISConnectorModule.cs
+++ b/Connectors/ArcGIS/Speckle.Connectors.ArcGIS3/DependencyInjection/ArcGISConnectorModule.cs
@@ -72,5 +72,8 @@ public class ArcGISConnectorModule : ISpeckleModule
 
     // register send conversion cache
     builder.AddSingleton<ISendConversionCache, SendConversionCache>();
+
+    // operation progress manager
+    builder.AddSingleton<IOperationProgressManager, OperationProgressManager>();
   }
 }

--- a/Connectors/Autocad/Speckle.Connectors.AutocadShared/Bindings/AutocadReceiveBinding.cs
+++ b/Connectors/Autocad/Speckle.Connectors.AutocadShared/Bindings/AutocadReceiveBinding.cs
@@ -19,25 +19,26 @@ public sealed class AutocadReceiveBinding : IReceiveBinding
   private readonly CancellationManager _cancellationManager;
   private readonly IUnitOfWorkFactory _unitOfWorkFactory;
   private readonly AutocadSettings _autocadSettings;
+  private readonly IOperationProgressManager _operationProgressManager;
 
   private ReceiveBindingUICommands Commands { get; }
-  private OperationProgressManager OperationProgressManager { get; }
 
   public AutocadReceiveBinding(
     DocumentModelStore store,
     IBridge parent,
     CancellationManager cancellationManager,
     IUnitOfWorkFactory unitOfWorkFactory,
-    AutocadSettings autocadSettings
+    AutocadSettings autocadSettings,
+    IOperationProgressManager operationProgressManager
   )
   {
     _store = store;
     _cancellationManager = cancellationManager;
     _unitOfWorkFactory = unitOfWorkFactory;
     _autocadSettings = autocadSettings;
+    _operationProgressManager = operationProgressManager;
     Parent = parent;
     Commands = new ReceiveBindingUICommands(parent);
-    OperationProgressManager = new OperationProgressManager(parent);
   }
 
   public void CancelReceive(string modelCardId) => _cancellationManager.CancelOperation(modelCardId);
@@ -68,7 +69,8 @@ public sealed class AutocadReceiveBinding : IReceiveBinding
           modelCard.GetReceiveInfo(_autocadSettings.HostAppInfo.Name),
           cts.Token,
           (status, progress) =>
-            OperationProgressManager.SetModelProgress(
+            _operationProgressManager.SetModelProgress(
+              Parent,
               modelCardId,
               new ModelCardProgress(modelCardId, status, progress),
               cts

--- a/Connectors/Autocad/Speckle.Connectors.AutocadShared/Bindings/AutocadReceiveBinding.cs
+++ b/Connectors/Autocad/Speckle.Connectors.AutocadShared/Bindings/AutocadReceiveBinding.cs
@@ -20,7 +20,8 @@ public sealed class AutocadReceiveBinding : IReceiveBinding
   private readonly IUnitOfWorkFactory _unitOfWorkFactory;
   private readonly AutocadSettings _autocadSettings;
 
-  public ReceiveBindingUICommands Commands { get; }
+  private ReceiveBindingUICommands Commands { get; }
+  private OperationProgressManager OperationProgressManager { get; }
 
   public AutocadReceiveBinding(
     DocumentModelStore store,
@@ -36,6 +37,7 @@ public sealed class AutocadReceiveBinding : IReceiveBinding
     _autocadSettings = autocadSettings;
     Parent = parent;
     Commands = new ReceiveBindingUICommands(parent);
+    OperationProgressManager = new OperationProgressManager(parent);
   }
 
   public void CancelReceive(string modelCardId) => _cancellationManager.CancelOperation(modelCardId);
@@ -66,7 +68,11 @@ public sealed class AutocadReceiveBinding : IReceiveBinding
           modelCard.GetReceiveInfo(_autocadSettings.HostAppInfo.Name),
           cts.Token,
           (status, progress) =>
-            Commands.SetModelProgress(modelCardId, new ModelCardProgress(modelCardId, status, progress), cts)
+            OperationProgressManager.SetModelProgress(
+              modelCardId,
+              new ModelCardProgress(modelCardId, status, progress),
+              cts
+            )
         )
         .ConfigureAwait(false);
 

--- a/Connectors/Autocad/Speckle.Connectors.AutocadShared/Bindings/AutocadSelectionBinding.cs
+++ b/Connectors/Autocad/Speckle.Connectors.AutocadShared/Bindings/AutocadSelectionBinding.cs
@@ -60,10 +60,10 @@ public class AutocadSelectionBinding : ISelectionBinding
     List<string> objectTypes = new();
     if (doc != null)
     {
+      using var tr = doc.TransactionManager.StartTransaction();
       PromptSelectionResult selection = doc.Editor.SelectImplied();
       if (selection.Status == PromptStatus.OK)
       {
-        using var tr = doc.TransactionManager.StartTransaction();
         foreach (SelectedObject obj in selection.Value)
         {
           var dbObject = tr.GetObject(obj.ObjectId, OpenMode.ForRead);

--- a/Connectors/Autocad/Speckle.Connectors.AutocadShared/Bindings/AutocadSendBinding.cs
+++ b/Connectors/Autocad/Speckle.Connectors.AutocadShared/Bindings/AutocadSendBinding.cs
@@ -21,6 +21,7 @@ public sealed class AutocadSendBinding : ISendBinding
 {
   public string Name => "sendBinding";
   public SendBindingUICommands Commands { get; }
+  public OperationProgressManager OperationProgressManager { get; }
   public IBridge Parent { get; }
 
   private readonly DocumentModelStore _store;
@@ -58,6 +59,7 @@ public sealed class AutocadSendBinding : ISendBinding
     _topLevelExceptionHandler = parent.TopLevelExceptionHandler;
     Parent = parent;
     Commands = new SendBindingUICommands(parent);
+    OperationProgressManager = new OperationProgressManager(parent);
 
     Application.DocumentManager.DocumentActivated += (_, args) =>
       _topLevelExceptionHandler.CatchUnhandled(() => SubscribeToObjectChanges(args.Document));
@@ -161,7 +163,11 @@ public sealed class AutocadSendBinding : ISendBinding
           autocadObjects,
           modelCard.GetSendInfo(_autocadSettings.HostAppInfo.Name),
           (status, progress) =>
-            Commands.SetModelProgress(modelCardId, new ModelCardProgress(modelCardId, status, progress), cts),
+            OperationProgressManager.SetModelProgress(
+              modelCardId,
+              new ModelCardProgress(modelCardId, status, progress),
+              cts
+            ),
           cts.Token
         )
         .ConfigureAwait(false);

--- a/Connectors/Autocad/Speckle.Connectors.AutocadShared/Bindings/AutocadSendBinding.cs
+++ b/Connectors/Autocad/Speckle.Connectors.AutocadShared/Bindings/AutocadSendBinding.cs
@@ -21,7 +21,7 @@ public sealed class AutocadSendBinding : ISendBinding
 {
   public string Name => "sendBinding";
   public SendBindingUICommands Commands { get; }
-  public OperationProgressManager OperationProgressManager { get; }
+  private OperationProgressManager OperationProgressManager { get; }
   public IBridge Parent { get; }
 
   private readonly DocumentModelStore _store;

--- a/Connectors/Autocad/Speckle.Connectors.AutocadShared/DependencyInjection/SharedRegistration.cs
+++ b/Connectors/Autocad/Speckle.Connectors.AutocadShared/DependencyInjection/SharedRegistration.cs
@@ -39,6 +39,9 @@ public static class SharedRegistration
     builder.AddScoped<AutocadLayerManager>();
     builder.AddSingleton<IAutocadIdleManager, AutocadIdleManager>();
 
+    // operation progress manager
+    builder.AddSingleton<IOperationProgressManager, OperationProgressManager>();
+
     // Register bindings
     builder.AddSingleton<IBinding, TestBinding>();
     builder.AddSingleton<IBinding, AccountBinding>();

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Bindings/RevitReceiveBinding.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Bindings/RevitReceiveBinding.cs
@@ -21,7 +21,9 @@ internal sealed class RevitReceiveBinding : IReceiveBinding
   private readonly CancellationManager _cancellationManager;
   private readonly DocumentModelStore _store;
   private readonly IUnitOfWorkFactory _unitOfWorkFactory;
-  public ReceiveBindingUICommands Commands { get; }
+  private ReceiveBindingUICommands Commands { get; }
+
+  private OperationProgressManager OperationProgressManager { get; }
 
   public RevitReceiveBinding(
     DocumentModelStore store,
@@ -37,6 +39,7 @@ internal sealed class RevitReceiveBinding : IReceiveBinding
     _revitSettings = revitSettings;
     _cancellationManager = cancellationManager;
     Commands = new ReceiveBindingUICommands(parent);
+    OperationProgressManager = new OperationProgressManager(parent);
   }
 
   public void CancelReceive(string modelCardId) => _cancellationManager.CancelOperation(modelCardId);
@@ -62,7 +65,11 @@ internal sealed class RevitReceiveBinding : IReceiveBinding
           modelCard.GetReceiveInfo(_revitSettings.HostSlug.NotNull()),
           cts.Token,
           (status, progress) =>
-            Commands.SetModelProgress(modelCardId, new ModelCardProgress(modelCardId, status, progress), cts)
+            OperationProgressManager.SetModelProgress(
+              modelCardId,
+              new ModelCardProgress(modelCardId, status, progress),
+              cts
+            )
         )
         .ConfigureAwait(false);
 

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Bindings/RevitReceiveBinding.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Bindings/RevitReceiveBinding.cs
@@ -18,28 +18,29 @@ internal sealed class RevitReceiveBinding : IReceiveBinding
   public IBridge Parent { get; }
 
   private readonly RevitSettings _revitSettings;
+  private readonly IOperationProgressManager _operationProgressManager;
   private readonly CancellationManager _cancellationManager;
   private readonly DocumentModelStore _store;
   private readonly IUnitOfWorkFactory _unitOfWorkFactory;
   private ReceiveBindingUICommands Commands { get; }
-
-  private OperationProgressManager OperationProgressManager { get; }
 
   public RevitReceiveBinding(
     DocumentModelStore store,
     CancellationManager cancellationManager,
     IBridge parent,
     IUnitOfWorkFactory unitOfWorkFactory,
-    RevitSettings revitSettings
+    RevitSettings revitSettings,
+    IOperationProgressManager operationProgressManager
   )
   {
     Parent = parent;
     _store = store;
     _unitOfWorkFactory = unitOfWorkFactory;
     _revitSettings = revitSettings;
+    _operationProgressManager = operationProgressManager;
     _cancellationManager = cancellationManager;
+
     Commands = new ReceiveBindingUICommands(parent);
-    OperationProgressManager = new OperationProgressManager(parent);
   }
 
   public void CancelReceive(string modelCardId) => _cancellationManager.CancelOperation(modelCardId);
@@ -65,7 +66,8 @@ internal sealed class RevitReceiveBinding : IReceiveBinding
           modelCard.GetReceiveInfo(_revitSettings.HostSlug.NotNull()),
           cts.Token,
           (status, progress) =>
-            OperationProgressManager.SetModelProgress(
+            _operationProgressManager.SetModelProgress(
+              Parent,
               modelCardId,
               new ModelCardProgress(modelCardId, status, progress),
               cts

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Bindings/RevitSendBinding.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Bindings/RevitSendBinding.cs
@@ -30,6 +30,8 @@ internal sealed class RevitSendBinding : RevitBaseBinding, ISendBinding
   private readonly IUnitOfWorkFactory _unitOfWorkFactory;
   private readonly ISendConversionCache _sendConversionCache;
 
+  private OperationProgressManager OperationProgressManager { get; }
+
   public RevitSendBinding(
     IRevitIdleManager idleManager,
     RevitContext revitContext,
@@ -50,6 +52,7 @@ internal sealed class RevitSendBinding : RevitBaseBinding, ISendBinding
     var topLevelExceptionHandler = Parent.TopLevelExceptionHandler;
 
     Commands = new SendBindingUICommands(bridge);
+    OperationProgressManager = new OperationProgressManager(bridge);
     // TODO expiry events
     // TODO filters need refresh events
     _idleManager.RunAsync(() =>
@@ -108,7 +111,11 @@ internal sealed class RevitSendBinding : RevitBaseBinding, ISendBinding
           revitObjects,
           modelCard.GetSendInfo(_revitSettings.HostSlug.NotNull()),
           (status, progress) =>
-            Commands.SetModelProgress(modelCardId, new ModelCardProgress(modelCardId, status, progress), cts),
+            OperationProgressManager.SetModelProgress(
+              modelCardId,
+              new ModelCardProgress(modelCardId, status, progress),
+              cts
+            ),
           cts.Token
         )
         .ConfigureAwait(false);

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/DependencyInjection/RevitConnectorModule.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/DependencyInjection/RevitConnectorModule.cs
@@ -74,6 +74,9 @@ public class RevitConnectorModule : ISpeckleModule
     builder.AddScoped<IHostObjectBuilder, RevitHostObjectBuilder>();
     builder.AddScoped<ITransactionManager, TransactionManager>();
     builder.AddSingleton(DefaultTraversal.CreateTraversalFunc());
+
+    // operation progress manager
+    builder.AddSingleton<IOperationProgressManager, OperationProgressManager>();
   }
 
   public void RegisterUiDependencies(SpeckleContainerBuilder builder)

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/Bindings/RhinoReceiveBinding.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/Bindings/RhinoReceiveBinding.cs
@@ -20,7 +20,9 @@ public class RhinoReceiveBinding : IReceiveBinding
   private readonly DocumentModelStore _store;
   private readonly IUnitOfWorkFactory _unitOfWorkFactory;
   private readonly RhinoSettings _rhinoSettings;
-  public ReceiveBindingUICommands Commands { get; }
+  private ReceiveBindingUICommands Commands { get; }
+
+  private OperationProgressManager OperationProgressManager { get; }
 
   public RhinoReceiveBinding(
     DocumentModelStore store,
@@ -36,6 +38,7 @@ public class RhinoReceiveBinding : IReceiveBinding
     _rhinoSettings = rhinoSettings;
     _cancellationManager = cancellationManager;
     Commands = new ReceiveBindingUICommands(parent);
+    OperationProgressManager = new OperationProgressManager(parent);
   }
 
   public void CancelReceive(string modelCardId) => _cancellationManager.CancelOperation(modelCardId);
@@ -61,7 +64,11 @@ public class RhinoReceiveBinding : IReceiveBinding
           modelCard.GetReceiveInfo(_rhinoSettings.HostAppInfo.Name),
           cts.Token,
           (status, progress) =>
-            Commands.SetModelProgress(modelCardId, new ModelCardProgress(modelCardId, status, progress), cts)
+            OperationProgressManager.SetModelProgress(
+              modelCardId,
+              new ModelCardProgress(modelCardId, status, progress),
+              cts
+            )
         )
         .ConfigureAwait(false);
 

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/Bindings/RhinoReceiveBinding.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/Bindings/RhinoReceiveBinding.cs
@@ -20,25 +20,25 @@ public class RhinoReceiveBinding : IReceiveBinding
   private readonly DocumentModelStore _store;
   private readonly IUnitOfWorkFactory _unitOfWorkFactory;
   private readonly RhinoSettings _rhinoSettings;
+  private readonly IOperationProgressManager _operationProgressManager;
   private ReceiveBindingUICommands Commands { get; }
-
-  private OperationProgressManager OperationProgressManager { get; }
 
   public RhinoReceiveBinding(
     DocumentModelStore store,
     CancellationManager cancellationManager,
     IBridge parent,
     IUnitOfWorkFactory unitOfWorkFactory,
-    RhinoSettings rhinoSettings
+    RhinoSettings rhinoSettings,
+    IOperationProgressManager operationProgressManager
   )
   {
     Parent = parent;
     _store = store;
     _unitOfWorkFactory = unitOfWorkFactory;
     _rhinoSettings = rhinoSettings;
+    _operationProgressManager = operationProgressManager;
     _cancellationManager = cancellationManager;
     Commands = new ReceiveBindingUICommands(parent);
-    OperationProgressManager = new OperationProgressManager(parent);
   }
 
   public void CancelReceive(string modelCardId) => _cancellationManager.CancelOperation(modelCardId);
@@ -64,7 +64,8 @@ public class RhinoReceiveBinding : IReceiveBinding
           modelCard.GetReceiveInfo(_rhinoSettings.HostAppInfo.Name),
           cts.Token,
           (status, progress) =>
-            OperationProgressManager.SetModelProgress(
+            _operationProgressManager.SetModelProgress(
+              Parent,
               modelCardId,
               new ModelCardProgress(modelCardId, status, progress),
               cts

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/Bindings/RhinoSendBinding.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/Bindings/RhinoSendBinding.cs
@@ -37,6 +37,8 @@ public sealed class RhinoSendBinding : ISendBinding
   /// </summary>
   private HashSet<string> ChangedObjectIds { get; set; } = new();
 
+  private OperationProgressManager OperationProgressManager { get; }
+
   public RhinoSendBinding(
     DocumentModelStore store,
     IRhinoIdleManager idleManager,
@@ -58,6 +60,7 @@ public sealed class RhinoSendBinding : ISendBinding
     _topLevelExceptionHandler = parent.TopLevelExceptionHandler.Parent.TopLevelExceptionHandler;
     Parent = parent;
     Commands = new SendBindingUICommands(parent); // POC: Commands are tightly coupled with their bindings, at least for now, saves us injecting a factory.
+    OperationProgressManager = new OperationProgressManager(parent);
     SubscribeToRhinoEvents();
   }
 
@@ -152,7 +155,11 @@ public sealed class RhinoSendBinding : ISendBinding
           rhinoObjects,
           modelCard.GetSendInfo(_rhinoSettings.HostAppInfo.Name),
           (status, progress) =>
-            Commands.SetModelProgress(modelCardId, new ModelCardProgress(modelCardId, status, progress), cts),
+            OperationProgressManager.SetModelProgress(
+              modelCardId,
+              new ModelCardProgress(modelCardId, status, progress),
+              cts
+            ),
           cts.Token
         )
         .ConfigureAwait(false);

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/DependencyInjection/RhinoConnectorModule.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/DependencyInjection/RhinoConnectorModule.cs
@@ -90,5 +90,8 @@ public class RhinoConnectorModule : ISpeckleModule
     builder.AddScoped<RhinoGroupManager>();
     builder.AddScoped<RhinoLayerManager>();
     builder.AddScoped<RhinoMaterialManager>();
+
+    // operation progress manager
+    builder.AddSingleton<IOperationProgressManager, OperationProgressManager>();
   }
 }

--- a/DUI3/Speckle.Connectors.DUI/Bindings/OperationProgressManager.cs
+++ b/DUI3/Speckle.Connectors.DUI/Bindings/OperationProgressManager.cs
@@ -1,0 +1,94 @@
+﻿// using System.Collections.Concurrent;
+// using System.Diagnostics;
+using Speckle.Connectors.DUI.Bridge;
+using Speckle.Connectors.DUI.Models.Card;
+
+namespace Speckle.Connectors.DUI.Bindings;
+
+/// <summary>
+/// Debouncing to progress update for UI.
+/// </summary>
+public class OperationProgressManager
+{
+  private const string SET_MODEL_PROGRESS_UI_COMMAND_NAME = "setModelProgress";
+  private static readonly Dictionary<string, DateTime> s_lastUpdateTimes = new();
+
+  // private static readonly Dictionary<string, Timer> s_timers = new();
+  private const int THROTTLE_INTERVAL_MS = 200;
+
+  private IBridge Bridge { get; }
+
+  public OperationProgressManager(IBridge bridge)
+  {
+    Bridge = bridge;
+  }
+
+  public void SetModelProgress(string modelCardId, ModelCardProgress progress, CancellationTokenSource cts)
+  {
+    if (cts.IsCancellationRequested)
+    {
+      return;
+    }
+
+    var now = DateTime.UtcNow;
+    if (!s_lastUpdateTimes.TryGetValue(modelCardId, out var lastUpdateTime))
+    {
+      lastUpdateTime = DateTime.MinValue;
+    }
+
+    var timeSinceLastUpdate = (now - lastUpdateTime).TotalMilliseconds;
+
+    if (timeSinceLastUpdate >= THROTTLE_INTERVAL_MS)
+    {
+      // Send immediately if interval has passed
+      SendProgress(modelCardId, progress);
+      s_lastUpdateTimes[modelCardId] = now;
+    }
+    else
+    {
+      // // Schedule a send after the remaining interval time
+      // var remainingTime = THROTTLE_INTERVAL_MS - (int)timeSinceLastUpdate;
+      // if (s_timers.TryGetValue(modelCardId, out var existingTimer))
+      // {
+      //   existingTimer.Change(remainingTime, Timeout.Infinite);
+      // }
+      // else
+      // {
+      //   var timer = new Timer(
+      //     _ =>
+      //     {
+      //       FinalizeProgress(modelCardId, progress, cts);
+      //       s_lastUpdateTimes[modelCardId] = DateTime.UtcNow;
+      //       s_timers.TryRemove(modelCardId, out Timer _);
+      //     },
+      //     null,
+      //     (long)remainingTime,
+      //     Timeout.Infinite
+      //   );
+      //
+      //   s_timers[modelCardId] = timer;
+      // }
+    }
+  }
+
+  private void SendProgress(string modelCardId, ModelCardProgress progress)
+  {
+    Bridge.Send(SET_MODEL_PROGRESS_UI_COMMAND_NAME, new { modelCardId, progress });
+  }
+
+  // public void FinalizeProgress(string modelCardId, ModelCardProgress progress, CancellationTokenSource cts)
+  // {
+  //   if (cts.IsCancellationRequested)
+  //   {
+  //     return;
+  //   }
+  //
+  //   // Cancel any existing timer and send the final progress update
+  //   if (s_timers.TryRemove(modelCardId, out var timer))
+  //   {
+  //     timer.Dispose();
+  //   }
+  //
+  //   SendProgress(modelCardId, progress);
+  // }
+}

--- a/DUI3/Speckle.Connectors.DUI/Bindings/OperationProgressManager.cs
+++ b/DUI3/Speckle.Connectors.DUI/Bindings/OperationProgressManager.cs
@@ -13,6 +13,7 @@ public class OperationProgressManager
   private const string SET_MODEL_PROGRESS_UI_COMMAND_NAME = "setModelProgress";
   private static readonly ConcurrentDictionary<string, (DateTime lastCallTime, string status)> s_lastProgressValues =
     new();
+  private const int THROTTLE_INTERVAL_MS = 50;
 
   private IBridge Bridge { get; }
 
@@ -39,7 +40,7 @@ public class OperationProgressManager
 
     var elapsedMs = (DateTime.Now - t.Item1).Milliseconds;
 
-    if (elapsedMs < 50 && t.Item2 == progress.Status) // '50' can be parametrised
+    if (elapsedMs < THROTTLE_INTERVAL_MS && t.Item2 == progress.Status)
     {
       return;
     }


### PR DESCRIPTION
My initial attempt was on Timers, but I had random behaviors on Autocad, then decided to go with percentage difference checks. Since we round decimals on UI, we don't need to send progress updates less than %1. OperationProgressManager handles it with concurrent dictionary. Open to suggestions, I might do more tests before merging it.