### PR TITLE
Fix(revit): Reference to CefSharp.Wpf.NETCore for Revit 2025

### DIFF
--- a/Connectors/Revit/Speckle.Connectors.Revit2025/Speckle.Connectors.Revit2025.csproj
+++ b/Connectors/Revit/Speckle.Connectors.Revit2025/Speckle.Connectors.Revit2025.csproj
@@ -14,6 +14,8 @@
 
   <Import Project="..\Speckle.Connectors.RevitShared\Speckle.Connectors.RevitShared.projitems" Label="Shared" />
 
+  <Import Project="..\Speckle.Connectors.RevitShared.Cef\Speckle.Connectors.RevitShared.Cef.projitems" Label="Shared" />
+
   <ItemGroup>
     <ProjectReference Include="..\..\..\Converters\Revit\Speckle.Converters.Revit2025.DependencyInjection\Speckle.Converters.Revit2025.DependencyInjection.csproj" />
     <ProjectReference Include="..\..\..\Converters\Revit\Speckle.Converters.Revit2025\Speckle.Converters.Revit2025.csproj" />
@@ -25,7 +27,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Web.WebView2" IncludeAssets="compile" />
+    <PackageReference Include="CefSharp.Wpf.NETCore" IncludeAssets="compile" VersionOverride="119.4.30.0" />
     <PackageReference Include="Revit.Async" />
   </ItemGroup>
 

--- a/Connectors/Revit/Speckle.Connectors.Revit2025/packages.lock.json
+++ b/Connectors/Revit/Speckle.Connectors.Revit2025/packages.lock.json
@@ -2,6 +2,15 @@
   "version": 2,
   "dependencies": {
     "net8.0-windows7.0": {
+      "CefSharp.Wpf.NETCore": {
+        "type": "Direct",
+        "requested": "[119.4.30, )",
+        "resolved": "119.4.30",
+        "contentHash": "S8iTV5UAO9my2O4c6mJKtScDrXbPPS9k5cOs247X7xvly4mb0XsLOFmLjXM1/gsuYfYx5Dy0k6mgCwTZMC6NMg==",
+        "dependencies": {
+          "CefSharp.Common.NETCore": "[119.4.30]"
+        }
+      },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",
         "requested": "[8.0.0, )",
@@ -11,12 +20,6 @@
           "Microsoft.Build.Tasks.Git": "8.0.0",
           "Microsoft.SourceLink.Common": "8.0.0"
         }
-      },
-      "Microsoft.Web.WebView2": {
-        "type": "Direct",
-        "requested": "[1.0.1938.49, )",
-        "resolved": "1.0.1938.49",
-        "contentHash": "z8KnFnaTYzhA/ZnyRX0qGfS1NU5ZBJeClAH64F0fVDvdDJTvME7xl6zTJ0Jlfe1BtL3C0NH9xTy64shg2baKdw=="
       },
       "PolySharp": {
         "type": "Direct",
@@ -35,6 +38,19 @@
         "requested": "[0.9.6, )",
         "resolved": "0.9.6",
         "contentHash": "HKH7tYrYYlCK1ct483hgxERAdVdMtl7gUKW9ijWXxA1UsYR4Z+TrRHYmzZ9qmpu1NnTycSrp005NYM78GDKV1w=="
+      },
+      "CefSharp.Common.NETCore": {
+        "type": "Transitive",
+        "resolved": "119.4.30",
+        "contentHash": "nu5zqeOL+ubs723jU/EJWdMNAefzXtucKAewv4Mvh3tLLeoGsGbz0oZM36vIuBgAzhhsE+ZO4uzkdhk6X9JwJA==",
+        "dependencies": {
+          "chromiumembeddedframework.runtime": "[119.4.3]"
+        }
+      },
+      "chromiumembeddedframework.runtime": {
+        "type": "Transitive",
+        "resolved": "119.4.3",
+        "contentHash": "JEYg94tEtdyIIm9hQvZ/vP0/+9w5ebvZFfcJ22NG16BjeEm5y6dC0B86DIsKwwhj1RhnfyEbp8JVKuY8imCO5w=="
       },
       "GraphQL.Client": {
         "type": "Transitive",
@@ -314,6 +330,12 @@
         "resolved": "3.1.0",
         "contentHash": "jjo4YXRx6MIpv6DiRxJjSpl+sPP0+5VW0clMEdLyIAz44PPwrDTFrd5PZckIxIXl1kKZ2KK6IL2nkt0+ug2MQg=="
       },
