### PR TITLE
chore: Use `rc` version of SDK and Objects

### DIFF
--- a/Connectors/ArcGIS/Speckle.Connectors.ArcGIS3/packages.lock.json
+++ b/Connectors/ArcGIS/Speckle.Connectors.ArcGIS3/packages.lock.json
@@ -180,8 +180,8 @@
       },
       "Speckle.Sdk.Logging": {
         "type": "Transitive",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "bM9t/LdnCoaSqnj6MgkFCBSxVad+KMzrsgGtJ6Y1S+WTY43ysArIW7r2cB84OG9IZH3g9DRHLU9Rob848gWj4g=="
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "NOEdqL0luzhm2Q0jShr5zti1yVihVVaFa9sxHLSQ4CqcxdydbmEuJyDBr86QQjJ8V3Q2E99z4zRis4NyYW3D6Q=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -240,7 +240,7 @@
           "Microsoft.Extensions.Logging.Abstractions": "[3.1.0, )",
           "Speckle.Autofac": "[1.0.0, )",
           "Speckle.Connectors.Utils": "[1.0.0, )",
-          "Speckle.Sdk": "[3.1.0-dev.115, )",
+          "Speckle.Sdk": "[3.0.1-rc.117, )",
           "System.Threading.Tasks.Dataflow": "[6.0.0, )"
         }
       },
@@ -256,8 +256,8 @@
         "dependencies": {
           "Microsoft.Extensions.Logging": "[3.1.0, )",
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.115, )",
-          "Speckle.Sdk": "[3.1.0-dev.115, )"
+          "Speckle.Objects": "[3.0.1-rc.117, )",
+          "Speckle.Sdk": "[3.0.1-rc.117, )"
         }
       },
       "speckle.converters.arcgis3": {
@@ -279,7 +279,7 @@
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[3.1.0, )",
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.115, )"
+          "Speckle.Objects": "[3.0.1-rc.117, )"
         }
       },
       "speckle.converters.common.dependencyinjection": {
@@ -315,18 +315,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.115, )",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "p4K3/pSsjmKgtM1vg3+TpXryRL3HM49VflQcqhF+zplfsb9vZUhgKf+BnNQtEDyxPcEOEby/nmU179dxtJnCLw==",
+        "requested": "[3.0.1-rc.117, )",
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "YjExrNc/8Ha7rJ5enSDV1idCbwtneYUFOiAc4G5dm6XujuKqGHd4cVafV37FffFNGYl5fqvjTGjQ8mjrUfIEFw==",
         "dependencies": {
-          "Speckle.Sdk": "3.1.0-dev.115"
+          "Speckle.Sdk": "3.0.1-rc.117"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.115, )",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "uCo2oOvXAA+Ya+PRRPpBTVPRVC27tZEJU6cH3xgDqkl7sLaycn1ygelz9yZmMorwmjECEHOYuabLsQ+u04M+VQ==",
+        "requested": "[3.0.1-rc.117, )",
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "0rcCz4Dw9Yi62dZ8YG+THCYzHJokvH0F2IYYgqCqgk1CsuoH2IM/lGYYspiGiOLEuR4GG6aLt+Dke6jExANRlw==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -336,7 +336,7 @@
           "Polly.Extensions.Http": "3.0.0",
           "Speckle.DoubleNumerics": "4.0.1",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Logging": "3.1.0-dev.115",
+          "Speckle.Sdk.Logging": "3.0.1-rc.117",
           "System.Text.Json": "5.0.2"
         }
       },

--- a/Connectors/Autocad/Speckle.Connectors.Autocad2022/packages.lock.json
+++ b/Connectors/Autocad/Speckle.Connectors.Autocad2022/packages.lock.json
@@ -189,8 +189,8 @@
       },
       "Speckle.Sdk.Logging": {
         "type": "Transitive",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "bM9t/LdnCoaSqnj6MgkFCBSxVad+KMzrsgGtJ6Y1S+WTY43ysArIW7r2cB84OG9IZH3g9DRHLU9Rob848gWj4g=="
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "NOEdqL0luzhm2Q0jShr5zti1yVihVVaFa9sxHLSQ4CqcxdydbmEuJyDBr86QQjJ8V3Q2E99z4zRis4NyYW3D6Q=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -318,7 +318,7 @@
           "Microsoft.Extensions.Logging.Abstractions": "[3.1.0, )",
           "Speckle.Autofac": "[1.0.0, )",
           "Speckle.Connectors.Utils": "[1.0.0, )",
-          "Speckle.Sdk": "[3.1.0-dev.115, )",
+          "Speckle.Sdk": "[3.0.1-rc.117, )",
           "System.Threading.Tasks.Dataflow": "[6.0.0, )"
         }
       },
@@ -334,8 +334,8 @@
         "dependencies": {
           "Microsoft.Extensions.Logging": "[3.1.0, )",
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.115, )",
-          "Speckle.Sdk": "[3.1.0-dev.115, )"
+          "Speckle.Objects": "[3.0.1-rc.117, )",
+          "Speckle.Sdk": "[3.0.1-rc.117, )"
         }
       },
       "speckle.converters.autocad2022": {
@@ -358,7 +358,7 @@
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[3.1.0, )",
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.115, )"
+          "Speckle.Objects": "[3.0.1-rc.117, )"
         }
       },
       "speckle.converters.common.dependencyinjection": {
@@ -403,18 +403,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.115, )",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "p4K3/pSsjmKgtM1vg3+TpXryRL3HM49VflQcqhF+zplfsb9vZUhgKf+BnNQtEDyxPcEOEby/nmU179dxtJnCLw==",
+        "requested": "[3.0.1-rc.117, )",
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "YjExrNc/8Ha7rJ5enSDV1idCbwtneYUFOiAc4G5dm6XujuKqGHd4cVafV37FffFNGYl5fqvjTGjQ8mjrUfIEFw==",
         "dependencies": {
-          "Speckle.Sdk": "3.1.0-dev.115"
+          "Speckle.Sdk": "3.0.1-rc.117"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.115, )",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "uCo2oOvXAA+Ya+PRRPpBTVPRVC27tZEJU6cH3xgDqkl7sLaycn1ygelz9yZmMorwmjECEHOYuabLsQ+u04M+VQ==",
+        "requested": "[3.0.1-rc.117, )",
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "0rcCz4Dw9Yi62dZ8YG+THCYzHJokvH0F2IYYgqCqgk1CsuoH2IM/lGYYspiGiOLEuR4GG6aLt+Dke6jExANRlw==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -424,7 +424,7 @@
           "Polly.Extensions.Http": "3.0.0",
           "Speckle.DoubleNumerics": "4.0.1",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Logging": "3.1.0-dev.115",
+          "Speckle.Sdk.Logging": "3.0.1-rc.117",
           "System.Text.Json": "5.0.2"
         }
       },

--- a/Connectors/Autocad/Speckle.Connectors.Autocad2023/packages.lock.json
+++ b/Connectors/Autocad/Speckle.Connectors.Autocad2023/packages.lock.json
@@ -189,8 +189,8 @@
       },
       "Speckle.Sdk.Logging": {
         "type": "Transitive",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "bM9t/LdnCoaSqnj6MgkFCBSxVad+KMzrsgGtJ6Y1S+WTY43ysArIW7r2cB84OG9IZH3g9DRHLU9Rob848gWj4g=="
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "NOEdqL0luzhm2Q0jShr5zti1yVihVVaFa9sxHLSQ4CqcxdydbmEuJyDBr86QQjJ8V3Q2E99z4zRis4NyYW3D6Q=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -318,7 +318,7 @@
           "Microsoft.Extensions.Logging.Abstractions": "[3.1.0, )",
           "Speckle.Autofac": "[1.0.0, )",
           "Speckle.Connectors.Utils": "[1.0.0, )",
-          "Speckle.Sdk": "[3.1.0-dev.115, )",
+          "Speckle.Sdk": "[3.0.1-rc.117, )",
           "System.Threading.Tasks.Dataflow": "[6.0.0, )"
         }
       },
@@ -334,8 +334,8 @@
         "dependencies": {
           "Microsoft.Extensions.Logging": "[3.1.0, )",
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.115, )",
-          "Speckle.Sdk": "[3.1.0-dev.115, )"
+          "Speckle.Objects": "[3.0.1-rc.117, )",
+          "Speckle.Sdk": "[3.0.1-rc.117, )"
         }
       },
       "speckle.converters.autocad2023": {
@@ -358,7 +358,7 @@
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[3.1.0, )",
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.115, )"
+          "Speckle.Objects": "[3.0.1-rc.117, )"
         }
       },
       "speckle.converters.common.dependencyinjection": {
@@ -403,18 +403,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.115, )",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "p4K3/pSsjmKgtM1vg3+TpXryRL3HM49VflQcqhF+zplfsb9vZUhgKf+BnNQtEDyxPcEOEby/nmU179dxtJnCLw==",
+        "requested": "[3.0.1-rc.117, )",
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "YjExrNc/8Ha7rJ5enSDV1idCbwtneYUFOiAc4G5dm6XujuKqGHd4cVafV37FffFNGYl5fqvjTGjQ8mjrUfIEFw==",
         "dependencies": {
-          "Speckle.Sdk": "3.1.0-dev.115"
+          "Speckle.Sdk": "3.0.1-rc.117"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.115, )",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "uCo2oOvXAA+Ya+PRRPpBTVPRVC27tZEJU6cH3xgDqkl7sLaycn1ygelz9yZmMorwmjECEHOYuabLsQ+u04M+VQ==",
+        "requested": "[3.0.1-rc.117, )",
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "0rcCz4Dw9Yi62dZ8YG+THCYzHJokvH0F2IYYgqCqgk1CsuoH2IM/lGYYspiGiOLEuR4GG6aLt+Dke6jExANRlw==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -424,7 +424,7 @@
           "Polly.Extensions.Http": "3.0.0",
           "Speckle.DoubleNumerics": "4.0.1",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Logging": "3.1.0-dev.115",
+          "Speckle.Sdk.Logging": "3.0.1-rc.117",
           "System.Text.Json": "5.0.2"
         }
       },

--- a/Connectors/Autocad/Speckle.Connectors.Autocad2024/packages.lock.json
+++ b/Connectors/Autocad/Speckle.Connectors.Autocad2024/packages.lock.json
@@ -189,8 +189,8 @@
       },
       "Speckle.Sdk.Logging": {
         "type": "Transitive",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "bM9t/LdnCoaSqnj6MgkFCBSxVad+KMzrsgGtJ6Y1S+WTY43ysArIW7r2cB84OG9IZH3g9DRHLU9Rob848gWj4g=="
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "NOEdqL0luzhm2Q0jShr5zti1yVihVVaFa9sxHLSQ4CqcxdydbmEuJyDBr86QQjJ8V3Q2E99z4zRis4NyYW3D6Q=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -318,7 +318,7 @@
           "Microsoft.Extensions.Logging.Abstractions": "[3.1.0, )",
           "Speckle.Autofac": "[1.0.0, )",
           "Speckle.Connectors.Utils": "[1.0.0, )",
-          "Speckle.Sdk": "[3.1.0-dev.115, )",
+          "Speckle.Sdk": "[3.0.1-rc.117, )",
           "System.Threading.Tasks.Dataflow": "[6.0.0, )"
         }
       },
@@ -334,8 +334,8 @@
         "dependencies": {
           "Microsoft.Extensions.Logging": "[3.1.0, )",
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.115, )",
-          "Speckle.Sdk": "[3.1.0-dev.115, )"
+          "Speckle.Objects": "[3.0.1-rc.117, )",
+          "Speckle.Sdk": "[3.0.1-rc.117, )"
         }
       },
       "speckle.converters.autocad2024": {
@@ -359,7 +359,7 @@
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[3.1.0, )",
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.115, )"
+          "Speckle.Objects": "[3.0.1-rc.117, )"
         }
       },
       "speckle.converters.common.dependencyinjection": {
@@ -404,18 +404,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.115, )",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "p4K3/pSsjmKgtM1vg3+TpXryRL3HM49VflQcqhF+zplfsb9vZUhgKf+BnNQtEDyxPcEOEby/nmU179dxtJnCLw==",
+        "requested": "[3.0.1-rc.117, )",
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "YjExrNc/8Ha7rJ5enSDV1idCbwtneYUFOiAc4G5dm6XujuKqGHd4cVafV37FffFNGYl5fqvjTGjQ8mjrUfIEFw==",
         "dependencies": {
-          "Speckle.Sdk": "3.1.0-dev.115"
+          "Speckle.Sdk": "3.0.1-rc.117"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.115, )",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "uCo2oOvXAA+Ya+PRRPpBTVPRVC27tZEJU6cH3xgDqkl7sLaycn1ygelz9yZmMorwmjECEHOYuabLsQ+u04M+VQ==",
+        "requested": "[3.0.1-rc.117, )",
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "0rcCz4Dw9Yi62dZ8YG+THCYzHJokvH0F2IYYgqCqgk1CsuoH2IM/lGYYspiGiOLEuR4GG6aLt+Dke6jExANRlw==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -425,7 +425,7 @@
           "Polly.Extensions.Http": "3.0.0",
           "Speckle.DoubleNumerics": "4.0.1",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Logging": "3.1.0-dev.115",
+          "Speckle.Sdk.Logging": "3.0.1-rc.117",
           "System.Text.Json": "5.0.2"
         }
       },

--- a/Connectors/Autocad/Speckle.Connectors.Autocad2025/packages.lock.json
+++ b/Connectors/Autocad/Speckle.Connectors.Autocad2025/packages.lock.json
@@ -174,8 +174,8 @@
       },
       "Speckle.Sdk.Logging": {
         "type": "Transitive",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "bM9t/LdnCoaSqnj6MgkFCBSxVad+KMzrsgGtJ6Y1S+WTY43ysArIW7r2cB84OG9IZH3g9DRHLU9Rob848gWj4g=="
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "NOEdqL0luzhm2Q0jShr5zti1yVihVVaFa9sxHLSQ4CqcxdydbmEuJyDBr86QQjJ8V3Q2E99z4zRis4NyYW3D6Q=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -234,7 +234,7 @@
           "Microsoft.Extensions.Logging.Abstractions": "[3.1.0, )",
           "Speckle.Autofac": "[1.0.0, )",
           "Speckle.Connectors.Utils": "[1.0.0, )",
-          "Speckle.Sdk": "[3.1.0-dev.115, )",
+          "Speckle.Sdk": "[3.0.1-rc.117, )",
           "System.Threading.Tasks.Dataflow": "[6.0.0, )"
         }
       },
@@ -250,8 +250,8 @@
         "dependencies": {
           "Microsoft.Extensions.Logging": "[3.1.0, )",
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.115, )",
-          "Speckle.Sdk": "[3.1.0-dev.115, )"
+          "Speckle.Objects": "[3.0.1-rc.117, )",
+          "Speckle.Sdk": "[3.0.1-rc.117, )"
         }
       },
       "speckle.converters.autocad2025": {
@@ -275,7 +275,7 @@
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[3.1.0, )",
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.115, )"
+          "Speckle.Objects": "[3.0.1-rc.117, )"
         }
       },
       "speckle.converters.common.dependencyinjection": {
@@ -317,18 +317,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.115, )",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "p4K3/pSsjmKgtM1vg3+TpXryRL3HM49VflQcqhF+zplfsb9vZUhgKf+BnNQtEDyxPcEOEby/nmU179dxtJnCLw==",
+        "requested": "[3.0.1-rc.117, )",
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "YjExrNc/8Ha7rJ5enSDV1idCbwtneYUFOiAc4G5dm6XujuKqGHd4cVafV37FffFNGYl5fqvjTGjQ8mjrUfIEFw==",
         "dependencies": {
-          "Speckle.Sdk": "3.1.0-dev.115"
+          "Speckle.Sdk": "3.0.1-rc.117"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.115, )",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "uCo2oOvXAA+Ya+PRRPpBTVPRVC27tZEJU6cH3xgDqkl7sLaycn1ygelz9yZmMorwmjECEHOYuabLsQ+u04M+VQ==",
+        "requested": "[3.0.1-rc.117, )",
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "0rcCz4Dw9Yi62dZ8YG+THCYzHJokvH0F2IYYgqCqgk1CsuoH2IM/lGYYspiGiOLEuR4GG6aLt+Dke6jExANRlw==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -338,7 +338,7 @@
           "Polly.Extensions.Http": "3.0.0",
           "Speckle.DoubleNumerics": "4.0.1",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Logging": "3.1.0-dev.115",
+          "Speckle.Sdk.Logging": "3.0.1-rc.117",
           "System.Text.Json": "5.0.2"
         }
       },

