### PR TITLE
fix(rhino): CNX-245 render materials inherited from layer bug

### DIFF
--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/Operations/Receive/RhinoHostObjectBuilder.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/Operations/Receive/RhinoHostObjectBuilder.cs
@@ -178,9 +178,9 @@ public class RhinoHostObjectBuilder : IHostObjectBuilder
           var objectId = obj.applicationId ?? obj.id; // POC: assuming objects have app ids for this to work?
 
           // 3: colors and materials
-          var matIndex = _materialManager.ObjectIdAndMaterialIndexMap.TryGetValue(objectId, out int mIndex)
+          int? matIndex = _materialManager.ObjectIdAndMaterialIndexMap.TryGetValue(objectId, out int mIndex)
             ? mIndex
-            : 0;
+            : null;
           Color? objColor = _colorManager.ObjectColorsIdMap.TryGetValue(objectId, out Color color) ? color : null;
 
           // 4: actually bake


### PR DESCRIPTION
Fixes bug where the first created render material was being used instead of none assigned when no render material is found on an object.

![image](https://github.com/user-attachments/assets/9bc18e71-dc5f-40e3-97b3-73196f6881aa)
