### PR TITLE
receive materials

### DIFF
--- a/Connectors/ArcGIS/Speckle.Connectors.ArcGIS3/HostApp/ArcGISColorManager.cs
+++ b/Connectors/ArcGIS/Speckle.Connectors.ArcGIS3/HostApp/ArcGISColorManager.cs
@@ -83,7 +83,7 @@ public class ArcGISColorManager
     var count = 0;
     foreach (RenderMaterialProxy colorProxy in materialProxies)
     {
-      onOperationProgressed?.Invoke("Converting colors", (double)++count / materialProxies.Count);
+      onOperationProgressed?.Invoke("Converting materials", (double)++count / materialProxies.Count);
       foreach (string objectId in colorProxy.objects)
       {
         Color convertedColor = Color.FromArgb(colorProxy.value.diffuse);
@@ -116,11 +116,11 @@ public class ArcGISColorManager
           color = objColorMaterial;
           break;
         }
-        //if (ObjectColorsIdMap.TryGetValue(appId, out Color objColor))
-        //{
-        //  color = objColor;
-        //  break;
-        //}
+        if (ObjectColorsIdMap.TryGetValue(appId, out Color objColor))
+        {
+          color = objColor;
+          break;
+        }
       }
     }
 

--- a/Connectors/ArcGIS/Speckle.Connectors.ArcGIS3/Operations/Receive/HostObjectBuilder.cs
+++ b/Connectors/ArcGIS/Speckle.Connectors.ArcGIS3/Operations/Receive/HostObjectBuilder.cs
@@ -12,6 +12,7 @@ using Speckle.Converters.ArcGIS3;
 using Speckle.Converters.ArcGIS3.Utils;
 using Speckle.Converters.Common;
 using Speckle.Objects.GIS;
+using Speckle.Objects.Other;
 using Speckle.Sdk;
 using Speckle.Sdk.Models;
 using Speckle.Sdk.Models.Collections;
@@ -69,6 +70,15 @@ public class ArcGISHostObjectBuilder : IHostObjectBuilder
 
     // Prompt the UI conversion started. Progress bar will swoosh.
     onOperationProgressed?.Invoke("Converting", null);
+
+    // get materials
+    List<RenderMaterialProxy>? materials = (rootObject["renderMaterialProxies"] as List<object>)
+      ?.Cast<RenderMaterialProxy>()
+      .ToList();
+    if (materials != null)
+    {
+      _colorManager.ParseMaterials(materials, onOperationProgressed);
+    }
 
     // get colors
     List<ColorProxy>? colors = (rootObject["colorProxies"] as List<object>)?.Cast<ColorProxy>().ToList();


### PR DESCRIPTION
In ArcGIS, receive and apply renderMaterials by default, and then, if not found - colors. 
This is due to lack of separate Shared/Rendered mode in ArcGIS

Reported here: https://linear.app/speckle/issue/CNX-373/some-multipatches-are-received-as-red

Outcome if this PR (before/after):
![image](https://github.com/user-attachments/assets/d72ca341-fc78-41da-90b5-243cc06dd3cc)
