### PR TITLE
CXPLA-17 Add XX_OR_GREATER flags to converter/connector projects

### DIFF
--- a/Connectors/Autocad/Speckle.Connectors.Autocad2022/Speckle.Connectors.Autocad2022.csproj
+++ b/Connectors/Autocad/Speckle.Connectors.Autocad2022/Speckle.Connectors.Autocad2022.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>net48</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
     <AutoCADVersion>2022</AutoCADVersion>
-    <DefineConstants>$(DefineConstants);AUTOCAD2022;AUTOCAD</DefineConstants>
+    <DefineConstants>$(DefineConstants);AUTOCAD;AUTOCAD2022;AUTOCAD2022_OR_GREATER</DefineConstants>
     <Configurations>Debug;Release;Local</Configurations>
   </PropertyGroup>
   

--- a/Connectors/Autocad/Speckle.Connectors.Autocad2023/Speckle.Connectors.Autocad2023.csproj
+++ b/Connectors/Autocad/Speckle.Connectors.Autocad2023/Speckle.Connectors.Autocad2023.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>net48</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
     <AutoCADVersion>2023</AutoCADVersion>
-    <DefineConstants>$(DefineConstants);AUTOCAD2023;AUTOCAD</DefineConstants>
+    <DefineConstants>$(DefineConstants);AUTOCAD;AUTOCAD2023;AUTOCAD2022_OR_GREATER;AUTOCAD2023_OR_GREATER</DefineConstants>
     <Configurations>Debug;Release;Local</Configurations>
   </PropertyGroup>
   

--- a/Connectors/Autocad/Speckle.Connectors.Autocad2024/Speckle.Connectors.Autocad2024.csproj
+++ b/Connectors/Autocad/Speckle.Connectors.Autocad2024/Speckle.Connectors.Autocad2024.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>net48</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
     <AutoCADVersion>2024</AutoCADVersion>
-    <DefineConstants>$(DefineConstants);AUTOCAD2024;AUTOCAD</DefineConstants>
+    <DefineConstants>$(DefineConstants)AUTOCAD;AUTOCAD2024;AUTOCAD2022_OR_GREATER;AUTOCAD2023_OR_GREATER;AUTOCAD2024_OR_GREATER</DefineConstants>
     <Configurations>Debug;Release;Local</Configurations>
   </PropertyGroup>
   

--- a/Connectors/Autocad/Speckle.Connectors.Civil3d2024/Speckle.Connectors.Civil3d2024.csproj
+++ b/Connectors/Autocad/Speckle.Connectors.Civil3d2024/Speckle.Connectors.Civil3d2024.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>net48</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
     <Civil3DVersion>2024</Civil3DVersion>
-    <DefineConstants>$(DefineConstants);CIVIL3D2024;CIVIL3D;</DefineConstants>
+    <DefineConstants>$(DefineConstants);CIVIL3D;CIVIL3D2024;CIVIL3D2024_OR_GREATER</DefineConstants>
     <Configurations>Debug;Release;Local</Configurations>
   </PropertyGroup>
 

--- a/Connectors/Revit/Speckle.Connectors.Revit2022/Speckle.Connectors.Revit2022.csproj
+++ b/Connectors/Revit/Speckle.Connectors.Revit2022/Speckle.Connectors.Revit2022.csproj
@@ -4,7 +4,7 @@
     <PlatformTarget>x64</PlatformTarget>
     <UseWpf>true</UseWpf>
     <RevitVersion>2022</RevitVersion>
-    <DefineConstants>$(DefineConstants);REVIT2022</DefineConstants>
+    <DefineConstants>$(DefineConstants);REVIT2022;REVIT2022_OR_GREATER</DefineConstants>
     <CefSharpAnyCpuSupport>true</CefSharpAnyCpuSupport>
     <Prefer32bit>false</Prefer32bit>
     <Configurations>Debug;Release;Local</Configurations>