--- a/Connectors/Autocad/Speckle.Connectors.Civil3d2024/packages.lock.json
+++ b/Connectors/Autocad/Speckle.Connectors.Civil3d2024/packages.lock.json
@@ -198,8 +198,8 @@
       },
       "Speckle.Sdk.Logging": {
         "type": "Transitive",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "bM9t/LdnCoaSqnj6MgkFCBSxVad+KMzrsgGtJ6Y1S+WTY43ysArIW7r2cB84OG9IZH3g9DRHLU9Rob848gWj4g=="
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "NOEdqL0luzhm2Q0jShr5zti1yVihVVaFa9sxHLSQ4CqcxdydbmEuJyDBr86QQjJ8V3Q2E99z4zRis4NyYW3D6Q=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -327,7 +327,7 @@
           "Microsoft.Extensions.Logging.Abstractions": "[3.1.0, )",
           "Speckle.Autofac": "[1.0.0, )",
           "Speckle.Connectors.Utils": "[1.0.0, )",
-          "Speckle.Sdk": "[3.1.0-dev.115, )",
+          "Speckle.Sdk": "[3.0.1-rc.117, )",
           "System.Threading.Tasks.Dataflow": "[6.0.0, )"
         }
       },
@@ -343,8 +343,8 @@
         "dependencies": {
           "Microsoft.Extensions.Logging": "[3.1.0, )",
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.115, )",
-          "Speckle.Sdk": "[3.1.0-dev.115, )"
+          "Speckle.Objects": "[3.0.1-rc.117, )",
+          "Speckle.Sdk": "[3.0.1-rc.117, )"
         }
       },
       "speckle.converters.autocad2023": {
@@ -367,7 +367,7 @@
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[3.1.0, )",
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.115, )"
+          "Speckle.Objects": "[3.0.1-rc.117, )"
         }
       },
       "speckle.converters.common.dependencyinjection": {
@@ -412,18 +412,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.115, )",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "p4K3/pSsjmKgtM1vg3+TpXryRL3HM49VflQcqhF+zplfsb9vZUhgKf+BnNQtEDyxPcEOEby/nmU179dxtJnCLw==",
+        "requested": "[3.0.1-rc.117, )",
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "YjExrNc/8Ha7rJ5enSDV1idCbwtneYUFOiAc4G5dm6XujuKqGHd4cVafV37FffFNGYl5fqvjTGjQ8mjrUfIEFw==",
         "dependencies": {
-          "Speckle.Sdk": "3.1.0-dev.115"
+          "Speckle.Sdk": "3.0.1-rc.117"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.115, )",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "uCo2oOvXAA+Ya+PRRPpBTVPRVC27tZEJU6cH3xgDqkl7sLaycn1ygelz9yZmMorwmjECEHOYuabLsQ+u04M+VQ==",
+        "requested": "[3.0.1-rc.117, )",
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "0rcCz4Dw9Yi62dZ8YG+THCYzHJokvH0F2IYYgqCqgk1CsuoH2IM/lGYYspiGiOLEuR4GG6aLt+Dke6jExANRlw==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -433,7 +433,7 @@
           "Polly.Extensions.Http": "3.0.0",
           "Speckle.DoubleNumerics": "4.0.1",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Logging": "3.1.0-dev.115",
+          "Speckle.Sdk.Logging": "3.0.1-rc.117",
           "System.Text.Json": "5.0.2"
         }
       },

--- a/Connectors/Revit/Speckle.Connectors.Revit2022/packages.lock.json
+++ b/Connectors/Revit/Speckle.Connectors.Revit2022/packages.lock.json
@@ -217,8 +217,8 @@
       },
       "Speckle.Sdk.Logging": {
         "type": "Transitive",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "bM9t/LdnCoaSqnj6MgkFCBSxVad+KMzrsgGtJ6Y1S+WTY43ysArIW7r2cB84OG9IZH3g9DRHLU9Rob848gWj4g=="
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "NOEdqL0luzhm2Q0jShr5zti1yVihVVaFa9sxHLSQ4CqcxdydbmEuJyDBr86QQjJ8V3Q2E99z4zRis4NyYW3D6Q=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -346,7 +346,7 @@
           "Microsoft.Extensions.Logging.Abstractions": "[3.1.0, )",
           "Speckle.Autofac": "[1.0.0, )",
           "Speckle.Connectors.Utils": "[1.0.0, )",
-          "Speckle.Sdk": "[3.1.0-dev.115, )",
+          "Speckle.Sdk": "[3.0.1-rc.117, )",
           "System.Threading.Tasks.Dataflow": "[6.0.0, )"
         }
       },
@@ -355,8 +355,8 @@
         "dependencies": {
           "Microsoft.Extensions.Logging": "[3.1.0, )",
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.115, )",
-          "Speckle.Sdk": "[3.1.0-dev.115, )"
+          "Speckle.Objects": "[3.0.1-rc.117, )",
+          "Speckle.Sdk": "[3.0.1-rc.117, )"
         }
       },
       "speckle.converters.common": {
@@ -364,7 +364,7 @@
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[3.1.0, )",
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.115, )"
+          "Speckle.Objects": "[3.0.1-rc.117, )"
         }
       },
       "speckle.converters.common.dependencyinjection": {
@@ -419,11 +419,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.115, )",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "p4K3/pSsjmKgtM1vg3+TpXryRL3HM49VflQcqhF+zplfsb9vZUhgKf+BnNQtEDyxPcEOEby/nmU179dxtJnCLw==",
+        "requested": "[3.0.1-rc.117, )",
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "YjExrNc/8Ha7rJ5enSDV1idCbwtneYUFOiAc4G5dm6XujuKqGHd4cVafV37FffFNGYl5fqvjTGjQ8mjrUfIEFw==",
         "dependencies": {
-          "Speckle.Sdk": "3.1.0-dev.115"
+          "Speckle.Sdk": "3.0.1-rc.117"
         }
       },
       "Speckle.Revit.API": {
@@ -434,9 +434,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.115, )",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "uCo2oOvXAA+Ya+PRRPpBTVPRVC27tZEJU6cH3xgDqkl7sLaycn1ygelz9yZmMorwmjECEHOYuabLsQ+u04M+VQ==",
+        "requested": "[3.0.1-rc.117, )",
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "0rcCz4Dw9Yi62dZ8YG+THCYzHJokvH0F2IYYgqCqgk1CsuoH2IM/lGYYspiGiOLEuR4GG6aLt+Dke6jExANRlw==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -446,7 +446,7 @@
           "Polly.Extensions.Http": "3.0.0",
           "Speckle.DoubleNumerics": "4.0.1",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Logging": "3.1.0-dev.115",
+          "Speckle.Sdk.Logging": "3.0.1-rc.117",
           "System.Text.Json": "5.0.2"
         }
       },

--- a/Connectors/Revit/Speckle.Connectors.Revit2023/packages.lock.json
+++ b/Connectors/Revit/Speckle.Connectors.Revit2023/packages.lock.json
@@ -217,8 +217,8 @@
       },
       "Speckle.Sdk.Logging": {
         "type": "Transitive",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "bM9t/LdnCoaSqnj6MgkFCBSxVad+KMzrsgGtJ6Y1S+WTY43ysArIW7r2cB84OG9IZH3g9DRHLU9Rob848gWj4g=="
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "NOEdqL0luzhm2Q0jShr5zti1yVihVVaFa9sxHLSQ4CqcxdydbmEuJyDBr86QQjJ8V3Q2E99z4zRis4NyYW3D6Q=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -346,7 +346,7 @@
           "Microsoft.Extensions.Logging.Abstractions": "[3.1.0, )",
           "Speckle.Autofac": "[1.0.0, )",
           "Speckle.Connectors.Utils": "[1.0.0, )",
-          "Speckle.Sdk": "[3.1.0-dev.115, )",
+          "Speckle.Sdk": "[3.0.1-rc.117, )",
           "System.Threading.Tasks.Dataflow": "[6.0.0, )"
         }
       },
@@ -355,8 +355,8 @@
         "dependencies": {
           "Microsoft.Extensions.Logging": "[3.1.0, )",
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.115, )",
-          "Speckle.Sdk": "[3.1.0-dev.115, )"
+          "Speckle.Objects": "[3.0.1-rc.117, )",
+          "Speckle.Sdk": "[3.0.1-rc.117, )"
         }
       },
       "speckle.converters.common": {
@@ -364,7 +364,7 @@
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[3.1.0, )",
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.115, )"
+          "Speckle.Objects": "[3.0.1-rc.117, )"
         }
       },
       "speckle.converters.common.dependencyinjection": {
@@ -418,11 +418,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.115, )",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "p4K3/pSsjmKgtM1vg3+TpXryRL3HM49VflQcqhF+zplfsb9vZUhgKf+BnNQtEDyxPcEOEby/nmU179dxtJnCLw==",
+        "requested": "[3.0.1-rc.117, )",
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "YjExrNc/8Ha7rJ5enSDV1idCbwtneYUFOiAc4G5dm6XujuKqGHd4cVafV37FffFNGYl5fqvjTGjQ8mjrUfIEFw==",
         "dependencies": {
-          "Speckle.Sdk": "3.1.0-dev.115"
+          "Speckle.Sdk": "3.0.1-rc.117"
         }
       },
       "Speckle.Revit.API": {
@@ -433,9 +433,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.115, )",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "uCo2oOvXAA+Ya+PRRPpBTVPRVC27tZEJU6cH3xgDqkl7sLaycn1ygelz9yZmMorwmjECEHOYuabLsQ+u04M+VQ==",
+        "requested": "[3.0.1-rc.117, )",
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "0rcCz4Dw9Yi62dZ8YG+THCYzHJokvH0F2IYYgqCqgk1CsuoH2IM/lGYYspiGiOLEuR4GG6aLt+Dke6jExANRlw==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -445,7 +445,7 @@
           "Polly.Extensions.Http": "3.0.0",
           "Speckle.DoubleNumerics": "4.0.1",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Logging": "3.1.0-dev.115",
+          "Speckle.Sdk.Logging": "3.0.1-rc.117",
           "System.Text.Json": "5.0.2"
         }
       },

--- a/Connectors/Revit/Speckle.Connectors.Revit2024/packages.lock.json
+++ b/Connectors/Revit/Speckle.Connectors.Revit2024/packages.lock.json
@@ -217,8 +217,8 @@
       },
       "Speckle.Sdk.Logging": {
         "type": "Transitive",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "bM9t/LdnCoaSqnj6MgkFCBSxVad+KMzrsgGtJ6Y1S+WTY43ysArIW7r2cB84OG9IZH3g9DRHLU9Rob848gWj4g=="
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "NOEdqL0luzhm2Q0jShr5zti1yVihVVaFa9sxHLSQ4CqcxdydbmEuJyDBr86QQjJ8V3Q2E99z4zRis4NyYW3D6Q=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -346,7 +346,7 @@
           "Microsoft.Extensions.Logging.Abstractions": "[3.1.0, )",
           "Speckle.Autofac": "[1.0.0, )",
           "Speckle.Connectors.Utils": "[1.0.0, )",
-          "Speckle.Sdk": "[3.1.0-dev.115, )",
+          "Speckle.Sdk": "[3.0.1-rc.117, )",
           "System.Threading.Tasks.Dataflow": "[6.0.0, )"
         }
       },
@@ -355,8 +355,8 @@
         "dependencies": {
           "Microsoft.Extensions.Logging": "[3.1.0, )",
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.115, )",
-          "Speckle.Sdk": "[3.1.0-dev.115, )"
+          "Speckle.Objects": "[3.0.1-rc.117, )",
+          "Speckle.Sdk": "[3.0.1-rc.117, )"
         }
       },
       "speckle.converters.common": {
@@ -364,7 +364,7 @@
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[3.1.0, )",
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.115, )"
+          "Speckle.Objects": "[3.0.1-rc.117, )"
         }
       },
       "speckle.converters.common.dependencyinjection": {
@@ -418,11 +418,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.115, )",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "p4K3/pSsjmKgtM1vg3+TpXryRL3HM49VflQcqhF+zplfsb9vZUhgKf+BnNQtEDyxPcEOEby/nmU179dxtJnCLw==",
+        "requested": "[3.0.1-rc.117, )",
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "YjExrNc/8Ha7rJ5enSDV1idCbwtneYUFOiAc4G5dm6XujuKqGHd4cVafV37FffFNGYl5fqvjTGjQ8mjrUfIEFw==",
         "dependencies": {
-          "Speckle.Sdk": "3.1.0-dev.115"
+          "Speckle.Sdk": "3.0.1-rc.117"
         }
       },
       "Speckle.Revit.API": {
@@ -433,9 +433,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.115, )",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "uCo2oOvXAA+Ya+PRRPpBTVPRVC27tZEJU6cH3xgDqkl7sLaycn1ygelz9yZmMorwmjECEHOYuabLsQ+u04M+VQ==",
+        "requested": "[3.0.1-rc.117, )",
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "0rcCz4Dw9Yi62dZ8YG+THCYzHJokvH0F2IYYgqCqgk1CsuoH2IM/lGYYspiGiOLEuR4GG6aLt+Dke6jExANRlw==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -445,7 +445,7 @@
           "Polly.Extensions.Http": "3.0.0",
           "Speckle.DoubleNumerics": "4.0.1",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Logging": "3.1.0-dev.115",
+          "Speckle.Sdk.Logging": "3.0.1-rc.117",
           "System.Text.Json": "5.0.2"
         }
       },

--- a/Connectors/Revit/Speckle.Connectors.Revit2025/packages.lock.json
+++ b/Connectors/Revit/Speckle.Connectors.Revit2025/packages.lock.json
@@ -196,8 +196,8 @@
       },
       "Speckle.Sdk.Logging": {
         "type": "Transitive",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "bM9t/LdnCoaSqnj6MgkFCBSxVad+KMzrsgGtJ6Y1S+WTY43ysArIW7r2cB84OG9IZH3g9DRHLU9Rob848gWj4g=="
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "NOEdqL0luzhm2Q0jShr5zti1yVihVVaFa9sxHLSQ4CqcxdydbmEuJyDBr86QQjJ8V3Q2E99z4zRis4NyYW3D6Q=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -256,7 +256,7 @@
           "Microsoft.Extensions.Logging.Abstractions": "[3.1.0, )",
           "Speckle.Autofac": "[1.0.0, )",
           "Speckle.Connectors.Utils": "[1.0.0, )",
-          "Speckle.Sdk": "[3.1.0-dev.115, )",
+          "Speckle.Sdk": "[3.0.1-rc.117, )",
           "System.Threading.Tasks.Dataflow": "[6.0.0, )"
         }
       },
@@ -272,8 +272,8 @@
         "dependencies": {
           "Microsoft.Extensions.Logging": "[3.1.0, )",
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.115, )",
-          "Speckle.Sdk": "[3.1.0-dev.115, )"
+          "Speckle.Objects": "[3.0.1-rc.117, )",
+          "Speckle.Sdk": "[3.0.1-rc.117, )"
         }
       },
       "speckle.converters.common": {
@@ -281,7 +281,7 @@
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[3.1.0, )",
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.115, )"
+          "Speckle.Objects": "[3.0.1-rc.117, )"
         }
       },
       "speckle.converters.common.dependencyinjection": {
@@ -338,11 +338,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.115, )",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "p4K3/pSsjmKgtM1vg3+TpXryRL3HM49VflQcqhF+zplfsb9vZUhgKf+BnNQtEDyxPcEOEby/nmU179dxtJnCLw==",
+        "requested": "[3.0.1-rc.117, )",
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "YjExrNc/8Ha7rJ5enSDV1idCbwtneYUFOiAc4G5dm6XujuKqGHd4cVafV37FffFNGYl5fqvjTGjQ8mjrUfIEFw==",
         "dependencies": {
-          "Speckle.Sdk": "3.1.0-dev.115"
+          "Speckle.Sdk": "3.0.1-rc.117"
         }
       },
       "Speckle.Revit.API": {
@@ -353,9 +353,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.115, )",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "uCo2oOvXAA+Ya+PRRPpBTVPRVC27tZEJU6cH3xgDqkl7sLaycn1ygelz9yZmMorwmjECEHOYuabLsQ+u04M+VQ==",
+        "requested": "[3.0.1-rc.117, )",
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "0rcCz4Dw9Yi62dZ8YG+THCYzHJokvH0F2IYYgqCqgk1CsuoH2IM/lGYYspiGiOLEuR4GG6aLt+Dke6jExANRlw==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -365,7 +365,7 @@
           "Polly.Extensions.Http": "3.0.0",
           "Speckle.DoubleNumerics": "4.0.1",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Logging": "3.1.0-dev.115",
+          "Speckle.Sdk.Logging": "3.0.1-rc.117",
           "System.Text.Json": "5.0.2"
         }
       },

