### PR TITLE
Feat(revit): CNX-470 add support for layer render materials

### DIFF
--- a/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/RevitMaterialBaker.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/RevitMaterialBaker.cs
@@ -5,10 +5,14 @@ using Speckle.Converters.RevitShared.Helpers;
 using Speckle.Objects.Other;
 using Speckle.Sdk;
 using Speckle.Sdk.Models.Collections;
+using Speckle.Sdk.Models.Extensions;
 using Speckle.Sdk.Models.GraphTraversal;
 
 namespace Speckle.Connectors.Revit.HostApp;
 
+/// <summary>
+/// Utility class that converts and bakes materials in Revit. Expects to be a scoped dependency per unit of work.
+/// </summary>
 public class RevitMaterialBaker
 {
   private readonly IRevitConversionContextStack _contextStack;
@@ -26,11 +30,10 @@ public class RevitMaterialBaker
     _revitUtils = revitUtils;
   }
 
-  public Dictionary<string, string> ObjectIdAndMaterialIndexMap { get; } = new();
-
   /// <summary>
   /// Checks the every atomic object has render material or not, if not it tries to find it from its layer tree and mutates
-  /// its render material proxy objects list with the traversal current.
+  /// its render material proxy objects list with the traversal current. It will also map displayable objects' display values to their
+  /// respective material proxy.
   /// </summary>
   public void MapLayersRenderMaterials(RootObjectUnpackerResult unpackedRoot)
   {
@@ -46,30 +49,69 @@ public class RevitMaterialBaker
         continue;
       }
 
-      var hasMaterial = unpackedRoot.RenderMaterialProxies.Any(rmp =>
+      var targetRenderMaterialProxy = unpackedRoot.RenderMaterialProxies.FirstOrDefault(rmp =>
         rmp.objects.Contains(context.Current.applicationId)
       );
 
-      if (!hasMaterial)
+      if (targetRenderMaterialProxy is null)
       {
         var layerParents = context.GetAscendants().Where(parent => parent is Layer);
-        var layer = layerParents.First(layer =>
+
+        var layer = layerParents.FirstOrDefault(layer =>
           unpackedRoot.RenderMaterialProxies.Any(rmp => rmp.objects.Contains(layer.applicationId!))
         );
+
         if (layer is not null)
         {
           var layerRenderMaterialProxy = unpackedRoot.RenderMaterialProxies.First(rmp =>
             rmp.objects.Contains(layer.applicationId!)
           );
-          // We mutate the existing proxy list that comes from source application. Because we do not keep track of parent-child relationship of objects in terms of render materials.
-          layerRenderMaterialProxy?.objects.Add(context.Current.applicationId!);
+
+          targetRenderMaterialProxy = layerRenderMaterialProxy;
+        }
+      }
+
+      if (targetRenderMaterialProxy is null)
+      {
+        continue; // exit fast, no proxy, we can't do much more.
+      }
+      // We mutate the existing proxy list that comes from source application. Because we do not keep track of parent-child relationship of objects in terms of render materials.
+      targetRenderMaterialProxy.objects.Add(context.Current.applicationId!);
+
+      // This is somewhat evil: we're unpacking here displayable elements by adding their display value to the target render material proxy.
+      // If the display value items do not have an application id, we will generate one.
+      var displayable = context.Current.TryGetDisplayValue();
+      if (displayable != null)
+      {
+        foreach (var @base in displayable)
+        {
+          if (@base.applicationId == null)
+          {
+            var guid = Guid.NewGuid().ToString();
+            @base.applicationId = guid;
+            targetRenderMaterialProxy.objects.Add(guid);
+          }
+          else
+          {
+            targetRenderMaterialProxy.objects.Add(@base.applicationId);
+          }
         }
       }
     }
   }
 
-  public void BakeMaterials(List<RenderMaterialProxy> speckleRenderMaterialProxies, string baseLayerName)
+  /// <summary>
+  /// Will bake render materials in the revit document.
+  /// </summary>
+  /// <param name="speckleRenderMaterialProxies"></param>
+  /// <param name="baseLayerName"></param>
+  /// <returns></returns>
+  public Dictionary<string, ElementId> BakeMaterials(
+    List<RenderMaterialProxy> speckleRenderMaterialProxies,
+    string baseLayerName
+  )
   {
+    Dictionary<string, ElementId> objectIdAndMaterialIndexMap = new();
     foreach (var proxy in speckleRenderMaterialProxies)
     {
       var speckleRenderMaterial = proxy.value;
@@ -92,7 +134,7 @@ public class RevitMaterialBaker
 
         foreach (var objectId in proxy.objects)
         {
-          ObjectIdAndMaterialIndexMap[objectId] = revitMaterial.Id.ToString();
+          objectIdAndMaterialIndexMap[objectId] = revitMaterial.Id;
         }
       }
       catch (Exception ex) when (!ex.IsFatal())
@@ -100,5 +142,7 @@ public class RevitMaterialBaker
         _logger.LogError(ex, "Failed to create material in Revit");
       }
     }
