### PR TITLE
fix: Prevent increment when release commit is tagged

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,2 +1,6 @@
 workflow: GitFlow/v1
 next-version: 3.0.0
+branches:
+  release:
+    prevent-increment:
+      when-current-commit-tagged: true


### PR DESCRIPTION
Prevents increase of commit version when the commit is tagged.

This aligns the tag with the version published, if not there it would +1 the suffix.