--- a/Connectors/Revit/Speckle.Connectors.Revit2023/Speckle.Connectors.Revit2023.csproj
+++ b/Connectors/Revit/Speckle.Connectors.Revit2023/Speckle.Connectors.Revit2023.csproj
@@ -4,7 +4,7 @@
     <PlatformTarget>x64</PlatformTarget>
     <UseWpf>true</UseWpf>    
     <RevitVersion>2023</RevitVersion>
-    <DefineConstants>$(DefineConstants);REVIT2023</DefineConstants>
+    <DefineConstants>$(DefineConstants);REVIT2023;REVIT2022_OR_GREATER;REVIT2023_OR_GREATER</DefineConstants>
     <Configurations>Debug;Release;Local</Configurations>
   </PropertyGroup>
 

--- a/Connectors/Revit/Speckle.Connectors.Revit2024/Speckle.Connectors.Revit2024.csproj
+++ b/Connectors/Revit/Speckle.Connectors.Revit2024/Speckle.Connectors.Revit2024.csproj
@@ -4,7 +4,7 @@
     <PlatformTarget>x64</PlatformTarget>
     <UseWpf>true</UseWpf>
     <RevitVersion>2024</RevitVersion>
-    <DefineConstants>$(DefineConstants);REVIT2024</DefineConstants>
+    <DefineConstants>$(DefineConstants);REVIT2024;REVIT2022_OR_GREATER;REVIT2023_OR_GREATER;REVIT2024_OR_GREATER</DefineConstants>
     <Configurations>Debug;Release;Local</Configurations>
   </PropertyGroup>
 

--- a/Connectors/Revit/Speckle.Connectors.Revit2025/Speckle.Connectors.Revit2025.csproj
+++ b/Connectors/Revit/Speckle.Connectors.Revit2025/Speckle.Connectors.Revit2025.csproj
@@ -5,7 +5,10 @@
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <UseWpf>true</UseWpf>
     <RevitVersion>2025</RevitVersion>
-    <DefineConstants>$(DefineConstants);REVIT2025</DefineConstants>
+    <DefineConstants>
+      $(DefineConstants);REVIT2025;
+      REVIT2022_OR_GREATER;REVIT2023_OR_GREATER;REVIT2024_OR_GREATER;REVIT2025_OR_GREATER
+    </DefineConstants>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
     <EnableWindowsTargeting>true</EnableWindowsTargeting>

--- a/Connectors/Rhino/Speckle.Connectors.Rhino7/Speckle.Connectors.Rhino7.csproj
+++ b/Connectors/Rhino/Speckle.Connectors.Rhino7/Speckle.Connectors.Rhino7.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>net48</TargetFramework>
     <Configurations>Debug;Release;Local</Configurations>
     <RhinoVersion>7</RhinoVersion>
-    <DefineConstants>$(DefineConstants);RHINO7</DefineConstants>
+    <DefineConstants>$(DefineConstants);RHINO7;RHINO7_OR_GREATER</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Connectors/Rhino/Speckle.Connectors.Rhino8/Speckle.Connectors.Rhino8.csproj
+++ b/Connectors/Rhino/Speckle.Connectors.Rhino8/Speckle.Connectors.Rhino8.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>net48</TargetFramework>
     <Configurations>Debug;Release;Local</Configurations>
     <RhinoVersion>8</RhinoVersion>
-    <DefineConstants>$(DefineConstants);RHINO8</DefineConstants>
+    <DefineConstants>$(DefineConstants);RHINO8;RHINO7_OR_GREATER;RHIN08_OR_GREATER</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Converters/Autocad/Speckle.Converters.Autocad2022/Speckle.Converters.Autocad2022.csproj
+++ b/Converters/Autocad/Speckle.Converters.Autocad2022/Speckle.Converters.Autocad2022.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net48</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
     <Configurations>Debug;Release;Local</Configurations>
