### PR TITLE
CNX-369 Rename all UI elements and commands in v3 connectors

### DIFF
--- a/Connectors/ArcGIS/Speckle.Connectors.ArcGIS3/Config.daml
+++ b/Connectors/ArcGIS/Speckle.Connectors.ArcGIS3/Config.daml
@@ -47,7 +47,7 @@
 			</groups>
 			<controls>
 				<!-- add your controls here -->
-				<button id="SpeckleDUI3_SpeckleDUI3OpenButton" caption="SpeckleNewUI"
+				<button id="SpeckleDUI3_SpeckleDUI3OpenButton" caption="Speckle v3"
 						className="SpeckleDUI3OpenButton" loadOnClick="true"
 						keytip="B1"
 						smallImage="Images/s2logo_16.png"
@@ -59,7 +59,7 @@
 			</controls>
 
             <dockPanes>
-                <dockPane id="SpeckleDUI3_SpeckleDUI3" caption="SpeckleNewUI" className="SpeckleDUI3ViewModel" keytip="DockPane" initiallyVisible="true" dock="group" dockWith="esri_core_projectDockPane">
+                <dockPane id="SpeckleDUI3_SpeckleDUI3" caption="Speckle v3" className="SpeckleDUI3ViewModel" keytip="DockPane" initiallyVisible="true" dock="group" dockWith="esri_core_projectDockPane">
                     <content className="SpeckleDUI3Wrapper" />
                 </dockPane>
             </dockPanes>

--- a/Connectors/ArcGIS/Speckle.Connectors.ArcGIS3/Config.daml
+++ b/Connectors/ArcGIS/Speckle.Connectors.ArcGIS3/Config.daml
@@ -59,7 +59,7 @@
 			</controls>
 
             <dockPanes>
-                <dockPane id="SpeckleDUI3_SpeckleDUI3" caption="Speckle for ArcGIS (Beta)" className="SpeckleDUI3ViewModel" keytip="DockPane" initiallyVisible="true" dock="group" dockWith="esri_core_projectDockPane">
+                <dockPane id="SpeckleDUI3_SpeckleDUI3" caption="Speckle (Beta) for ArcGIS" className="SpeckleDUI3ViewModel" keytip="DockPane" initiallyVisible="true" dock="group" dockWith="esri_core_projectDockPane">
                     <content className="SpeckleDUI3Wrapper" />
                 </dockPane>
             </dockPanes>

--- a/Connectors/ArcGIS/Speckle.Connectors.ArcGIS3/Config.daml
+++ b/Connectors/ArcGIS/Speckle.Connectors.ArcGIS3/Config.daml
@@ -47,7 +47,7 @@
 			</groups>
 			<controls>
 				<!-- add your controls here -->
-				<button id="SpeckleDUI3_SpeckleDUI3OpenButton" caption="Speckle v3"
+				<button id="SpeckleDUI3_SpeckleDUI3OpenButton" caption="Speckle (Beta)"
 						className="SpeckleDUI3OpenButton" loadOnClick="true"
 						keytip="B1"
 						smallImage="Images/s2logo_16.png"
@@ -59,7 +59,7 @@
 			</controls>
 
             <dockPanes>
-                <dockPane id="SpeckleDUI3_SpeckleDUI3" caption="Speckle v3" className="SpeckleDUI3ViewModel" keytip="DockPane" initiallyVisible="true" dock="group" dockWith="esri_core_projectDockPane">
+                <dockPane id="SpeckleDUI3_SpeckleDUI3" caption="Speckle for ArcGIS (Beta)" className="SpeckleDUI3ViewModel" keytip="DockPane" initiallyVisible="true" dock="group" dockWith="esri_core_projectDockPane">
                     <content className="SpeckleDUI3Wrapper" />
                 </dockPane>
             </dockPanes>