--- a/Connectors/Rhino/Speckle.Connectors.Rhino7/packages.lock.json
+++ b/Connectors/Rhino/Speckle.Connectors.Rhino7/packages.lock.json
@@ -198,8 +198,8 @@
       },
       "Speckle.Sdk.Logging": {
         "type": "Transitive",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "bM9t/LdnCoaSqnj6MgkFCBSxVad+KMzrsgGtJ6Y1S+WTY43ysArIW7r2cB84OG9IZH3g9DRHLU9Rob848gWj4g=="
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "NOEdqL0luzhm2Q0jShr5zti1yVihVVaFa9sxHLSQ4CqcxdydbmEuJyDBr86QQjJ8V3Q2E99z4zRis4NyYW3D6Q=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -327,7 +327,7 @@
           "Microsoft.Extensions.Logging.Abstractions": "[3.1.0, )",
           "Speckle.Autofac": "[1.0.0, )",
           "Speckle.Connectors.Utils": "[1.0.0, )",
-          "Speckle.Sdk": "[3.1.0-dev.115, )",
+          "Speckle.Sdk": "[3.0.1-rc.117, )",
           "System.Threading.Tasks.Dataflow": "[6.0.0, )"
         }
       },
@@ -343,8 +343,8 @@
         "dependencies": {
           "Microsoft.Extensions.Logging": "[3.1.0, )",
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.115, )",
-          "Speckle.Sdk": "[3.1.0-dev.115, )"
+          "Speckle.Objects": "[3.0.1-rc.117, )",
+          "Speckle.Sdk": "[3.0.1-rc.117, )"
         }
       },
       "speckle.converters.common": {
@@ -352,7 +352,7 @@
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[3.1.0, )",
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.115, )"
+          "Speckle.Objects": "[3.0.1-rc.117, )"
         }
       },
       "speckle.converters.common.dependencyinjection": {
@@ -410,18 +410,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.115, )",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "p4K3/pSsjmKgtM1vg3+TpXryRL3HM49VflQcqhF+zplfsb9vZUhgKf+BnNQtEDyxPcEOEby/nmU179dxtJnCLw==",
+        "requested": "[3.0.1-rc.117, )",
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "YjExrNc/8Ha7rJ5enSDV1idCbwtneYUFOiAc4G5dm6XujuKqGHd4cVafV37FffFNGYl5fqvjTGjQ8mjrUfIEFw==",
         "dependencies": {
-          "Speckle.Sdk": "3.1.0-dev.115"
+          "Speckle.Sdk": "3.0.1-rc.117"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.115, )",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "uCo2oOvXAA+Ya+PRRPpBTVPRVC27tZEJU6cH3xgDqkl7sLaycn1ygelz9yZmMorwmjECEHOYuabLsQ+u04M+VQ==",
+        "requested": "[3.0.1-rc.117, )",
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "0rcCz4Dw9Yi62dZ8YG+THCYzHJokvH0F2IYYgqCqgk1CsuoH2IM/lGYYspiGiOLEuR4GG6aLt+Dke6jExANRlw==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -431,7 +431,7 @@
           "Polly.Extensions.Http": "3.0.0",
           "Speckle.DoubleNumerics": "4.0.1",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Logging": "3.1.0-dev.115",
+          "Speckle.Sdk.Logging": "3.0.1-rc.117",
           "System.Text.Json": "5.0.2"
         }
       },

--- a/Connectors/Rhino/Speckle.Connectors.Rhino8/packages.lock.json
+++ b/Connectors/Rhino/Speckle.Connectors.Rhino8/packages.lock.json
@@ -198,8 +198,8 @@
       },
       "Speckle.Sdk.Logging": {
         "type": "Transitive",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "bM9t/LdnCoaSqnj6MgkFCBSxVad+KMzrsgGtJ6Y1S+WTY43ysArIW7r2cB84OG9IZH3g9DRHLU9Rob848gWj4g=="
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "NOEdqL0luzhm2Q0jShr5zti1yVihVVaFa9sxHLSQ4CqcxdydbmEuJyDBr86QQjJ8V3Q2E99z4zRis4NyYW3D6Q=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -327,7 +327,7 @@
           "Microsoft.Extensions.Logging.Abstractions": "[3.1.0, )",
           "Speckle.Autofac": "[1.0.0, )",
           "Speckle.Connectors.Utils": "[1.0.0, )",
-          "Speckle.Sdk": "[3.1.0-dev.115, )",
+          "Speckle.Sdk": "[3.0.1-rc.117, )",
           "System.Threading.Tasks.Dataflow": "[6.0.0, )"
         }
       },
@@ -343,8 +343,8 @@
         "dependencies": {
           "Microsoft.Extensions.Logging": "[3.1.0, )",
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.115, )",
-          "Speckle.Sdk": "[3.1.0-dev.115, )"
+          "Speckle.Objects": "[3.0.1-rc.117, )",
+          "Speckle.Sdk": "[3.0.1-rc.117, )"
         }
       },
       "speckle.converters.common": {
@@ -352,7 +352,7 @@
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[3.1.0, )",
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.115, )"
+          "Speckle.Objects": "[3.0.1-rc.117, )"
         }
       },
       "speckle.converters.common.dependencyinjection": {
@@ -410,18 +410,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.115, )",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "p4K3/pSsjmKgtM1vg3+TpXryRL3HM49VflQcqhF+zplfsb9vZUhgKf+BnNQtEDyxPcEOEby/nmU179dxtJnCLw==",
+        "requested": "[3.0.1-rc.117, )",
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "YjExrNc/8Ha7rJ5enSDV1idCbwtneYUFOiAc4G5dm6XujuKqGHd4cVafV37FffFNGYl5fqvjTGjQ8mjrUfIEFw==",
         "dependencies": {
-          "Speckle.Sdk": "3.1.0-dev.115"
+          "Speckle.Sdk": "3.0.1-rc.117"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.115, )",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "uCo2oOvXAA+Ya+PRRPpBTVPRVC27tZEJU6cH3xgDqkl7sLaycn1ygelz9yZmMorwmjECEHOYuabLsQ+u04M+VQ==",
+        "requested": "[3.0.1-rc.117, )",
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "0rcCz4Dw9Yi62dZ8YG+THCYzHJokvH0F2IYYgqCqgk1CsuoH2IM/lGYYspiGiOLEuR4GG6aLt+Dke6jExANRlw==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -431,7 +431,7 @@
           "Polly.Extensions.Http": "3.0.0",
           "Speckle.DoubleNumerics": "4.0.1",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Logging": "3.1.0-dev.115",
+          "Speckle.Sdk.Logging": "3.0.1-rc.117",
           "System.Text.Json": "5.0.2"
         }
       },

--- a/Converters/ArcGIS/Speckle.Converters.ArcGIS3.DependencyInjection/packages.lock.json
+++ b/Converters/ArcGIS/Speckle.Converters.ArcGIS3.DependencyInjection/packages.lock.json
@@ -117,8 +117,8 @@
       },
       "Speckle.Sdk.Logging": {
         "type": "Transitive",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "bM9t/LdnCoaSqnj6MgkFCBSxVad+KMzrsgGtJ6Y1S+WTY43ysArIW7r2cB84OG9IZH3g9DRHLU9Rob848gWj4g=="
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "NOEdqL0luzhm2Q0jShr5zti1yVihVVaFa9sxHLSQ4CqcxdydbmEuJyDBr86QQjJ8V3Q2E99z4zRis4NyYW3D6Q=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -183,7 +183,7 @@
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[3.1.0, )",
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.115, )"
+          "Speckle.Objects": "[3.0.1-rc.117, )"
         }
       },
       "speckle.converters.common.dependencyinjection": {
@@ -213,18 +213,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.115, )",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "p4K3/pSsjmKgtM1vg3+TpXryRL3HM49VflQcqhF+zplfsb9vZUhgKf+BnNQtEDyxPcEOEby/nmU179dxtJnCLw==",
+        "requested": "[3.0.1-rc.117, )",
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "YjExrNc/8Ha7rJ5enSDV1idCbwtneYUFOiAc4G5dm6XujuKqGHd4cVafV37FffFNGYl5fqvjTGjQ8mjrUfIEFw==",
         "dependencies": {
-          "Speckle.Sdk": "3.1.0-dev.115"
+          "Speckle.Sdk": "3.0.1-rc.117"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.115, )",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "uCo2oOvXAA+Ya+PRRPpBTVPRVC27tZEJU6cH3xgDqkl7sLaycn1ygelz9yZmMorwmjECEHOYuabLsQ+u04M+VQ==",
+        "requested": "[3.0.1-rc.117, )",
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "0rcCz4Dw9Yi62dZ8YG+THCYzHJokvH0F2IYYgqCqgk1CsuoH2IM/lGYYspiGiOLEuR4GG6aLt+Dke6jExANRlw==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -234,7 +234,7 @@
           "Polly.Extensions.Http": "3.0.0",
           "Speckle.DoubleNumerics": "4.0.1",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Logging": "3.1.0-dev.115",
+          "Speckle.Sdk.Logging": "3.0.1-rc.117",
           "System.Text.Json": "5.0.2"
         }
       }

--- a/Converters/ArcGIS/Speckle.Converters.ArcGIS3/ArcGISToSpeckleUnitConverter.cs
+++ b/Converters/ArcGIS/Speckle.Converters.ArcGIS3/ArcGISToSpeckleUnitConverter.cs
@@ -22,7 +22,7 @@ public class ArcGISToSpeckleUnitConverter : IHostToSpeckleUnitConverter<Unit>
     dict[LinearUnit.Feet.FactoryCode] = Units.Feet;
     dict[LinearUnit.Yards.FactoryCode] = Units.Yards;
     dict[LinearUnit.Miles.FactoryCode] = Units.Miles;
-    dict[9003] = Units.USFeet;
+    //dict[9003] = Units.USFeet;
     return dict;
   }
 

--- a/Converters/ArcGIS/Speckle.Converters.ArcGIS3/packages.lock.json
+++ b/Converters/ArcGIS/Speckle.Converters.ArcGIS3/packages.lock.json
@@ -123,8 +123,8 @@
       },
       "Speckle.Sdk.Logging": {
         "type": "Transitive",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "bM9t/LdnCoaSqnj6MgkFCBSxVad+KMzrsgGtJ6Y1S+WTY43ysArIW7r2cB84OG9IZH3g9DRHLU9Rob848gWj4g=="
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "NOEdqL0luzhm2Q0jShr5zti1yVihVVaFa9sxHLSQ4CqcxdydbmEuJyDBr86QQjJ8V3Q2E99z4zRis4NyYW3D6Q=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -182,7 +182,7 @@
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[3.1.0, )",
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.115, )"
+          "Speckle.Objects": "[3.0.1-rc.117, )"
         }
       },
       "Autofac": {
@@ -199,18 +199,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.115, )",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "p4K3/pSsjmKgtM1vg3+TpXryRL3HM49VflQcqhF+zplfsb9vZUhgKf+BnNQtEDyxPcEOEby/nmU179dxtJnCLw==",
+        "requested": "[3.0.1-rc.117, )",
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "YjExrNc/8Ha7rJ5enSDV1idCbwtneYUFOiAc4G5dm6XujuKqGHd4cVafV37FffFNGYl5fqvjTGjQ8mjrUfIEFw==",
         "dependencies": {
-          "Speckle.Sdk": "3.1.0-dev.115"
+          "Speckle.Sdk": "3.0.1-rc.117"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.115, )",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "uCo2oOvXAA+Ya+PRRPpBTVPRVC27tZEJU6cH3xgDqkl7sLaycn1ygelz9yZmMorwmjECEHOYuabLsQ+u04M+VQ==",
+        "requested": "[3.0.1-rc.117, )",
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "0rcCz4Dw9Yi62dZ8YG+THCYzHJokvH0F2IYYgqCqgk1CsuoH2IM/lGYYspiGiOLEuR4GG6aLt+Dke6jExANRlw==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -220,7 +220,7 @@
           "Polly.Extensions.Http": "3.0.0",
           "Speckle.DoubleNumerics": "4.0.1",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Logging": "3.1.0-dev.115",
+          "Speckle.Sdk.Logging": "3.0.1-rc.117",
           "System.Text.Json": "5.0.2"
         }
       }

--- a/Converters/Autocad/Speckle.Converters.Autocad2022.DependencyInjection/packages.lock.json
+++ b/Converters/Autocad/Speckle.Converters.Autocad2022.DependencyInjection/packages.lock.json
@@ -135,8 +135,8 @@
       },
       "Speckle.Sdk.Logging": {
         "type": "Transitive",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "bM9t/LdnCoaSqnj6MgkFCBSxVad+KMzrsgGtJ6Y1S+WTY43ysArIW7r2cB84OG9IZH3g9DRHLU9Rob848gWj4g=="
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "NOEdqL0luzhm2Q0jShr5zti1yVihVVaFa9sxHLSQ4CqcxdydbmEuJyDBr86QQjJ8V3Q2E99z4zRis4NyYW3D6Q=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -265,7 +265,7 @@
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[3.1.0, )",
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.115, )"
+          "Speckle.Objects": "[3.0.1-rc.117, )"
         }
       },
       "speckle.converters.common.dependencyinjection": {
@@ -289,18 +289,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.115, )",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "p4K3/pSsjmKgtM1vg3+TpXryRL3HM49VflQcqhF+zplfsb9vZUhgKf+BnNQtEDyxPcEOEby/nmU179dxtJnCLw==",
+        "requested": "[3.0.1-rc.117, )",
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "YjExrNc/8Ha7rJ5enSDV1idCbwtneYUFOiAc4G5dm6XujuKqGHd4cVafV37FffFNGYl5fqvjTGjQ8mjrUfIEFw==",
         "dependencies": {
-          "Speckle.Sdk": "3.1.0-dev.115"
+          "Speckle.Sdk": "3.0.1-rc.117"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.115, )",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "uCo2oOvXAA+Ya+PRRPpBTVPRVC27tZEJU6cH3xgDqkl7sLaycn1ygelz9yZmMorwmjECEHOYuabLsQ+u04M+VQ==",
+        "requested": "[3.0.1-rc.117, )",
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "0rcCz4Dw9Yi62dZ8YG+THCYzHJokvH0F2IYYgqCqgk1CsuoH2IM/lGYYspiGiOLEuR4GG6aLt+Dke6jExANRlw==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -310,7 +310,7 @@
           "Polly.Extensions.Http": "3.0.0",
           "Speckle.DoubleNumerics": "4.0.1",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Logging": "3.1.0-dev.115",
+          "Speckle.Sdk.Logging": "3.0.1-rc.117",
           "System.Text.Json": "5.0.2"
         }
       }

--- a/Converters/Autocad/Speckle.Converters.Autocad2022/packages.lock.json
+++ b/Converters/Autocad/Speckle.Converters.Autocad2022/packages.lock.json
@@ -132,8 +132,8 @@
       },
       "Speckle.Sdk.Logging": {
         "type": "Transitive",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "bM9t/LdnCoaSqnj6MgkFCBSxVad+KMzrsgGtJ6Y1S+WTY43ysArIW7r2cB84OG9IZH3g9DRHLU9Rob848gWj4g=="
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "NOEdqL0luzhm2Q0jShr5zti1yVihVVaFa9sxHLSQ4CqcxdydbmEuJyDBr86QQjJ8V3Q2E99z4zRis4NyYW3D6Q=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -255,7 +255,7 @@
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[3.1.0, )",
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.115, )"
+          "Speckle.Objects": "[3.0.1-rc.117, )"
         }
       },
       "Autofac": {
@@ -275,18 +275,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.115, )",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "p4K3/pSsjmKgtM1vg3+TpXryRL3HM49VflQcqhF+zplfsb9vZUhgKf+BnNQtEDyxPcEOEby/nmU179dxtJnCLw==",
+        "requested": "[3.0.1-rc.117, )",
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "YjExrNc/8Ha7rJ5enSDV1idCbwtneYUFOiAc4G5dm6XujuKqGHd4cVafV37FffFNGYl5fqvjTGjQ8mjrUfIEFw==",
         "dependencies": {
-          "Speckle.Sdk": "3.1.0-dev.115"
+          "Speckle.Sdk": "3.0.1-rc.117"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.115, )",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "uCo2oOvXAA+Ya+PRRPpBTVPRVC27tZEJU6cH3xgDqkl7sLaycn1ygelz9yZmMorwmjECEHOYuabLsQ+u04M+VQ==",
+        "requested": "[3.0.1-rc.117, )",
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "0rcCz4Dw9Yi62dZ8YG+THCYzHJokvH0F2IYYgqCqgk1CsuoH2IM/lGYYspiGiOLEuR4GG6aLt+Dke6jExANRlw==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -296,7 +296,7 @@
           "Polly.Extensions.Http": "3.0.0",
           "Speckle.DoubleNumerics": "4.0.1",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Logging": "3.1.0-dev.115",
+          "Speckle.Sdk.Logging": "3.0.1-rc.117",
           "System.Text.Json": "5.0.2"
         }
       }

