### PR TITLE
Fix(dui3): Use Invoke function instead InvokeAsync

### DIFF
--- a/DUI3/Speckle.Connectors.DUI.WebView/DUI3ControlWebView.xaml.cs
+++ b/DUI3/Speckle.Connectors.DUI.WebView/DUI3ControlWebView.xaml.cs
@@ -33,7 +33,7 @@ public sealed partial class DUI3ControlWebView : UserControl, IBrowserScriptExec
       throw new InvalidOperationException("Failed to execute script, Webview2 is not initialized yet.");
     }
 
-    Browser.Dispatcher.InvokeAsync(() => Browser.ExecuteScriptAsync(script), DispatcherPriority.Background);
+    Browser.Dispatcher.Invoke(() => Browser.ExecuteScriptAsync(script), DispatcherPriority.Background);
   }
 
   private void OnInitialized(object? sender, CoreWebView2InitializationCompletedEventArgs e)


### PR DESCRIPTION
Reverting the mistake that caused important regression on autocad. TESTED, see gif

![acad_2PMJkxaSBS](https://github.com/user-attachments/assets/0d8a23cf-22b0-4f12-91f1-d4298983e7f5)
