### PR TITLE
chore(autocad/rhino): CNX-357 removes unnecessary definition color logic

### DIFF
--- a/Connectors/Autocad/Speckle.Connectors.AutocadShared/HostApp/AutocadColorManager.cs
+++ b/Connectors/Autocad/Speckle.Connectors.AutocadShared/HostApp/AutocadColorManager.cs
@@ -2,7 +2,6 @@ using Autodesk.AutoCAD.Colors;
 using Autodesk.AutoCAD.DatabaseServices;
 using Speckle.Connectors.Autocad.HostApp.Extensions;
 using Speckle.Connectors.Autocad.Operations.Send;
-using Speckle.Sdk.Models.Instances;
 using Speckle.Sdk.Models.Proxies;
 using AutocadColor = Autodesk.AutoCAD.Colors.Color;
 
@@ -25,18 +24,15 @@ public class AutocadColorManager
   /// For send operations
   /// </summary>
   private Dictionary<string, ColorProxy> ColorProxies { get; } = new();
-  private readonly Dictionary<string, AutocadColor> _layerColorDict = new(); // keeps track of layer colors for object inheritance
-  private readonly Dictionary<string, string> _objectsByLayerDict = new(); // keeps track of ids for all objects that inherited their color by layer
 
   /// <summary>
   /// Processes an object's color and adds the object id to a color proxy in <see cref="ColorProxies"/> if object color is set ByAci, ByColor, or ByBlock.
-  /// Otherwise, stores the object id and color in a corresponding ByLayer dictionary for further processing block definitions after all objects are converted.
-  /// From testing, a definition object will inherit its layer's color if by layer, otherwise it will inherit the instance color settings (which we are sending with the instance).
   /// Skips processing ByPen for now, because I don't understand what this means.
   /// </summary>
   /// <param name="objectId"></param>
   /// <param name="color"></param>
-  private void ProcessObjectColor(string objectId, AutocadColor color, string? layerId = null)
+  /// <remarks>Skips processing object colors if it is "ByLayer" since autocad commits are structured by layer and by default sets the color by layer on receive. If this ever changes, then we do need to start processing object colors by layer.</remarks>
+  private void ProcessObjectColor(string objectId, AutocadColor color)
   {
     switch (color.ColorMethod)
     {
@@ -45,19 +41,7 @@ public class AutocadColorManager
       case ColorMethod.ByBlock:
         AddObjectIdToColorProxy(objectId, color);
         break;
-      case ColorMethod.ByLayer:
-        if (layerId != null)
-        {
-#if NET8_0
-          _objectsByLayerDict.TryAdd(objectId, layerId);
-#else
-          if (!_objectsByLayerDict.ContainsKey(objectId))
-          {
-            _objectsByLayerDict.Add(objectId, layerId);
-          }
-#endif
-        }
-        break;
+      case ColorMethod.ByLayer: // skipping these since autocad commits are structured by layer. Will need to be updated if this ever changes!!
       case ColorMethod.ByPen: // POC: no idea what this means
         break;
     }
@@ -110,62 +94,28 @@ public class AutocadColorManager
   }
 
   /// <summary>
-  /// Processes colors for definition objects that had their colors inherited. This method is in place primarily to process complex color inheritance in blocks.
+  /// Iterates through a given set of autocad objects and layers to collect colors.
   /// </summary>
-  /// <returns></returns>
-  /// <remarks>
-  /// We are **always setting the color** (treating it as ColorMethod.ByColor) for definition objects with color "ByLayer" because this overrides instance color, to guarantee they look correct in the viewer and when receiving.
-  /// </remarks>
-  public void ProcessDefinitionObjects(List<InstanceDefinitionProxy> definitions)
-  {
-    // process all definition objects, while removing process objects from the by block color dict as necessary
-    foreach (InstanceDefinitionProxy definition in definitions)
-    {
-      foreach (string objectId in definition.objects)
-      {
-        if (_objectsByLayerDict.TryGetValue(objectId, out string? layerId))
-        {
-          if (_layerColorDict.TryGetValue(layerId, out AutocadColor? layerColor))
-          {
-            AddObjectIdToColorProxy(objectId, layerColor);
-          }
-        }
-      }
-    }
-  }
-
-  /// <summary>
-  /// Iterates through a given set of autocad objects, layers, and definitions to collect atomic object colors.
-  /// </summary>
-  /// <param name="unpackedAutocadRootObjects">atomic root objects, including definition objects</param>
+  /// <param name="unpackedAutocadRootObjects">atomic root objects, including instance objects</param>
   /// <param name="layers">layers used by atomic objects</param>