+      "Microsoft.Web.WebView2": {
+        "type": "CentralTransitive",
+        "requested": "[1.0.1938.49, )",
+        "resolved": "1.0.1938.49",
+        "contentHash": "z8KnFnaTYzhA/ZnyRX0qGfS1NU5ZBJeClAH64F0fVDvdDJTvME7xl6zTJ0Jlfe1BtL3C0NH9xTy64shg2baKdw=="
+      },
       "Speckle.Objects": {
         "type": "CentralTransitive",
         "requested": "[3.1.0-dev.115, )",
@@ -355,16 +377,37 @@
       }
     },
     "net8.0-windows7.0/win-x64": {
-      "Microsoft.Web.WebView2": {
-        "type": "Direct",
-        "requested": "[1.0.1938.49, )",
-        "resolved": "1.0.1938.49",
-        "contentHash": "z8KnFnaTYzhA/ZnyRX0qGfS1NU5ZBJeClAH64F0fVDvdDJTvME7xl6zTJ0Jlfe1BtL3C0NH9xTy64shg2baKdw=="
+      "CefSharp.Common.NETCore": {
+        "type": "Transitive",
+        "resolved": "119.4.30",
+        "contentHash": "nu5zqeOL+ubs723jU/EJWdMNAefzXtucKAewv4Mvh3tLLeoGsGbz0oZM36vIuBgAzhhsE+ZO4uzkdhk6X9JwJA==",
+        "dependencies": {
+          "chromiumembeddedframework.runtime": "[119.4.3]"
+        }
+      },
+      "chromiumembeddedframework.runtime": {
+        "type": "Transitive",
+        "resolved": "119.4.3",
+        "contentHash": "JEYg94tEtdyIIm9hQvZ/vP0/+9w5ebvZFfcJ22NG16BjeEm5y6dC0B86DIsKwwhj1RhnfyEbp8JVKuY8imCO5w==",
+        "dependencies": {
+          "chromiumembeddedframework.runtime.win-x64": "119.4.3"
+        }
+      },
+      "chromiumembeddedframework.runtime.win-x64": {
+        "type": "Transitive",
+        "resolved": "119.4.3",
+        "contentHash": "teW7othTAZyUVTlvO2DP7hceibFo1cKcjGXITFzIIhygNQVu2iAeFivzgH9HKK/tU1IUACOSSceaoR99USZ8Sw=="
       },
       "SQLitePCLRaw.lib.e_sqlite3": {
         "type": "Transitive",
         "resolved": "2.1.4",
         "contentHash": "2C9Q9eX7CPLveJA0rIhf9RXAvu+7nWZu1A2MdG6SD/NOu26TakGgL1nsbc0JAspGijFOo3HoN79xrx8a368fBg=="
+      },
+      "Microsoft.Web.WebView2": {
+        "type": "CentralTransitive",
+        "requested": "[1.0.1938.49, )",
+        "resolved": "1.0.1938.49",
+        "contentHash": "z8KnFnaTYzhA/ZnyRX0qGfS1NU5ZBJeClAH64F0fVDvdDJTvME7xl6zTJ0Jlfe1BtL3C0NH9xTy64shg2baKdw=="
       }
     }
   }

--- a/Connectors/Revit/Speckle.Connectors.RevitShared.Cef/CefSharpPanel.xaml.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared.Cef/CefSharpPanel.xaml.cs
@@ -1,4 +1,3 @@
-#if !REVIT2025
 using System.Windows.Controls;
 using System.Windows.Threading;
 using Autodesk.Revit.UI;
@@ -32,4 +31,3 @@ public partial class CefSharpPanel : Page, Autodesk.Revit.UI.IDockablePaneProvid
     };
   }
 }