--- a/Converters/Autocad/Speckle.Converters.Autocad2023.DependencyInjection/packages.lock.json
+++ b/Converters/Autocad/Speckle.Converters.Autocad2023.DependencyInjection/packages.lock.json
@@ -135,8 +135,8 @@
       },
       "Speckle.Sdk.Logging": {
         "type": "Transitive",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "bM9t/LdnCoaSqnj6MgkFCBSxVad+KMzrsgGtJ6Y1S+WTY43ysArIW7r2cB84OG9IZH3g9DRHLU9Rob848gWj4g=="
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "NOEdqL0luzhm2Q0jShr5zti1yVihVVaFa9sxHLSQ4CqcxdydbmEuJyDBr86QQjJ8V3Q2E99z4zRis4NyYW3D6Q=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -265,7 +265,7 @@
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[3.1.0, )",
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.115, )"
+          "Speckle.Objects": "[3.0.1-rc.117, )"
         }
       },
       "speckle.converters.common.dependencyinjection": {
@@ -289,18 +289,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.115, )",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "p4K3/pSsjmKgtM1vg3+TpXryRL3HM49VflQcqhF+zplfsb9vZUhgKf+BnNQtEDyxPcEOEby/nmU179dxtJnCLw==",
+        "requested": "[3.0.1-rc.117, )",
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "YjExrNc/8Ha7rJ5enSDV1idCbwtneYUFOiAc4G5dm6XujuKqGHd4cVafV37FffFNGYl5fqvjTGjQ8mjrUfIEFw==",
         "dependencies": {
-          "Speckle.Sdk": "3.1.0-dev.115"
+          "Speckle.Sdk": "3.0.1-rc.117"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.115, )",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "uCo2oOvXAA+Ya+PRRPpBTVPRVC27tZEJU6cH3xgDqkl7sLaycn1ygelz9yZmMorwmjECEHOYuabLsQ+u04M+VQ==",
+        "requested": "[3.0.1-rc.117, )",
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "0rcCz4Dw9Yi62dZ8YG+THCYzHJokvH0F2IYYgqCqgk1CsuoH2IM/lGYYspiGiOLEuR4GG6aLt+Dke6jExANRlw==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -310,7 +310,7 @@
           "Polly.Extensions.Http": "3.0.0",
           "Speckle.DoubleNumerics": "4.0.1",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Logging": "3.1.0-dev.115",
+          "Speckle.Sdk.Logging": "3.0.1-rc.117",
           "System.Text.Json": "5.0.2"
         }
       }

--- a/Converters/Autocad/Speckle.Converters.Autocad2023/packages.lock.json
+++ b/Converters/Autocad/Speckle.Converters.Autocad2023/packages.lock.json
@@ -132,8 +132,8 @@
       },
       "Speckle.Sdk.Logging": {
         "type": "Transitive",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "bM9t/LdnCoaSqnj6MgkFCBSxVad+KMzrsgGtJ6Y1S+WTY43ysArIW7r2cB84OG9IZH3g9DRHLU9Rob848gWj4g=="
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "NOEdqL0luzhm2Q0jShr5zti1yVihVVaFa9sxHLSQ4CqcxdydbmEuJyDBr86QQjJ8V3Q2E99z4zRis4NyYW3D6Q=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -255,7 +255,7 @@
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[3.1.0, )",
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.115, )"
+          "Speckle.Objects": "[3.0.1-rc.117, )"
         }
       },
       "Autofac": {
@@ -275,18 +275,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.115, )",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "p4K3/pSsjmKgtM1vg3+TpXryRL3HM49VflQcqhF+zplfsb9vZUhgKf+BnNQtEDyxPcEOEby/nmU179dxtJnCLw==",
+        "requested": "[3.0.1-rc.117, )",
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "YjExrNc/8Ha7rJ5enSDV1idCbwtneYUFOiAc4G5dm6XujuKqGHd4cVafV37FffFNGYl5fqvjTGjQ8mjrUfIEFw==",
         "dependencies": {
-          "Speckle.Sdk": "3.1.0-dev.115"
+          "Speckle.Sdk": "3.0.1-rc.117"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.115, )",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "uCo2oOvXAA+Ya+PRRPpBTVPRVC27tZEJU6cH3xgDqkl7sLaycn1ygelz9yZmMorwmjECEHOYuabLsQ+u04M+VQ==",
+        "requested": "[3.0.1-rc.117, )",
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "0rcCz4Dw9Yi62dZ8YG+THCYzHJokvH0F2IYYgqCqgk1CsuoH2IM/lGYYspiGiOLEuR4GG6aLt+Dke6jExANRlw==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -296,7 +296,7 @@
           "Polly.Extensions.Http": "3.0.0",
           "Speckle.DoubleNumerics": "4.0.1",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Logging": "3.1.0-dev.115",
+          "Speckle.Sdk.Logging": "3.0.1-rc.117",
           "System.Text.Json": "5.0.2"
         }
       }

--- a/Converters/Autocad/Speckle.Converters.Autocad2024.DependencyInjection/packages.lock.json
+++ b/Converters/Autocad/Speckle.Converters.Autocad2024.DependencyInjection/packages.lock.json
@@ -192,8 +192,8 @@
       },
       "Speckle.Sdk.Logging": {
         "type": "Transitive",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "bM9t/LdnCoaSqnj6MgkFCBSxVad+KMzrsgGtJ6Y1S+WTY43ysArIW7r2cB84OG9IZH3g9DRHLU9Rob848gWj4g=="
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "NOEdqL0luzhm2Q0jShr5zti1yVihVVaFa9sxHLSQ4CqcxdydbmEuJyDBr86QQjJ8V3Q2E99z4zRis4NyYW3D6Q=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -321,7 +321,7 @@
           "Microsoft.Extensions.Logging.Abstractions": "[3.1.0, )",
           "Speckle.Autofac": "[1.0.0, )",
           "Speckle.Connectors.Utils": "[1.0.0, )",
-          "Speckle.Sdk": "[3.1.0-dev.115, )",
+          "Speckle.Sdk": "[3.0.1-rc.117, )",
           "System.Threading.Tasks.Dataflow": "[6.0.0, )"
         }
       },
@@ -337,8 +337,8 @@
         "dependencies": {
           "Microsoft.Extensions.Logging": "[3.1.0, )",
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.115, )",
-          "Speckle.Sdk": "[3.1.0-dev.115, )"
+          "Speckle.Objects": "[3.0.1-rc.117, )",
+          "Speckle.Sdk": "[3.0.1-rc.117, )"
         }
       },
       "speckle.converters.autocad2024": {
@@ -354,7 +354,7 @@
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[3.1.0, )",
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.115, )"
+          "Speckle.Objects": "[3.0.1-rc.117, )"
         }
       },
       "speckle.converters.common.dependencyinjection": {
@@ -396,18 +396,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.115, )",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "p4K3/pSsjmKgtM1vg3+TpXryRL3HM49VflQcqhF+zplfsb9vZUhgKf+BnNQtEDyxPcEOEby/nmU179dxtJnCLw==",
+        "requested": "[3.0.1-rc.117, )",
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "YjExrNc/8Ha7rJ5enSDV1idCbwtneYUFOiAc4G5dm6XujuKqGHd4cVafV37FffFNGYl5fqvjTGjQ8mjrUfIEFw==",
         "dependencies": {
-          "Speckle.Sdk": "3.1.0-dev.115"
+          "Speckle.Sdk": "3.0.1-rc.117"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.115, )",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "uCo2oOvXAA+Ya+PRRPpBTVPRVC27tZEJU6cH3xgDqkl7sLaycn1ygelz9yZmMorwmjECEHOYuabLsQ+u04M+VQ==",
+        "requested": "[3.0.1-rc.117, )",
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "0rcCz4Dw9Yi62dZ8YG+THCYzHJokvH0F2IYYgqCqgk1CsuoH2IM/lGYYspiGiOLEuR4GG6aLt+Dke6jExANRlw==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -417,7 +417,7 @@
           "Polly.Extensions.Http": "3.0.0",
           "Speckle.DoubleNumerics": "4.0.1",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Logging": "3.1.0-dev.115",
+          "Speckle.Sdk.Logging": "3.0.1-rc.117",
           "System.Text.Json": "5.0.2"
         }
       },

--- a/Converters/Autocad/Speckle.Converters.Autocad2024/packages.lock.json
+++ b/Converters/Autocad/Speckle.Converters.Autocad2024/packages.lock.json
@@ -189,8 +189,8 @@
       },
       "Speckle.Sdk.Logging": {
         "type": "Transitive",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "bM9t/LdnCoaSqnj6MgkFCBSxVad+KMzrsgGtJ6Y1S+WTY43ysArIW7r2cB84OG9IZH3g9DRHLU9Rob848gWj4g=="
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "NOEdqL0luzhm2Q0jShr5zti1yVihVVaFa9sxHLSQ4CqcxdydbmEuJyDBr86QQjJ8V3Q2E99z4zRis4NyYW3D6Q=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -318,7 +318,7 @@
           "Microsoft.Extensions.Logging.Abstractions": "[3.1.0, )",
           "Speckle.Autofac": "[1.0.0, )",
           "Speckle.Connectors.Utils": "[1.0.0, )",
-          "Speckle.Sdk": "[3.1.0-dev.115, )",
+          "Speckle.Sdk": "[3.0.1-rc.117, )",
           "System.Threading.Tasks.Dataflow": "[6.0.0, )"
         }
       },
@@ -334,8 +334,8 @@
         "dependencies": {
           "Microsoft.Extensions.Logging": "[3.1.0, )",
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.115, )",
-          "Speckle.Sdk": "[3.1.0-dev.115, )"
+          "Speckle.Objects": "[3.0.1-rc.117, )",
+          "Speckle.Sdk": "[3.0.1-rc.117, )"
         }
       },
       "speckle.converters.common": {
@@ -343,7 +343,7 @@
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[3.1.0, )",
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.115, )"
+          "Speckle.Objects": "[3.0.1-rc.117, )"
         }
       },
       "Autofac": {
@@ -381,18 +381,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.115, )",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "p4K3/pSsjmKgtM1vg3+TpXryRL3HM49VflQcqhF+zplfsb9vZUhgKf+BnNQtEDyxPcEOEby/nmU179dxtJnCLw==",
+        "requested": "[3.0.1-rc.117, )",
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "YjExrNc/8Ha7rJ5enSDV1idCbwtneYUFOiAc4G5dm6XujuKqGHd4cVafV37FffFNGYl5fqvjTGjQ8mjrUfIEFw==",
         "dependencies": {
-          "Speckle.Sdk": "3.1.0-dev.115"
+          "Speckle.Sdk": "3.0.1-rc.117"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.115, )",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "uCo2oOvXAA+Ya+PRRPpBTVPRVC27tZEJU6cH3xgDqkl7sLaycn1ygelz9yZmMorwmjECEHOYuabLsQ+u04M+VQ==",
+        "requested": "[3.0.1-rc.117, )",
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "0rcCz4Dw9Yi62dZ8YG+THCYzHJokvH0F2IYYgqCqgk1CsuoH2IM/lGYYspiGiOLEuR4GG6aLt+Dke6jExANRlw==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -402,7 +402,7 @@
           "Polly.Extensions.Http": "3.0.0",
           "Speckle.DoubleNumerics": "4.0.1",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Logging": "3.1.0-dev.115",
+          "Speckle.Sdk.Logging": "3.0.1-rc.117",
           "System.Text.Json": "5.0.2"
         }
       },

--- a/Converters/Autocad/Speckle.Converters.Autocad2025.DependencyInjection/packages.lock.json
+++ b/Converters/Autocad/Speckle.Converters.Autocad2025.DependencyInjection/packages.lock.json
@@ -174,8 +174,8 @@
       },
       "Speckle.Sdk.Logging": {
         "type": "Transitive",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "bM9t/LdnCoaSqnj6MgkFCBSxVad+KMzrsgGtJ6Y1S+WTY43ysArIW7r2cB84OG9IZH3g9DRHLU9Rob848gWj4g=="
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "NOEdqL0luzhm2Q0jShr5zti1yVihVVaFa9sxHLSQ4CqcxdydbmEuJyDBr86QQjJ8V3Q2E99z4zRis4NyYW3D6Q=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -234,7 +234,7 @@
           "Microsoft.Extensions.Logging.Abstractions": "[3.1.0, )",
           "Speckle.Autofac": "[1.0.0, )",
           "Speckle.Connectors.Utils": "[1.0.0, )",
-          "Speckle.Sdk": "[3.1.0-dev.115, )",
+          "Speckle.Sdk": "[3.0.1-rc.117, )",
           "System.Threading.Tasks.Dataflow": "[6.0.0, )"
         }
       },
@@ -250,8 +250,8 @@
         "dependencies": {
           "Microsoft.Extensions.Logging": "[3.1.0, )",
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.115, )",
-          "Speckle.Sdk": "[3.1.0-dev.115, )"
+          "Speckle.Objects": "[3.0.1-rc.117, )",
+          "Speckle.Sdk": "[3.0.1-rc.117, )"
         }
       },
       "speckle.converters.autocad2025": {
@@ -267,7 +267,7 @@
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[3.1.0, )",
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.115, )"
+          "Speckle.Objects": "[3.0.1-rc.117, )"
         }
       },
       "speckle.converters.common.dependencyinjection": {
@@ -309,18 +309,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.115, )",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "p4K3/pSsjmKgtM1vg3+TpXryRL3HM49VflQcqhF+zplfsb9vZUhgKf+BnNQtEDyxPcEOEby/nmU179dxtJnCLw==",
+        "requested": "[3.0.1-rc.117, )",
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "YjExrNc/8Ha7rJ5enSDV1idCbwtneYUFOiAc4G5dm6XujuKqGHd4cVafV37FffFNGYl5fqvjTGjQ8mjrUfIEFw==",
         "dependencies": {
-          "Speckle.Sdk": "3.1.0-dev.115"
+          "Speckle.Sdk": "3.0.1-rc.117"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.115, )",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "uCo2oOvXAA+Ya+PRRPpBTVPRVC27tZEJU6cH3xgDqkl7sLaycn1ygelz9yZmMorwmjECEHOYuabLsQ+u04M+VQ==",
+        "requested": "[3.0.1-rc.117, )",
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "0rcCz4Dw9Yi62dZ8YG+THCYzHJokvH0F2IYYgqCqgk1CsuoH2IM/lGYYspiGiOLEuR4GG6aLt+Dke6jExANRlw==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -330,7 +330,7 @@
           "Polly.Extensions.Http": "3.0.0",
           "Speckle.DoubleNumerics": "4.0.1",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Logging": "3.1.0-dev.115",
+          "Speckle.Sdk.Logging": "3.0.1-rc.117",
           "System.Text.Json": "5.0.2"
         }
       },

--- a/Converters/Autocad/Speckle.Converters.Autocad2025/packages.lock.json
+++ b/Converters/Autocad/Speckle.Converters.Autocad2025/packages.lock.json
@@ -174,8 +174,8 @@
       },
       "Speckle.Sdk.Logging": {
         "type": "Transitive",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "bM9t/LdnCoaSqnj6MgkFCBSxVad+KMzrsgGtJ6Y1S+WTY43ysArIW7r2cB84OG9IZH3g9DRHLU9Rob848gWj4g=="
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "NOEdqL0luzhm2Q0jShr5zti1yVihVVaFa9sxHLSQ4CqcxdydbmEuJyDBr86QQjJ8V3Q2E99z4zRis4NyYW3D6Q=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -234,7 +234,7 @@
           "Microsoft.Extensions.Logging.Abstractions": "[3.1.0, )",
           "Speckle.Autofac": "[1.0.0, )",
           "Speckle.Connectors.Utils": "[1.0.0, )",
-          "Speckle.Sdk": "[3.1.0-dev.115, )",
+          "Speckle.Sdk": "[3.0.1-rc.117, )",
           "System.Threading.Tasks.Dataflow": "[6.0.0, )"
         }
       },
@@ -250,8 +250,8 @@
         "dependencies": {
           "Microsoft.Extensions.Logging": "[3.1.0, )",
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.115, )",
-          "Speckle.Sdk": "[3.1.0-dev.115, )"
+          "Speckle.Objects": "[3.0.1-rc.117, )",
+          "Speckle.Sdk": "[3.0.1-rc.117, )"
         }
       },
       "speckle.converters.common": {
@@ -259,7 +259,7 @@
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[3.1.0, )",
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.115, )"
+          "Speckle.Objects": "[3.0.1-rc.117, )"
         }
       },
       "Autofac": {
@@ -294,18 +294,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.115, )",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "p4K3/pSsjmKgtM1vg3+TpXryRL3HM49VflQcqhF+zplfsb9vZUhgKf+BnNQtEDyxPcEOEby/nmU179dxtJnCLw==",
+        "requested": "[3.0.1-rc.117, )",
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "YjExrNc/8Ha7rJ5enSDV1idCbwtneYUFOiAc4G5dm6XujuKqGHd4cVafV37FffFNGYl5fqvjTGjQ8mjrUfIEFw==",
         "dependencies": {
-          "Speckle.Sdk": "3.1.0-dev.115"
+          "Speckle.Sdk": "3.0.1-rc.117"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.115, )",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "uCo2oOvXAA+Ya+PRRPpBTVPRVC27tZEJU6cH3xgDqkl7sLaycn1ygelz9yZmMorwmjECEHOYuabLsQ+u04M+VQ==",
+        "requested": "[3.0.1-rc.117, )",
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "0rcCz4Dw9Yi62dZ8YG+THCYzHJokvH0F2IYYgqCqgk1CsuoH2IM/lGYYspiGiOLEuR4GG6aLt+Dke6jExANRlw==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -315,7 +315,7 @@
           "Polly.Extensions.Http": "3.0.0",
           "Speckle.DoubleNumerics": "4.0.1",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Logging": "3.1.0-dev.115",