--- a/Connectors/Autocad/Speckle.Connectors.AutocadShared/Plugin/AutocadCommand.cs
+++ b/Connectors/Autocad/Speckle.Connectors.AutocadShared/Plugin/AutocadCommand.cs
@@ -16,7 +16,7 @@ public class AutocadCommand
   private static readonly Guid s_id = new("3223E594-1B09-4E54-B3DD-8EA0BECE7BA5");
   public SpeckleContainer? Container { get; private set; }
   private IDisposable? _disposableLogger;
-  public const string COMMAND_STRING = "SpeckleV3";
+  public const string COMMAND_STRING = "SpeckleBeta";
 
   [CommandMethod(COMMAND_STRING)]
   public void Command()
@@ -27,7 +27,7 @@ public class AutocadCommand
       return;
     }
 
-    PaletteSet = new PaletteSet("Speckle DUI3", s_id)
+    PaletteSet = new PaletteSet("Speckle for Autocad (Beta)", s_id)
     {
       Size = new Size(400, 500),
       DockEnabled = (DockSides)((int)DockSides.Left + (int)DockSides.Right)
@@ -46,7 +46,7 @@ public class AutocadCommand
 
     var panelWebView = Container.Resolve<DUI3ControlWebView>();
 
-    PaletteSet.AddVisual("Speckle DUI3 WebView", panelWebView);
+    PaletteSet.AddVisual("Speckle for Autocad (Beta) WebView", panelWebView);
 
     FocusPalette();
   }

--- a/Connectors/Autocad/Speckle.Connectors.AutocadShared/Plugin/AutocadCommand.cs
+++ b/Connectors/Autocad/Speckle.Connectors.AutocadShared/Plugin/AutocadCommand.cs
@@ -16,7 +16,7 @@ public class AutocadCommand
   private static readonly Guid s_id = new("3223E594-1B09-4E54-B3DD-8EA0BECE7BA5");
   public SpeckleContainer? Container { get; private set; }
   private IDisposable? _disposableLogger;
-  public const string COMMAND_STRING = "SpeckleNewUI";
+  public const string COMMAND_STRING = "SpeckleV3";
 
   [CommandMethod(COMMAND_STRING)]
   public void Command()

--- a/Connectors/Autocad/Speckle.Connectors.AutocadShared/Plugin/AutocadCommand.cs
+++ b/Connectors/Autocad/Speckle.Connectors.AutocadShared/Plugin/AutocadCommand.cs
@@ -27,7 +27,7 @@ public class AutocadCommand
       return;
     }
 
-    PaletteSet = new PaletteSet("Speckle for Autocad (Beta)", s_id)
+    PaletteSet = new PaletteSet("Speckle (Beta) for Autocad", s_id)
     {
       Size = new Size(400, 500),
       DockEnabled = (DockSides)((int)DockSides.Left + (int)DockSides.Right)
@@ -46,7 +46,7 @@ public class AutocadCommand
 
     var panelWebView = Container.Resolve<DUI3ControlWebView>();
 
-    PaletteSet.AddVisual("Speckle for Autocad (Beta) WebView", panelWebView);
+    PaletteSet.AddVisual("Speckle (Beta) for Autocad WebView", panelWebView);
 
     FocusPalette();
   }

--- a/Connectors/Revit/Speckle.Connectors.Revit2022/Plugin/Speckle.Connectors.Revit2022.addin
+++ b/Connectors/Revit/Speckle.Connectors.Revit2022/Plugin/Speckle.Connectors.Revit2022.addin
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <RevitAddIns>
   <AddIn Type="Application">
-    <Name>Speckle for Revit v3</Name>
-    <Description>Speckle for Revit v3</Description>
+    <Name>Speckle for Revit (Beta)</Name>
+    <Description>Speckle for Revit (Beta)</Description>
     <Assembly>Speckle.Connectors.Revit2022\Speckle.Connectors.Revit2022.dll</Assembly>
     <FullClassName>Speckle.Connectors.Revit.Plugin.RevitExternalApplication</FullClassName>
     <ClientId>27ccff2c-011c-4374-bb79-b93990d0c86a</ClientId>

