### PR TITLE
chore: Silence SDK1206 warnings for now

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,6 +9,7 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageVersionOverrideEnabled>true</CentralPackageVersionOverrideEnabled>
     <EnableWindowsTargeting>true</EnableWindowsTargeting> <!-- windows packs for .net core  -->
+    <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
   </PropertyGroup>
   
   <PropertyGroup Label="Analyers">
@@ -54,6 +55,7 @@ complexity threshold -->
   <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
   </PropertyGroup>
+  
   <PropertyGroup>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -31,6 +31,8 @@
       CA1848;CA2254;CA1727;
       <!-- Others we don't want -->
       CA1815;CA1725;
+      <!-- Package using wrong RIDs (Net8 changed them). Usually fixable by updating.  -->
+      NETSDK1206;
       $(NoWarn)
     </NoWarn>
   </PropertyGroup>


### PR DESCRIPTION
Silences warning regarding RIDs for linux in the SQL package that we don't use or need.

This can be fixed properly by updating our SQL package to `2.1.9`, but this has deeper consequences that we don't want to be tackling right now

> Additionally, i also sneakily fixed the product version info to not include the commit sha