+          "Speckle.Sdk.Logging": "3.0.1-rc.117",
           "System.Text.Json": "5.0.2"
         }
       },

--- a/Converters/Civil3d/Speckle.Converters.Civil3d2024.DependencyInjection/packages.lock.json
+++ b/Converters/Civil3d/Speckle.Converters.Civil3d2024.DependencyInjection/packages.lock.json
@@ -135,8 +135,8 @@
       },
       "Speckle.Sdk.Logging": {
         "type": "Transitive",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "bM9t/LdnCoaSqnj6MgkFCBSxVad+KMzrsgGtJ6Y1S+WTY43ysArIW7r2cB84OG9IZH3g9DRHLU9Rob848gWj4g=="
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "NOEdqL0luzhm2Q0jShr5zti1yVihVVaFa9sxHLSQ4CqcxdydbmEuJyDBr86QQjJ8V3Q2E99z4zRis4NyYW3D6Q=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -266,7 +266,7 @@
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[3.1.0, )",
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.115, )"
+          "Speckle.Objects": "[3.0.1-rc.117, )"
         }
       },
       "speckle.converters.common.dependencyinjection": {
@@ -299,18 +299,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.115, )",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "p4K3/pSsjmKgtM1vg3+TpXryRL3HM49VflQcqhF+zplfsb9vZUhgKf+BnNQtEDyxPcEOEby/nmU179dxtJnCLw==",
+        "requested": "[3.0.1-rc.117, )",
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "YjExrNc/8Ha7rJ5enSDV1idCbwtneYUFOiAc4G5dm6XujuKqGHd4cVafV37FffFNGYl5fqvjTGjQ8mjrUfIEFw==",
         "dependencies": {
-          "Speckle.Sdk": "3.1.0-dev.115"
+          "Speckle.Sdk": "3.0.1-rc.117"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.115, )",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "uCo2oOvXAA+Ya+PRRPpBTVPRVC27tZEJU6cH3xgDqkl7sLaycn1ygelz9yZmMorwmjECEHOYuabLsQ+u04M+VQ==",
+        "requested": "[3.0.1-rc.117, )",
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "0rcCz4Dw9Yi62dZ8YG+THCYzHJokvH0F2IYYgqCqgk1CsuoH2IM/lGYYspiGiOLEuR4GG6aLt+Dke6jExANRlw==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -320,7 +320,7 @@
           "Polly.Extensions.Http": "3.0.0",
           "Speckle.DoubleNumerics": "4.0.1",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Logging": "3.1.0-dev.115",
+          "Speckle.Sdk.Logging": "3.0.1-rc.117",
           "System.Text.Json": "5.0.2"
         }
       }

--- a/Converters/Civil3d/Speckle.Converters.Civil3d2024/packages.lock.json
+++ b/Converters/Civil3d/Speckle.Converters.Civil3d2024/packages.lock.json
@@ -141,8 +141,8 @@
       },
       "Speckle.Sdk.Logging": {
         "type": "Transitive",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "bM9t/LdnCoaSqnj6MgkFCBSxVad+KMzrsgGtJ6Y1S+WTY43ysArIW7r2cB84OG9IZH3g9DRHLU9Rob848gWj4g=="
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "NOEdqL0luzhm2Q0jShr5zti1yVihVVaFa9sxHLSQ4CqcxdydbmEuJyDBr86QQjJ8V3Q2E99z4zRis4NyYW3D6Q=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -264,7 +264,7 @@
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[3.1.0, )",
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.115, )"
+          "Speckle.Objects": "[3.0.1-rc.117, )"
         }
       },
       "Autofac": {
@@ -284,18 +284,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.115, )",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "p4K3/pSsjmKgtM1vg3+TpXryRL3HM49VflQcqhF+zplfsb9vZUhgKf+BnNQtEDyxPcEOEby/nmU179dxtJnCLw==",
+        "requested": "[3.0.1-rc.117, )",
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "YjExrNc/8Ha7rJ5enSDV1idCbwtneYUFOiAc4G5dm6XujuKqGHd4cVafV37FffFNGYl5fqvjTGjQ8mjrUfIEFw==",
         "dependencies": {
-          "Speckle.Sdk": "3.1.0-dev.115"
+          "Speckle.Sdk": "3.0.1-rc.117"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.115, )",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "uCo2oOvXAA+Ya+PRRPpBTVPRVC27tZEJU6cH3xgDqkl7sLaycn1ygelz9yZmMorwmjECEHOYuabLsQ+u04M+VQ==",
+        "requested": "[3.0.1-rc.117, )",
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "0rcCz4Dw9Yi62dZ8YG+THCYzHJokvH0F2IYYgqCqgk1CsuoH2IM/lGYYspiGiOLEuR4GG6aLt+Dke6jExANRlw==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -305,7 +305,7 @@
           "Polly.Extensions.Http": "3.0.0",
           "Speckle.DoubleNumerics": "4.0.1",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Logging": "3.1.0-dev.115",
+          "Speckle.Sdk.Logging": "3.0.1-rc.117",
           "System.Text.Json": "5.0.2"
         }
       }

--- a/Converters/Civil3d/Speckle.Converters.Civil3dShared/Civil3dToSpeckleUnitConverter.cs
+++ b/Converters/Civil3d/Speckle.Converters.Civil3dShared/Civil3dToSpeckleUnitConverter.cs
@@ -20,7 +20,7 @@ public class Civil3dToSpeckleUnitConverter : IHostToSpeckleUnitConverter<AAEC.Bu
     dict[AAEC.BuiltInUnit.Mile] = Units.Miles;
     dict[AAEC.BuiltInUnit.Yards] = Units.Yards;
     dict[AAEC.BuiltInUnit.Foot] = Units.Feet;
-    dict[AAEC.BuiltInUnit.SurveyFoot] = Units.USFeet;
+    //dict[AAEC.BuiltInUnit.SurveyFoot] = Units.USFeet;
     dict[AAEC.BuiltInUnit.Inch] = Units.Inches;
     dict[AAEC.BuiltInUnit.Dimensionless] = Units.None;
     return dict;

--- a/Converters/Revit/Speckle.Converters.Revit2022.DependencyInjection/packages.lock.json
+++ b/Converters/Revit/Speckle.Converters.Revit2022.DependencyInjection/packages.lock.json
@@ -126,8 +126,8 @@
       },
       "Speckle.Sdk.Logging": {
         "type": "Transitive",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "bM9t/LdnCoaSqnj6MgkFCBSxVad+KMzrsgGtJ6Y1S+WTY43ysArIW7r2cB84OG9IZH3g9DRHLU9Rob848gWj4g=="
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "NOEdqL0luzhm2Q0jShr5zti1yVihVVaFa9sxHLSQ4CqcxdydbmEuJyDBr86QQjJ8V3Q2E99z4zRis4NyYW3D6Q=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -249,7 +249,7 @@
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[3.1.0, )",
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.115, )"
+          "Speckle.Objects": "[3.0.1-rc.117, )"
         }
       },
       "speckle.converters.common.dependencyinjection": {
@@ -284,11 +284,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.115, )",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "p4K3/pSsjmKgtM1vg3+TpXryRL3HM49VflQcqhF+zplfsb9vZUhgKf+BnNQtEDyxPcEOEby/nmU179dxtJnCLw==",
+        "requested": "[3.0.1-rc.117, )",
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "YjExrNc/8Ha7rJ5enSDV1idCbwtneYUFOiAc4G5dm6XujuKqGHd4cVafV37FffFNGYl5fqvjTGjQ8mjrUfIEFw==",
         "dependencies": {
-          "Speckle.Sdk": "3.1.0-dev.115"
+          "Speckle.Sdk": "3.0.1-rc.117"
         }
       },
       "Speckle.Revit.API": {
@@ -299,9 +299,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.115, )",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "uCo2oOvXAA+Ya+PRRPpBTVPRVC27tZEJU6cH3xgDqkl7sLaycn1ygelz9yZmMorwmjECEHOYuabLsQ+u04M+VQ==",
+        "requested": "[3.0.1-rc.117, )",
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "0rcCz4Dw9Yi62dZ8YG+THCYzHJokvH0F2IYYgqCqgk1CsuoH2IM/lGYYspiGiOLEuR4GG6aLt+Dke6jExANRlw==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -311,7 +311,7 @@
           "Polly.Extensions.Http": "3.0.0",
           "Speckle.DoubleNumerics": "4.0.1",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Logging": "3.1.0-dev.115",
+          "Speckle.Sdk.Logging": "3.0.1-rc.117",
           "System.Text.Json": "5.0.2"
         }
       }

--- a/Converters/Revit/Speckle.Converters.Revit2022.Tests/packages.lock.json
+++ b/Converters/Revit/Speckle.Converters.Revit2022.Tests/packages.lock.json
@@ -218,8 +218,8 @@
       },
       "Speckle.Sdk.Logging": {
         "type": "Transitive",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "bM9t/LdnCoaSqnj6MgkFCBSxVad+KMzrsgGtJ6Y1S+WTY43ysArIW7r2cB84OG9IZH3g9DRHLU9Rob848gWj4g=="
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "NOEdqL0luzhm2Q0jShr5zti1yVihVVaFa9sxHLSQ4CqcxdydbmEuJyDBr86QQjJ8V3Q2E99z4zRis4NyYW3D6Q=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -308,7 +308,7 @@
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[3.1.0, )",
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.115, )"
+          "Speckle.Objects": "[3.0.1-rc.117, )"
         }
       },
       "speckle.testing": {
@@ -332,18 +332,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.115, )",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "p4K3/pSsjmKgtM1vg3+TpXryRL3HM49VflQcqhF+zplfsb9vZUhgKf+BnNQtEDyxPcEOEby/nmU179dxtJnCLw==",
+        "requested": "[3.0.1-rc.117, )",
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "YjExrNc/8Ha7rJ5enSDV1idCbwtneYUFOiAc4G5dm6XujuKqGHd4cVafV37FffFNGYl5fqvjTGjQ8mjrUfIEFw==",
         "dependencies": {
-          "Speckle.Sdk": "3.1.0-dev.115"
+          "Speckle.Sdk": "3.0.1-rc.117"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.115, )",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "uCo2oOvXAA+Ya+PRRPpBTVPRVC27tZEJU6cH3xgDqkl7sLaycn1ygelz9yZmMorwmjECEHOYuabLsQ+u04M+VQ==",
+        "requested": "[3.0.1-rc.117, )",
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "0rcCz4Dw9Yi62dZ8YG+THCYzHJokvH0F2IYYgqCqgk1CsuoH2IM/lGYYspiGiOLEuR4GG6aLt+Dke6jExANRlw==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -353,7 +353,7 @@
           "Polly.Extensions.Http": "3.0.0",
           "Speckle.DoubleNumerics": "4.0.1",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Logging": "3.1.0-dev.115",
+          "Speckle.Sdk.Logging": "3.0.1-rc.117",
           "System.Text.Json": "5.0.2"
         }
       }

--- a/Converters/Revit/Speckle.Converters.Revit2022/packages.lock.json
+++ b/Converters/Revit/Speckle.Converters.Revit2022/packages.lock.json
@@ -132,8 +132,8 @@
       },
       "Speckle.Sdk.Logging": {
         "type": "Transitive",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "bM9t/LdnCoaSqnj6MgkFCBSxVad+KMzrsgGtJ6Y1S+WTY43ysArIW7r2cB84OG9IZH3g9DRHLU9Rob848gWj4g=="
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "NOEdqL0luzhm2Q0jShr5zti1yVihVVaFa9sxHLSQ4CqcxdydbmEuJyDBr86QQjJ8V3Q2E99z4zRis4NyYW3D6Q=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -255,7 +255,7 @@
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[3.1.0, )",
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.115, )"
+          "Speckle.Objects": "[3.0.1-rc.117, )"
         }
       },
       "speckle.converters.common.dependencyinjection": {
@@ -282,18 +282,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.115, )",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "p4K3/pSsjmKgtM1vg3+TpXryRL3HM49VflQcqhF+zplfsb9vZUhgKf+BnNQtEDyxPcEOEby/nmU179dxtJnCLw==",
+        "requested": "[3.0.1-rc.117, )",
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "YjExrNc/8Ha7rJ5enSDV1idCbwtneYUFOiAc4G5dm6XujuKqGHd4cVafV37FffFNGYl5fqvjTGjQ8mjrUfIEFw==",
         "dependencies": {
-          "Speckle.Sdk": "3.1.0-dev.115"
+          "Speckle.Sdk": "3.0.1-rc.117"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.115, )",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "uCo2oOvXAA+Ya+PRRPpBTVPRVC27tZEJU6cH3xgDqkl7sLaycn1ygelz9yZmMorwmjECEHOYuabLsQ+u04M+VQ==",
+        "requested": "[3.0.1-rc.117, )",
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "0rcCz4Dw9Yi62dZ8YG+THCYzHJokvH0F2IYYgqCqgk1CsuoH2IM/lGYYspiGiOLEuR4GG6aLt+Dke6jExANRlw==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -303,7 +303,7 @@
           "Polly.Extensions.Http": "3.0.0",
           "Speckle.DoubleNumerics": "4.0.1",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Logging": "3.1.0-dev.115",
+          "Speckle.Sdk.Logging": "3.0.1-rc.117",
           "System.Text.Json": "5.0.2"
         }
       }

--- a/Converters/Revit/Speckle.Converters.Revit2023.DependencyInjection/packages.lock.json
+++ b/Converters/Revit/Speckle.Converters.Revit2023.DependencyInjection/packages.lock.json
@@ -126,8 +126,8 @@
       },
       "Speckle.Sdk.Logging": {
         "type": "Transitive",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "bM9t/LdnCoaSqnj6MgkFCBSxVad+KMzrsgGtJ6Y1S+WTY43ysArIW7r2cB84OG9IZH3g9DRHLU9Rob848gWj4g=="
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "NOEdqL0luzhm2Q0jShr5zti1yVihVVaFa9sxHLSQ4CqcxdydbmEuJyDBr86QQjJ8V3Q2E99z4zRis4NyYW3D6Q=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -249,7 +249,7 @@
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[3.1.0, )",
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.115, )"
+          "Speckle.Objects": "[3.0.1-rc.117, )"
         }
       },
       "speckle.converters.common.dependencyinjection": {
@@ -283,11 +283,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.115, )",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "p4K3/pSsjmKgtM1vg3+TpXryRL3HM49VflQcqhF+zplfsb9vZUhgKf+BnNQtEDyxPcEOEby/nmU179dxtJnCLw==",
+        "requested": "[3.0.1-rc.117, )",
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "YjExrNc/8Ha7rJ5enSDV1idCbwtneYUFOiAc4G5dm6XujuKqGHd4cVafV37FffFNGYl5fqvjTGjQ8mjrUfIEFw==",
         "dependencies": {
-          "Speckle.Sdk": "3.1.0-dev.115"
+          "Speckle.Sdk": "3.0.1-rc.117"
         }
       },
       "Speckle.Revit.API": {
@@ -298,9 +298,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.115, )",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "uCo2oOvXAA+Ya+PRRPpBTVPRVC27tZEJU6cH3xgDqkl7sLaycn1ygelz9yZmMorwmjECEHOYuabLsQ+u04M+VQ==",
+        "requested": "[3.0.1-rc.117, )",
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "0rcCz4Dw9Yi62dZ8YG+THCYzHJokvH0F2IYYgqCqgk1CsuoH2IM/lGYYspiGiOLEuR4GG6aLt+Dke6jExANRlw==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -310,7 +310,7 @@
           "Polly.Extensions.Http": "3.0.0",
           "Speckle.DoubleNumerics": "4.0.1",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Logging": "3.1.0-dev.115",
+          "Speckle.Sdk.Logging": "3.0.1-rc.117",
           "System.Text.Json": "5.0.2"
         }
       }