--- a/Connectors/Revit/Speckle.Connectors.Revit2022/Plugin/Speckle.Connectors.Revit2022.addin
+++ b/Connectors/Revit/Speckle.Connectors.Revit2022/Plugin/Speckle.Connectors.Revit2022.addin
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <RevitAddIns>
   <AddIn Type="Application">
-    <Name>Speckle for Revit (Beta)</Name>
-    <Description>Speckle for Revit (Beta)</Description>
+    <Name>Speckle (Beta) for Revit</Name>
+    <Description>Speckle (Beta) for Revit</Description>
     <Assembly>Speckle.Connectors.Revit2022\Speckle.Connectors.Revit2022.dll</Assembly>
     <FullClassName>Speckle.Connectors.Revit.Plugin.RevitExternalApplication</FullClassName>
     <ClientId>27ccff2c-011c-4374-bb79-b93990d0c86a</ClientId>

--- a/Connectors/Revit/Speckle.Connectors.Revit2022/Plugin/Speckle.Connectors.Revit2022.addin
+++ b/Connectors/Revit/Speckle.Connectors.Revit2022/Plugin/Speckle.Connectors.Revit2022.addin
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <RevitAddIns>
   <AddIn Type="Application">
-    <Name>Speckle Revit Connector New UI</Name>
-    <Description>Speckle Revit Connector New UI</Description>
+    <Name>Speckle for Revit v3</Name>
+    <Description>Speckle for Revit v3</Description>
     <Assembly>Speckle.Connectors.Revit2022\Speckle.Connectors.Revit2022.dll</Assembly>
     <FullClassName>Speckle.Connectors.Revit.Plugin.RevitExternalApplication</FullClassName>
     <ClientId>27ccff2c-011c-4374-bb79-b93990d0c86a</ClientId>

--- a/Connectors/Revit/Speckle.Connectors.Revit2023/Plugin/Speckle.Connectors.Revit2023.addin
+++ b/Connectors/Revit/Speckle.Connectors.Revit2023/Plugin/Speckle.Connectors.Revit2023.addin
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <RevitAddIns>
   <AddIn Type="Application">
-    <Name>Speckle for Revit v3</Name>
-    <Description>Speckle for Revit v3</Description>
+    <Name>Speckle for Revit (Beta)</Name>
+    <Description>Speckle for Revit (Beta)</Description>
     <Assembly>Speckle.Connectors.Revit2023\Speckle.Connectors.Revit2023.dll</Assembly>
     <FullClassName>Speckle.Connectors.Revit.Plugin.RevitExternalApplication</FullClassName>
     <ClientId>27ccff2c-011c-4374-bb79-b93990d0c86a</ClientId>

--- a/Connectors/Revit/Speckle.Connectors.Revit2023/Plugin/Speckle.Connectors.Revit2023.addin
+++ b/Connectors/Revit/Speckle.Connectors.Revit2023/Plugin/Speckle.Connectors.Revit2023.addin
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <RevitAddIns>
   <AddIn Type="Application">
-    <Name>Speckle for Revit (Beta)</Name>
-    <Description>Speckle for Revit (Beta)</Description>
+    <Name>Speckle (Beta) for Revit</Name>
+    <Description>Speckle (Beta) for Revit</Description>
     <Assembly>Speckle.Connectors.Revit2023\Speckle.Connectors.Revit2023.dll</Assembly>
     <FullClassName>Speckle.Connectors.Revit.Plugin.RevitExternalApplication</FullClassName>
     <ClientId>27ccff2c-011c-4374-bb79-b93990d0c86a</ClientId>

--- a/Connectors/Revit/Speckle.Connectors.Revit2023/Plugin/Speckle.Connectors.Revit2023.addin
+++ b/Connectors/Revit/Speckle.Connectors.Revit2023/Plugin/Speckle.Connectors.Revit2023.addin
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <RevitAddIns>
   <AddIn Type="Application">
