### PR TITLE
ArcGIS GroupLayers

### DIFF
--- a/Connectors/ArcGIS/Speckle.Connectors.ArcGIS3/Bindings/ArcGISSelectionBinding.cs
+++ b/Connectors/ArcGIS/Speckle.Connectors.ArcGIS3/Bindings/ArcGISSelectionBinding.cs
@@ -1,5 +1,6 @@
 using ArcGIS.Desktop.Mapping;
 using ArcGIS.Desktop.Mapping.Events;
+using Speckle.Connectors.ArcGIS.Utils;
 using Speckle.Connectors.DUI.Bindings;
 using Speckle.Connectors.DUI.Bridge;
 
@@ -7,11 +8,13 @@ namespace Speckle.Connectors.ArcGIS.Bindings;
 
 public class ArcGISSelectionBinding : ISelectionBinding
 {
+  private readonly MapMembersUtils _mapMemberUtils;
   public string Name => "selectionBinding";
   public IBrowserBridge Parent { get; }
 
-  public ArcGISSelectionBinding(IBrowserBridge parent)
+  public ArcGISSelectionBinding(IBrowserBridge parent, MapMembersUtils mapMemberUtils)
   {
+    _mapMemberUtils = mapMemberUtils;
     Parent = parent;
     var topLevelHandler = parent.TopLevelExceptionHandler;
 
@@ -52,14 +55,8 @@ public class ArcGISSelectionBinding : ISelectionBinding
     List<MapMember> allNestedMembers = new();
     foreach (MapMember member in selectedMembers)
     {
-      if (member is GroupLayer group)
-      {
-        GetLayersFromGroup(group, allNestedMembers);
-      }
-      else
-      {
-        allNestedMembers.Add(member);
-      }
+      var layerMapMembers = _mapMemberUtils.UnpackMapLayers(selectedMembers);
+      allNestedMembers.AddRange(layerMapMembers);
     }
 
     List<string> objectTypes = allNestedMembers

--- a/Connectors/ArcGIS/Speckle.Connectors.ArcGIS3/HostApp/ArcGISColorManager.cs
+++ b/Connectors/ArcGIS/Speckle.Connectors.ArcGIS3/HostApp/ArcGISColorManager.cs
@@ -502,6 +502,11 @@ public class ArcGISColorManager
         // set the group color to class symbol color if conditions are met
         if (groupConditionsMet)
         {
+          if (groupClass.Symbol is null)
+          {
+            color = RbgToInt(255, 255, 255, 255);
+            return false;
+          }
           if (!TryGetSymbolColor(groupClass.Symbol.Symbol, out color))
           {
             return false;
@@ -553,6 +558,11 @@ public class ArcGISColorManager
     out int color
   )
   {
+    if (graduatedRenderer.DefaultSymbol is null)
+    {
+      color = RbgToInt(255, 255, 255, 255);
+      return false;
+    }
     if (!TryGetSymbolColor(graduatedRenderer.DefaultSymbol.Symbol, out color)) // get default color
     {
       return false;

--- a/Connectors/ArcGIS/Speckle.Connectors.ArcGIS3/HostApp/ArcGISColorManager.cs
+++ b/Connectors/ArcGIS/Speckle.Connectors.ArcGIS3/HostApp/ArcGISColorManager.cs
@@ -316,6 +316,7 @@ public class ArcGISColorManager
     int count = 1;
     using (RowCursor rowCursor = layer.Search())
     {
+      // if layer doesn't have a valid data source (and the conversion likely failed), don't create a colorProxy
       if (rowCursor is null)
       {
         return;

--- a/Connectors/ArcGIS/Speckle.Connectors.ArcGIS3/HostApp/ArcGISColorManager.cs
+++ b/Connectors/ArcGIS/Speckle.Connectors.ArcGIS3/HostApp/ArcGISColorManager.cs
@@ -316,6 +316,10 @@ public class ArcGISColorManager
     int count = 1;
     using (RowCursor rowCursor = layer.Search())
     {
+      if (rowCursor is null)
+      {
+        return;
+      }
       while (rowCursor.MoveNext())
       {
         string elementAppId = $"{layer.URI}_{count}";
@@ -451,6 +455,11 @@ public class ArcGISColorManager
     out int color
   )
   {
+    if (uniqueRenderer.DefaultSymbol is null)
+    {
+      color = RbgToInt(255, 255, 255, 255);
+      return false;
+    }
     if (!TryGetSymbolColor(uniqueRenderer.DefaultSymbol.Symbol, out color)) // get default color
     {
       return false;

--- a/Connectors/ArcGIS/Speckle.Connectors.ArcGIS3/Operations/Send/ArcGISRootObjectBuilder.cs
+++ b/Connectors/ArcGIS/Speckle.Connectors.ArcGIS3/Operations/Send/ArcGISRootObjectBuilder.cs
@@ -71,7 +71,7 @@ public class ArcGISRootObjectBuilder : IRootObjectBuilder<MapMember>
 
     List<SendConversionResult> results = new(objects.Count);
     var cacheHitCount = 0;
-    List<(GroupLayer, Collection)> nestedGroups = new();
+    List<(ILayerContainer, Collection)> nestedGroups = new();
 
     // reorder selected layers by Table of Content (TOC) order
     List<(MapMember, int)> layersWithDisplayPriority = _mapMemberUtils.GetLayerDisplayPriority(
@@ -112,7 +112,7 @@ public class ArcGISRootObjectBuilder : IRootObjectBuilder<MapMember>
 
             // don't use cache for group layers
             if (
-              mapMember is not GroupLayer
+              mapMember is not ILayerContainer
               && _sendConversionCache.TryGetValue(sendInfo.ProjectId, applicationId, out ObjectReference? value)
             )
             {
@@ -121,7 +121,7 @@ public class ArcGISRootObjectBuilder : IRootObjectBuilder<MapMember>
             }
             else
             {
-              if (mapMember is GroupLayer group)
+              if (mapMember is ILayerContainer group)
               {
                 // group layer will always come before it's contained layers
                 // keep active group last in the list

--- a/Connectors/ArcGIS/Speckle.Connectors.ArcGIS3/Utils/MapMembersUtils.cs
+++ b/Connectors/ArcGIS/Speckle.Connectors.ArcGIS3/Utils/MapMembersUtils.cs
@@ -1,4 +1,3 @@
-using ArcGIS.Desktop.Internal.Mapping;
 using ArcGIS.Desktop.Mapping;
 
 namespace Speckle.Connectors.ArcGIS.Utils;
@@ -28,20 +27,12 @@ public class MapMembersUtils
     List<MapMember> mapMembers = new();
     foreach (var layer in mapMembersToUnpack)
     {
+      mapMembers.Add(layer);
       switch (layer)
       {
-        case GroupLayer subGroup:
-          mapMembers.Add(layer);
-          var subGroupMapMembers = UnpackMapLayers(subGroup.Layers);
-          mapMembers.AddRange(subGroupMapMembers);
-          break;
-        case ILayerContainerInternal subLayerContainerInternal:
-          mapMembers.Add(layer);
-          var subLayerMapMembers = UnpackMapLayers(subLayerContainerInternal.InternalLayers);
+        case ILayerContainer subGroup:
+          var subLayerMapMembers = UnpackMapLayers(subGroup.Layers);
           mapMembers.AddRange(subLayerMapMembers);
-          break;
-        default:
-          mapMembers.Add(layer);
           break;
       }
     }


### PR DESCRIPTION
Treat all Collection-alike layers as GroupLayers (converting to Collections). Otherwise, they are passed to the Converter and justifiably failing. 