--- a/Converters/Revit/Speckle.Converters.Revit2023.Tests/packages.lock.json
+++ b/Converters/Revit/Speckle.Converters.Revit2023.Tests/packages.lock.json
@@ -218,8 +218,8 @@
       },
       "Speckle.Sdk.Logging": {
         "type": "Transitive",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "bM9t/LdnCoaSqnj6MgkFCBSxVad+KMzrsgGtJ6Y1S+WTY43ysArIW7r2cB84OG9IZH3g9DRHLU9Rob848gWj4g=="
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "NOEdqL0luzhm2Q0jShr5zti1yVihVVaFa9sxHLSQ4CqcxdydbmEuJyDBr86QQjJ8V3Q2E99z4zRis4NyYW3D6Q=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -308,7 +308,7 @@
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[3.1.0, )",
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.115, )"
+          "Speckle.Objects": "[3.0.1-rc.117, )"
         }
       },
       "speckle.testing": {
@@ -332,18 +332,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.115, )",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "p4K3/pSsjmKgtM1vg3+TpXryRL3HM49VflQcqhF+zplfsb9vZUhgKf+BnNQtEDyxPcEOEby/nmU179dxtJnCLw==",
+        "requested": "[3.0.1-rc.117, )",
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "YjExrNc/8Ha7rJ5enSDV1idCbwtneYUFOiAc4G5dm6XujuKqGHd4cVafV37FffFNGYl5fqvjTGjQ8mjrUfIEFw==",
         "dependencies": {
-          "Speckle.Sdk": "3.1.0-dev.115"
+          "Speckle.Sdk": "3.0.1-rc.117"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.115, )",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "uCo2oOvXAA+Ya+PRRPpBTVPRVC27tZEJU6cH3xgDqkl7sLaycn1ygelz9yZmMorwmjECEHOYuabLsQ+u04M+VQ==",
+        "requested": "[3.0.1-rc.117, )",
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "0rcCz4Dw9Yi62dZ8YG+THCYzHJokvH0F2IYYgqCqgk1CsuoH2IM/lGYYspiGiOLEuR4GG6aLt+Dke6jExANRlw==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -353,7 +353,7 @@
           "Polly.Extensions.Http": "3.0.0",
           "Speckle.DoubleNumerics": "4.0.1",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Logging": "3.1.0-dev.115",
+          "Speckle.Sdk.Logging": "3.0.1-rc.117",
           "System.Text.Json": "5.0.2"
         }
       }

--- a/Converters/Revit/Speckle.Converters.Revit2023/packages.lock.json
+++ b/Converters/Revit/Speckle.Converters.Revit2023/packages.lock.json
@@ -132,8 +132,8 @@
       },
       "Speckle.Sdk.Logging": {
         "type": "Transitive",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "bM9t/LdnCoaSqnj6MgkFCBSxVad+KMzrsgGtJ6Y1S+WTY43ysArIW7r2cB84OG9IZH3g9DRHLU9Rob848gWj4g=="
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "NOEdqL0luzhm2Q0jShr5zti1yVihVVaFa9sxHLSQ4CqcxdydbmEuJyDBr86QQjJ8V3Q2E99z4zRis4NyYW3D6Q=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -255,7 +255,7 @@
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[3.1.0, )",
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.115, )"
+          "Speckle.Objects": "[3.0.1-rc.117, )"
         }
       },
       "Autofac": {
@@ -275,18 +275,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.115, )",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "p4K3/pSsjmKgtM1vg3+TpXryRL3HM49VflQcqhF+zplfsb9vZUhgKf+BnNQtEDyxPcEOEby/nmU179dxtJnCLw==",
+        "requested": "[3.0.1-rc.117, )",
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "YjExrNc/8Ha7rJ5enSDV1idCbwtneYUFOiAc4G5dm6XujuKqGHd4cVafV37FffFNGYl5fqvjTGjQ8mjrUfIEFw==",
         "dependencies": {
-          "Speckle.Sdk": "3.1.0-dev.115"
+          "Speckle.Sdk": "3.0.1-rc.117"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.115, )",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "uCo2oOvXAA+Ya+PRRPpBTVPRVC27tZEJU6cH3xgDqkl7sLaycn1ygelz9yZmMorwmjECEHOYuabLsQ+u04M+VQ==",
+        "requested": "[3.0.1-rc.117, )",
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "0rcCz4Dw9Yi62dZ8YG+THCYzHJokvH0F2IYYgqCqgk1CsuoH2IM/lGYYspiGiOLEuR4GG6aLt+Dke6jExANRlw==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -296,7 +296,7 @@
           "Polly.Extensions.Http": "3.0.0",
           "Speckle.DoubleNumerics": "4.0.1",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Logging": "3.1.0-dev.115",
+          "Speckle.Sdk.Logging": "3.0.1-rc.117",
           "System.Text.Json": "5.0.2"
         }
       }

--- a/Converters/Revit/Speckle.Converters.Revit2024.DependencyInjection/packages.lock.json
+++ b/Converters/Revit/Speckle.Converters.Revit2024.DependencyInjection/packages.lock.json
@@ -126,8 +126,8 @@
       },
       "Speckle.Sdk.Logging": {
         "type": "Transitive",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "bM9t/LdnCoaSqnj6MgkFCBSxVad+KMzrsgGtJ6Y1S+WTY43ysArIW7r2cB84OG9IZH3g9DRHLU9Rob848gWj4g=="
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "NOEdqL0luzhm2Q0jShr5zti1yVihVVaFa9sxHLSQ4CqcxdydbmEuJyDBr86QQjJ8V3Q2E99z4zRis4NyYW3D6Q=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -249,7 +249,7 @@
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[3.1.0, )",
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.115, )"
+          "Speckle.Objects": "[3.0.1-rc.117, )"
         }
       },
       "speckle.converters.common.dependencyinjection": {
@@ -283,11 +283,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.115, )",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "p4K3/pSsjmKgtM1vg3+TpXryRL3HM49VflQcqhF+zplfsb9vZUhgKf+BnNQtEDyxPcEOEby/nmU179dxtJnCLw==",
+        "requested": "[3.0.1-rc.117, )",
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "YjExrNc/8Ha7rJ5enSDV1idCbwtneYUFOiAc4G5dm6XujuKqGHd4cVafV37FffFNGYl5fqvjTGjQ8mjrUfIEFw==",
         "dependencies": {
-          "Speckle.Sdk": "3.1.0-dev.115"
+          "Speckle.Sdk": "3.0.1-rc.117"
         }
       },
       "Speckle.Revit.API": {
@@ -298,9 +298,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.115, )",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "uCo2oOvXAA+Ya+PRRPpBTVPRVC27tZEJU6cH3xgDqkl7sLaycn1ygelz9yZmMorwmjECEHOYuabLsQ+u04M+VQ==",
+        "requested": "[3.0.1-rc.117, )",
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "0rcCz4Dw9Yi62dZ8YG+THCYzHJokvH0F2IYYgqCqgk1CsuoH2IM/lGYYspiGiOLEuR4GG6aLt+Dke6jExANRlw==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -310,7 +310,7 @@
           "Polly.Extensions.Http": "3.0.0",
           "Speckle.DoubleNumerics": "4.0.1",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Logging": "3.1.0-dev.115",
+          "Speckle.Sdk.Logging": "3.0.1-rc.117",
           "System.Text.Json": "5.0.2"
         }
       }

--- a/Converters/Revit/Speckle.Converters.Revit2024.Tests/packages.lock.json
+++ b/Converters/Revit/Speckle.Converters.Revit2024.Tests/packages.lock.json
@@ -218,8 +218,8 @@
       },
       "Speckle.Sdk.Logging": {
         "type": "Transitive",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "bM9t/LdnCoaSqnj6MgkFCBSxVad+KMzrsgGtJ6Y1S+WTY43ysArIW7r2cB84OG9IZH3g9DRHLU9Rob848gWj4g=="
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "NOEdqL0luzhm2Q0jShr5zti1yVihVVaFa9sxHLSQ4CqcxdydbmEuJyDBr86QQjJ8V3Q2E99z4zRis4NyYW3D6Q=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -308,7 +308,7 @@
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[3.1.0, )",
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.115, )"
+          "Speckle.Objects": "[3.0.1-rc.117, )"
         }
       },
       "speckle.testing": {
@@ -332,18 +332,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.115, )",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "p4K3/pSsjmKgtM1vg3+TpXryRL3HM49VflQcqhF+zplfsb9vZUhgKf+BnNQtEDyxPcEOEby/nmU179dxtJnCLw==",
+        "requested": "[3.0.1-rc.117, )",
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "YjExrNc/8Ha7rJ5enSDV1idCbwtneYUFOiAc4G5dm6XujuKqGHd4cVafV37FffFNGYl5fqvjTGjQ8mjrUfIEFw==",
         "dependencies": {
-          "Speckle.Sdk": "3.1.0-dev.115"
+          "Speckle.Sdk": "3.0.1-rc.117"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.115, )",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "uCo2oOvXAA+Ya+PRRPpBTVPRVC27tZEJU6cH3xgDqkl7sLaycn1ygelz9yZmMorwmjECEHOYuabLsQ+u04M+VQ==",
+        "requested": "[3.0.1-rc.117, )",
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "0rcCz4Dw9Yi62dZ8YG+THCYzHJokvH0F2IYYgqCqgk1CsuoH2IM/lGYYspiGiOLEuR4GG6aLt+Dke6jExANRlw==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -353,7 +353,7 @@
           "Polly.Extensions.Http": "3.0.0",
           "Speckle.DoubleNumerics": "4.0.1",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Logging": "3.1.0-dev.115",
+          "Speckle.Sdk.Logging": "3.0.1-rc.117",
           "System.Text.Json": "5.0.2"
         }
       }

--- a/Converters/Revit/Speckle.Converters.Revit2024/packages.lock.json
+++ b/Converters/Revit/Speckle.Converters.Revit2024/packages.lock.json
@@ -132,8 +132,8 @@
       },
       "Speckle.Sdk.Logging": {
         "type": "Transitive",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "bM9t/LdnCoaSqnj6MgkFCBSxVad+KMzrsgGtJ6Y1S+WTY43ysArIW7r2cB84OG9IZH3g9DRHLU9Rob848gWj4g=="
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "NOEdqL0luzhm2Q0jShr5zti1yVihVVaFa9sxHLSQ4CqcxdydbmEuJyDBr86QQjJ8V3Q2E99z4zRis4NyYW3D6Q=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -255,7 +255,7 @@
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[3.1.0, )",
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.115, )"
+          "Speckle.Objects": "[3.0.1-rc.117, )"
         }
       },
       "Autofac": {
@@ -275,18 +275,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.115, )",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "p4K3/pSsjmKgtM1vg3+TpXryRL3HM49VflQcqhF+zplfsb9vZUhgKf+BnNQtEDyxPcEOEby/nmU179dxtJnCLw==",
+        "requested": "[3.0.1-rc.117, )",
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "YjExrNc/8Ha7rJ5enSDV1idCbwtneYUFOiAc4G5dm6XujuKqGHd4cVafV37FffFNGYl5fqvjTGjQ8mjrUfIEFw==",
         "dependencies": {
-          "Speckle.Sdk": "3.1.0-dev.115"
+          "Speckle.Sdk": "3.0.1-rc.117"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.115, )",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "uCo2oOvXAA+Ya+PRRPpBTVPRVC27tZEJU6cH3xgDqkl7sLaycn1ygelz9yZmMorwmjECEHOYuabLsQ+u04M+VQ==",
+        "requested": "[3.0.1-rc.117, )",
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "0rcCz4Dw9Yi62dZ8YG+THCYzHJokvH0F2IYYgqCqgk1CsuoH2IM/lGYYspiGiOLEuR4GG6aLt+Dke6jExANRlw==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -296,7 +296,7 @@
           "Polly.Extensions.Http": "3.0.0",
           "Speckle.DoubleNumerics": "4.0.1",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Logging": "3.1.0-dev.115",
+          "Speckle.Sdk.Logging": "3.0.1-rc.117",
           "System.Text.Json": "5.0.2"
         }
       }

--- a/Converters/Revit/Speckle.Converters.Revit2025.DependencyInjection/packages.lock.json
+++ b/Converters/Revit/Speckle.Converters.Revit2025.DependencyInjection/packages.lock.json
@@ -117,8 +117,8 @@
       },
       "Speckle.Sdk.Logging": {
         "type": "Transitive",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "bM9t/LdnCoaSqnj6MgkFCBSxVad+KMzrsgGtJ6Y1S+WTY43ysArIW7r2cB84OG9IZH3g9DRHLU9Rob848gWj4g=="
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "NOEdqL0luzhm2Q0jShr5zti1yVihVVaFa9sxHLSQ4CqcxdydbmEuJyDBr86QQjJ8V3Q2E99z4zRis4NyYW3D6Q=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -176,7 +176,7 @@
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[3.1.0, )",
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.115, )"
+          "Speckle.Objects": "[3.0.1-rc.117, )"
         }
       },
       "speckle.converters.common.dependencyinjection": {
@@ -207,11 +207,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.115, )",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "p4K3/pSsjmKgtM1vg3+TpXryRL3HM49VflQcqhF+zplfsb9vZUhgKf+BnNQtEDyxPcEOEby/nmU179dxtJnCLw==",
+        "requested": "[3.0.1-rc.117, )",
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "YjExrNc/8Ha7rJ5enSDV1idCbwtneYUFOiAc4G5dm6XujuKqGHd4cVafV37FffFNGYl5fqvjTGjQ8mjrUfIEFw==",
         "dependencies": {
-          "Speckle.Sdk": "3.1.0-dev.115"
+          "Speckle.Sdk": "3.0.1-rc.117"
         }
       },
       "Speckle.Revit.API": {
@@ -222,9 +222,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.115, )",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "uCo2oOvXAA+Ya+PRRPpBTVPRVC27tZEJU6cH3xgDqkl7sLaycn1ygelz9yZmMorwmjECEHOYuabLsQ+u04M+VQ==",
+        "requested": "[3.0.1-rc.117, )",
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "0rcCz4Dw9Yi62dZ8YG+THCYzHJokvH0F2IYYgqCqgk1CsuoH2IM/lGYYspiGiOLEuR4GG6aLt+Dke6jExANRlw==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -234,7 +234,7 @@
           "Polly.Extensions.Http": "3.0.0",
           "Speckle.DoubleNumerics": "4.0.1",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Logging": "3.1.0-dev.115",
+          "Speckle.Sdk.Logging": "3.0.1-rc.117",
           "System.Text.Json": "5.0.2"
         }
       }

--- a/Converters/Revit/Speckle.Converters.Revit2025/packages.lock.json
+++ b/Converters/Revit/Speckle.Converters.Revit2025/packages.lock.json
@@ -123,8 +123,8 @@
       },
       "Speckle.Sdk.Logging": {
         "type": "Transitive",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "bM9t/LdnCoaSqnj6MgkFCBSxVad+KMzrsgGtJ6Y1S+WTY43ysArIW7r2cB84OG9IZH3g9DRHLU9Rob848gWj4g=="
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "NOEdqL0luzhm2Q0jShr5zti1yVihVVaFa9sxHLSQ4CqcxdydbmEuJyDBr86QQjJ8V3Q2E99z4zRis4NyYW3D6Q=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -182,7 +182,7 @@
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[3.1.0, )",
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.115, )"
+          "Speckle.Objects": "[3.0.1-rc.117, )"
         }
       },
       "Autofac": {
@@ -199,18 +199,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.115, )",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "p4K3/pSsjmKgtM1vg3+TpXryRL3HM49VflQcqhF+zplfsb9vZUhgKf+BnNQtEDyxPcEOEby/nmU179dxtJnCLw==",
+        "requested": "[3.0.1-rc.117, )",
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "YjExrNc/8Ha7rJ5enSDV1idCbwtneYUFOiAc4G5dm6XujuKqGHd4cVafV37FffFNGYl5fqvjTGjQ8mjrUfIEFw==",
         "dependencies": {
-          "Speckle.Sdk": "3.1.0-dev.115"
+          "Speckle.Sdk": "3.0.1-rc.117"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.115, )",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "uCo2oOvXAA+Ya+PRRPpBTVPRVC27tZEJU6cH3xgDqkl7sLaycn1ygelz9yZmMorwmjECEHOYuabLsQ+u04M+VQ==",
+        "requested": "[3.0.1-rc.117, )",
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "0rcCz4Dw9Yi62dZ8YG+THCYzHJokvH0F2IYYgqCqgk1CsuoH2IM/lGYYspiGiOLEuR4GG6aLt+Dke6jExANRlw==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -220,7 +220,7 @@
           "Polly.Extensions.Http": "3.0.0",
           "Speckle.DoubleNumerics": "4.0.1",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Logging": "3.1.0-dev.115",
+          "Speckle.Sdk.Logging": "3.0.1-rc.117",
           "System.Text.Json": "5.0.2"
         }
       }