-    <Name>Speckle Revit Connector New UI</Name>
-    <Description>Speckle Revit Connector New UI</Description>
+    <Name>Speckle for Revit v3</Name>
+    <Description>Speckle for Revit v3</Description>
     <Assembly>Speckle.Connectors.Revit2023\Speckle.Connectors.Revit2023.dll</Assembly>
     <FullClassName>Speckle.Connectors.Revit.Plugin.RevitExternalApplication</FullClassName>
     <ClientId>27ccff2c-011c-4374-bb79-b93990d0c86a</ClientId>

--- a/Connectors/Revit/Speckle.Connectors.Revit2024/Plugin/Speckle.Connectors.Revit2024.addin
+++ b/Connectors/Revit/Speckle.Connectors.Revit2024/Plugin/Speckle.Connectors.Revit2024.addin
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <RevitAddIns>
   <AddIn Type="Application">
-    <Name>Speckle for Revit v3</Name>
-    <Description>Speckle for Revit v3</Description>
+    <Name>Speckle for Revit (Beta)</Name>
+    <Description>Speckle for Revit (Beta)</Description>
     <Assembly>Speckle.Connectors.Revit2024\Speckle.Connectors.Revit2024.dll</Assembly>
     <FullClassName>Speckle.Connectors.Revit.Plugin.RevitExternalApplication</FullClassName>
     <ClientId>27ccff2c-011c-4374-bb79-b93990d0c86a</ClientId>

--- a/Connectors/Revit/Speckle.Connectors.Revit2024/Plugin/Speckle.Connectors.Revit2024.addin
+++ b/Connectors/Revit/Speckle.Connectors.Revit2024/Plugin/Speckle.Connectors.Revit2024.addin
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <RevitAddIns>
   <AddIn Type="Application">
-    <Name>Speckle for Revit (Beta)</Name>
-    <Description>Speckle for Revit (Beta)</Description>
+    <Name>Speckle (Beta) for Revit</Name>
+    <Description>Speckle (Beta) for Revit</Description>
     <Assembly>Speckle.Connectors.Revit2024\Speckle.Connectors.Revit2024.dll</Assembly>
     <FullClassName>Speckle.Connectors.Revit.Plugin.RevitExternalApplication</FullClassName>
     <ClientId>27ccff2c-011c-4374-bb79-b93990d0c86a</ClientId>

--- a/Connectors/Revit/Speckle.Connectors.Revit2024/Plugin/Speckle.Connectors.Revit2024.addin
+++ b/Connectors/Revit/Speckle.Connectors.Revit2024/Plugin/Speckle.Connectors.Revit2024.addin
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <RevitAddIns>
   <AddIn Type="Application">
-    <Name>Speckle Revit Connector New UI</Name>
-    <Description>Speckle Revit Connector New UI</Description>
+    <Name>Speckle for Revit v3</Name>
+    <Description>Speckle for Revit v3</Description>
     <Assembly>Speckle.Connectors.Revit2024\Speckle.Connectors.Revit2024.dll</Assembly>
     <FullClassName>Speckle.Connectors.Revit.Plugin.RevitExternalApplication</FullClassName>
     <ClientId>27ccff2c-011c-4374-bb79-b93990d0c86a</ClientId>

--- a/Connectors/Revit/Speckle.Connectors.Revit2025/Plugin/Speckle.Connectors.Revit2025.addin
+++ b/Connectors/Revit/Speckle.Connectors.Revit2025/Plugin/Speckle.Connectors.Revit2025.addin
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <RevitAddIns>
   <AddIn Type="Application">
-    <Name>Speckle for Revit (Beta)</Name>
-    <Description>Speckle for Revit (Beta)</Description>
+    <Name>Speckle (Beta) for Revit</Name>
+    <Description>Speckle (Beta) for Revit</Description>
     <Assembly>Speckle.Connectors.Revit2025\Speckle.Connectors.Revit2025.dll</Assembly>
     <FullClassName>Speckle.Connectors.Revit.Plugin.RevitExternalApplication</FullClassName>
     <ClientId>27ccff2c-011c-4374-bb79-b93990d0c86a</ClientId>

