### PR TITLE
fix(autocad): CNX-272 adds unit conversions to blocks in connector

### DIFF
--- a/Connectors/Autocad/Speckle.Connectors.AutocadShared/DependencyInjection/SharedRegistration.cs
+++ b/Connectors/Autocad/Speckle.Connectors.AutocadShared/DependencyInjection/SharedRegistration.cs
@@ -18,6 +18,7 @@ using Speckle.Connectors.Utils.Builders;
 using Speckle.Connectors.Utils.Caching;
 using Speckle.Connectors.Utils.Instances;
 using Speckle.Connectors.Utils.Operations;
+using Speckle.Converters.Common;
 using Speckle.Sdk.Models.GraphTraversal;
 
 namespace Speckle.Connectors.Autocad.DependencyInjection;
@@ -41,6 +42,7 @@ public static class SharedRegistration
     builder.AddScoped<AutocadColorManager>();
     builder.AddScoped<AutocadMaterialManager>();
     builder.AddSingleton<IAutocadIdleManager, AutocadIdleManager>();
+    builder.AddSingleton<IHostToSpeckleUnitConverter<UnitsValue>>();
 
     // operation progress manager
     builder.AddSingleton<IOperationProgressManager, OperationProgressManager>();


### PR DESCRIPTION
Block instance units were not being converted previously - it was jsut fortuitous that our speckle units strings coincide with `UnitsValue` enums in autocad. This lack of conversion was being exposed when autocad doc units were set to "none", which were correctly mapped to meters in the converter, but kept as none in the instance conversion in the connector.

Now we are injecting the units converter into the instance manager in the connector to fix this problem.

Units after (sent from acad unitless doc):
[https://app.speckle.systems/projects/b53a53697a/models/66aca735ab](https://app.speckle.systems/projects/b53a53697a/models/66aca735ab)