### PR TITLE
Made Conversion Results no longer inherit `Base`

### DIFF
--- a/Sdk/Speckle.Connectors.Utils/Connector.cs
+++ b/Sdk/Speckle.Connectors.Utils/Connector.cs
@@ -1,4 +1,4 @@
-﻿using Speckle.Objects.Structural.GSA.Geometry;
+using Speckle.Objects.Geometry;
 using Speckle.Sdk;
 using Speckle.Sdk.Host;
 using Speckle.Sdk.Logging;
@@ -10,7 +10,7 @@ public static class Connector
 {
   public static IDisposable? Initialize(HostApplication application, HostAppVersion version)
   {
-    TypeLoader.Initialize(typeof(Base).Assembly, typeof(GSAAssembly).Assembly);
+    TypeLoader.Initialize(typeof(Base).Assembly, typeof(Point).Assembly);
     var config = new SpeckleConfiguration(
       application,
       version,

--- a/Sdk/Speckle.Connectors.Utils/Conversion/ReportResult.cs
+++ b/Sdk/Speckle.Connectors.Utils/Conversion/ReportResult.cs
@@ -2,10 +2,12 @@ using Speckle.Sdk.Models;
 
 namespace Speckle.Connectors.Utils.Conversion;
 
-public class Report : Base
-{
-  public required IEnumerable<ConversionResult> ConversionResults { get; set; }
-}
+// Removing this for now, this was to faciliate us sending conversion results inside the commit object
+// We may want this back in future, but need to spark a discussion first
+// public sealed class Report : Base
+// {
+//   public required IEnumerable<ConversionResult> ConversionResults { get; set; }
+// }
 
 public enum Status
 {
@@ -16,7 +18,7 @@ public enum Status
   ERROR = 4
 }
 
-public class SendConversionResult : ConversionResult
+public sealed class SendConversionResult : ConversionResult
 {
   public SendConversionResult(
     Status status,
@@ -67,7 +69,7 @@ public class ReceiveConversionResult : ConversionResult
 /// this one and provided clean constructors for each case.
 /// POC: Inherits from Base so we can attach the conversion report to the root commit object. Can be revisited later (it's not a problem to not inherit from base).
 /// </summary>
-public abstract class ConversionResult : Base
+public abstract class ConversionResult
 {
   public Status Status { get; init; }
 
@@ -105,7 +107,7 @@ public abstract class ConversionResult : Base
 /// <summary>
 /// Wraps around exceptions to make them nicely serializable for the ui.
 /// </summary>
-public class ErrorWrapper : Base
+public sealed class ErrorWrapper : Base
 {
   public required string Message { get; set; }
   public required string StackTrace { get; set; }

--- a/Sdk/Speckle.Connectors.Utils/Operations/SendOperation.cs
+++ b/Sdk/Speckle.Connectors.Utils/Operations/SendOperation.cs
@@ -29,7 +29,7 @@ public sealed class SendOperation<T>
       .ConfigureAwait(false);
 
     // POC: Jonathon asks on behalf of willow twin - let's explore how this can work
-    buildResult.RootObject["@report"] = new Report { ConversionResults = buildResult.ConversionResults };
+    // buildResult.RootObject["@report"] = new Report { ConversionResults = buildResult.ConversionResults };
 
     // base object handler is separated, so we can do some testing on non-production databases
     // exact interface may want to be tweaked when we implement this


### PR DESCRIPTION
Due to the Sdk changes & re-namespacing (see https://www.notion.so/speckle/Re-namespacing-of-3-x-SDK-for-2-x-side-by-side-b70e768915014fc6a19f44db7e46c8ec)
all base subclasses now need an explicit speckle_type attribute.

I didn't want to have to spark up the discussion about "what should the speckle type of conversion results be" since I don't think we have a clear picture of how this feature should work.

After agreeing with @didimitrie, for the September launch we'll not send conversion results in the current way.
We can chat later to decide what we should do, and if needed we can make them `Base` subclasses again.