--- a/Connectors/Revit/Speckle.Connectors.Revit2025/Plugin/Speckle.Connectors.Revit2025.addin
+++ b/Connectors/Revit/Speckle.Connectors.Revit2025/Plugin/Speckle.Connectors.Revit2025.addin
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <RevitAddIns>
   <AddIn Type="Application">
-    <Name>Speckle for Revit v3</Name>
-    <Description>Speckle for Revit v3</Description>
+    <Name>Speckle for Revit (Beta)</Name>
+    <Description>Speckle for Revit (Beta)</Description>
     <Assembly>Speckle.Connectors.Revit2025\Speckle.Connectors.Revit2025.dll</Assembly>
     <FullClassName>Speckle.Connectors.Revit.Plugin.RevitExternalApplication</FullClassName>
     <ClientId>27ccff2c-011c-4374-bb79-b93990d0c86a</ClientId>

--- a/Connectors/Revit/Speckle.Connectors.Revit2025/Plugin/Speckle.Connectors.Revit2025.addin
+++ b/Connectors/Revit/Speckle.Connectors.Revit2025/Plugin/Speckle.Connectors.Revit2025.addin
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <RevitAddIns>
   <AddIn Type="Application">
-    <Name>Speckle Revit Connector New UI</Name>
-    <Description>Speckle Revit Connector New UI</Description>
+    <Name>Speckle for Revit v3</Name>
+    <Description>Speckle for Revit v3</Description>
     <Assembly>Speckle.Connectors.Revit2025\Speckle.Connectors.Revit2025.dll</Assembly>
     <FullClassName>Speckle.Connectors.Revit.Plugin.RevitExternalApplication</FullClassName>
     <ClientId>27ccff2c-011c-4374-bb79-b93990d0c86a</ClientId>

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Plugin/RevitCefPlugin.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Plugin/RevitCefPlugin.cs
@@ -88,7 +88,7 @@ internal sealed class RevitCefPlugin : IRevitPlugin
       $"Speckle.Connectors.Revit{Connector.VersionString}.Assets.logo32.png",
       path
     );
-    dui3Button.ToolTip = "Speckle Connector for Revit New UI";
+    dui3Button.ToolTip = "Speckle for Revit v3";
     //dui3Button.AvailabilityClassName = typeof(CmdAvailabilityViews).FullName;
     dui3Button.SetContextualHelp(new ContextualHelp(ContextualHelpType.Url, "https://speckle.systems"));
   }

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Plugin/RevitCefPlugin.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Plugin/RevitCefPlugin.cs
@@ -71,7 +71,7 @@ internal sealed class RevitCefPlugin : IRevitPlugin
     var dui3Button = (PushButton)
       specklePanel.AddItem(
         new PushButtonData(
-          Connector.Name,
+          "testing whatever",
           Connector.TabTitle,
           typeof(RevitExternalApplication).Assembly.Location,
           typeof(SpeckleRevitCommand).FullName
@@ -88,7 +88,7 @@ internal sealed class RevitCefPlugin : IRevitPlugin
       $"Speckle.Connectors.Revit{Connector.VersionString}.Assets.logo32.png",
       path
     );
-    dui3Button.ToolTip = "Speckle for Revit v3";
+    dui3Button.ToolTip = "Speckle for Revit (Beta)";
     //dui3Button.AvailabilityClassName = typeof(CmdAvailabilityViews).FullName;
     dui3Button.SetContextualHelp(new ContextualHelp(ContextualHelpType.Url, "https://speckle.systems"));
   }