-#endif

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/DependencyInjection/RevitConnectorModule.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/DependencyInjection/RevitConnectorModule.cs
@@ -78,13 +78,6 @@ public class RevitConnectorModule : ISpeckleModule
 
   public void RegisterUiDependencies(SpeckleContainerBuilder builder)
   {
-    // if revit 2025 or higher, register webview2 dependencies
-    // else register cefSharp depenedencies
-    // #if REVIT2025
-    // builder.AddDUIView();
-    // builder.AddSingleton<IRevitPlugin, RevitWebViewPlugin>();
-    // builder.AddSingleton<IBrowserScriptExecutor>(c => c.Resolve<DUI3ControlWebView>());
-    // builder.AddSingleton<DUI3ControlWebViewDockable>();
 #if REVIT2022
     //different versons for different versions of CEF
     builder.AddSingleton(new BindingOptions() { CamelCaseJavascriptNames = false });

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/DependencyInjection/RevitConnectorModule.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/DependencyInjection/RevitConnectorModule.cs
@@ -1,5 +1,6 @@
 using Autodesk.Revit.DB;
 using Autofac;
+using CefSharp;
 using Speckle.Autofac;
 using Speckle.Autofac.DependencyInjection;
 using Speckle.Connectors.DUI;
@@ -16,11 +17,6 @@ using Speckle.Connectors.Utils.Builders;
 using Speckle.Connectors.Utils.Caching;
 using Speckle.Connectors.Utils.Operations;
 using Speckle.Sdk.Models.GraphTraversal;
-#if REVIT2025
-using Speckle.Connectors.DUI.WebView;
-#else
-using CefSharp;
-#endif
 
 namespace Speckle.Connectors.Revit.DependencyInjection;
 
@@ -84,12 +80,12 @@ public class RevitConnectorModule : ISpeckleModule
   {
     // if revit 2025 or higher, register webview2 dependencies
     // else register cefSharp depenedencies
-#if REVIT2025
-    builder.AddDUIView();
-    builder.AddSingleton<IRevitPlugin, RevitWebViewPlugin>();
-    builder.AddSingleton<DUI3ControlWebView>();
-    builder.AddSingleton<DUI3ControlWebViewDockable>();
-#elif REVIT2022
+    // #if REVIT2025
+    // builder.AddDUIView();
+    // builder.AddSingleton<IRevitPlugin, RevitWebViewPlugin>();
+    // builder.AddSingleton<IBrowserScriptExecutor>(c => c.Resolve<DUI3ControlWebView>());
+    // builder.AddSingleton<DUI3ControlWebViewDockable>();
+#if REVIT2022
     //different versons for different versions of CEF
     builder.AddSingleton(new BindingOptions() { CamelCaseJavascriptNames = false });
     builder.AddSingleton<CefSharpPanel>();

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Plugin/RevitCefPlugin.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Plugin/RevitCefPlugin.cs
@@ -1,4 +1,3 @@
-#if !REVIT2025
 using System.Diagnostics;
 using System.IO;
 using System.Reflection;
@@ -93,7 +92,7 @@ internal sealed class RevitCefPlugin : IRevitPlugin
     dui3Button.SetContextualHelp(new ContextualHelp(ContextualHelpType.Url, "https://speckle.systems"));
   }
 
-  private void OnApplicationInitialized(object sender, Autodesk.Revit.DB.Events.ApplicationInitializedEventArgs e)
+  private void OnApplicationInitialized(object? sender, Autodesk.Revit.DB.Events.ApplicationInitializedEventArgs e)
   {
     var uiApplication = new UIApplication(sender as Application);
     _revitContext.UIApplication = uiApplication;
@@ -130,12 +129,18 @@ internal sealed class RevitCefPlugin : IRevitPlugin
       {
         IBridge bridge = binding.Parent;
 
+#if REVIT2025_OR_GREATER
+
+        _cefSharpPanel.Browser.JavascriptObjectRepository.Register(bridge.FrontendBoundName, bridge, _bindingOptions);
+
+#else
         _cefSharpPanel.Browser.JavascriptObjectRepository.Register(
           bridge.FrontendBoundName,
           bridge,
           true,
           _bindingOptions
         );
+#endif
       }
     };
   }
@@ -171,4 +176,3 @@ internal sealed class RevitCefPlugin : IRevitPlugin
     return null;
   }
 }
-#endif

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Plugin/RevitCefPlugin.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Plugin/RevitCefPlugin.cs
@@ -130,9 +130,7 @@ internal sealed class RevitCefPlugin : IRevitPlugin
         IBridge bridge = binding.Parent;
 
 #if REVIT2025_OR_GREATER
-
         _cefSharpPanel.Browser.JavascriptObjectRepository.Register(bridge.FrontendBoundName, bridge, _bindingOptions);
-
 #else
         _cefSharpPanel.Browser.JavascriptObjectRepository.Register(
           bridge.FrontendBoundName,


### PR DESCRIPTION
TL;DR > Moved from WebView2 to CefSharp.Wpf.NETCore for Revit 2025

Reviewer should test too!
- Open Revit 2025
- Open relatively big model
- Send model
- TRY to navigate viewer of Revit -> Expectation is not frozen Revit UI and responsive UI interactions

Since the thread management is different between WebView2 and CefSharp, Revit UI was freezing in 2025 bc we moved to WebView2 with it. The source of the problem was we were running SendOperation with `RevitTask.RunAsync` to prevent random `AccessMemoryVialoation` exceptions. And running the operation with `RevitTask.RunAsync` was freezing Revit UI with WebView2.

Thanks to @JR-Morgan and @didimitrie for live fixing effort!