### PR TITLE
feat(revit): CNX-344 parameter elementid values sent as elements names when available

### DIFF
--- a/Converters/Revit/Speckle.Converters.RevitShared/Helpers/ParameterValueExtractor.cs
+++ b/Converters/Revit/Speckle.Converters.RevitShared/Helpers/ParameterValueExtractor.cs
@@ -246,9 +246,4 @@ public class ParameterValueExtractor
       paramDict[internalName] = param;
     }
   }
-
-  public void RemoveUniqueId(string uniqueId)
-  {
-    _uniqueIdToUsedParameterSetMap.Remove(uniqueId);
-  }
 }


### PR DESCRIPTION
Aligned V3 with V2 parameter behavior to send any `ElementId` parameter value as the element name where a name exists.

Fixed in V2 with https://github.com/specklesystems/speckle-sharp/pull/3422

Note: Element lookup may be expensive in large commits with many parameters. Should reevaluate this aspect when we get around to a Parameter refactor.

Sample commit with element name parameter values: 
https://app.speckle.systems/projects/b53a53697a/models/d7f7cf1df9