--- a/Converters/Rhino/Speckle.Converters.Rhino7.DependencyInjection/packages.lock.json
+++ b/Converters/Rhino/Speckle.Converters.Rhino7.DependencyInjection/packages.lock.json
@@ -126,8 +126,8 @@
       },
       "Speckle.Sdk.Logging": {
         "type": "Transitive",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "bM9t/LdnCoaSqnj6MgkFCBSxVad+KMzrsgGtJ6Y1S+WTY43ysArIW7r2cB84OG9IZH3g9DRHLU9Rob848gWj4g=="
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "NOEdqL0luzhm2Q0jShr5zti1yVihVVaFa9sxHLSQ4CqcxdydbmEuJyDBr86QQjJ8V3Q2E99z4zRis4NyYW3D6Q=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -249,7 +249,7 @@
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[3.1.0, )",
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.115, )"
+          "Speckle.Objects": "[3.0.1-rc.117, )"
         }
       },
       "speckle.converters.common.dependencyinjection": {
@@ -289,18 +289,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.115, )",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "p4K3/pSsjmKgtM1vg3+TpXryRL3HM49VflQcqhF+zplfsb9vZUhgKf+BnNQtEDyxPcEOEby/nmU179dxtJnCLw==",
+        "requested": "[3.0.1-rc.117, )",
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "YjExrNc/8Ha7rJ5enSDV1idCbwtneYUFOiAc4G5dm6XujuKqGHd4cVafV37FffFNGYl5fqvjTGjQ8mjrUfIEFw==",
         "dependencies": {
-          "Speckle.Sdk": "3.1.0-dev.115"
+          "Speckle.Sdk": "3.0.1-rc.117"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.115, )",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "uCo2oOvXAA+Ya+PRRPpBTVPRVC27tZEJU6cH3xgDqkl7sLaycn1ygelz9yZmMorwmjECEHOYuabLsQ+u04M+VQ==",
+        "requested": "[3.0.1-rc.117, )",
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "0rcCz4Dw9Yi62dZ8YG+THCYzHJokvH0F2IYYgqCqgk1CsuoH2IM/lGYYspiGiOLEuR4GG6aLt+Dke6jExANRlw==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -310,7 +310,7 @@
           "Polly.Extensions.Http": "3.0.0",
           "Speckle.DoubleNumerics": "4.0.1",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Logging": "3.1.0-dev.115",
+          "Speckle.Sdk.Logging": "3.0.1-rc.117",
           "System.Text.Json": "5.0.2"
         }
       }

--- a/Converters/Rhino/Speckle.Converters.Rhino7.Tests/packages.lock.json
+++ b/Converters/Rhino/Speckle.Converters.Rhino7.Tests/packages.lock.json
@@ -218,8 +218,8 @@
       },
       "Speckle.Sdk.Logging": {
         "type": "Transitive",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "bM9t/LdnCoaSqnj6MgkFCBSxVad+KMzrsgGtJ6Y1S+WTY43ysArIW7r2cB84OG9IZH3g9DRHLU9Rob848gWj4g=="
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "NOEdqL0luzhm2Q0jShr5zti1yVihVVaFa9sxHLSQ4CqcxdydbmEuJyDBr86QQjJ8V3Q2E99z4zRis4NyYW3D6Q=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -308,7 +308,7 @@
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[3.1.0, )",
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.115, )"
+          "Speckle.Objects": "[3.0.1-rc.117, )"
         }
       },
       "speckle.testing": {
@@ -332,18 +332,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.115, )",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "p4K3/pSsjmKgtM1vg3+TpXryRL3HM49VflQcqhF+zplfsb9vZUhgKf+BnNQtEDyxPcEOEby/nmU179dxtJnCLw==",
+        "requested": "[3.0.1-rc.117, )",
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "YjExrNc/8Ha7rJ5enSDV1idCbwtneYUFOiAc4G5dm6XujuKqGHd4cVafV37FffFNGYl5fqvjTGjQ8mjrUfIEFw==",
         "dependencies": {
-          "Speckle.Sdk": "3.1.0-dev.115"
+          "Speckle.Sdk": "3.0.1-rc.117"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.115, )",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "uCo2oOvXAA+Ya+PRRPpBTVPRVC27tZEJU6cH3xgDqkl7sLaycn1ygelz9yZmMorwmjECEHOYuabLsQ+u04M+VQ==",
+        "requested": "[3.0.1-rc.117, )",
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "0rcCz4Dw9Yi62dZ8YG+THCYzHJokvH0F2IYYgqCqgk1CsuoH2IM/lGYYspiGiOLEuR4GG6aLt+Dke6jExANRlw==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -353,7 +353,7 @@
           "Polly.Extensions.Http": "3.0.0",
           "Speckle.DoubleNumerics": "4.0.1",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Logging": "3.1.0-dev.115",
+          "Speckle.Sdk.Logging": "3.0.1-rc.117",
           "System.Text.Json": "5.0.2"
         }
       }

--- a/Converters/Rhino/Speckle.Converters.Rhino7/packages.lock.json
+++ b/Converters/Rhino/Speckle.Converters.Rhino7/packages.lock.json
@@ -132,8 +132,8 @@
       },
       "Speckle.Sdk.Logging": {
         "type": "Transitive",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "bM9t/LdnCoaSqnj6MgkFCBSxVad+KMzrsgGtJ6Y1S+WTY43ysArIW7r2cB84OG9IZH3g9DRHLU9Rob848gWj4g=="
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "NOEdqL0luzhm2Q0jShr5zti1yVihVVaFa9sxHLSQ4CqcxdydbmEuJyDBr86QQjJ8V3Q2E99z4zRis4NyYW3D6Q=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -255,7 +255,7 @@
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[3.1.0, )",
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.115, )"
+          "Speckle.Objects": "[3.0.1-rc.117, )"
         }
       },
       "Autofac": {
@@ -275,18 +275,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.115, )",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "p4K3/pSsjmKgtM1vg3+TpXryRL3HM49VflQcqhF+zplfsb9vZUhgKf+BnNQtEDyxPcEOEby/nmU179dxtJnCLw==",
+        "requested": "[3.0.1-rc.117, )",
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "YjExrNc/8Ha7rJ5enSDV1idCbwtneYUFOiAc4G5dm6XujuKqGHd4cVafV37FffFNGYl5fqvjTGjQ8mjrUfIEFw==",
         "dependencies": {
-          "Speckle.Sdk": "3.1.0-dev.115"
+          "Speckle.Sdk": "3.0.1-rc.117"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.115, )",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "uCo2oOvXAA+Ya+PRRPpBTVPRVC27tZEJU6cH3xgDqkl7sLaycn1ygelz9yZmMorwmjECEHOYuabLsQ+u04M+VQ==",
+        "requested": "[3.0.1-rc.117, )",
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "0rcCz4Dw9Yi62dZ8YG+THCYzHJokvH0F2IYYgqCqgk1CsuoH2IM/lGYYspiGiOLEuR4GG6aLt+Dke6jExANRlw==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -296,7 +296,7 @@
           "Polly.Extensions.Http": "3.0.0",
           "Speckle.DoubleNumerics": "4.0.1",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Logging": "3.1.0-dev.115",
+          "Speckle.Sdk.Logging": "3.0.1-rc.117",
           "System.Text.Json": "5.0.2"
         }
       }

--- a/Converters/Rhino/Speckle.Converters.Rhino8.DependencyInjection/packages.lock.json
+++ b/Converters/Rhino/Speckle.Converters.Rhino8.DependencyInjection/packages.lock.json
@@ -126,8 +126,8 @@
       },
       "Speckle.Sdk.Logging": {
         "type": "Transitive",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "bM9t/LdnCoaSqnj6MgkFCBSxVad+KMzrsgGtJ6Y1S+WTY43ysArIW7r2cB84OG9IZH3g9DRHLU9Rob848gWj4g=="
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "NOEdqL0luzhm2Q0jShr5zti1yVihVVaFa9sxHLSQ4CqcxdydbmEuJyDBr86QQjJ8V3Q2E99z4zRis4NyYW3D6Q=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -249,7 +249,7 @@
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[3.1.0, )",
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.115, )"
+          "Speckle.Objects": "[3.0.1-rc.117, )"
         }
       },
       "speckle.converters.common.dependencyinjection": {
@@ -289,18 +289,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.115, )",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "p4K3/pSsjmKgtM1vg3+TpXryRL3HM49VflQcqhF+zplfsb9vZUhgKf+BnNQtEDyxPcEOEby/nmU179dxtJnCLw==",
+        "requested": "[3.0.1-rc.117, )",
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "YjExrNc/8Ha7rJ5enSDV1idCbwtneYUFOiAc4G5dm6XujuKqGHd4cVafV37FffFNGYl5fqvjTGjQ8mjrUfIEFw==",
         "dependencies": {
-          "Speckle.Sdk": "3.1.0-dev.115"
+          "Speckle.Sdk": "3.0.1-rc.117"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.115, )",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "uCo2oOvXAA+Ya+PRRPpBTVPRVC27tZEJU6cH3xgDqkl7sLaycn1ygelz9yZmMorwmjECEHOYuabLsQ+u04M+VQ==",
+        "requested": "[3.0.1-rc.117, )",
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "0rcCz4Dw9Yi62dZ8YG+THCYzHJokvH0F2IYYgqCqgk1CsuoH2IM/lGYYspiGiOLEuR4GG6aLt+Dke6jExANRlw==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -310,7 +310,7 @@
           "Polly.Extensions.Http": "3.0.0",
           "Speckle.DoubleNumerics": "4.0.1",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Logging": "3.1.0-dev.115",
+          "Speckle.Sdk.Logging": "3.0.1-rc.117",
           "System.Text.Json": "5.0.2"
         }
       }

--- a/Converters/Rhino/Speckle.Converters.Rhino8/packages.lock.json
+++ b/Converters/Rhino/Speckle.Converters.Rhino8/packages.lock.json
@@ -132,8 +132,8 @@
       },
       "Speckle.Sdk.Logging": {
         "type": "Transitive",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "bM9t/LdnCoaSqnj6MgkFCBSxVad+KMzrsgGtJ6Y1S+WTY43ysArIW7r2cB84OG9IZH3g9DRHLU9Rob848gWj4g=="
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "NOEdqL0luzhm2Q0jShr5zti1yVihVVaFa9sxHLSQ4CqcxdydbmEuJyDBr86QQjJ8V3Q2E99z4zRis4NyYW3D6Q=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -255,7 +255,7 @@
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[3.1.0, )",
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.115, )"
+          "Speckle.Objects": "[3.0.1-rc.117, )"
         }
       },
       "Autofac": {
@@ -275,18 +275,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.115, )",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "p4K3/pSsjmKgtM1vg3+TpXryRL3HM49VflQcqhF+zplfsb9vZUhgKf+BnNQtEDyxPcEOEby/nmU179dxtJnCLw==",
+        "requested": "[3.0.1-rc.117, )",
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "YjExrNc/8Ha7rJ5enSDV1idCbwtneYUFOiAc4G5dm6XujuKqGHd4cVafV37FffFNGYl5fqvjTGjQ8mjrUfIEFw==",
         "dependencies": {
-          "Speckle.Sdk": "3.1.0-dev.115"
+          "Speckle.Sdk": "3.0.1-rc.117"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.115, )",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "uCo2oOvXAA+Ya+PRRPpBTVPRVC27tZEJU6cH3xgDqkl7sLaycn1ygelz9yZmMorwmjECEHOYuabLsQ+u04M+VQ==",
+        "requested": "[3.0.1-rc.117, )",
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "0rcCz4Dw9Yi62dZ8YG+THCYzHJokvH0F2IYYgqCqgk1CsuoH2IM/lGYYspiGiOLEuR4GG6aLt+Dke6jExANRlw==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -296,7 +296,7 @@
           "Polly.Extensions.Http": "3.0.0",
           "Speckle.DoubleNumerics": "4.0.1",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Logging": "3.1.0-dev.115",
+          "Speckle.Sdk.Logging": "3.0.1-rc.117",
           "System.Text.Json": "5.0.2"
         }
       }

--- a/DUI3/Speckle.Connectors.DUI.Tests/packages.lock.json
+++ b/DUI3/Speckle.Connectors.DUI.Tests/packages.lock.json
@@ -255,8 +255,8 @@
       },
       "Speckle.Sdk.Logging": {
         "type": "Transitive",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "bM9t/LdnCoaSqnj6MgkFCBSxVad+KMzrsgGtJ6Y1S+WTY43ysArIW7r2cB84OG9IZH3g9DRHLU9Rob848gWj4g=="
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "NOEdqL0luzhm2Q0jShr5zti1yVihVVaFa9sxHLSQ4CqcxdydbmEuJyDBr86QQjJ8V3Q2E99z4zRis4NyYW3D6Q=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -338,7 +338,7 @@
           "Microsoft.Extensions.Logging.Abstractions": "[3.1.0, )",
           "Speckle.Autofac": "[1.0.0, )",
           "Speckle.Connectors.Utils": "[1.0.0, )",
-          "Speckle.Sdk": "[3.1.0-dev.115, )",
+          "Speckle.Sdk": "[3.0.1-rc.117, )",
           "System.Threading.Tasks.Dataflow": "[6.0.0, )"
         }
       },
@@ -347,8 +347,8 @@
         "dependencies": {
           "Microsoft.Extensions.Logging": "[3.1.0, )",
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.115, )",
-          "Speckle.Sdk": "[3.1.0-dev.115, )"
+          "Speckle.Objects": "[3.0.1-rc.117, )",
+          "Speckle.Sdk": "[3.0.1-rc.117, )"
         }
       },
       "speckle.testing": {
@@ -384,18 +384,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.115, )",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "p4K3/pSsjmKgtM1vg3+TpXryRL3HM49VflQcqhF+zplfsb9vZUhgKf+BnNQtEDyxPcEOEby/nmU179dxtJnCLw==",
+        "requested": "[3.0.1-rc.117, )",
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "YjExrNc/8Ha7rJ5enSDV1idCbwtneYUFOiAc4G5dm6XujuKqGHd4cVafV37FffFNGYl5fqvjTGjQ8mjrUfIEFw==",
         "dependencies": {
-          "Speckle.Sdk": "3.1.0-dev.115"
+          "Speckle.Sdk": "3.0.1-rc.117"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.115, )",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "uCo2oOvXAA+Ya+PRRPpBTVPRVC27tZEJU6cH3xgDqkl7sLaycn1ygelz9yZmMorwmjECEHOYuabLsQ+u04M+VQ==",
+        "requested": "[3.0.1-rc.117, )",
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "0rcCz4Dw9Yi62dZ8YG+THCYzHJokvH0F2IYYgqCqgk1CsuoH2IM/lGYYspiGiOLEuR4GG6aLt+Dke6jExANRlw==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -405,7 +405,7 @@
           "Polly.Extensions.Http": "3.0.0",
           "Speckle.DoubleNumerics": "4.0.1",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Logging": "3.1.0-dev.115",
+          "Speckle.Sdk.Logging": "3.0.1-rc.117",
           "System.Text.Json": "5.0.2"
         }
       },

--- a/DUI3/Speckle.Connectors.DUI.WebView/packages.lock.json
+++ b/DUI3/Speckle.Connectors.DUI.WebView/packages.lock.json
@@ -189,8 +189,8 @@
       },
       "Speckle.Sdk.Logging": {
         "type": "Transitive",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "bM9t/LdnCoaSqnj6MgkFCBSxVad+KMzrsgGtJ6Y1S+WTY43ysArIW7r2cB84OG9IZH3g9DRHLU9Rob848gWj4g=="
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "NOEdqL0luzhm2Q0jShr5zti1yVihVVaFa9sxHLSQ4CqcxdydbmEuJyDBr86QQjJ8V3Q2E99z4zRis4NyYW3D6Q=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -318,7 +318,7 @@
           "Microsoft.Extensions.Logging.Abstractions": "[3.1.0, )",
           "Speckle.Autofac": "[1.0.0, )",
           "Speckle.Connectors.Utils": "[1.0.0, )",
-          "Speckle.Sdk": "[3.1.0-dev.115, )",
+          "Speckle.Sdk": "[3.0.1-rc.117, )",
           "System.Threading.Tasks.Dataflow": "[6.0.0, )"
         }
       },
@@ -327,8 +327,8 @@
         "dependencies": {
           "Microsoft.Extensions.Logging": "[3.1.0, )",
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.115, )",
-          "Speckle.Sdk": "[3.1.0-dev.115, )"
+          "Speckle.Objects": "[3.0.1-rc.117, )",
+          "Speckle.Sdk": "[3.0.1-rc.117, )"
         }
       },
       "Autofac": {
@@ -360,18 +360,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.115, )",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "p4K3/pSsjmKgtM1vg3+TpXryRL3HM49VflQcqhF+zplfsb9vZUhgKf+BnNQtEDyxPcEOEby/nmU179dxtJnCLw==",
+        "requested": "[3.0.1-rc.117, )",
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "YjExrNc/8Ha7rJ5enSDV1idCbwtneYUFOiAc4G5dm6XujuKqGHd4cVafV37FffFNGYl5fqvjTGjQ8mjrUfIEFw==",
         "dependencies": {
-          "Speckle.Sdk": "3.1.0-dev.115"
+          "Speckle.Sdk": "3.0.1-rc.117"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.115, )",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "uCo2oOvXAA+Ya+PRRPpBTVPRVC27tZEJU6cH3xgDqkl7sLaycn1ygelz9yZmMorwmjECEHOYuabLsQ+u04M+VQ==",
+        "requested": "[3.0.1-rc.117, )",
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "0rcCz4Dw9Yi62dZ8YG+THCYzHJokvH0F2IYYgqCqgk1CsuoH2IM/lGYYspiGiOLEuR4GG6aLt+Dke6jExANRlw==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -381,7 +381,7 @@
           "Polly.Extensions.Http": "3.0.0",
           "Speckle.DoubleNumerics": "4.0.1",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Logging": "3.1.0-dev.115",
