### PR TITLE
Dimitrie/cnx 358 caching element from another model sent

### DIFF
--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Bindings/RevitSendBinding.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Bindings/RevitSendBinding.cs
@@ -234,10 +234,22 @@ internal sealed class RevitSendBinding : RevitBaseBinding, ISendBinding
   {
     var senders = Store.GetSenders();
     string[] objectIdsList = ChangedObjectIds.Keys.ToArray();
+    var doc = RevitContext.UIApplication?.ActiveUIDocument.Document;
+
+    if (doc == null)
+    {
+      return;
+    }
+
+    // Note: We're using unique ids as application ids in revit, so cache eviction must happen by those.
+    var objUniqueIds = objectIdsList
+      .Select(id => new ElementId(Convert.ToInt32(id)))
+      .Select(doc.GetElement)
+      .Select(el => el.UniqueId);
+    _sendConversionCache.EvictObjects(objUniqueIds);
+
+    // Note: we're doing object selection and card expiry management by old school ids
     List<string> expiredSenderIds = new();
-
-    _sendConversionCache.EvictObjects(objectIdsList);
-
     foreach (SenderModelCard modelCard in senders)
     {
       var intersection = modelCard.SendFilter.NotNull().GetObjectIds().Intersect(objectIdsList).ToList();

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Bindings/RevitSendBinding.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Bindings/RevitSendBinding.cs
@@ -255,6 +255,7 @@ internal sealed class RevitSendBinding : RevitBaseBinding, ISendBinding
     var objUniqueIds = objectIdsList
       .Select(id => new ElementId(Convert.ToInt32(id)))
       .Select(doc.GetElement)
+      .Where(el => el is not null)
       .Select(el => el.UniqueId);
     _sendConversionCache.EvictObjects(objUniqueIds);
 

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/RevitRootObjectBuilder.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/RevitRootObjectBuilder.cs
@@ -89,7 +89,7 @@ public class RevitRootObjectBuilder : IRootObjectBuilder<ElementId>
       foreach (Element revitElement in atomicObjects)
       {
         ct.ThrowIfCancellationRequested();
-        var applicationId = revitElement.Id.ToString();
+        var applicationId = revitElement.UniqueId; // NOTE: converter set applicationIds to unique ids; if we ever change this in the converter, behaviour here needs to match.
         try
         {
           Base converted;

--- a/Converters/Revit/Speckle.Converters.RevitShared/RevitRootToSpeckleConverter.cs
+++ b/Converters/Revit/Speckle.Converters.RevitShared/RevitRootToSpeckleConverter.cs
@@ -44,7 +44,7 @@ public class RevitRootToSpeckleConverter : IRootToSpeckleConverter
     if (target is DB.Element element)
     {
       // POC: is this the right place?
-      result.applicationId = element.UniqueId;
+      result.applicationId = element.UniqueId; // NOTE: caching logic uses unique ids. if we ever change this behaviour here, we should update to match.
       // POC: should we assign parameters here instead?
       //_parameterObjectAssigner.AssignParametersToBase(element, result);
       _parameterValueExtractor.RemoveUniqueId(element.UniqueId);


### PR DESCRIPTION
There were several compounding issues that this PR is resolving: 
- harmonises applicationId mismatch between caching logic and converter by centralising on UniqueIds
- correctly invalidates cache in expiry checks by transforming elementIds into uniqueIds