@@ -148,7 +148,7 @@ internal sealed class RevitCefPlugin : IRevitPlugin
     // Otherwise pane cannot be registered for double-click file open.
     _uIControlledApplication.RegisterDockablePane(
       RevitExternalApplication.DockablePanelId,
-      Connector.Name,
+      "Speckle for Revit (Beta)",
       _cefSharpPanel
     );
   }

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Plugin/RevitCefPlugin.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Plugin/RevitCefPlugin.cs
@@ -70,7 +70,7 @@ internal sealed class RevitCefPlugin : IRevitPlugin
     var dui3Button = (PushButton)
       specklePanel.AddItem(
         new PushButtonData(
-          "testing whatever",
+          Connector.Name,
           Connector.TabTitle,
           typeof(RevitExternalApplication).Assembly.Location,
           typeof(SpeckleRevitCommand).FullName

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Plugin/RevitCefPlugin.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Plugin/RevitCefPlugin.cs
@@ -88,7 +88,7 @@ internal sealed class RevitCefPlugin : IRevitPlugin
       $"Speckle.Connectors.Revit{Connector.VersionString}.Assets.logo32.png",
       path
     );
-    dui3Button.ToolTip = "Speckle for Revit (Beta)";
+    dui3Button.ToolTip = "Speckle (Beta) for Revit";
     //dui3Button.AvailabilityClassName = typeof(CmdAvailabilityViews).FullName;
     dui3Button.SetContextualHelp(new ContextualHelp(ContextualHelpType.Url, "https://speckle.systems"));
   }
@@ -148,7 +148,7 @@ internal sealed class RevitCefPlugin : IRevitPlugin
     // Otherwise pane cannot be registered for double-click file open.
     _uIControlledApplication.RegisterDockablePane(
       RevitExternalApplication.DockablePanelId,
-      "Speckle for Revit (Beta)",
+      "Speckle (Beta) for Revit",
       _cefSharpPanel
     );
   }

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Plugin/RevitWebViewPlugin.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Plugin/RevitWebViewPlugin.cs
@@ -67,7 +67,7 @@ internal sealed class RevitWebViewPlugin : IRevitPlugin
     var dui3Button = (PushButton)
       specklePanel.AddItem(
         new PushButtonData(
-          "Speckle for Revit (Beta)",
+          "Speckle (Beta) for Revit",
           Connector.TabTitle,
           typeof(RevitExternalApplication).Assembly.Location,
           typeof(SpeckleRevitCommand).FullName
@@ -84,7 +84,7 @@ internal sealed class RevitWebViewPlugin : IRevitPlugin
       $"Speckle.Connectors.Revit{Connector.VersionString}.Assets.logo32.png",
       path
     );
-    dui3Button.ToolTip = "Speckle for Revit (Beta)";
+    dui3Button.ToolTip = "Speckle (Beta) for Revit";
     //dui3Button.AvailabilityClassName = typeof(CmdAvailabilityViews).FullName;
     dui3Button.SetContextualHelp(new ContextualHelp(ContextualHelpType.Url, "https://speckle.systems"));
   }

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Plugin/RevitWebViewPlugin.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Plugin/RevitWebViewPlugin.cs
@@ -67,7 +67,7 @@ internal sealed class RevitWebViewPlugin : IRevitPlugin
     var dui3Button = (PushButton)
       specklePanel.AddItem(
         new PushButtonData(
-          Connector.Name,
+          "Speckle for Revit (Beta)",
           Connector.TabTitle,
           typeof(RevitExternalApplication).Assembly.Location,
           typeof(SpeckleRevitCommand).FullName
@@ -84,7 +84,7 @@ internal sealed class RevitWebViewPlugin : IRevitPlugin
       $"Speckle.Connectors.Revit{Connector.VersionString}.Assets.logo32.png",
       path
     );
-    dui3Button.ToolTip = "Speckle for Revit v3";
+    dui3Button.ToolTip = "Speckle for Revit (Beta)";
     //dui3Button.AvailabilityClassName = typeof(CmdAvailabilityViews).FullName;
     dui3Button.SetContextualHelp(new ContextualHelp(ContextualHelpType.Url, "https://speckle.systems"));
   }

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Plugin/RevitWebViewPlugin.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Plugin/RevitWebViewPlugin.cs
@@ -84,7 +84,7 @@ internal sealed class RevitWebViewPlugin : IRevitPlugin
       $"Speckle.Connectors.Revit{Connector.VersionString}.Assets.logo32.png",
       path
     );
