### PR TITLE
fix(arcgis): CNX-307 correct hsv color conversions to rgb

### DIFF
--- a/Connectors/ArcGIS/Speckle.Connectors.ArcGIS3/HostApp/ArcGISColorManager.cs
+++ b/Connectors/ArcGIS/Speckle.Connectors.ArcGIS3/HostApp/ArcGISColorManager.cs
@@ -395,46 +395,6 @@ public class ArcGISColorManager
     return RbgToInt(255, red, green, blue);
   }
 
-  /// <summary>
-  /// Converts HSV color values to RGB
-  /// </summary>
-  /// <param name="h">0 - 360</param>
-  /// <param name="s">0 - 100</param>
-  /// <param name="v">0 - 100</param>
-  /// <param name="r">0 - 255</param>
-  /// <param name="g">0 - 255</param>
-  /// <param name="b">0 - 255</param>
-  private int HSVToRGB(int h, int s, int v, out int r, out int g, out int b)
-  {
-    var rgb = new int[3];
-
-    var baseColor = (h + 60) % 360 / 120;
-    var shift = (h + 60) % 360 - (120 * baseColor + 60);
-    var secondaryColor = (baseColor + (shift >= 0 ? 1 : -1) + 3) % 3;
-
-    //Setting Hue
-    rgb[baseColor] = 255;
-    rgb[secondaryColor] = (int)((Math.Abs(shift) / 60.0f) * 255.0f);
-
-    //Setting Saturation
-    for (var i = 0; i < 3; i++)
-    {
-      rgb[i] += (int)((255 - rgb[i]) * ((100 - s) / 100.0f));
-    }
-
-    //Setting Value
-    for (var i = 0; i < 3; i++)
-    {
-      rgb[i] -= (int)(rgb[i] * (100 - v) / 100.0f);
-    }
-
-    r = rgb[0];
-    g = rgb[1];
-    b = rgb[2];
-
-    return RbgToInt(255, r, g, b);
-  }
-
   private bool TryGetUniqueRendererColor(
     CIMUniqueValueRenderer uniqueRenderer,
     Row row,


### PR DESCRIPTION
using this library as reference from @AlexandruPopovici : https://gist.github.com/Aeldrion/48c82912f632eec4c8b9da7394b89c5d

Original:
![image](https://github.com/user-attachments/assets/3fcedaf0-928f-4d4e-b834-b113d982ffbf)

Before:
![image](https://github.com/user-attachments/assets/d7496b3f-4921-4d8e-962e-50a6fc4fee45)

After:
![image](https://github.com/user-attachments/assets/d2bcc83b-f56b-4b14-86cd-841181747f64)
