### PR TITLE
Dimitrie/cnx 635 curtain wall doors duplicated geometry

### DIFF
--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Bindings/BasicConnectorBindingRevit.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Bindings/BasicConnectorBindingRevit.cs
@@ -105,6 +105,8 @@ internal sealed class BasicConnectorBindingRevit : IBasicConnectorBinding
         .SendFilter.NotNull()
         .GetObjectIds()
         .Select(uid => ElementIdHelper.GetElementIdFromUniqueId(activeUIDoc.Document, uid))
+        .Where(el => el is not null)
+        .Cast<ElementId>()
         .ToList();
     }
 
@@ -113,6 +115,8 @@ internal sealed class BasicConnectorBindingRevit : IBasicConnectorBinding
       elementIds = receiverModelCard
         .BakedObjectIds.NotNull()
         .Select(uid => ElementIdHelper.GetElementIdFromUniqueId(activeUIDoc.Document, uid))
+        .Where(el => el is not null)
+        .Cast<ElementId>()
         .ToList();
     }
 
@@ -138,7 +142,11 @@ internal sealed class BasicConnectorBindingRevit : IBasicConnectorBinding
       ?? throw new SpeckleException("Unable to retrieve active UI document");
 
     await HighlightObjectsOnView(
-        objectIds.Select(uid => ElementIdHelper.GetElementIdFromUniqueId(activeUIDoc.Document, uid)).ToList()
+        objectIds
+          .Select(uid => ElementIdHelper.GetElementIdFromUniqueId(activeUIDoc.Document, uid))
+          .Where(el => el is not null)
+          .Cast<ElementId>()
+          .ToList()
       )
       .ConfigureAwait(false);
     ;

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Bindings/RevitSendBinding.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Bindings/RevitSendBinding.cs
@@ -251,6 +251,9 @@ internal sealed class RevitSendBinding : RevitBaseBinding, ISendBinding
     }
 
     // Note: We're using unique ids as application ids in revit, so cache eviction must happen by those.
+    // NOTE: this is currently broken when deleting freestanding elements (e.g. unhosted elements)
+    // To reproduce, draw two unconnected walls, send, delete one wall -> no expiration notice
+    // I do not yet know the solution besides going back to element ids, but it would mean revisiting why we switched to unique ids (conflicting ids)
     var objUniqueIds = objectIdsList
       .Select(id => new ElementId(Convert.ToInt32(id)))
       .Select(doc.GetElement)

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Bindings/RevitSendBinding.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Bindings/RevitSendBinding.cs
@@ -132,7 +132,9 @@ internal sealed class RevitSendBinding : RevitBaseBinding, ISendBinding
       List<ElementId> revitObjects = modelCard
         .SendFilter.NotNull()
         .GetObjectIds()
-        .Select(uid => activeUIDoc.Document.GetElement(uid).Id)
+        .Select(uid => activeUIDoc.Document.GetElement(uid))
+        .Where(el => el is not null) // NOTE: elements can get deleted from the host app.
+        .Select(el => el.Id)
         .ToList();
 
       if (revitObjects.Count == 0)

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/ElementIdHelper.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/ElementIdHelper.cs
@@ -5,14 +5,9 @@ namespace Speckle.Connectors.RevitShared;
 
 public static class ElementIdHelper
 {
-  public static ElementId GetElementIdFromUniqueId(Document doc, string uniqueId)
+  public static ElementId? GetElementIdFromUniqueId(Document doc, string uniqueId)
   {
     Element element = doc.GetElement(uniqueId);
-    if (element == null)
-    {
-      throw new SpeckleException($"Cannot find element with UniqueId: {uniqueId}");
-    }
-
-    return element.Id;
+    return element?.Id;
   }
 }

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/ElementUnpacker.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/ElementUnpacker.cs
@@ -93,8 +93,15 @@ public class ElementUnpacker
   private List<Element> PackCurtainWallElements(List<Element> elements)
   {
     var ids = elements.Select(el => el.Id).ToArray();
+    var doc = _revitContext.UIApplication?.ActiveUIDocument.Document!;
     elements.RemoveAll(element =>
-      (element is Mullion m && ids.Contains(m.Host.Id)) || (element is Panel p && ids.Contains(p.Host.Id))
+      (element is Mullion m && ids.Contains(m.Host.Id))
+      || (element is Panel p && ids.Contains(p.Host.Id))
+      || (
+        element is FamilyInstance { Host: not null } f
+        && doc.GetElement(f.Host.Id) is Wall { CurtainGrid: not null }
+        && ids.Contains(f.Host.Id)
+      )
     );
     return elements;
   }


### PR DESCRIPTION
Fixes [CNX-656: Revit: deleted elements cause send and preview selection to fail](https://linear.app/speckle/issue/CNX-656/revit-deleted-elements-cause-send-and-preview-selection-to-fail) and [CNX-635: Curtain wall doors - duplicated geometry](https://linear.app/speckle/issue/CNX-635/curtain-wall-doors-duplicated-geometry)