### PR TITLE
Fix(autocad): Pass parent base object instead base under displayValues to find material

### DIFF
--- a/Connectors/Autocad/Speckle.Connectors.AutocadShared/Operations/Receive/AutocadHostObjectBuilder.cs
+++ b/Connectors/Autocad/Speckle.Connectors.AutocadShared/Operations/Receive/AutocadHostObjectBuilder.cs
@@ -224,7 +224,7 @@ public class AutocadHostObjectBuilder : IHostObjectBuilder
   {
     var ids = new ObjectIdCollection();
     var entities = new List<Entity>();
-    foreach (var (conversionResult, originalBaseObject) in fallbackConversionResult)
+    foreach (var (conversionResult, _) in fallbackConversionResult)
     {
       if (conversionResult is not Entity entity)
       {
@@ -232,7 +232,7 @@ public class AutocadHostObjectBuilder : IHostObjectBuilder
         continue;
       }
 
-      BakeObject(entity, originalBaseObject, layerName);
+      BakeObject(entity, originatingObject, layerName);
       ids.Add(entity.ObjectId);
       entities.Add(entity);
     }


### PR DESCRIPTION
We were passing base object under `displayValue` which was lacking `applicationId`. Instead I pass Brep object as base into `BakeObjectsAsGroup` function.

https://latest.speckle.systems/projects/126cd4b7bb/models/f3b0250890

BEFORE

![acad_IAghjmNXXa](https://github.com/user-attachments/assets/b58cca0e-ec98-4493-be45-7f45785a21f8)

AFTER

![acad_tG2736MrEK](https://github.com/user-attachments/assets/91d8689a-2e41-4af8-81d8-83d0251c11c8)
