### PR TITLE
fix: Use ConversionNotSupportedException instead of system one

### DIFF
--- a/Converters/Autocad/Speckle.Converters.AutocadShared/AutocadRootToHostConverter.cs
+++ b/Converters/Autocad/Speckle.Converters.AutocadShared/AutocadRootToHostConverter.cs
@@ -2,6 +2,7 @@ using Autodesk.AutoCAD.DatabaseServices;
 using Speckle.Converters.Common;
 using Speckle.Converters.Common.Objects;
 using Speckle.Converters.Common.Registration;
+using Speckle.Sdk.Common;
 using Speckle.Sdk.Models;
 
 namespace Speckle.Converters.Autocad;
@@ -24,7 +25,7 @@ public class AutocadRootToHostConverter : IRootToSpeckleConverter
   {
     if (target is not DBObject dbObject)
     {
-      throw new NotSupportedException(
+      throw new ConversionNotSupportedException(
         $"Conversion of {target.GetType().Name} to Speckle is not supported. Only objects that inherit from DBObject are."
       );
     }
@@ -41,7 +42,7 @@ public class AutocadRootToHostConverter : IRootToSpeckleConverter
 
           if (objectConverter == null)
           {
-            throw new NotSupportedException($"No conversion found for {target.GetType().Name}");
+            throw new ConversionNotSupportedException($"No conversion found for {target.GetType().Name}");
           }
 
           var convertedObject = objectConverter.Convert(dbObject);

--- a/Converters/Civil3d/Speckle.Converters.Civil3dShared/Civil3dRootToHostConverter.cs
+++ b/Converters/Civil3d/Speckle.Converters.Civil3dShared/Civil3dRootToHostConverter.cs
@@ -2,6 +2,7 @@ using Autodesk.AutoCAD.DatabaseServices;
 using Speckle.Converters.Common;
 using Speckle.Converters.Common.Objects;
 using Speckle.Converters.Common.Registration;
+using Speckle.Sdk.Common;
 using Speckle.Sdk.Models;
 
 namespace Speckle.Converters.Civil3d;
@@ -24,7 +25,7 @@ public class Civil3dRootToHostConverter : IRootToSpeckleConverter
   {
     if (target is not DBObject dbObject)
     {
-      throw new NotSupportedException(
+      throw new ConversionNotSupportedException(
         $"Conversion of {target.GetType().Name} to Speckle is not supported. Only objects that inherit from DBObject are."
       );
     }
@@ -41,7 +42,7 @@ public class Civil3dRootToHostConverter : IRootToSpeckleConverter
 
           if (objectConverter == null)
           {
-            throw new NotSupportedException($"No conversion found for {target.GetType().Name}");
+            throw new ConversionNotSupportedException($"No conversion found for {target.GetType().Name}");
           }
 
           var convertedObject = objectConverter.Convert(dbObject);


### PR DESCRIPTION
Within conversions, we should be returning "ConversionNotSupportedException" instead of the system "NotSupportedException".