-    dui3Button.ToolTip = "Speckle Connector for Revit New UI";
+    dui3Button.ToolTip = "Speckle for Revit v3";
     //dui3Button.AvailabilityClassName = typeof(CmdAvailabilityViews).FullName;
     dui3Button.SetContextualHelp(new ContextualHelp(ContextualHelpType.Url, "https://speckle.systems"));
   }

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/Plugin/Speckle.Connectors.RhinoCommand.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/Plugin/Speckle.Connectors.RhinoCommand.cs
@@ -21,7 +21,7 @@ public class SpeckleConnectorsRhinoCommand : Command
     Panels.RegisterPanel(
       SpeckleConnectorsRhinoPlugin.Instance,
       typeof(SpeckleRhinoPanelHost),
-      "Speckle for Rhino (Beta)",
+      "Speckle (Beta) for Rhino",
       new Icon(iconPath),
       PanelType.System
     );

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/Plugin/Speckle.Connectors.RhinoCommand.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/Plugin/Speckle.Connectors.RhinoCommand.cs
@@ -21,7 +21,7 @@ public class SpeckleConnectorsRhinoCommand : Command
     Panels.RegisterPanel(
       SpeckleConnectorsRhinoPlugin.Instance,
       typeof(SpeckleRhinoPanelHost),
-      "Speckle (New UI)",
+      "Speckle v3",
       new Icon(iconPath),
       PanelType.System
     );
@@ -57,7 +57,7 @@ public class SpeckleConnectorsRhinoCommand : Command
 #pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
 
   ///<returns>The command name as it appears on the Rhino command line.</returns>
