### PR TITLE
Fix(autocad): Clear the cache on doc swap

### DIFF
--- a/Connectors/Autocad/Speckle.Connectors.AutocadShared/Bindings/AutocadSendBinding.cs
+++ b/Connectors/Autocad/Speckle.Connectors.AutocadShared/Bindings/AutocadSendBinding.cs
@@ -80,6 +80,11 @@ public sealed class AutocadSendBinding : ISendBinding
       // catches the case when autocad just opens up with a blank new doc
       SubscribeToObjectChanges(Application.DocumentManager.CurrentDocument);
     }
+    // Since ids of the objects generates from same seed, we should clear the cache always whenever doc swapped.
+    _store.DocumentChanged += (_, _) =>
+    {
+      _sendConversionCache.ClearCache();
+    };
   }
 
   private readonly List<string> _docSubsTracker = new();

--- a/Sdk/Speckle.Connectors.Utils/Caching/ISendConversionCache.cs
+++ b/Sdk/Speckle.Connectors.Utils/Caching/ISendConversionCache.cs
@@ -19,5 +19,7 @@ public interface ISendConversionCache
   /// </summary>
   /// <param name="objectIds"></param>
   public void EvictObjects(IEnumerable<string> objectIds);
+
+  public void ClearCache();
   bool TryGetValue(string projectId, string applicationId, out ObjectReference objectReference);
 }

--- a/Sdk/Speckle.Connectors.Utils/Caching/NullSendConversionCache.cs
+++ b/Sdk/Speckle.Connectors.Utils/Caching/NullSendConversionCache.cs
@@ -11,6 +11,8 @@ public class NullSendConversionCache : ISendConversionCache
 
   public void EvictObjects(IEnumerable<string> objectIds) { }
 
+  public void ClearCache() { }
+
   public bool TryGetValue(string projectId, string applicationId, out ObjectReference objectReference)
   {
     objectReference = new ObjectReference();

--- a/Sdk/Speckle.Connectors.Utils/Caching/SendConversionCache.cs
+++ b/Sdk/Speckle.Connectors.Utils/Caching/SendConversionCache.cs
@@ -23,6 +23,8 @@ public class SendConversionCache : ISendConversionCache
       .Where(kvp => !objectIds.Contains(kvp.Key.applicationId))
       .ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
 
+  public void ClearCache() => Cache.Clear();
+
   public bool TryGetValue(string projectId, string applicationId, out ObjectReference objectReference) =>
     Cache.TryGetValue((applicationId, projectId), out objectReference);
 }


### PR DESCRIPTION
We should have done this before.
Since autocad applicationIds generated from same seed, we should clear the cache on doc swap to prevent weird states as @bimgeek found in https://linear.app/speckle/issue/CNX-269/errors-when-multi-receiving-in-autocad