### PR TITLE
Fix(autocad): Change active layer to 0 if active layer name and will be erased matches

### DIFF
--- a/Connectors/Autocad/Speckle.Connectors.AutocadShared/HostApp/AutocadLayerManager.cs
+++ b/Connectors/Autocad/Speckle.Connectors.AutocadShared/HostApp/AutocadLayerManager.cs
@@ -151,12 +151,19 @@ public class AutocadLayerManager
     using Transaction transaction = Doc.TransactionManager.StartTransaction();
 
     var layerTable = (LayerTable)transaction.TransactionManager.GetObject(Doc.Database.LayerTableId, OpenMode.ForRead);
+    var activeLayer = (LayerTableRecord)transaction.GetObject(Doc.Database.Clayer, OpenMode.ForRead);
     foreach (var layerId in layerTable)
     {
       var layer = (LayerTableRecord)transaction.GetObject(layerId, OpenMode.ForRead);
       var layerName = layer.Name;
       if (layer.Name.Contains(prefix))
       {
+        if (activeLayer.Name == layerName)
+        {
+          // Layer `0` cannot be deleted or renamed in Autocad, so it is safe to get zero layer id.
+          ObjectId zeroLayerId = layerTable["0"];
+          Doc.Database.Clayer = zeroLayerId;
+        }
         // Delete objects from this layer
         TypedValue[] tvs = [new((int)DxfCode.LayerName, layerName)];
         SelectionFilter selectionFilter = new(tvs);


### PR DESCRIPTION
BEFORE
was crashing if we try to erase active layer for the second receives.
![image](https://github.com/user-attachments/assets/017abc6b-72a4-4d84-ac68-b9458e5f3967)

AFTER
switches back to layer `0`
![rider64_biJGlIV1uI](https://github.com/user-attachments/assets/cc51189e-9e6a-42c8-84b2-8c5d7474da65)
