### PR TITLE
Dimitrie/cnx 201 group names from autocad to rhino are not supported

### DIFF
--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/HostApp/RhinoGroupManager.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/HostApp/RhinoGroupManager.cs
@@ -8,6 +8,7 @@ namespace Speckle.Connectors.Rhino.HostApp;
 
 /// <summary>
 /// Unpacks the group lists for each object and sub-objects.
+/// POC: Split me into group unpacker and group baker classes please!
 /// It should be in scoped lifetime.
 /// </summary>
 public class RhinoGroupManager // POC: later make it more clean with RhinoGroupUnpacker Packer??? + see same POC comments in instance managers

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/HostApp/RhinoGroupManager.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/HostApp/RhinoGroupManager.cs
@@ -1,5 +1,7 @@
 using Rhino;
 using Rhino.DocObjects;
+using Speckle.Converters.Common;
+using Speckle.Sdk.Logging;
 using Speckle.Sdk.Models.Proxies;
 
 namespace Speckle.Connectors.Rhino.HostApp;
@@ -10,6 +12,13 @@ namespace Speckle.Connectors.Rhino.HostApp;
 /// </summary>
 public class RhinoGroupManager // POC: later make it more clean with RhinoGroupUnpacker Packer??? + see same POC comments in instance managers
 {
+  private readonly IConversionContextStack<RhinoDoc, UnitSystem> _contextStack;
+
+  public RhinoGroupManager(IConversionContextStack<RhinoDoc, UnitSystem> contextStack)
+  {
+    _contextStack = contextStack;
+  }
+
   public Dictionary<string, GroupProxy> GroupProxies { get; } = new();
 
   public void UnpackGroups(IEnumerable<RhinoObject> rhinoObjects)
@@ -41,6 +50,33 @@ public class RhinoGroupManager // POC: later make it more clean with RhinoGroupU
             objects = [rhinoObject.Id.ToString()]
           };
         }
+      }
+    }
+  }
+
+  public void BakeGroups(
+    List<GroupProxy> groupProxies,
+    Dictionary<string, List<string>> applicationIdMap,
+    string baseLayerName
+  )
+  {
+    using var _ = SpeckleActivityFactory.Start();
+    foreach (GroupProxy groupProxy in groupProxies.OrderBy(g => g.objects.Count))
+    {
+      var appIds = groupProxy.objects.SelectMany(oldObjId => applicationIdMap[oldObjId]).Select(id => new Guid(id));
+      var groupName = (groupProxy.name ?? "No Name Group") + $" ({baseLayerName})";
+      _contextStack.Current.Document.Groups.Add(groupName, appIds);
+    }
+  }
+
+  public void PurgeGroups(string baseLayerName)
+  {
+    for (int i = _contextStack.Current.Document.Groups.Count; i >= 0; i--)
+    {
+      var group = _contextStack.Current.Document.Groups.FindIndex(i);
+      if (group is { Name: not null } && group.Name.Contains(baseLayerName))
+      {
+        _contextStack.Current.Document.Groups.Delete(i);
       }
     }
   }

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/HostApp/RhinoMaterialManager.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/HostApp/RhinoMaterialManager.cs
@@ -145,7 +145,7 @@ public class RhinoMaterialManager
     var currentDoc = RhinoDoc.ActiveDoc; // POC: too much right now to interface around
     foreach (Material material in currentDoc.Materials)
     {
-      if (!material.IsDeleted && material.Name.Contains(namePrefix))
+      if (!material.IsDeleted && material.Name != null && material.Name.Contains(namePrefix))
       {
         currentDoc.Materials.Delete(material);
       }

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/Operations/Receive/RhinoHostObjectBuilder.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/Operations/Receive/RhinoHostObjectBuilder.cs
@@ -233,9 +233,8 @@ public class RhinoHostObjectBuilder : IHostObjectBuilder
     foreach (GroupProxy groupProxy in groupProxies.OrderBy(g => g.objects.Count))
     {
       var appIds = groupProxy.objects.SelectMany(oldObjId => applicationIdMap[oldObjId]).Select(id => new Guid(id));
-      var index = RhinoDoc.ActiveDoc.Groups.Add(appIds);
-      var addedGroup = RhinoDoc.ActiveDoc.Groups.FindIndex(index);
-      addedGroup.Name = groupProxy.name;
+      var groupName = groupProxy.name ?? "No Name Group";
+      RhinoDoc.ActiveDoc.Groups.Add(groupName, appIds);
     }
   }
 


### PR DESCRIPTION
Fixes group creation so they are correctly named; this required purging previously created groups for second receive workflows. I've taken the chance to also move a lot of the group creation logic outside of the host object builder to the group manager itself, though IIRC the group manager was meant to be split into group unpacker and group baker, but it got merged into one in the last PR on render materials. 

See [CNX-201](https://linear.app/speckle/issue/CNX-201/group-names-from-autocad-to-rhino-are-not-supported) for full details of the issue.

Proof it works for Bilal:
![image](https://github.com/user-attachments/assets/3aec140f-8046-4e55-b36c-edbd13495e16).
