### PR TITLE
Feat(dui3): CNX-182 upload download progress updates

### DIFF
--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/Bindings/RhinoSendBinding.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/Bindings/RhinoSendBinding.cs
@@ -188,7 +188,7 @@ public sealed class RhinoSendBinding : ISendBinding
   private void RunExpirationChecks()
   {
     var senders = _store.GetSenders();
-    string[] objectIdsList = ChangedObjectIds.ToArray();
+    string[] objectIdsList = ChangedObjectIds.ToArray(); // NOTE: could not copy to array happens here
     List<string> expiredSenderIds = new();
 
     _sendConversionCache.EvictObjects(objectIdsList);

--- a/Sdk/Speckle.Connectors.Utils/Operations/ReceiveOperation.cs
+++ b/Sdk/Speckle.Connectors.Utils/Operations/ReceiveOperation.cs
@@ -46,10 +46,11 @@ public sealed class ReceiveOperation
         version.referencedObject,
         transport,
         onProgressAction: dict =>
-          onOperationProgressed?.Invoke(
-            $"Downloading - {string.Join(" ", dict.Keys)}",
-            dict.Values.Average() / totalCount
-          ),
+        {
+          // NOTE: this looks weird for the user, as when deserialization kicks in, the progress bar will go down, and then start progressing again.
+          // This is something we're happy to live with until we refactor the whole receive pipeline.
+          onOperationProgressed?.Invoke($"Downloading and deserializing", dict.Values.Average() / totalCount);
+        },
         onTotalChildrenCountKnown: c => totalCount = c,
         cancellationToken: cancellationToken
       )


### PR DESCRIPTION
If the data not in .db, downloading loop twice one for remote transport and one for deserialization, they also overlaps in terms of progress value. Some concurrency happening. We've decided this is good enough for now.