### PR TITLE
Fix(dui3): Go with default CancellationTokenSource.None for ActionBlock

### DIFF
--- a/DUI3/Speckle.Connectors.DUI/Bridge/BrowserBridge.cs
+++ b/DUI3/Speckle.Connectors.DUI/Bridge/BrowserBridge.cs
@@ -105,11 +105,7 @@ public sealed class BrowserBridge : IBridge
     // This conveniently executes the code outside the UI thread and does not block during long operations (such as sending).
     _actionBlock = new ActionBlock<RunMethodArgs>(
       OnActionBlock,
-      new ExecutionDataflowBlockOptions
-      {
-        MaxDegreeOfParallelism = 1000,
-        CancellationToken = new CancellationTokenSource(TimeSpan.FromDays(10000)).Token // Do not change the timespan. This time defines the session time that we enable for user.
-      }
+      new ExecutionDataflowBlockOptions { MaxDegreeOfParallelism = 1000 }
     );
 
     _logger.LogInformation("Bridge bound to front end name {FrontEndName}", binding.Name);


### PR DESCRIPTION
Somehow, TimeSpan.FromDays(10000) is not good for this. It crashes...... So by default there is no cancellation logic on ActionBlock. I just removed it. @didimitrie let me know if there was a reason adding this CancellationTokenSource..

![image](https://github.com/user-attachments/assets/8e749eda-0583-45b2-b4ce-3401813544c6)