+          "Speckle.Sdk.Logging": "3.0.1-rc.117",
           "System.Text.Json": "5.0.2"
         }
       },
@@ -565,8 +565,8 @@
       },
       "Speckle.Sdk.Logging": {
         "type": "Transitive",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "bM9t/LdnCoaSqnj6MgkFCBSxVad+KMzrsgGtJ6Y1S+WTY43ysArIW7r2cB84OG9IZH3g9DRHLU9Rob848gWj4g=="
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "NOEdqL0luzhm2Q0jShr5zti1yVihVVaFa9sxHLSQ4CqcxdydbmEuJyDBr86QQjJ8V3Q2E99z4zRis4NyYW3D6Q=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -625,7 +625,7 @@
           "Microsoft.Extensions.Logging.Abstractions": "[3.1.0, )",
           "Speckle.Autofac": "[1.0.0, )",
           "Speckle.Connectors.Utils": "[1.0.0, )",
-          "Speckle.Sdk": "[3.1.0-dev.115, )",
+          "Speckle.Sdk": "[3.0.1-rc.117, )",
           "System.Threading.Tasks.Dataflow": "[6.0.0, )"
         }
       },
@@ -634,8 +634,8 @@
         "dependencies": {
           "Microsoft.Extensions.Logging": "[3.1.0, )",
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.115, )",
-          "Speckle.Sdk": "[3.1.0-dev.115, )"
+          "Speckle.Objects": "[3.0.1-rc.117, )",
+          "Speckle.Sdk": "[3.0.1-rc.117, )"
         }
       },
       "Autofac": {
@@ -664,18 +664,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.115, )",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "p4K3/pSsjmKgtM1vg3+TpXryRL3HM49VflQcqhF+zplfsb9vZUhgKf+BnNQtEDyxPcEOEby/nmU179dxtJnCLw==",
+        "requested": "[3.0.1-rc.117, )",
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "YjExrNc/8Ha7rJ5enSDV1idCbwtneYUFOiAc4G5dm6XujuKqGHd4cVafV37FffFNGYl5fqvjTGjQ8mjrUfIEFw==",
         "dependencies": {
-          "Speckle.Sdk": "3.1.0-dev.115"
+          "Speckle.Sdk": "3.0.1-rc.117"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.115, )",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "uCo2oOvXAA+Ya+PRRPpBTVPRVC27tZEJU6cH3xgDqkl7sLaycn1ygelz9yZmMorwmjECEHOYuabLsQ+u04M+VQ==",
+        "requested": "[3.0.1-rc.117, )",
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "0rcCz4Dw9Yi62dZ8YG+THCYzHJokvH0F2IYYgqCqgk1CsuoH2IM/lGYYspiGiOLEuR4GG6aLt+Dke6jExANRlw==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -685,7 +685,7 @@
           "Polly.Extensions.Http": "3.0.0",
           "Speckle.DoubleNumerics": "4.0.1",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Logging": "3.1.0-dev.115",
+          "Speckle.Sdk.Logging": "3.0.1-rc.117",
           "System.Text.Json": "5.0.2"
         }
       },

--- a/DUI3/Speckle.Connectors.DUI/packages.lock.json
+++ b/DUI3/Speckle.Connectors.DUI/packages.lock.json
@@ -41,9 +41,9 @@
       },
       "Speckle.Sdk": {
         "type": "Direct",
-        "requested": "[3.1.0-dev.115, )",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "uCo2oOvXAA+Ya+PRRPpBTVPRVC27tZEJU6cH3xgDqkl7sLaycn1ygelz9yZmMorwmjECEHOYuabLsQ+u04M+VQ==",
+        "requested": "[3.0.1-rc.117, )",
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "0rcCz4Dw9Yi62dZ8YG+THCYzHJokvH0F2IYYgqCqgk1CsuoH2IM/lGYYspiGiOLEuR4GG6aLt+Dke6jExANRlw==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -53,7 +53,7 @@
           "Polly.Extensions.Http": "3.0.0",
           "Speckle.DoubleNumerics": "4.0.1",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Logging": "3.1.0-dev.115",
+          "Speckle.Sdk.Logging": "3.0.1-rc.117",
           "System.Text.Json": "5.0.2"
         }
       },
@@ -231,8 +231,8 @@
       },
       "Speckle.Sdk.Logging": {
         "type": "Transitive",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "bM9t/LdnCoaSqnj6MgkFCBSxVad+KMzrsgGtJ6Y1S+WTY43ysArIW7r2cB84OG9IZH3g9DRHLU9Rob848gWj4g=="
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "NOEdqL0luzhm2Q0jShr5zti1yVihVVaFa9sxHLSQ4CqcxdydbmEuJyDBr86QQjJ8V3Q2E99z4zRis4NyYW3D6Q=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -362,8 +362,8 @@
         "dependencies": {
           "Microsoft.Extensions.Logging": "[3.1.0, )",
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.115, )",
-          "Speckle.Sdk": "[3.1.0-dev.115, )"
+          "Speckle.Objects": "[3.0.1-rc.117, )",
+          "Speckle.Sdk": "[3.0.1-rc.117, )"
         }
       },
       "Autofac": {
@@ -389,11 +389,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.115, )",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "p4K3/pSsjmKgtM1vg3+TpXryRL3HM49VflQcqhF+zplfsb9vZUhgKf+BnNQtEDyxPcEOEby/nmU179dxtJnCLw==",
+        "requested": "[3.0.1-rc.117, )",
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "YjExrNc/8Ha7rJ5enSDV1idCbwtneYUFOiAc4G5dm6XujuKqGHd4cVafV37FffFNGYl5fqvjTGjQ8mjrUfIEFw==",
         "dependencies": {
-          "Speckle.Sdk": "3.1.0-dev.115"
+          "Speckle.Sdk": "3.0.1-rc.117"
         }
       }
     }

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -19,8 +19,8 @@
     <PackageVersion Include="Revit.Async" Version="2.1.1" />
     <PackageVersion Include="RhinoCommon" Version="8.9.24194.18121" />
     <PackageVersion Include="RhinoWindows" Version="8.9.24194.18121" />
-    <PackageVersion Include="Speckle.Objects" Version="3.1.0-dev.115" />
-    <PackageVersion Include="Speckle.Sdk" Version="3.1.0-dev.115" />
+    <PackageVersion Include="Speckle.Objects" Version="3.0.1-rc.117" />
+    <PackageVersion Include="Speckle.Sdk" Version="3.0.1-rc.117" />
     <PackageVersion Include="Speckle.AutoCAD.API" Version="2023.0.0" />
     <PackageVersion Include="Speckle.Civil3D.API" Version="2024.0.0" />
     <PackageVersion Include="Speckle.Revit.API" Version="2023.0.0" />

--- a/Sdk/Speckle.Connectors.Tests/packages.lock.json
+++ b/Sdk/Speckle.Connectors.Tests/packages.lock.json
@@ -255,8 +255,8 @@
       },
       "Speckle.Sdk.Logging": {
         "type": "Transitive",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "bM9t/LdnCoaSqnj6MgkFCBSxVad+KMzrsgGtJ6Y1S+WTY43ysArIW7r2cB84OG9IZH3g9DRHLU9Rob848gWj4g=="
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "NOEdqL0luzhm2Q0jShr5zti1yVihVVaFa9sxHLSQ4CqcxdydbmEuJyDBr86QQjJ8V3Q2E99z4zRis4NyYW3D6Q=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -337,8 +337,8 @@
         "dependencies": {
           "Microsoft.Extensions.Logging": "[3.1.0, )",
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.115, )",
-          "Speckle.Sdk": "[3.1.0-dev.115, )"
+          "Speckle.Objects": "[3.0.1-rc.117, )",
+          "Speckle.Sdk": "[3.0.1-rc.117, )"
         }
       },
       "speckle.testing": {
@@ -368,18 +368,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.115, )",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "p4K3/pSsjmKgtM1vg3+TpXryRL3HM49VflQcqhF+zplfsb9vZUhgKf+BnNQtEDyxPcEOEby/nmU179dxtJnCLw==",
+        "requested": "[3.0.1-rc.117, )",
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "YjExrNc/8Ha7rJ5enSDV1idCbwtneYUFOiAc4G5dm6XujuKqGHd4cVafV37FffFNGYl5fqvjTGjQ8mjrUfIEFw==",
         "dependencies": {
-          "Speckle.Sdk": "3.1.0-dev.115"
+          "Speckle.Sdk": "3.0.1-rc.117"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.115, )",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "uCo2oOvXAA+Ya+PRRPpBTVPRVC27tZEJU6cH3xgDqkl7sLaycn1ygelz9yZmMorwmjECEHOYuabLsQ+u04M+VQ==",
+        "requested": "[3.0.1-rc.117, )",
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "0rcCz4Dw9Yi62dZ8YG+THCYzHJokvH0F2IYYgqCqgk1CsuoH2IM/lGYYspiGiOLEuR4GG6aLt+Dke6jExANRlw==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -389,7 +389,7 @@
           "Polly.Extensions.Http": "3.0.0",
           "Speckle.DoubleNumerics": "4.0.1",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Logging": "3.1.0-dev.115",
+          "Speckle.Sdk.Logging": "3.0.1-rc.117",
           "System.Text.Json": "5.0.2"
         }
       }

--- a/Sdk/Speckle.Connectors.Utils/packages.lock.json
+++ b/Sdk/Speckle.Connectors.Utils/packages.lock.json
@@ -56,18 +56,18 @@
       },
       "Speckle.Objects": {
         "type": "Direct",
-        "requested": "[3.1.0-dev.115, )",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "p4K3/pSsjmKgtM1vg3+TpXryRL3HM49VflQcqhF+zplfsb9vZUhgKf+BnNQtEDyxPcEOEby/nmU179dxtJnCLw==",
+        "requested": "[3.0.1-rc.117, )",
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "YjExrNc/8Ha7rJ5enSDV1idCbwtneYUFOiAc4G5dm6XujuKqGHd4cVafV37FffFNGYl5fqvjTGjQ8mjrUfIEFw==",
         "dependencies": {
-          "Speckle.Sdk": "3.1.0-dev.115"
+          "Speckle.Sdk": "3.0.1-rc.117"
         }
       },
       "Speckle.Sdk": {
         "type": "Direct",
-        "requested": "[3.1.0-dev.115, )",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "uCo2oOvXAA+Ya+PRRPpBTVPRVC27tZEJU6cH3xgDqkl7sLaycn1ygelz9yZmMorwmjECEHOYuabLsQ+u04M+VQ==",
+        "requested": "[3.0.1-rc.117, )",
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "0rcCz4Dw9Yi62dZ8YG+THCYzHJokvH0F2IYYgqCqgk1CsuoH2IM/lGYYspiGiOLEuR4GG6aLt+Dke6jExANRlw==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -77,7 +77,7 @@
           "Polly.Extensions.Http": "3.0.0",
           "Speckle.DoubleNumerics": "4.0.1",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Logging": "3.1.0-dev.115",
+          "Speckle.Sdk.Logging": "3.0.1-rc.117",
           "System.Text.Json": "5.0.2"
         }
       },
@@ -249,8 +249,8 @@
       },
       "Speckle.Sdk.Logging": {
         "type": "Transitive",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "bM9t/LdnCoaSqnj6MgkFCBSxVad+KMzrsgGtJ6Y1S+WTY43ysArIW7r2cB84OG9IZH3g9DRHLU9Rob848gWj4g=="
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "NOEdqL0luzhm2Q0jShr5zti1yVihVVaFa9sxHLSQ4CqcxdydbmEuJyDBr86QQjJ8V3Q2E99z4zRis4NyYW3D6Q=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",

--- a/Sdk/Speckle.Converters.Common.DependencyInjection/packages.lock.json
+++ b/Sdk/Speckle.Converters.Common.DependencyInjection/packages.lock.json
@@ -153,8 +153,8 @@
       },
       "Speckle.Sdk.Logging": {
         "type": "Transitive",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "bM9t/LdnCoaSqnj6MgkFCBSxVad+KMzrsgGtJ6Y1S+WTY43ysArIW7r2cB84OG9IZH3g9DRHLU9Rob848gWj4g=="
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "NOEdqL0luzhm2Q0jShr5zti1yVihVVaFa9sxHLSQ4CqcxdydbmEuJyDBr86QQjJ8V3Q2E99z4zRis4NyYW3D6Q=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -279,7 +279,7 @@
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[3.1.0, )",
           "Speckle.Autofac": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.115, )"
+          "Speckle.Objects": "[3.0.1-rc.117, )"
         }
       },
       "Microsoft.Extensions.Logging.Abstractions": {
@@ -290,18 +290,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.115, )",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "p4K3/pSsjmKgtM1vg3+TpXryRL3HM49VflQcqhF+zplfsb9vZUhgKf+BnNQtEDyxPcEOEby/nmU179dxtJnCLw==",
+        "requested": "[3.0.1-rc.117, )",
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "YjExrNc/8Ha7rJ5enSDV1idCbwtneYUFOiAc4G5dm6XujuKqGHd4cVafV37FffFNGYl5fqvjTGjQ8mjrUfIEFw==",
         "dependencies": {
-          "Speckle.Sdk": "3.1.0-dev.115"
+          "Speckle.Sdk": "3.0.1-rc.117"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.115, )",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "uCo2oOvXAA+Ya+PRRPpBTVPRVC27tZEJU6cH3xgDqkl7sLaycn1ygelz9yZmMorwmjECEHOYuabLsQ+u04M+VQ==",
+        "requested": "[3.0.1-rc.117, )",
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "0rcCz4Dw9Yi62dZ8YG+THCYzHJokvH0F2IYYgqCqgk1CsuoH2IM/lGYYspiGiOLEuR4GG6aLt+Dke6jExANRlw==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -311,7 +311,7 @@
           "Polly.Extensions.Http": "3.0.0",
           "Speckle.DoubleNumerics": "4.0.1",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Logging": "3.1.0-dev.115",
+          "Speckle.Sdk.Logging": "3.0.1-rc.117",
           "System.Text.Json": "5.0.2"
         }
       }

--- a/Sdk/Speckle.Converters.Common/packages.lock.json
+++ b/Sdk/Speckle.Converters.Common/packages.lock.json
@@ -41,11 +41,11 @@
       },
       "Speckle.Objects": {
         "type": "Direct",
-        "requested": "[3.1.0-dev.115, )",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "p4K3/pSsjmKgtM1vg3+TpXryRL3HM49VflQcqhF+zplfsb9vZUhgKf+BnNQtEDyxPcEOEby/nmU179dxtJnCLw==",
+        "requested": "[3.0.1-rc.117, )",
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "YjExrNc/8Ha7rJ5enSDV1idCbwtneYUFOiAc4G5dm6XujuKqGHd4cVafV37FffFNGYl5fqvjTGjQ8mjrUfIEFw==",
         "dependencies": {
-          "Speckle.Sdk": "3.1.0-dev.115"
+          "Speckle.Sdk": "3.0.1-rc.117"
         }
       },
       "GraphQL.Client": {
@@ -159,8 +159,8 @@
       },
       "Speckle.Sdk.Logging": {
         "type": "Transitive",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "bM9t/LdnCoaSqnj6MgkFCBSxVad+KMzrsgGtJ6Y1S+WTY43ysArIW7r2cB84OG9IZH3g9DRHLU9Rob848gWj4g=="
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "NOEdqL0luzhm2Q0jShr5zti1yVihVVaFa9sxHLSQ4CqcxdydbmEuJyDBr86QQjJ8V3Q2E99z4zRis4NyYW3D6Q=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -291,9 +291,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.115, )",
-        "resolved": "3.1.0-dev.115",
-        "contentHash": "uCo2oOvXAA+Ya+PRRPpBTVPRVC27tZEJU6cH3xgDqkl7sLaycn1ygelz9yZmMorwmjECEHOYuabLsQ+u04M+VQ==",
+        "requested": "[3.0.1-rc.117, )",
+        "resolved": "3.0.1-rc.117",
+        "contentHash": "0rcCz4Dw9Yi62dZ8YG+THCYzHJokvH0F2IYYgqCqgk1CsuoH2IM/lGYYspiGiOLEuR4GG6aLt+Dke6jExANRlw==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -303,7 +303,7 @@
           "Polly.Extensions.Http": "3.0.0",
           "Speckle.DoubleNumerics": "4.0.1",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Logging": "3.1.0-dev.115",
+          "Speckle.Sdk.Logging": "3.0.1-rc.117",
           "System.Text.Json": "5.0.2"
         }
       }


### PR DESCRIPTION
`rc` version is the one to be used on our initial beta release.

Additionally, removes USFeet usage from ArcGIS and Civil unit conversions