### PR TITLE
Fix(autocad): Evaluate mid point with angle

### DIFF
--- a/Converters/Autocad/Speckle.Converters.AutocadShared/ToSpeckle/Raw/CircularArc3dToSpeckleRawConverter.cs
+++ b/Converters/Autocad/Speckle.Converters.AutocadShared/ToSpeckle/Raw/CircularArc3dToSpeckleRawConverter.cs
@@ -27,16 +27,7 @@ public class CircularArc3dToSpeckleConverter : ITypedConverter<AG.CircularArc3d,
     SOG.Point end = _pointConverter.Convert(target.EndPoint);
     double startParam = target.GetParameterOf(target.StartPoint);
     double endParam = target.GetParameterOf(target.EndPoint);
-    AG.Point3d midPoint = target.EvaluatePoint(endParam - startParam / 2.0);
-
-    // some circular arcs will **not** return a correct value from `EvaluatePoint` using the indicated parameter at the midpoint.
-    // so far, this has happened with some arc segments in the polyline method. They will have an end param > 1, and evaluatePoint returns the endpoint
-    // this is why we are checking for midpoint == endpoint, and using a [0,1] parameterization if this is the case.
-    if (midPoint.IsEqualTo(target.EndPoint))
-    {
-      midPoint = target.EvaluatePoint(0.5);
-    }
-
+    AG.Point3d midPoint = target.EvaluatePoint(target.StartAngle + (target.EndAngle - target.StartAngle) / 2);
     SOG.Point mid = _pointConverter.Convert(midPoint);
 
     SOG.Arc arc =


### PR DESCRIPTION
I believe we were evaluating mid point with params, seems like it was a wrong approach. `target.EvaluatePoint(midAngle)` seems doing good so far.

BEFORE
![chrome_AermPOeF9T](https://github.com/user-attachments/assets/8002cba1-3e35-4e1f-9b3d-ce957035b1f3)

AFTER
![chrome_Enom68gxRw](https://github.com/user-attachments/assets/22bae4a6-cc71-4ffd-b5a9-64e0e045f6d9)

TRIED TO BREAK IT
![image](https://github.com/user-attachments/assets/f2176773-3a70-4af0-b894-765dd6666a79)
![chrome_a9erSYLBF8](https://github.com/user-attachments/assets/1fac3e03-6433-4e16-a215-b0bc5705dede)