+
+    return objectIdAndMaterialIndexMap;
   }
 }

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/RevitMaterialBaker.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/RevitMaterialBaker.cs
@@ -1,8 +1,11 @@
 using Autodesk.Revit.DB;
 using Microsoft.Extensions.Logging;
+using Speckle.Connectors.Utils.Operations.Receive;
 using Speckle.Converters.RevitShared.Helpers;
 using Speckle.Objects.Other;
 using Speckle.Sdk;
+using Speckle.Sdk.Models.Collections;
+using Speckle.Sdk.Models.GraphTraversal;
 
 namespace Speckle.Connectors.Revit.HostApp;
 
@@ -24,6 +27,46 @@ public class RevitMaterialBaker
   }
 
   public Dictionary<string, string> ObjectIdAndMaterialIndexMap { get; } = new();
+
+  /// <summary>
+  /// Checks the every atomic object has render material or not, if not it tries to find it from its layer tree and mutates
+  /// its render material proxy objects list with the traversal current.
+  /// </summary>
+  public void MapLayersRenderMaterials(RootObjectUnpackerResult unpackedRoot)
+  {
+    if (unpackedRoot.RenderMaterialProxies is null)
+    {
+      return;
+    }
+
+    foreach (var context in unpackedRoot.ObjectsToConvert)
+    {
+      if (context.Current.applicationId is null)
+      {
+        continue;
+      }
+
+      var hasMaterial = unpackedRoot.RenderMaterialProxies.Any(rmp =>
+        rmp.objects.Contains(context.Current.applicationId)
+      );
+
+      if (!hasMaterial)
+      {
+        var layerParents = context.GetAscendants().Where(parent => parent is Layer);
+        var layer = layerParents.First(layer =>
+          unpackedRoot.RenderMaterialProxies.Any(rmp => rmp.objects.Contains(layer.applicationId!))
+        );
+        if (layer is not null)
+        {
+          var layerRenderMaterialProxy = unpackedRoot.RenderMaterialProxies.First(rmp =>
+            rmp.objects.Contains(layer.applicationId!)
+          );
+          // We mutate the existing proxy list that comes from source application. Because we do not keep track of parent-child relationship of objects in terms of render materials.
+          layerRenderMaterialProxy?.objects.Add(context.Current.applicationId!);
+        }
+      }
+    }
+  }
 
   public void BakeMaterials(List<RenderMaterialProxy> speckleRenderMaterialProxies, string baseLayerName)
   {

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Receive/RevitHostObjectBuilder.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Receive/RevitHostObjectBuilder.cs
@@ -83,6 +83,7 @@ internal sealed class RevitHostObjectBuilder : IHostObjectBuilder, IDisposable
 
     if (unpackedRoot.RenderMaterialProxies != null)
     {
+      _materialBaker.MapLayersRenderMaterials(unpackedRoot);
       _materialBaker.BakeMaterials(unpackedRoot.RenderMaterialProxies, baseLayerName);
       foreach (var item in _materialBaker.ObjectIdAndMaterialIndexMap)
       {

--- a/Converters/Revit/Speckle.Converters.RevitShared/Helpers/RevitMaterialCacheSingleton.cs
+++ b/Converters/Revit/Speckle.Converters.RevitShared/Helpers/RevitMaterialCacheSingleton.cs
@@ -18,9 +18,9 @@ public class RevitMaterialCacheSingleton
   public Dictionary<string, Dictionary<string, RenderMaterialProxy>> ObjectRenderMaterialProxiesMap { get; } = new();
 
   /// <summary>
-  /// // POC: The map we mutate PER RECEIVE operation, this smells a LOT! Once we have better conversion context stack that we can manage our data between connector - converter, this property must go away!
+  /// POC: The map we mutate PER RECEIVE operation, this smells a LOT! Once we have better conversion context stack that we can manage our data between connector - converter, this property must go away!
   /// </summary>
-  public Dictionary<string, string> ObjectIdAndMaterialIndexMap { get; } = new();
+  public Dictionary<string, DB.ElementId> ObjectIdAndMaterialIndexMap { get; } = new();
 
   /// <summary>
   /// map (DB.Material id, RevitMaterial). This can be generated from converting render materials or material quantities.

--- a/Converters/Revit/Speckle.Converters.RevitShared/ToHost/Raw/Geometry/MeshConverterToHost.cs
+++ b/Converters/Revit/Speckle.Converters.RevitShared/ToHost/Raw/Geometry/MeshConverterToHost.cs
@@ -45,7 +45,7 @@ public class MeshConverterToHost : ITypedConverter<SOG.Mesh, List<DB.GeometryObj
       )
     )
     {
-      materialId = ElementId.Parse(mappedElementId);
+      materialId = mappedElementId;
     }
 
     int i = 0;


### PR DESCRIPTION
Sent from rhino as meshes -> https://latest.speckle.systems/projects/126cd4b7bb/models/f3b0250890
It doesn't work with Breps, because on converter we don't know the relationship between parent and its list of displayValues.

![Revit_oyFlaOYJg4](https://github.com/user-attachments/assets/2f17d37c-3f7c-4704-aa93-d9032e669388)

