### PR TITLE
fix(revit): handles curtain grids hosted on roof elements

### DIFF
--- a/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/ElementUnpacker.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/ElementUnpacker.cs
@@ -132,6 +132,22 @@ public class ElementUnpacker
             }
           }
           break;
+        case FootPrintRoof footPrintRoof:
+          if (footPrintRoof.CurtainGrids is { } gs)
+          {
+            foreach (CurtainGrid roofGrid in gs)
+            {
+              foreach (var mullionId in roofGrid.GetMullionIds())
+              {
+                ids.Add(mullionId.ToString());
+              }
+              foreach (var panelId in roofGrid.GetPanelIds())
+              {
+                ids.Add(panelId.ToString());
+              }
+            }
+          }
+          break;
         default:
           break;
       }


### PR DESCRIPTION
see repro in here [CNX-572: Revit Sloped Glazing missing](https://linear.app/speckle/issue/CNX-572/revit-sloped-glazing-missing). 

It's a simple fix: those elements now send. 