### PR TITLE
fix(autocad2024): define constants missing semicolon

### DIFF
--- a/Connectors/Autocad/Speckle.Connectors.Autocad2024/Speckle.Connectors.Autocad2024.csproj
+++ b/Connectors/Autocad/Speckle.Connectors.Autocad2024/Speckle.Connectors.Autocad2024.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>net48</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
     <AutoCADVersion>2024</AutoCADVersion>
-    <DefineConstants>$(DefineConstants)AUTOCAD;AUTOCAD2024;AUTOCAD2022_OR_GREATER;AUTOCAD2023_OR_GREATER;AUTOCAD2024_OR_GREATER</DefineConstants>
+    <DefineConstants>$(DefineConstants);AUTOCAD;AUTOCAD2024;AUTOCAD2022_OR_GREATER;AUTOCAD2023_OR_GREATER;AUTOCAD2024_OR_GREATER</DefineConstants>
     <Configurations>Debug;Release;Local</Configurations>
   </PropertyGroup>
   


### PR DESCRIPTION
bug introduced in https://github.com/specklesystems/speckle-sharp-connectors/pull/136/files

adds back a missing semicolon to prevent `GetApp()` from throwing in the connector