+    <DefineConstants>$(DefineConstants);AUTOCAD;AUTOCAD2022;AUTOCAD2022_OR_GREATER</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Converters/Autocad/Speckle.Converters.Autocad2023/Speckle.Converters.Autocad2023.csproj
+++ b/Converters/Autocad/Speckle.Converters.Autocad2023/Speckle.Converters.Autocad2023.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net48</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
     <Configurations>Debug;Release;Local</Configurations>
+    <DefineConstants>$(DefineConstants);AUTOCAD;AUTOCAD2023;AUTOCAD2022_OR_GREATER;AUTOCAD2023_OR_GREATER</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Converters/Autocad/Speckle.Converters.Autocad2024/Speckle.Converters.Autocad2024.csproj
+++ b/Converters/Autocad/Speckle.Converters.Autocad2024/Speckle.Converters.Autocad2024.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>net48</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
     <AutoCADVersion>2024</AutoCADVersion>
-    <DefineConstants>$(DefineConstants);AUTOCAD2024;AUTOCAD</DefineConstants>
+    <DefineConstants>$(DefineConstants)AUTOCAD;AUTOCAD2024;AUTOCAD2022_OR_GREATER;AUTOCAD2023_OR_GREATER;AUTOCAD2024_OR_GREATER</DefineConstants>
     <Configurations>Debug;Release;Local</Configurations>
   </PropertyGroup>
 

--- a/Converters/Civil3d/Speckle.Converters.Civil3d2024/Speckle.Converters.Civil3d2024.csproj
+++ b/Converters/Civil3d/Speckle.Converters.Civil3d2024/Speckle.Converters.Civil3d2024.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
+    <DefineConstants>$(DefineConstants);CIVIL3D;CIVIL3D2024;CIVIL3D2024_OR_GREATER</DefineConstants>
     <Configurations>Debug;Release;Local</Configurations>
   </PropertyGroup>
 

--- a/Converters/Revit/Speckle.Converters.Revit2022/Speckle.Converters.Revit2022.csproj
+++ b/Converters/Revit/Speckle.Converters.Revit2022/Speckle.Converters.Revit2022.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
-    <DefineConstants>$(DefineConstants);REVIT2022</DefineConstants>
+    <DefineConstants>$(DefineConstants);REVIT2022;REVIT2022_OR_GREATER</DefineConstants>
     <Configurations>Debug;Release;Local</Configurations>
   </PropertyGroup>
 

--- a/Converters/Revit/Speckle.Converters.Revit2023/Speckle.Converters.Revit2023.csproj
+++ b/Converters/Revit/Speckle.Converters.Revit2023/Speckle.Converters.Revit2023.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net48</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
     <Configurations>Debug;Release;Local</Configurations>
+    <DefineConstants>$(DefineConstants);REVIT2023;REVIT2022_OR_GREATER;REVIT2023_OR_GREATER</DefineConstants>
   </PropertyGroup>
 
   <Import Project="..\Speckle.Converters.RevitShared\Speckle.Converters.RevitShared.projitems" Label="Shared" />

--- a/Converters/Revit/Speckle.Converters.Revit2024/Speckle.Converters.Revit2024.csproj
+++ b/Converters/Revit/Speckle.Converters.Revit2024/Speckle.Converters.Revit2024.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net48</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
     <Configurations>Debug;Release;Local</Configurations>
+    <DefineConstants>$(DefineConstants);REVIT2024;REVIT2022_OR_GREATER;REVIT2023_OR_GREATER;REVIT2024_OR_GREATER</DefineConstants>
   </PropertyGroup>
 
   <Import Project="..\Speckle.Converters.RevitShared\Speckle.Converters.RevitShared.projitems" Label="Shared" />

--- a/Converters/Revit/Speckle.Converters.Revit2025/Speckle.Converters.Revit2025.csproj
+++ b/Converters/Revit/Speckle.Converters.Revit2025/Speckle.Converters.Revit2025.csproj
@@ -4,6 +4,10 @@
     <TargetFramework>net8.0-windows</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
     <Configurations>Debug;Release;Local</Configurations>
