### PR TITLE
Fix(send): Fail fast if all conversion status is ERROR

### DIFF
--- a/Connectors/ArcGIS/Speckle.Connectors.ArcGIS3/Operations/Send/ArcGISRootObjectBuilder.cs
+++ b/Connectors/ArcGIS/Speckle.Connectors.ArcGIS3/Operations/Send/ArcGISRootObjectBuilder.cs
@@ -158,6 +158,11 @@ public class ArcGISRootObjectBuilder : IRootObjectBuilder<MapMember>
       onOperationProgressed?.Invoke("Converting", (double)++count / objects.Count);
     }
 
+    if (results.All(x => x.Status == Status.ERROR))
+    {
+      throw new SpeckleConversionException("Failed to convert all objects."); // fail fast instead creating empty commit! It will appear as model card error with red color.
+    }
+
     // POC: Add Color Proxies
     List<ColorProxy> colorProxies = _colorManager.UnpackColors(layersWithDisplayPriority);
     rootObjectCollection["colorProxies"] = colorProxies;

--- a/Connectors/Autocad/Speckle.Connectors.AutocadShared/Operations/Send/AutocadRootObjectBuilder.cs
+++ b/Connectors/Autocad/Speckle.Connectors.AutocadShared/Operations/Send/AutocadRootObjectBuilder.cs
@@ -48,7 +48,12 @@ public class AutocadRootObjectBuilder : IRootObjectBuilder<AutocadRootObject>
     _syncToThread = syncToThread;
   }
 
+  // It is already simplified but has many different references since it is a builder. Do not know can we simplify it now.
+  // Later we might consider to refactor proxies from one proxy manager? but we do not know the shape of it all potential
+  // proxy classes yet. So I'm disabling this with pragma now!!!
+#pragma warning disable CA1506
   public Task<RootObjectBuilderResult> Build(
+#pragma warning restore CA1506
     IReadOnlyList<AutocadRootObject> objects,
     SendInfo sendInfo,
     Action<string, double?>? onOperationProgressed = null,
@@ -120,6 +125,11 @@ public class AutocadRootObjectBuilder : IRootObjectBuilder<AutocadRootObject>
           // POC: add logging
         }
         onOperationProgressed?.Invoke("Converting", (double)++count / atomicObjects.Count);
+      }
+
+      if (results.All(x => x.Status == Status.ERROR))
+      {
+        throw new SpeckleConversionException("Failed to convert all objects."); // fail fast instead creating empty commit! It will appear as model card error with red color.
       }
 
       // POC: Log would be nice, or can be removed.

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/RevitRootObjectBuilder.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/RevitRootObjectBuilder.cs
@@ -116,6 +116,11 @@ public class RevitRootObjectBuilder : IRootObjectBuilder<ElementId>
         onOperationProgressed?.Invoke("Converting", (double)++countProgress / atomicObjects.Count);
       }
 
+      if (results.All(x => x.Status == Status.ERROR))
+      {
+        throw new SpeckleConversionException("Failed to convert all objects."); // fail fast instead creating empty commit! It will appear as model card error with red color.
+      }
+
       var idsAndSubElementIds = _elementUnpacker.GetElementsAndSubelementIdsFromAtomicObjects(atomicObjects);
       var materialProxies = _conversionContextStack.RenderMaterialProxyCache.GetRenderMaterialProxyListForObjects(
         idsAndSubElementIds

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/Operations/Send/RhinoRootObjectBuilder.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/Operations/Send/RhinoRootObjectBuilder.cs
@@ -134,6 +134,11 @@ public class RhinoRootObjectBuilder : IRootObjectBuilder<RhinoObject>
         }
       }
 
+      if (results.All(x => x.Status == Status.ERROR))
+      {
+        throw new SpeckleConversionException("Failed to convert all objects."); // fail fast instead creating empty commit! It will appear as model card error with red color.
+      }
+
       using (var _ = SpeckleActivityFactory.Start("UnpackRenderMaterials"))
       {
         // set render materials and colors


### PR DESCRIPTION
We even won't create commit if all objects already `ERROR`ed. Tested in ArcGIS, Rhino and Autocad. Revit can send everything, couldn't find any type of object. But faked it by tweaking the code and it works for sure.

ARCGIS
![ArcGISPro_Y86v0edP8D](https://github.com/user-attachments/assets/54b21ed6-1ecd-4eaf-93c9-39a40080e8d2)

AUTOCAD
![acad_HeJ7w99Gxw](https://github.com/user-attachments/assets/bbd9a276-011b-4fee-8801-4f6b9bf6db3a)

RHINO
![Rhino_UM0eQ5z6ON](https://github.com/user-attachments/assets/d40a5990-7a14-4234-a090-8659a0d3771c)