### PR TITLE
fix: handles correctly nested dynamic instances (inside other instances)

### DIFF
--- a/Connectors/Autocad/Speckle.Connectors.AutocadShared/HostApp/AutocadInstanceObjectManager.cs
+++ b/Connectors/Autocad/Speckle.Connectors.AutocadShared/HostApp/AutocadInstanceObjectManager.cs
@@ -148,7 +148,7 @@ public class AutocadInstanceObjectManager : IInstanceUnpacker<AutocadRootObject>
       var handleIdString = obj.Handle.Value.ToString();
       definitionProxy.objects.Add(handleIdString);
 
-      if (obj is BlockReference blockReference && !blockReference.IsDynamicBlock)
+      if (obj is BlockReference blockReference)
       {
         UnpackInstance(blockReference, depth + 1, transaction);
       }


### PR DESCRIPTION
resolves [CNX-200: Some dynamic blocks are missing nested blocks](https://linear.app/speckle/issue/CNX-200/some-dynamic-blocks-are-missing-nested-blocks)