### PR TITLE
Fix(autocad): Add "layer_" prefix for layer application ids

### DIFF
--- a/Connectors/Autocad/Speckle.Connectors.AutocadShared/HostApp/AutocadColorManager.cs
+++ b/Connectors/Autocad/Speckle.Connectors.AutocadShared/HostApp/AutocadColorManager.cs
@@ -77,7 +77,11 @@ public class AutocadColorManager
     {
       // assumes color names are unique
       string colorId = layer.Color.ColorNameForDisplay;
-      string layerId = layer.Handle.ToString();
+
+      // Layers and geometries can have same application ids.....
+      // We should prevent it for sketchup converter. Because when it happens "objects_to_bake" definition
+      // is changing on the way if it happens.
+      string layerId = $"layer_{layer.Handle}";
 
       if (colorProxies.TryGetValue(colorId, out ColorProxy? value))
       {

--- a/Connectors/Autocad/Speckle.Connectors.AutocadShared/HostApp/AutocadColorManager.cs
+++ b/Connectors/Autocad/Speckle.Connectors.AutocadShared/HostApp/AutocadColorManager.cs
@@ -1,5 +1,6 @@
 using Autodesk.AutoCAD.Colors;
 using Autodesk.AutoCAD.DatabaseServices;
+using Speckle.Connectors.Autocad.HostApp.Extensions;
 using Speckle.Connectors.Autocad.Operations.Send;
 using Speckle.Sdk.Models.Proxies;
 using AutocadColor = Autodesk.AutoCAD.Colors.Color;
@@ -77,11 +78,7 @@ public class AutocadColorManager
     {
       // assumes color names are unique
       string colorId = layer.Color.ColorNameForDisplay;
-
-      // Layers and geometries can have same application ids.....
-      // We should prevent it for sketchup converter. Because when it happens "objects_to_bake" definition
-      // is changing on the way if it happens.
-      string layerId = $"layer_{layer.Handle}";
+      string layerId = layer.GetSpeckleApplicationId(); // Do not use handle directly, see note in the 'GetSpeckleApplicationId' method
 
       if (colorProxies.TryGetValue(colorId, out ColorProxy? value))
       {

--- a/Connectors/Autocad/Speckle.Connectors.AutocadShared/HostApp/AutocadLayerManager.cs
+++ b/Connectors/Autocad/Speckle.Connectors.AutocadShared/HostApp/AutocadLayerManager.cs
@@ -1,6 +1,7 @@
 using Autodesk.AutoCAD.DatabaseServices;
 using Autodesk.AutoCAD.EditorInput;
 using Autodesk.AutoCAD.LayerManager;
+using Speckle.Connectors.Autocad.HostApp.Extensions;
 using Speckle.Converters.Common;
 using Speckle.Sdk.Models.Collections;
 using Speckle.Sdk.Models.GraphTraversal;
@@ -47,7 +48,7 @@ public class AutocadLayerManager
       // Layers and geometries can have same application ids.....
       // We should prevent it for sketchup converter. Because when it happens "objects_to_bake" definition
       // is changing on the way if it happens.
-      speckleLayer = new Layer(layerName) { applicationId = $"layer_{autocadLayer.Handle}" };
+      speckleLayer = new Layer(layerName) { applicationId = autocadLayer.GetSpeckleApplicationId() }; // Do not use handle directly, see note in the 'GetSpeckleApplicationId' method
       CollectionCache[layerName] = speckleLayer;
       layer = autocadLayer;
       return speckleLayer;

--- a/Connectors/Autocad/Speckle.Connectors.AutocadShared/HostApp/AutocadLayerManager.cs
+++ b/Connectors/Autocad/Speckle.Connectors.AutocadShared/HostApp/AutocadLayerManager.cs
@@ -44,7 +44,10 @@ public class AutocadLayerManager
     }
     if (tr.GetObject(entity.LayerId, OpenMode.ForRead) is LayerTableRecord autocadLayer)
     {
-      speckleLayer = new Layer(layerName) { applicationId = autocadLayer.Handle.ToString() };
+      // Layers and geometries can have same application ids.....
+      // We should prevent it for sketchup converter. Because when it happens "objects_to_bake" definition
+      // is changing on the way if it happens.
+      speckleLayer = new Layer(layerName) { applicationId = $"layer_{autocadLayer.Handle}" };
       CollectionCache[layerName] = speckleLayer;
       layer = autocadLayer;
       return speckleLayer;

--- a/Connectors/Autocad/Speckle.Connectors.AutocadShared/HostApp/AutocadMaterialManager.cs
+++ b/Connectors/Autocad/Speckle.Connectors.AutocadShared/HostApp/AutocadMaterialManager.cs
@@ -1,6 +1,7 @@
 using Autodesk.AutoCAD.Colors;
 using Autodesk.AutoCAD.DatabaseServices;
 using Autodesk.AutoCAD.GraphicsInterface;
+using Speckle.Connectors.Autocad.HostApp.Extensions;
 using Speckle.Connectors.Autocad.Operations.Send;
 using Speckle.Connectors.Utils.Conversion;
 using Speckle.Objects.Other;
@@ -95,7 +96,7 @@ public class AutocadMaterialManager
       if (transaction.GetObject(layer.MaterialId, OpenMode.ForRead) is Material material)
       {
         string materialId = material.Handle.ToString();
-        string layerId = layer.Handle.ToString();
+        string layerId = layer.GetSpeckleApplicationId(); // Do not use handle directly, see note in the 'GetSpeckleApplicationId' method
         if (materialProxies.TryGetValue(materialId, out RenderMaterialProxy? value))
         {
           value.objects.Add(layerId);

--- a/Connectors/Autocad/Speckle.Connectors.AutocadShared/HostApp/Extensions/LayerTableRecordExtensions.cs
+++ b/Connectors/Autocad/Speckle.Connectors.AutocadShared/HostApp/Extensions/LayerTableRecordExtensions.cs
@@ -1,0 +1,14 @@
+﻿using Autodesk.AutoCAD.DatabaseServices;
+
+namespace Speckle.Connectors.Autocad.HostApp.Extensions;
+
+public static class LayerTableRecordExtensions
+{
+  /// <summary>
+  /// Layers and geometries can have same application ids.....
+  /// We should prevent it for sketchup converter. Because when it happens "objects_to_bake" definition
+  /// is changing on the way if it happens.
+  /// </summary>
+  public static string GetSpeckleApplicationId(this LayerTableRecord layerTableRecord) =>
+    $"layer_{layerTableRecord.Handle}";
+}

--- a/Connectors/Autocad/Speckle.Connectors.AutocadShared/Speckle.Connectors.AutocadShared.projitems
+++ b/Connectors/Autocad/Speckle.Connectors.AutocadShared/Speckle.Connectors.AutocadShared.projitems
@@ -31,6 +31,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)HostApp\Extensions\DocumentExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HostApp\Extensions\EditorExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HostApp\Extensions\EntityExtensions.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)HostApp\Extensions\LayerTableRecordExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HostApp\TransactionContext.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Operations\Receive\AutocadHostObjectBuilder.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Operations\Send\AutocadRootObject.cs" />


### PR DESCRIPTION
Autocad layer and object can have same `applicationId`. It became visible on sketchup receive since sketchup converter change its context to bake on the way. If you wonder more I can explain more, just find me :)

BEFORE
![image](https://github.com/user-attachments/assets/665bc7cd-c99a-4a35-ace9-5d1250a5823a)
![image](https://github.com/user-attachments/assets/8a410de8-8136-43bb-b2e4-a7971a9ff01a)
