### PR TITLE
fix(dui3): ensures we don't override structure layers

### DIFF
--- a/Converters/Revit/Speckle.Converters.RevitShared/ToSpeckle/Parameters/ParameterExtractor.cs
+++ b/Converters/Revit/Speckle.Converters.RevitShared/ToSpeckle/Parameters/ParameterExtractor.cs
@@ -77,7 +77,8 @@ public class ParameterExtractor
       {
         if (_settingsStore.Current.Document.GetElement(layer.MaterialId) is DB.Material material)
         {
-          structureDictionary[material.Name] = new Dictionary<string, object>()
+          var uniqueLayerName = $"{material.Name} ({layer.LayerId})";
+          structureDictionary[uniqueLayerName] = new Dictionary<string, object>()
           {
             ["material"] = material.Name,
             ["function"] = layer.Function.ToString(),


### PR DESCRIPTION
where there's two materials of the same type in the same type, they would override each other; nevertheless, having two plywood layers for one wall is totally acceptable.

note: this is a poc solution for now, as i envision the whole parameter extractor stuff to be properly typed out.