### PR TITLE
fix(autocad): CNX-274 circulararc conversion now handles edge case

### DIFF
--- a/Converters/Autocad/Speckle.Converters.AutocadShared/ToSpeckle/Raw/CircularArc3dToSpeckleRawConverter.cs
+++ b/Converters/Autocad/Speckle.Converters.AutocadShared/ToSpeckle/Raw/CircularArc3dToSpeckleRawConverter.cs
@@ -25,9 +25,19 @@ public class CircularArc3dToSpeckleConverter : ITypedConverter<AG.CircularArc3d,
     SOG.Plane plane = _planeConverter.Convert(target.GetPlane());
     SOG.Point start = _pointConverter.Convert(target.StartPoint);
     SOG.Point end = _pointConverter.Convert(target.EndPoint);
-    double domainUpper = target.GetInterval().UpperBound;
-    double domainLower = target.GetInterval().LowerBound;
-    SOG.Point mid = _pointConverter.Convert(target.EvaluatePoint(domainUpper - domainLower / 2.0));
+    double startParam = target.GetParameterOf(target.StartPoint);
+    double endParam = target.GetParameterOf(target.EndPoint);
+    AG.Point3d midPoint = target.EvaluatePoint(endParam - startParam / 2.0);
+
+    // some circular arcs will **not** return a correct value from `EvaluatePoint` using the indicated parameter at the midpoint.
+    // so far, this has happened with some arc segments in the polyline method. They will have an end param > 1, and evaluatePoint returns the endpoint
+    // this is why we are checking for midpoint == endpoint, and using a [0,1] parameterization if this is the case.
+    if (midPoint.IsEqualTo(target.EndPoint))
+    {
+      midPoint = target.EvaluatePoint(0.5);
+    }
+
+    SOG.Point mid = _pointConverter.Convert(midPoint);
 
     SOG.Arc arc =
       new(
@@ -42,7 +52,7 @@ public class CircularArc3dToSpeckleConverter : ITypedConverter<AG.CircularArc3d,
         startPoint = start,
         endPoint = end,
         midPoint = mid,
-        domain = new(domainLower, domainUpper),
+        domain = new(startParam, endParam),
         length = target.GetLength(0, 1, 0.000)
       };
 

--- a/Converters/Rhino/Speckle.Converters.RhinoShared/ToHost/Raw/ArcToHostConverter.cs
+++ b/Converters/Rhino/Speckle.Converters.RhinoShared/ToHost/Raw/ArcToHostConverter.cs
@@ -1,4 +1,4 @@
-﻿using Speckle.Converters.Common.Objects;
+using Speckle.Converters.Common.Objects;
 
 namespace Speckle.Converters.Rhino.ToHost.Raw;
 
@@ -28,12 +28,10 @@ public class ArcToHostConverter : ITypedConverter<SOG.Arc, RG.Arc>, ITypedConver
   /// <remarks><br/>⚠️ This method does not preserve the original curve domain</remarks>
   public RG.Arc Convert(SOG.Arc target)
   {
-    var rhinoArc = new RG.Arc(
-      _pointConverter.Convert(target.startPoint),
-      _pointConverter.Convert(target.midPoint),
-      _pointConverter.Convert(target.endPoint)
-    );
-    return rhinoArc;
+    RG.Point3d startPoint = _pointConverter.Convert(target.startPoint);
+    RG.Point3d midPoint = _pointConverter.Convert(target.midPoint);
+    RG.Point3d endPoint = _pointConverter.Convert(target.endPoint);
+    return new(startPoint, midPoint, endPoint);
   }
 
   // POC: CNX-9271 Potential code-smell by directly implementing the interface. We should discuss this further but

--- a/Converters/Rhino/Speckle.Converters.RhinoShared/ToHost/Raw/PolyCurveToHostConverter.cs
+++ b/Converters/Rhino/Speckle.Converters.RhinoShared/ToHost/Raw/PolyCurveToHostConverter.cs
@@ -1,4 +1,4 @@
-﻿using Speckle.Converters.Common.Objects;
+using Speckle.Converters.Common.Objects;
 using Speckle.Objects;
 using Speckle.Sdk.Common;
 
@@ -27,9 +27,13 @@ public class PolyCurveToHostConverter : ITypedConverter<SOG.Polycurve, RG.PolyCu
 
     foreach (var segment in target.segments)
     {
-      var childCurve = CurveConverter.NotNull().Convert(segment);
-      bool success = result.AppendSegment(childCurve);
-      if (!success)
+      RG.Curve childCurve = CurveConverter.NotNull().Convert(segment);
+      if (!childCurve.IsValid)
+      {
+        throw new ConversionException($"Failed to convert segment {segment}");
+      }
+
+      if (!result.AppendSegment(childCurve))
       {
         throw new ConversionException($"Failed to append segment {segment}");
       }


### PR DESCRIPTION
Previously some polylines with arc segments were resulting in the arc segments being converted with a midpoint = endpoint. This was resulting in failed conversions when receiving in rhino.

I've added some comments on why this seems to happen, as well as an extra check in the arc conversion to use a re-parametrized domain for midpoint calculation.

I've also added a new exception thrown in the rhino polycurve conversion when any segment is not converted to a valid curve.

Tested with multiple autocad files, and receiving them in rhino.