### PR TITLE
fix(Revit):CNX-414 fixes DirectShape category bug

### DIFF
--- a/Converters/Revit/Speckle.Converters.RevitShared/RevitRootToSpeckleConverter.cs
+++ b/Converters/Revit/Speckle.Converters.RevitShared/RevitRootToSpeckleConverter.cs
@@ -48,6 +48,7 @@ public class RevitRootToSpeckleConverter : IRootToSpeckleConverter
 
       // POC DirectShapes have RevitCategory enum as the type or the category property, DS category property is already set in the converter
       // trying to set the category as a string will throw
+      // the category should be moved to be set in each converter instead of the root to speckle converter
       if (target is not DB.DirectShape)
       {
         result["category"] = element.Category?.Name;

--- a/Converters/Revit/Speckle.Converters.RevitShared/RevitRootToSpeckleConverter.cs
+++ b/Converters/Revit/Speckle.Converters.RevitShared/RevitRootToSpeckleConverter.cs
@@ -45,7 +45,13 @@ public class RevitRootToSpeckleConverter : IRootToSpeckleConverter
     if (target is DB.Element element) // Note: aren't all targets DB elements?
     {
       result.applicationId = element.UniqueId;
-      result["category"] = element.Category?.Name;
+
+      // POC DirectShapes have RevitCategory enum as the type or the category property, DS category property is already set in the converter
+      // trying to set the category as a string will throw
+      if (target is not DB.DirectShape)
+      {
+        result["category"] = element.Category?.Name;
+      }
 
       try
       {


### PR DESCRIPTION
DirectShapes have a category property of type RevitCategory enum. We are assigning category to all converterd revit elements as a string after conversion. This was resulting in an exception for DirectShapes due to type mismatch. This is a POC fix to skip DirectShapes during category assigment. We should revisit DirectShape class to consider changing category type.