### PR TITLE
Fix(autocad): Do not select if object to highlight is in Block

### DIFF
--- a/Connectors/Autocad/Speckle.Connectors.AutocadShared/Bindings/AutocadBasicConnectorBinding.cs
+++ b/Connectors/Autocad/Speckle.Connectors.AutocadShared/Bindings/AutocadBasicConnectorBinding.cs
@@ -120,7 +120,17 @@ public class AutocadBasicConnectorBinding : IBasicConnectorBinding
       try
       {
         doc.Editor.SetImpliedSelection(Array.Empty<ObjectId>()); // Deselects
-        doc.Editor.SetImpliedSelection(objectIds); // Selects
+        try
+        {
+          doc.Editor.SetImpliedSelection(objectIds);
+        }
+        catch (Exception e) when (!e.IsFatal())
+        {
+          // SWALLOW REASON:
+          // If the objects under the blocks, it won't be able to select them.
+          // If we try, API will throw the invalid input error, because we request something from API that Autocad doesn't
+          // handle it on its current canvas. Block elements only selectable when in its scope.
+        }
         doc.Editor.UpdateScreen();
 
         Extents3d selectedExtents = new();


### PR DESCRIPTION
See the linear for more info. As a result we do not select sub objects on highlight functionality. We will only zoom extend the objects. See gif below

![RmH7d6ig2H](https://github.com/user-attachments/assets/2d260714-7e12-4ac5-a8a3-0a647178db25)