-  /// <param name="definitions">definitions used by instances in atomic objects</param>
   /// <returns></returns>
-  /// <remarks>
-  /// Due to complications in color inheritance for blocks, we are processing block definition object colors last.
-  /// </remarks>
   public List<ColorProxy> UnpackColors(
     List<AutocadRootObject> unpackedAutocadRootObjects,
-    List<LayerTableRecord> layers,
-    List<InstanceDefinitionProxy> definitions
+    List<LayerTableRecord> layers
   )
   {
     // Stage 1: unpack colors from objects
     foreach (AutocadRootObject rootObj in unpackedAutocadRootObjects)
     {
       Entity entity = rootObj.Root;
-      ProcessObjectColor(rootObj.ApplicationId, entity.Color, entity.LayerId.ToString());
+      ProcessObjectColor(rootObj.ApplicationId, entity.Color);
     }
 
     // Stage 2: make sure we collect layer colors as well
     foreach (LayerTableRecord layer in layers)
     {
       ProcessObjectColor(layer.GetSpeckleApplicationId(), layer.Color);
-      _layerColorDict.Add(layer.Id.ToString(), layer.Color);
     }
-
-    // Stage 3: process definition objects that inherited their colors
-    ProcessDefinitionObjects(definitions);
 
     return ColorProxies.Values.ToList();
   }

--- a/Connectors/Autocad/Speckle.Connectors.AutocadShared/Operations/Send/AutocadRootObjectBuilder.cs
+++ b/Connectors/Autocad/Speckle.Connectors.AutocadShared/Operations/Send/AutocadRootObjectBuilder.cs
@@ -149,11 +149,7 @@ public class AutocadRootObjectBuilder : IRootObjectBuilder<AutocadRootObject>
       modelWithLayers["renderMaterialProxies"] = materialProxies;
 
       // set colors
-      List<ColorProxy> colorProxies = _colorManager.UnpackColors(
-        atomicObjects,
-        usedAcadLayers,
-        instanceDefinitionProxies
-      );
+      List<ColorProxy> colorProxies = _colorManager.UnpackColors(atomicObjects, usedAcadLayers);
       modelWithLayers["colorProxies"] = colorProxies;
 
       return new RootObjectBuilderResult(modelWithLayers, results);

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/Operations/Send/RhinoRootObjectBuilder.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/Operations/Send/RhinoRootObjectBuilder.cs
@@ -12,7 +12,6 @@ using Speckle.Sdk;
 using Speckle.Sdk.Logging;
 using Speckle.Sdk.Models;
 using Speckle.Sdk.Models.Collections;
-using Speckle.Sdk.Models.Proxies;
 using Layer = Rhino.DocObjects.Layer;
 
 namespace Speckle.Connectors.Rhino.Operations.Send;
@@ -139,12 +138,7 @@ public class RhinoRootObjectBuilder : IRootObjectBuilder<RhinoObject>
       {
         // set render materials and colors
         rootObjectCollection["renderMaterialProxies"] = _materialManager.UnpackRenderMaterial(atomicObjects);
-        List<ColorProxy> colorProxies = _colorManager.UnpackColors(
-          atomicObjects,
-          versionLayers.ToList(),
-          instanceDefinitionProxies
-        );
-        rootObjectCollection["colorProxies"] = colorProxies;
+        rootObjectCollection["colorProxies"] = _colorManager.UnpackColors(atomicObjects, versionLayers.ToList());
       }
 
       // 5. profit


### PR DESCRIPTION
After a sync with @AlexandruPopovici , we've decided that the viewer will implement color logic to take into account display behavior by source. 

This behavior is outlined in detail in: https://www.notion.so/speckle/Objects-Colors-3a16d721e9fd46bda5e1b31072a38f29?pvs=4

PR removes hacky logic in autocad and rhino to send definition object colors `by layer` as if `by object`. There is no change in behavior in autocad<>autocad, rhino<>rhino, and autocad<>rhino workflows for color.