### PR TITLE
Fix(rhino): Do not skip first item if it is one-to-one conversion

### DIFF
--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/Operations/Receive/RhinoHostObjectBuilder.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/Operations/Receive/RhinoHostObjectBuilder.cs
@@ -207,7 +207,16 @@ public class RhinoHostObjectBuilder : IHostObjectBuilder
           // 4: log
           var id = conversionIds[0]; // this is group id if it is a one to many conversion, otherwise id of object itself
           conversionResults.Add(new(Status.SUCCESS, obj, id, result.GetType().ToString()));
-          bakedObjectIds.AddRange(conversionIds.Skip(1)); // first item always a group id, which we do not want to deal with later groups and its sub elements. It causes a huge issue on performance.
+          if (conversionIds.Count == 1)
+          {
+            bakedObjectIds.Add(id);
+          }
+          else
+          {
+            // first item always a group id if it is a one-to-many,
+            // we do not want to deal with later groups and its sub elements. It causes a huge issue on performance.
+            bakedObjectIds.AddRange(conversionIds.Skip(1));
+          }
 
           // 5: populate app id map
           applicationIdMap[obj.applicationId ?? obj.id] = conversionIds;


### PR DESCRIPTION
It was on me. While fixing the group highlight performance issue, this scenario skipped..