-  public override string EnglishName => "SpeckleNewUI";
+  public override string EnglishName => "SpeckleV3";
 
   protected override Result RunCommand(RhinoDoc doc, RunMode mode)
   {

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/Plugin/Speckle.Connectors.RhinoCommand.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/Plugin/Speckle.Connectors.RhinoCommand.cs
@@ -21,7 +21,7 @@ public class SpeckleConnectorsRhinoCommand : Command
     Panels.RegisterPanel(
       SpeckleConnectorsRhinoPlugin.Instance,
       typeof(SpeckleRhinoPanelHost),
-      "Speckle v3",
+      "Speckle for Rhino (Beta)",
       new Icon(iconPath),
       PanelType.System
     );
@@ -57,7 +57,7 @@ public class SpeckleConnectorsRhinoCommand : Command
 #pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
 
   ///<returns>The command name as it appears on the Rhino command line.</returns>
-  public override string EnglishName => "SpeckleV3";
+  public override string EnglishName => "SpeckleBeta";
 
   protected override Result RunCommand(RhinoDoc doc, RunMode mode)
   {

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/Plugin/Speckle.Connectors.RhinoPlugin.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/Plugin/Speckle.Connectors.RhinoPlugin.cs
@@ -25,7 +25,7 @@ public class SpeckleConnectorsRhinoPlugin : PlugIn
   private IRhinoPlugin? _rhinoPlugin;
   private IDisposable? _disposableLogger;
 
-  protected override string LocalPlugInName => "Speckle (New UI)";
+  protected override string LocalPlugInName => "Speckle v3";
   public SpeckleContainer? Container { get; private set; }
 
   public SpeckleConnectorsRhinoPlugin()

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/Plugin/Speckle.Connectors.RhinoPlugin.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/Plugin/Speckle.Connectors.RhinoPlugin.cs
@@ -25,7 +25,7 @@ public class SpeckleConnectorsRhinoPlugin : PlugIn
   private IRhinoPlugin? _rhinoPlugin;
   private IDisposable? _disposableLogger;
 
-  protected override string LocalPlugInName => "Speckle for Rhino (Beta)";
+  protected override string LocalPlugInName => "Speckle (Beta) for Rhino";
   public SpeckleContainer? Container { get; private set; }
 
   public SpeckleConnectorsRhinoPlugin()

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/Plugin/Speckle.Connectors.RhinoPlugin.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/Plugin/Speckle.Connectors.RhinoPlugin.cs
@@ -25,7 +25,7 @@ public class SpeckleConnectorsRhinoPlugin : PlugIn
   private IRhinoPlugin? _rhinoPlugin;
   private IDisposable? _disposableLogger;
 
-  protected override string LocalPlugInName => "Speckle v3";
+  protected override string LocalPlugInName => "Speckle for Rhino (Beta)";
   public SpeckleContainer? Container { get; private set; }
 
   public SpeckleConnectorsRhinoPlugin()

--- a/Converters/ArcGIS/Speckle.Converters.ArcGIS3/ToSpeckle/Raw/PolygonFeatureToSpeckleConverter.cs
+++ b/Converters/ArcGIS/Speckle.Converters.ArcGIS3/ToSpeckle/Raw/PolygonFeatureToSpeckleConverter.cs
@@ -33,7 +33,7 @@ public class PolygonFeatureToSpeckleConverter : ITypedConverter<ACG.Polygon, IRe
       SOG.Polyline polyline = _segmentConverter.Convert(segmentCollection);
 
       bool isExteriorRing = target.IsExteriorRing(idx);
-      if (isExteriorRing is true)
+      if (isExteriorRing)
       {
         polygon = new() { boundary = polyline, voids = new List<SOG.Polyline>() };
         polygonList.Add(polygon);

--- a/Converters/ArcGIS/Speckle.Converters.ArcGIS3/ToSpeckle/Raw/PolylineFeatureToSpeckleConverter.cs
+++ b/Converters/ArcGIS/Speckle.Converters.ArcGIS3/ToSpeckle/Raw/PolylineFeatureToSpeckleConverter.cs
@@ -24,7 +24,7 @@ public class PolyineFeatureToSpeckleConverter : ITypedConverter<ACG.Polyline, IR
     ACG.Polyline polylineToConvert = target;
 
     // densify the polylines with curves using precision value of the Map's Spatial Reference
-    if (target.HasCurves is true)
+    if (target.HasCurves)
     {
       double tolerance = _contextStack.Current.Document.ActiveCRSoffsetRotation.SpatialReference.XYTolerance;
       double conversionFactorToMeter = _contextStack
@@ -34,6 +34,7 @@ public class PolyineFeatureToSpeckleConverter : ITypedConverter<ACG.Polyline, IR
         .SpatialReference
         .Unit
         .ConversionFactor;
+
       var densifiedPolyline = ACG.GeometryEngine.Instance.DensifyByDeviation(
         target,
         tolerance * conversionFactorToMeter

--- a/Sdk/Speckle.Connectors.Utils/Connector.cs
+++ b/Sdk/Speckle.Connectors.Utils/Connector.cs
@@ -9,7 +9,7 @@ namespace Speckle.Connectors.Utils;
 public static class Connector
 {
   public static readonly string TabName = "Speckle";
-  public static readonly string TabTitle = "Speckle v3";
+  public static readonly string TabTitle = "Speckle (Beta)";
 
   public static HostAppVersion Version { get; private set; } = HostAppVersion.v3;
   public static string VersionString { get; private set; } = string.Empty;
@@ -24,6 +24,7 @@ public static class Connector
     VersionString = HostApplications.GetVersion(version);
     HostApp = application;
     TypeLoader.Initialize(typeof(Base).Assembly, typeof(Point).Assembly);
+
 #if DEBUG || LOCAL
     var config = new SpeckleConfiguration(
       application,

--- a/Sdk/Speckle.Connectors.Utils/Connector.cs
+++ b/Sdk/Speckle.Connectors.Utils/Connector.cs
@@ -9,7 +9,7 @@ namespace Speckle.Connectors.Utils;
 public static class Connector
 {
   public static readonly string TabName = "Speckle";
-  public static readonly string TabTitle = "Speckle New UI";
+  public static readonly string TabTitle = "Speckle v3";
 
   public static HostAppVersion Version { get; private set; } = HostAppVersion.v3;
   public static string VersionString { get; private set; } = string.Empty;


### PR DESCRIPTION
- Commands (where existing) are now called `SpeckleBeta`
- Plugin names and panels are now called `Speckle (Beta) for XXX`