### PR TITLE
Dim/cnx 23 fixes

### DIFF
--- a/Connectors/Autocad/Speckle.Connectors.AutocadShared/HostApp/AutocadInstanceObjectManager.cs
+++ b/Connectors/Autocad/Speckle.Connectors.AutocadShared/HostApp/AutocadInstanceObjectManager.cs
@@ -229,12 +229,7 @@ public class AutocadInstanceObjectManager : IInstanceUnpacker<AutocadRootObject>
           );
 
           // POC: collectionPath for instances should be an array of size 1, because we are flattening collections on traversal
-          string layerName = _autocadLayerManager.CreateLayerForReceive(
-            collectionPath,
-            baseLayerName,
-            _autocadColorManager.ObjectColorsIdMap,
-            _autocadMaterialManager.ObjectMaterialsIdMap
-          );
+          string layerName = _autocadLayerManager.CreateLayerForReceive(collectionPath, baseLayerName);
 
           // get color and material if any
           string instanceId = instanceProxy.applicationId ?? instanceProxy.id;

--- a/Connectors/Autocad/Speckle.Connectors.AutocadShared/HostApp/AutocadLayerManager.cs
+++ b/Connectors/Autocad/Speckle.Connectors.AutocadShared/HostApp/AutocadLayerManager.cs
@@ -62,12 +62,7 @@ public class AutocadLayerManager
   /// This ensures we're creating the new objects we've just received rather than overlaying them.
   /// </summary>
   /// <returns>The name of the existing or created layer</returns>
