### PR TITLE
Fixed esri targets file

### DIFF
--- a/Connectors/ArcGIS/Speckle.Connectors.ArcGIS3/Esri.ArcGISPro.Extensions30.Speckle.targets
+++ b/Connectors/ArcGIS/Speckle.Connectors.ArcGIS3/Esri.ArcGISPro.Extensions30.Speckle.targets
@@ -204,8 +204,8 @@
       <CleanInfo ParameterType="System.String" Output="true"/>
     </ParameterGroup>
     <Task>
-      <Reference Include="System.Xml.Linq"/>
-      <Reference Include="System.Xml"/>
+<!--      <Reference Include="System.Xml.Linq"/>-->
+<!--      <Reference Include="System.Xml"/>-->
       <Using Namespace="System"/>
       <Using Namespace="System.IO"/>
       <Using Namespace="System.Xml.Linq"/>


### PR DESCRIPTION
Last time I updated the esri file, I had to remove some references to nugets.
This fixed build, but clean was still broken

I thought that this was because of the commenting out I'd done.
Turns out, @AlanRynne has better eyes than I, and found that the clean build has its own references that can be commented out, which fixes clean and rebuilds.

Sorry @KatKatKateryna, this has been an annoyance for both of us, and an easy fix. Thanks @AlanRynne! 🙌 