### PR TITLE
CNX-299: Adds support for sending SubD elements as BREPs

### DIFF
--- a/Converters/Rhino/Speckle.Converters.RhinoShared/ToSpeckle/TopLevel/SubDObjectToSpeckleTopLevelConverter.cs
+++ b/Converters/Rhino/Speckle.Converters.RhinoShared/ToSpeckle/TopLevel/SubDObjectToSpeckleTopLevelConverter.cs
@@ -1,0 +1,25 @@
+﻿using Speckle.Converters.Common;
+using Rhino.DocObjects;
+using Speckle.Converters.Common.Objects;
+using Speckle.Sdk.Models;
+
+namespace Speckle.Converters.Rhino.ToSpeckle.TopLevel;
+
+[NameAndRankValue(nameof(SubDObject), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
+public class SubDObjectToSpeckleTopLevelConverter: IToSpeckleTopLevelConverter
+{
+  private readonly ITypedConverter<RG.Brep, SOG.Brep> _brepConverter;
+
+  public SubDObjectToSpeckleTopLevelConverter(ITypedConverter<RG.Brep, SOG.Brep> curveConverter)
+  {
+    _brepConverter = curveConverter;
+  }
+
+  public Base Convert(object target)
+  {
+    var subDObject = (SubDObject)target;
+    var subD = (RG.SubD)subDObject.Geometry;
+    var speckleCurve = _brepConverter.Convert(subD.ToBrep());
+    return speckleCurve;
+  }
+}

--- a/Converters/Rhino/Speckle.Converters.RhinoShared/ToSpeckle/TopLevel/SubDObjectToSpeckleTopLevelConverter.cs
+++ b/Converters/Rhino/Speckle.Converters.RhinoShared/ToSpeckle/TopLevel/SubDObjectToSpeckleTopLevelConverter.cs
@@ -1,12 +1,12 @@
-﻿using Speckle.Converters.Common;
-using Rhino.DocObjects;
+﻿using Rhino.DocObjects;
+using Speckle.Converters.Common;
 using Speckle.Converters.Common.Objects;
 using Speckle.Sdk.Models;
 
 namespace Speckle.Converters.Rhino.ToSpeckle.TopLevel;
 
 [NameAndRankValue(nameof(SubDObject), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
-public class SubDObjectToSpeckleTopLevelConverter: IToSpeckleTopLevelConverter
+public class SubDObjectToSpeckleTopLevelConverter : IToSpeckleTopLevelConverter
 {
   private readonly ITypedConverter<RG.Brep, SOG.Brep> _brepConverter;
 


### PR DESCRIPTION
Adds SubD sending support in the same way Extrusions are currently supported:

The SubD Object is converted to Brep and sent as such.