### PR TITLE
fix(civil3d): adds basecurves for parcel segments

### DIFF
--- a/Converters/Civil3d/Speckle.Converters.Civil3dShared/Helpers/BaseCurveExtractor.cs
+++ b/Converters/Civil3d/Speckle.Converters.Civil3dShared/Helpers/BaseCurveExtractor.cs
@@ -54,6 +54,7 @@ public sealed class BaseCurveExtractor
 
       case CDB.FeatureLine:
       case CDB.Parcel:
+      case CDB.ParcelSegment:
         return new() { _curveConverter.Convert(entity.BaseCurve) };
 
       // for any entities where basecurve prop doesn't make sense

--- a/Converters/Civil3d/Speckle.Converters.Civil3dShared/ToSpeckle/BuiltElements/CivilEntityToSpeckleTopLevelConverter.cs
+++ b/Converters/Civil3d/Speckle.Converters.Civil3dShared/ToSpeckle/BuiltElements/CivilEntityToSpeckleTopLevelConverter.cs
@@ -104,7 +104,6 @@ public class CivilEntityToSpeckleTopLevelConverter : IToSpeckleTopLevelConverter
   private List<Base>? GetSiteChildren(CDB.Site site)
   {
     List<Base> parcels = new();
-
     using (var tr = _settingsStore.Current.Document.Database.TransactionManager.StartTransaction())
     {
       foreach (ADB.ObjectId parcelId in site.GetParcelIds())
@@ -115,6 +114,7 @@ public class CivilEntityToSpeckleTopLevelConverter : IToSpeckleTopLevelConverter
 
       tr.Commit();
     }
+
     return parcels.Count > 0 ? parcels : null;
   }
 


### PR DESCRIPTION
Parcel segments were missing basecurves, resulting in no displayable geo in the viewer
sample commit:
https://latest.speckle.systems/projects/3f895e614f/models/fff1132068@067c74a512