### PR TITLE
fix: Tweak logging to console on debug and seq on release

### DIFF
--- a/Sdk/Speckle.Connectors.Utils/Connector.cs
+++ b/Sdk/Speckle.Connectors.Utils/Connector.cs
@@ -39,6 +39,9 @@ public static class Connector
       Slug,
       Assembly.GetExecutingAssembly().GetVersion(),
       new(
+#if DEBUG || LOCAL
+        new SpeckleLogging(Console: true, MinimumLevel: SpeckleLogLevel.Debug), new SpeckleTracing(Console: false)
+#else
         new SpeckleLogging(
           Console: true,
           Otel: new(
@@ -54,6 +57,7 @@ public static class Connector
             Headers: new() { { "X-Seq-ApiKey", "y5YnBp12ZE1Czh4tzZWn" } }
           )
         )
+#endif
       )
     );
 


### PR DESCRIPTION
Log everything to console on DEBUG
Log warnings to SEQ on RELEASE