-  public string CreateLayerForReceive(
-    Collection[] layerPath,
-    string baseLayerPrefix
-  // Dictionary<string, AutocadColor> objectColorsIdMap,
-  // Dictionary<string, ObjectId> objectMaterialsIdMap
-  )
+  public string CreateLayerForReceive(Collection[] layerPath, string baseLayerPrefix)
   {
     string[] namePath = layerPath.Select(c => c.name).ToArray();
     string layerName = _autocadContext.RemoveInvalidChars(baseLayerPrefix + string.Join("-", namePath));

--- a/Connectors/Autocad/Speckle.Connectors.AutocadShared/Operations/Receive/AutocadHostObjectBuilder.cs
+++ b/Connectors/Autocad/Speckle.Connectors.AutocadShared/Operations/Receive/AutocadHostObjectBuilder.cs
@@ -105,6 +105,7 @@ public class AutocadHostObjectBuilder : IHostObjectBuilder
       List<RenderMaterialProxy>? renderMaterials = (rootObject["renderMaterialProxies"] as List<object>)
         ?.Cast<RenderMaterialProxy>()
         .ToList();
+
       if (renderMaterials != null)
       {
         List<ReceiveConversionResult> materialResults = _materialManager.ParseAndBakeRenderMaterials(

--- a/Connectors/Autocad/Speckle.Connectors.AutocadShared/Operations/Receive/AutocadHostObjectBuilder.cs
+++ b/Connectors/Autocad/Speckle.Connectors.AutocadShared/Operations/Receive/AutocadHostObjectBuilder.cs
@@ -202,17 +202,11 @@ public class AutocadHostObjectBuilder : IHostObjectBuilder
 
   private IEnumerable<Entity> ConvertObject(Base obj, Collection[] layerPath, string baseLayerNamePrefix)
   {
-    string layerName = _autocadLayerManager.CreateLayerForReceive(
-      layerPath,
-      baseLayerNamePrefix,
-      _colorManager.ObjectColorsIdMap,
-      _materialManager.ObjectMaterialsIdMap
-    );
+    string layerName = _autocadLayerManager.CreateLayerForReceive(layerPath, baseLayerNamePrefix);
 
-    object converted;
     using (var tr = Application.DocumentManager.CurrentDocument.Database.TransactionManager.StartTransaction())
     {
-      converted = _converter.Convert(obj);
+      var converted = _converter.Convert(obj);
 
       IEnumerable<Entity?> flattened = Utilities.FlattenToHostConversionResult(converted).Cast<Entity>();
 

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/HostApp/RhinoColorManager.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/HostApp/RhinoColorManager.cs
@@ -65,13 +65,10 @@ public class RhinoColorManager
   /// Parse Color Proxies and stores in ObjectColorsIdMap the relationship between object ids and colors
   /// </summary>
   /// <param name="colorProxies"></param>
-  /// <param name="onOperationProgressed"></param>
-  public void ParseColors(List<ColorProxy> colorProxies, Action<string, double?>? onOperationProgressed)
+  public void ParseColors(List<ColorProxy> colorProxies)
   {
-    var count = 0;
     foreach (ColorProxy colorProxy in colorProxies)
     {
-      onOperationProgressed?.Invoke("Converting colors", (double)++count / colorProxies.Count);
       foreach (string objectId in colorProxy.objects)
       {
         Color convertedColor = Color.FromArgb(colorProxy.value);

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/HostApp/RhinoLayerManager.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/HostApp/RhinoLayerManager.cs
@@ -12,8 +12,16 @@ namespace Speckle.Connectors.Rhino.HostApp;
 /// </summary>
 public class RhinoLayerManager
 {
+  private readonly RhinoMaterialManager _materialManager;
+  private readonly RhinoColorManager _colorManager;
   private readonly Dictionary<string, int> _hostLayerCache = new();
   private readonly Dictionary<int, Collection> _layerCollectionCache = new();
+
+  public RhinoLayerManager(RhinoMaterialManager materialManager, RhinoColorManager colorManager)
+  {
+    _materialManager = materialManager;
+    _colorManager = colorManager;
+  }
 
   /// <summary>
   /// Creates the base layer and adds it to the cache.
@@ -56,6 +64,23 @@ public class RhinoLayerManager
 
       var cleanNewLayerName = collection.name.Replace("{", "").Replace("}", "");
       Layer newLayer = new() { Name = cleanNewLayerName, ParentLayerId = previousLayer.Id };
+
+      // set material
+      if (
+        _materialManager.ObectIdAndMaterialIndexMap.TryGetValue(
+          collection.applicationId ?? collection.id,
+          out int mIndex
+        )
+      )
+      {
+        newLayer.RenderMaterialIndex = mIndex;
+      }
+
+      // set color
+      if (_colorManager.ObjectColorsIdMap.TryGetValue(collection.applicationId ?? collection.id, out Color color))
+      {
+        newLayer.Color = color;
+      }
 
       int index = currentDocument.Layers.Add(newLayer);
       _hostLayerCache.Add(currentLayerName, index);

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/HostApp/RhinoLayerManager.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/HostApp/RhinoLayerManager.cs
@@ -67,7 +67,7 @@ public class RhinoLayerManager
 
       // set material
       if (
-        _materialManager.ObectIdAndMaterialIndexMap.TryGetValue(
+        _materialManager.ObjectIdAndMaterialIndexMap.TryGetValue(
           collection.applicationId ?? collection.id,
           out int mIndex
         )

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/HostApp/RhinoMaterialManager.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/HostApp/RhinoMaterialManager.cs
@@ -74,14 +74,14 @@ public class RhinoMaterialManager
   /// <summary>
   /// A map keeping track of ids, <b>either layer id or object id</b>, and their material index. It's generated from the material proxy list as we bake materials; <see cref="BakeMaterials"/> must be called in advance for this to be populated with the correct data.
   /// </summary>
-  public Dictionary<string, int> ObectIdAndMaterialIndexMap { get; } = new();
+  public Dictionary<string, int> ObjectIdAndMaterialIndexMap { get; } = new();
 
-  public void BakeMaterials(List<RenderMaterialProxy> speckleRenderMaterials, string baseLayerName)
+  public void BakeMaterials(List<RenderMaterialProxy> speckleRenderMaterialProxies, string baseLayerName)
   {
     var doc = _contextStack.Current.Document; // POC: too much right now to interface around
     List<ReceiveConversionResult> conversionResults = new(); // TODO: return this guy
 
-    foreach (var proxy in speckleRenderMaterials)
+    foreach (var proxy in speckleRenderMaterialProxies)
     {
       var speckleRenderMaterial = proxy.value;
 
@@ -124,7 +124,7 @@ public class RhinoMaterialManager
         // Create the object <> material index map
         foreach (var objectId in proxy.objects)
         {
-          ObectIdAndMaterialIndexMap[objectId] = matIndex;
+          ObjectIdAndMaterialIndexMap[objectId] = matIndex;
         }
 
         conversionResults.Add(new(Status.SUCCESS, speckleRenderMaterial, matName, "Material"));

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/HostApp/RhinoMaterialManager.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/HostApp/RhinoMaterialManager.cs
@@ -71,6 +71,9 @@ public class RhinoMaterialManager
     return speckleRenderMaterial;
   }
 
+  /// <summary>
+  /// A map keeping track of ids, <b>either layer id or object id</b>, and their material index. It's generated from the material proxy list as we bake materials; <see cref="BakeMaterials"/> must be called in advance for this to be populated with the correct data.
+  /// </summary>
   public Dictionary<string, int> ObectIdAndMaterialIndexMap { get; } = new();
 
   public void BakeMaterials(List<RenderMaterialProxy> speckleRenderMaterials, string baseLayerName)

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/HostApp/RhinoMaterialManager.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/HostApp/RhinoMaterialManager.cs
@@ -2,10 +2,10 @@ using Rhino;
 using Rhino.DocObjects;
 using Rhino.Render;
 using Speckle.Connectors.Utils.Conversion;
+using Speckle.Converters.Common;
 using Speckle.Objects.Other;
 using Speckle.Sdk;
 using Speckle.Sdk.Common;
-using BakeResult = Speckle.Connectors.Utils.RenderMaterials.BakeResult;
 using Material = Rhino.DocObjects.Material;
 using PhysicallyBasedMaterial = Rhino.DocObjects.PhysicallyBasedMaterial;
 using RenderMaterial = Rhino.Render.RenderMaterial;
@@ -18,6 +18,13 @@ namespace Speckle.Connectors.Rhino.HostApp;
 /// </summary>
 public class RhinoMaterialManager
 {
+  private readonly IConversionContextStack<RhinoDoc, UnitSystem> _contextStack;
+
+  public RhinoMaterialManager(IConversionContextStack<RhinoDoc, UnitSystem> contextStack)
+  {
+    _contextStack = contextStack;
+  }
+
   // converts a rhino material to a rhino render material
   private RenderMaterial ConvertMaterialToRenderMaterial(Material material)
   {
@@ -64,26 +71,20 @@ public class RhinoMaterialManager
     return speckleRenderMaterial;
   }
 
-  public BakeResult BakeMaterials(
-    List<SpeckleRenderMaterial> speckleRenderMaterials,
-    string baseLayerName,
-    Action<string, double?>? onOperationProgressed
-  )
+  public Dictionary<string, int> ObectIdAndMaterialIndexMap { get; } = new();
+
+  public void BakeMaterials(List<RenderMaterialProxy> speckleRenderMaterials, string baseLayerName)
   {
-    var doc = RhinoDoc.ActiveDoc; // POC: too much right now to interface around
+    var doc = _contextStack.Current.Document; // POC: too much right now to interface around
+    List<ReceiveConversionResult> conversionResults = new(); // TODO: return this guy
 
-    // Keeps track of the incoming SpeckleRenderMaterial application Id and the index of the corresponding Rhino Material in the doc material table
-    Dictionary<string, int> materialIdAndIndexMap = new();
-
-    int count = 0;
-    List<ReceiveConversionResult> conversionResults = new();
-    foreach (SpeckleRenderMaterial speckleRenderMaterial in speckleRenderMaterials)
+    foreach (var proxy in speckleRenderMaterials)
     {
-      onOperationProgressed?.Invoke("Converting render materials", (double)++count / speckleRenderMaterials.Count);
+      var speckleRenderMaterial = proxy.value;
+
       try
       {
         // POC: Currently we're relying on the render material name for identification if it's coming from speckle and from which model; could we do something else?
-        // POC: we should assume render materials all have application ids?
         string materialId = speckleRenderMaterial.applicationId ?? speckleRenderMaterial.id;
         string matName = $"{speckleRenderMaterial.name}-({materialId})-{baseLayerName}";
         Color diffuse = Color.FromArgb(speckleRenderMaterial.diffuse);
@@ -117,7 +118,11 @@ public class RhinoMaterialManager
           throw new ConversionException("Failed to add a material to the document.");
         }
 
-        materialIdAndIndexMap[materialId] = matIndex;
+        // Create the object <> material index map
+        foreach (var objectId in proxy.objects)
+        {
+          ObectIdAndMaterialIndexMap[objectId] = matIndex;
+        }
 
         conversionResults.Add(new(Status.SUCCESS, speckleRenderMaterial, matName, "Material"));
       }
@@ -126,8 +131,6 @@ public class RhinoMaterialManager
         conversionResults.Add(new(Status.ERROR, speckleRenderMaterial, null, null, ex));
       }
     }
-
-    return new(materialIdAndIndexMap, conversionResults);
   }
 
   /// <summary>

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/Operations/Receive/RhinoHostObjectBuilder.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/Operations/Receive/RhinoHostObjectBuilder.cs
@@ -174,7 +174,9 @@ public class RhinoHostObjectBuilder : IHostObjectBuilder
           var objectId = obj.applicationId ?? obj.id; // POC: assuming objects have app ids for this to work?
 
           // 3: colors and materials
-          var matIndex = _materialManager.ObectIdAndMaterialIndexMap.TryGetValue(objectId, out int mIndex) ? mIndex : 0;
+          var matIndex = _materialManager.ObjectIdAndMaterialIndexMap.TryGetValue(objectId, out int mIndex)
+            ? mIndex
+            : 0;
           Color? objColor = _colorManager.ObjectColorsIdMap.TryGetValue(objectId, out Color color) ? color : null;
 
           // 4: actually bake

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/Operations/Receive/RhinoHostObjectBuilder.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/Operations/Receive/RhinoHostObjectBuilder.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics.CodeAnalysis;
 using Rhino;
 using Rhino.DocObjects;
 using Rhino.Geometry;
@@ -119,16 +118,10 @@ public class RhinoHostObjectBuilder : IHostObjectBuilder
     List<(Collection[] collectionPath, Base obj)> atomicObjects = new();
     RhinoDoc doc = _contextStack.Current.Document;
     List<(Collection[] collectionPath, IInstanceComponent obj)> instanceComponents = new();
+
     using (var _ = SpeckleActivityFactory.Start("BakeObjects"))
     {
-      // Remove all previously received layers and render materials from the document
-      int rootLayerIndex = _contextStack.Current.Document.Layers.Find(
-        Guid.Empty,
-        baseLayerName,
-        RhinoMath.UnsetIntIndex
-      );
-      PreReceiveDeepClean(baseLayerName, rootLayerIndex);
-
+      PreReceiveDeepClean(baseLayerName);
       _layerManager.CreateBaseLayer(baseLayerName);
 
       // POC: these are not captured by traversal, so we need to re-add them here
@@ -158,16 +151,20 @@ public class RhinoHostObjectBuilder : IHostObjectBuilder
 
     List<ReceiveConversionResult> conversionResults = new();
 
-    // Stage 0: Render Materials
-    Dictionary<string, int> objectMaterialsIdMap = new();
+    // Dictionary<string, int> objectMaterialsIdMap = new();
+    // if (materialProxies != null)
+    // {
+    //   objectMaterialsIdMap = BakeRenderMaterials(
+    //     materialProxies,
+    //     baseLayerName,
+    //     onOperationProgressed,
+    //     conversionResults
+    //   );
+    // }
+
     if (materialProxies != null)
     {
-      objectMaterialsIdMap = BakeRenderMaterials(
-        materialProxies,
-        baseLayerName,
-        onOperationProgressed,
-        conversionResults
-      );
+      _materialManager.BakeMaterials(materialProxies, baseLayerName);
     }
 
     // Stage 1: Convert atomic objects
@@ -182,27 +179,29 @@ public class RhinoHostObjectBuilder : IHostObjectBuilder
         onOperationProgressed?.Invoke("Converting objects", (double)++count / atomicObjects.Count);
         try
         {
-          // POC: it's messy creating layers while in the obj loop, need to set layer material here
-          int layerIndex = _layerManager.GetAndCreateLayerFromPath(path, baseLayerName, out bool isNewLayer);
-          if (isNewLayer)
-          {
-            string collectionId = path[^1].applicationId ?? path[^1].id;
-            if (objectMaterialsIdMap.TryGetValue(collectionId, out int lIndex))
-            {
-              doc.Layers[layerIndex].RenderMaterialIndex = lIndex;
-            }
-
-            if (_colorManager.ObjectColorsIdMap.TryGetValue(collectionId, out Color layerColor))
-            {
-              doc.Layers[layerIndex].Color = layerColor;
-            }
-          }
+          int layerIndex = _layerManager.GetAndCreateLayerFromPath(path, baseLayerName, out bool _);
+          // if (isNewLayer)
+          // {
+          //   string collectionId = path[^1].applicationId ?? path[^1].id;
+          //   if (objectMaterialsIdMap.TryGetValue(collectionId, out int lIndex))
+          //   {
+          //     doc.Layers[layerIndex].RenderMaterialIndex = lIndex;
+          //   }
+          //
+          //   if (_colorManager.ObjectColorsIdMap.TryGetValue(collectionId, out Color layerColor))
+          //   {
+          //     doc.Layers[layerIndex].Color = layerColor;
+          //   }
+          // }
 
           var result = _converter.Convert(obj);
           var objectId = obj.applicationId ?? obj.id; // POC: assuming objects have app ids for this to work?
-          var objMaterialIndex = objectMaterialsIdMap.TryGetValue(objectId, out int oIndex) ? oIndex : 0;
+
+          var matIndex = _materialManager.ObectIdAndMaterialIndexMap.TryGetValue(objectId, out int mIndex) ? mIndex : 0;
           Color? objColor = _colorManager.ObjectColorsIdMap.TryGetValue(objectId, out Color color) ? color : null;
-          var conversionIds = HandleConversionResult(result, obj, layerIndex, objMaterialIndex, objColor).ToList();
+
+          var conversionIds = HandleConversionResult(result, obj, layerIndex, matIndex, objColor).ToList();
+
           foreach (var r in conversionIds)
           {
             conversionResults.Add(new(Status.SUCCESS, obj, r, result.GetType().ToString()));
@@ -224,7 +223,6 @@ public class RhinoHostObjectBuilder : IHostObjectBuilder
       var (createdInstanceIds, consumedObjectIds, instanceConversionResults) = BakeInstances(
         instanceComponents,
         applicationIdMap,
-        objectMaterialsIdMap,
         baseLayerName,
         onOperationProgressed
       );
@@ -248,45 +246,45 @@ public class RhinoHostObjectBuilder : IHostObjectBuilder
     return new(bakedObjectIds, conversionResults);
   }
 
-  [SuppressMessage("Performance", "CA1864:Prefer the \'IDictionary.TryAdd(TKey, TValue)\' method")]
-  private Dictionary<string, int> BakeRenderMaterials(
-    List<RenderMaterialProxy> materialProxies,
-    string baseLayerName,
-    Action<string, double?>? onOperationProgressed,
-    List<ReceiveConversionResult> conversionResults
-  )
-  {
-    using var _ = SpeckleActivityFactory.Start("BakeRenderMaterials");
-    // keeps track of the material id to created index in the materials table
-    Dictionary<string, int> materialsIdMap = new();
-
-    (materialsIdMap, List<ReceiveConversionResult> materialsConversionResults) = _materialManager.BakeMaterials(
-      materialProxies.Select(o => o.value).ToList(),
-      baseLayerName,
-      onOperationProgressed
-    );
-
-    conversionResults.AddRange(materialsConversionResults); // add render material conversion results to our list
-
-    // keeps track of the object id to material index
-    Dictionary<string, int> objectMaterialsIdMap = new();
-    foreach (RenderMaterialProxy materialProxy in materialProxies)
-    {
-      string materialId = materialProxy.value.applicationId ?? materialProxy.value.id;
-      foreach (string objectId in materialProxy.objects)
-      {
-        if (materialsIdMap.TryGetValue(materialId, out int materialIndex))
-        {
-          if (!objectMaterialsIdMap.ContainsKey(objectId))
-          {
-            objectMaterialsIdMap.Add(objectId, materialIndex);
-          }
-        }
-      }
-    }
-
-    return objectMaterialsIdMap;
-  }
+  // [SuppressMessage("Performance", "CA1864:Prefer the \'IDictionary.TryAdd(TKey, TValue)\' method")]
+  // private Dictionary<string, int> BakeRenderMaterials(
+  //   List<RenderMaterialProxy> materialProxies,
+  //   string baseLayerName,
+  //   Action<string, double?>? onOperationProgressed,
+  //   List<ReceiveConversionResult> conversionResults
+  // )
+  // {
+  //   using var _ = SpeckleActivityFactory.Start("BakeRenderMaterials");
+  //   // keeps track of the material id to created index in the materials table
+  //   Dictionary<string, int> materialsIdMap = new();
+  //
+  //   (materialsIdMap, List<ReceiveConversionResult> materialsConversionResults) = _materialManager.BakeMaterials(
+  //     materialProxies.Select(o => o.value).ToList(),
+  //     baseLayerName,
+  //     onOperationProgressed
+  //   );
+  //
+  //   conversionResults.AddRange(materialsConversionResults); // add render material conversion results to our list
+  //
+  //   // keeps track of the object id to material index
+  //   Dictionary<string, int> objectMaterialsIdMap = new();
+  //   foreach (RenderMaterialProxy materialProxy in materialProxies)
+  //   {
+  //     string materialId = materialProxy.value.applicationId ?? materialProxy.value.id;
+  //     foreach (string objectId in materialProxy.objects)
+  //     {
+  //       if (materialsIdMap.TryGetValue(materialId, out int materialIndex))
+  //       {
+  //         if (!objectMaterialsIdMap.ContainsKey(objectId))
+  //         {
+  //           objectMaterialsIdMap.Add(objectId, materialIndex);
+  //         }
+  //       }
+  //     }
+  //   }
+  //
+  //   return objectMaterialsIdMap;
+  // }
 
   private (
     List<string> createdInstanceIds,
@@ -295,7 +293,7 @@ public class RhinoHostObjectBuilder : IHostObjectBuilder
   ) BakeInstances(
     List<(Collection[] collectionPath, IInstanceComponent obj)> instanceComponents,
     Dictionary<string, List<string>> applicationIdMap,
-    Dictionary<string, int> materialIdMap,
+    // Dictionary<string, int> materialIdMap,
     string baseLayerName,
     Action<string, double?>? onOperationProgressed
   )
@@ -308,23 +306,23 @@ public class RhinoHostObjectBuilder : IHostObjectBuilder
     );
 
     // add materials to created instances
-    foreach (IInstanceComponent instanceComponent in instanceComponents.Select(o => o.obj).ToList())
-    {
-      if (instanceComponent is InstanceProxy instanceProxy)
-      {
-        string instanceProxyId = instanceProxy.applicationId ?? instanceProxy.id;
-        if (createdInstanceIds.Contains(instanceProxyId))
-        {
-          int instanceMaterialIndex = materialIdMap.TryGetValue(instanceProxyId, out int iIndex) ? iIndex : 0;
-          if (instanceMaterialIndex != 0)
-          {
-            RhinoObject createdInstance = RhinoDoc.ActiveDoc.Objects.FindId(new Guid(instanceProxyId));
-            createdInstance.Attributes.MaterialIndex = instanceMaterialIndex;
-            createdInstance.Attributes.MaterialSource = ObjectMaterialSource.MaterialFromObject;
-          }
-        }
-      }
-    }
+    // foreach (IInstanceComponent instanceComponent in instanceComponents.Select(o => o.obj).ToList())
+    // {
+    //   if (instanceComponent is InstanceProxy instanceProxy)
+    //   {
+    //     string instanceProxyId = instanceProxy.applicationId ?? instanceProxy.id;
+    //     if (createdInstanceIds.Contains(instanceProxyId))
+    //     {
+    //       int instanceMaterialIndex = materialIdMap.TryGetValue(instanceProxyId, out int iIndex) ? iIndex : 0;
+    //       if (instanceMaterialIndex != 0)
+    //       {
+    //         RhinoObject createdInstance = RhinoDoc.ActiveDoc.Objects.FindId(new Guid(instanceProxyId));
+    //         createdInstance.Attributes.MaterialIndex = instanceMaterialIndex;
+    //         createdInstance.Attributes.MaterialSource = ObjectMaterialSource.MaterialFromObject;
+    //       }
+    //     }
+    //   }
+    // }
     return (createdInstanceIds, consumedObjectIds, instanceConversionResults);
   }
 
@@ -339,8 +337,11 @@ public class RhinoHostObjectBuilder : IHostObjectBuilder
     }
   }
 
-  private void PreReceiveDeepClean(string baseLayerName, int rootLayerIndex)
+  private void PreReceiveDeepClean(string baseLayerName)
   {
+    // Remove all previously received layers and render materials from the document
+    int rootLayerIndex = _contextStack.Current.Document.Layers.Find(Guid.Empty, baseLayerName, RhinoMath.UnsetIntIndex);
+
     _instanceObjectsManager.PurgeInstances(baseLayerName);
     _materialManager.PurgeMaterials(baseLayerName);
 

--- a/Sdk/Speckle.Connectors.Utils/RenderMaterials/BakeResult.cs
+++ b/Sdk/Speckle.Connectors.Utils/RenderMaterials/BakeResult.cs
@@ -1,8 +1,0 @@
-using Speckle.Connectors.Utils.Conversion;
-
-namespace Speckle.Connectors.Utils.RenderMaterials;
-
-public record BakeResult(
-  Dictionary<string, int> MaterialIdMap,
-  List<ReceiveConversionResult> InstanceConversionResults
-);


### PR DESCRIPTION
Cleanp & simplifications. tl;dr: 


**Rhino**: 
- **FIX: instance creation was broken because of unwanted non-population of application id map**
- simplifies material assigning logic by creating a flat object <> material proxy map on material conversion, and removes a lotta indirect redundant code as a result; 
- layer manager is now responsible for assigning layer color/mat on creation; 
- object color/material assigning is simpler now from host object builder

**Acad:** 
- nothing really to change in here, stuff was as simple as it could get already imho