+    <DefineConstants>
+      $(DefineConstants);REVIT2025;
+      REVIT2022_OR_GREATER;REVIT2023_OR_GREATER;REVIT2024_OR_GREATER;REVIT2025_OR_GREATER
+    </DefineConstants>
   </PropertyGroup>
 
   <Import Project="..\Speckle.Converters.RevitShared\Speckle.Converters.RevitShared.projitems" Label="Shared" />

--- a/Converters/Rhino/Speckle.Converters.Rhino7/Speckle.Converters.Rhino7.csproj
+++ b/Converters/Rhino/Speckle.Converters.Rhino7/Speckle.Converters.Rhino7.csproj
@@ -1,17 +1,18 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <TargetFramework>net48</TargetFramework>
-        <Configurations>Debug;Release;Local</Configurations>
-    </PropertyGroup>
+  <PropertyGroup>
+    <TargetFramework>net48</TargetFramework>
+    <Configurations>Debug;Release;Local</Configurations>
+    <DefineConstants>$(DefineConstants);RHINO7;RHINO7_OR_GREATER</DefineConstants>
+  </PropertyGroup>
 
-  <Import Project="..\Speckle.Converters.RhinoShared\Speckle.Converters.RhinoShared.projitems" Label="Shared" />
-  
+  <Import Project="..\Speckle.Converters.RhinoShared\Speckle.Converters.RhinoShared.projitems" Label="Shared"/>
+
   <ItemGroup>
-    <PackageReference Include="RhinoCommon" VersionOverride="7.13.21348.13001" IncludeAssets="compile;build" />
+    <PackageReference Include="RhinoCommon" VersionOverride="7.13.21348.13001" IncludeAssets="compile;build"/>
   </ItemGroup>
-    <ItemGroup>
-      <ProjectReference Include="..\..\..\Sdk\Speckle.Converters.Common\Speckle.Converters.Common.csproj" />
-    </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\Sdk\Speckle.Converters.Common\Speckle.Converters.Common.csproj"/>
+  </ItemGroup>
 
 </Project>

--- a/Converters/Rhino/Speckle.Converters.Rhino8/Speckle.Converters.Rhino8.csproj
+++ b/Converters/Rhino/Speckle.Converters.Rhino8/Speckle.Converters.Rhino8.csproj
@@ -1,17 +1,19 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <TargetFramework>net48</TargetFramework>
-        <Configurations>Debug;Release;Local</Configurations>
-    </PropertyGroup>
+  <PropertyGroup>
+    <TargetFramework>net48</TargetFramework>
+    <Configurations>Debug;Release;Local</Configurations>
+    <DefineConstants>$(DefineConstants);RHINO8;RHINO7_OR_GREATER;RHIN08_OR_GREATER</DefineConstants>
 
-  <Import Project="..\Speckle.Converters.RhinoShared\Speckle.Converters.RhinoShared.projitems" Label="Shared" />
-  
+  </PropertyGroup>
+
+  <Import Project="..\Speckle.Converters.RhinoShared\Speckle.Converters.RhinoShared.projitems" Label="Shared"/>
+
   <ItemGroup>
-    <PackageReference Include="RhinoCommon" VersionOverride="8.9.24194.18121" IncludeAssets="compile;build" />
+    <PackageReference Include="RhinoCommon" VersionOverride="8.9.24194.18121" IncludeAssets="compile;build"/>
   </ItemGroup>
-    <ItemGroup>
-      <ProjectReference Include="..\..\..\Sdk\Speckle.Converters.Common\Speckle.Converters.Common.csproj" />
-    </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\Sdk\Speckle.Converters.Common\Speckle.Converters.Common.csproj"/>
+  </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Adds XX_OR_GREATER to all converter and connector projects:

- Rhino
- Revit
- Acad/Civil

Left ArcGIS out because it has no other version, so it's intention is not as clear.