### PR TITLE
Fix(revit): regression on switching ElementId to UniqueId

### DIFF
--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Bindings/BasicConnectorBindingRevit.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Bindings/BasicConnectorBindingRevit.cs
@@ -84,7 +84,7 @@ internal sealed class BasicConnectorBindingRevit : IBasicConnectorBinding
     var elementIds = model
       .SendFilter.NotNull()
       .GetObjectIds()
-      .Select(uid => ElementIdHelper.GetElementIdByUniqueId(activeUIDoc.Document, uid))
+      .Select(uid => ElementIdHelper.GetElementIdFromUniqueId(activeUIDoc.Document, uid))
       .ToList();
     if (elementIds.Count == 0)
     {
@@ -106,7 +106,7 @@ internal sealed class BasicConnectorBindingRevit : IBasicConnectorBinding
       ?? throw new SpeckleException("Unable to retrieve active UI document");
 
     HighlightObjectsOnView(
-      objectIds.Select(uid => ElementIdHelper.GetElementIdByUniqueId(activeUIDoc.Document, uid)).ToList()
+      objectIds.Select(uid => ElementIdHelper.GetElementIdFromUniqueId(activeUIDoc.Document, uid)).ToList()
     );
   }
 

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Bindings/BasicConnectorBindingRevit.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Bindings/BasicConnectorBindingRevit.cs
@@ -77,14 +77,10 @@ internal sealed class BasicConnectorBindingRevit : IBasicConnectorBinding
   {
     SenderModelCard model = (SenderModelCard)_store.GetModelById(modelCardId);
 
-    var activeUIDoc =
-      _revitContext.UIApplication?.ActiveUIDocument
-      ?? throw new SpeckleException("Unable to retrieve active UI document");
-
     var elementIds = model
       .SendFilter.NotNull()
       .GetObjectIds()
-      .Select(uid => ElementIdHelper.GetElementIdByUniqueId(activeUIDoc.Document, uid))
+      .Select(ElementIdHelper.Parse) // On model card level we store ElementIds of the objects, in report they are UniqueId. It doesn't make sense for now to send UniqueIds via Selection to model card bc API gave us ElementIds from selection.
       .ToList();
     if (elementIds.Count == 0)
     {
@@ -95,11 +91,16 @@ internal sealed class BasicConnectorBindingRevit : IBasicConnectorBinding
     HighlightObjectsOnView(elementIds);
   }
 
+  /// <summary>
+  /// Highlights the objects from the given ids.
+  /// </summary>
+  /// <param name="objectIds"> UniqueId's of the DB.Elements.</param>
   public void HighlightObjects(List<string> objectIds)
   {
     var activeUIDoc =
       _revitContext.UIApplication?.ActiveUIDocument
       ?? throw new SpeckleException("Unable to retrieve active UI document");
+
     HighlightObjectsOnView(
       objectIds.Select(uid => ElementIdHelper.GetElementIdByUniqueId(activeUIDoc.Document, uid)).ToList()
     );

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Bindings/BasicConnectorBindingRevit.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Bindings/BasicConnectorBindingRevit.cs
@@ -77,10 +77,14 @@ internal sealed class BasicConnectorBindingRevit : IBasicConnectorBinding
   {
     SenderModelCard model = (SenderModelCard)_store.GetModelById(modelCardId);
 
+    var activeUIDoc =
+      _revitContext.UIApplication?.ActiveUIDocument
+      ?? throw new SpeckleException("Unable to retrieve active UI document");
+
     var elementIds = model
       .SendFilter.NotNull()
       .GetObjectIds()
-      .Select(ElementIdHelper.Parse) // On model card level we store ElementIds of the objects, in report they are UniqueId. It doesn't make sense for now to send UniqueIds via Selection to model card bc API gave us ElementIds from selection.
+      .Select(uid => ElementIdHelper.GetElementIdByUniqueId(activeUIDoc.Document, uid))
       .ToList();
     if (elementIds.Count == 0)
     {

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Bindings/RevitSendBinding.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Bindings/RevitSendBinding.cs
@@ -130,10 +130,14 @@ internal sealed class RevitSendBinding : RevitBaseBinding, ISendBinding
         }
       );
 
+      var activeUIDoc =
+        RevitContext.UIApplication?.ActiveUIDocument
+        ?? throw new SpeckleException("Unable to retrieve active UI document");
+
       List<ElementId> revitObjects = modelCard
         .SendFilter.NotNull()
         .GetObjectIds()
-        .Select(ElementIdHelper.Parse)
+        .Select(uid => ElementIdHelper.GetElementIdByUniqueId(activeUIDoc.Document, uid))
         .ToList();
 
       if (revitObjects.Count == 0)

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Bindings/RevitSendBinding.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Bindings/RevitSendBinding.cs
@@ -259,14 +259,15 @@ internal sealed class RevitSendBinding : RevitBaseBinding, ISendBinding
       .Select(id => new ElementId(Convert.ToInt32(id)))
       .Select(doc.GetElement)
       .Where(el => el is not null)
-      .Select(el => el.UniqueId);
+      .Select(el => el.UniqueId)
+      .ToList();
     _sendConversionCache.EvictObjects(objUniqueIds);
 
     // Note: we're doing object selection and card expiry management by old school ids
     List<string> expiredSenderIds = new();
     foreach (SenderModelCard modelCard in senders)
     {
-      var intersection = modelCard.SendFilter.NotNull().GetObjectIds().Intersect(objectIdsList).ToList();
+      var intersection = modelCard.SendFilter.NotNull().GetObjectIds().Intersect(objUniqueIds).ToList();
       bool isExpired = intersection.Count != 0;
       if (isExpired)
       {

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Bindings/RevitSendBinding.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Bindings/RevitSendBinding.cs
@@ -13,7 +13,6 @@ using Speckle.Connectors.DUI.Models.Card.SendFilter;
 using Speckle.Connectors.DUI.Settings;
 using Speckle.Connectors.Revit.Operations.Send.Settings;
 using Speckle.Connectors.Revit.Plugin;
-using Speckle.Connectors.RevitShared;
 using Speckle.Connectors.Utils.Caching;
 using Speckle.Connectors.Utils.Cancellation;
 using Speckle.Connectors.Utils.Operations;
@@ -137,7 +136,7 @@ internal sealed class RevitSendBinding : RevitBaseBinding, ISendBinding
       List<ElementId> revitObjects = modelCard
         .SendFilter.NotNull()
         .GetObjectIds()
-        .Select(uid => ElementIdHelper.GetElementIdByUniqueId(activeUIDoc.Document, uid))
+        .Select(uid => activeUIDoc.Document.GetElement(uid).Id)
         .ToList();
 
       if (revitObjects.Count == 0)

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Bindings/SelectionBinding.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Bindings/SelectionBinding.cs
@@ -4,7 +4,6 @@ using Speckle.Connectors.DUI.Models;
 using Speckle.Connectors.Revit.Plugin;
 using Speckle.Converters.RevitShared.Helpers;
 using Speckle.Sdk;
-using Speckle.Sdk.Common;
 
 namespace Speckle.Connectors.Revit.Bindings;
 

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Bindings/SelectionBinding.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Bindings/SelectionBinding.cs
@@ -3,7 +3,7 @@ using Speckle.Connectors.DUI.Bridge;
 using Speckle.Connectors.DUI.Models;
 using Speckle.Connectors.Revit.Plugin;
 using Speckle.Converters.RevitShared.Helpers;
-using Speckle.Sdk;
+using Speckle.Sdk.Common;
 
 namespace Speckle.Connectors.Revit.Bindings;
 
@@ -52,9 +52,7 @@ internal sealed class SelectionBinding : RevitBaseBinding, ISelectionBinding, ID
       return new SelectionInfo(Array.Empty<string>(), "No objects selected.");
     }
 
-    var activeUIDoc =
-      RevitContext.UIApplication?.ActiveUIDocument
-      ?? throw new SpeckleException("Unable to retrieve active UI document");
+    var activeUIDoc = RevitContext.UIApplication.ActiveUIDocument.NotNull();
 
     // POC: this was also being called on shutdown
     // probably the bridge needs to be able to know if the plugin has been terminated

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Bindings/SelectionBinding.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Bindings/SelectionBinding.cs
@@ -3,6 +3,7 @@ using Speckle.Connectors.DUI.Bridge;
 using Speckle.Connectors.DUI.Models;
 using Speckle.Connectors.Revit.Plugin;
 using Speckle.Converters.RevitShared.Helpers;
+using Speckle.Sdk;
 using Speckle.Sdk.Common;
 
 namespace Speckle.Connectors.Revit.Bindings;
@@ -52,12 +53,16 @@ internal sealed class SelectionBinding : RevitBaseBinding, ISelectionBinding, ID
       return new SelectionInfo(Array.Empty<string>(), "No objects selected.");
     }
 
+    var activeUIDoc =
+      RevitContext.UIApplication?.ActiveUIDocument
+      ?? throw new SpeckleException("Unable to retrieve active UI document");
+
     // POC: this was also being called on shutdown
     // probably the bridge needs to be able to know if the plugin has been terminated
     // also on termination the OnSelectionChanged event needs unwinding
-    var selectionIds = (RevitContext.UIApplication?.ActiveUIDocument?.Selection.GetElementIds())
-      .NotNull()
-      .Select(id => id.ToString())
+    var selectionIds = activeUIDoc
+      .Selection.GetElementIds()
+      .Select(eid => activeUIDoc.Document.GetElement(eid).UniqueId.ToString())
       .ToList();
     return new SelectionInfo(selectionIds, $"{selectionIds.Count} objects selected.");
   }

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/ElementIdHelper.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/ElementIdHelper.cs
@@ -5,7 +5,7 @@ namespace Speckle.Connectors.RevitShared;
 
 public static class ElementIdHelper
 {
-  public static ElementId GetElementIdByUniqueId(Document doc, string uniqueId)
+  public static ElementId GetElementIdFromUniqueId(Document doc, string uniqueId)
   {
     Element element = doc.GetElement(uniqueId);
     if (element == null)

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/ElementIdHelper.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/ElementIdHelper.cs
@@ -5,16 +5,6 @@ namespace Speckle.Connectors.RevitShared;
 
 public static class ElementIdHelper
 {
-  public static ElementId Parse(string idStr)
-  {
-    if (!int.TryParse(idStr, out var result))
-    {
-      throw new SpeckleConversionException($"Cannot parse ElementId: {idStr}");
-    }
-
-    return new ElementId(result);
-  }
-
   public static ElementId GetElementIdByUniqueId(Document doc, string uniqueId)
   {
     Element element = doc.GetElement(uniqueId);

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/ElementIdHelper.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/ElementIdHelper.cs
@@ -14,4 +14,15 @@ public static class ElementIdHelper
 
     return new ElementId(result);
   }
+
+  public static ElementId GetElementIdByUniqueId(Document doc, string uniqueId)
+  {
+    Element element = doc.GetElement(uniqueId);
+    if (element == null)
+    {
+      throw new SpeckleConversionException($"Cannot find element with UniqueId: {uniqueId}");
+    }
+
+    return element.Id;
+  }
 }

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Receive/RevitHostObjectBuilder.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Receive/RevitHostObjectBuilder.cs
@@ -76,6 +76,8 @@ internal sealed class RevitHostObjectBuilder : IHostObjectBuilder, IDisposable
     using (var _ = SpeckleActivityFactory.Start("BakeObjects"))
     {
       var conversionResults = new List<ReceiveConversionResult>();
+
+      // NOTE!!!! Add 'UniqueId' of the elements once we have receiving in place, otherwise highlight logic will fail.
       var bakedObjectIds = new List<string>();
 
       foreach (TraversalContext tc in objectsGraph)


### PR DESCRIPTION
It was a regression on switch from ElementId to UniqueId, since we send report items as UniqueId, it can't parse them directly to ElementId