### PR TITLE
fix(civil3d): uses basecurves as display value when no display value exists

### DIFF
--- a/Converters/Civil3d/Speckle.Converters.Civil3dShared/Helpers/DisplayValueExtractor.cs
+++ b/Converters/Civil3d/Speckle.Converters.Civil3dShared/Helpers/DisplayValueExtractor.cs
@@ -31,7 +31,7 @@ public sealed class DisplayValueExtractor
     _converterSettings = converterSettings;
   }
 
-  public List<Base> GetDisplayValue(CDB.Entity entity)
+  public List<Base>? GetDisplayValue(CDB.Entity entity)
   {
     switch (entity)
     {
@@ -56,7 +56,7 @@ public sealed class DisplayValueExtractor
         return new() { gridSurfaceMesh };
 
       default:
-        return new();
+        return null;
     }
   }
 }

--- a/Converters/Civil3d/Speckle.Converters.Civil3dShared/ToSpeckle/BuiltElements/CivilEntityToSpeckleTopLevelConverter.cs
+++ b/Converters/Civil3d/Speckle.Converters.Civil3dShared/ToSpeckle/BuiltElements/CivilEntityToSpeckleTopLevelConverter.cs
@@ -59,9 +59,10 @@ public class CivilEntityToSpeckleTopLevelConverter : IToSpeckleTopLevelConverter
       civilObject["baseCurves"] = baseCurves;
     }
 
-    // extract display value
-    List<Base> display = _displayValueExtractor.GetDisplayValue(target);
-    if (display.Count > 0)
+    // extract display value.
+    // If object has no display but has basecurves, use basecurves for display instead (for viewer selection)
+    List<Base>? display = _displayValueExtractor.GetDisplayValue(target) ?? baseCurves?.Select(o => (Base)o).ToList();
+    if (display is not null)
     {
       civilObject["displayValue"] = display;
     }

--- a/Converters/Civil3d/Speckle.Converters.Civil3dShared/ToSpeckle/Properties/GeneralPropertiesExtractor.cs
+++ b/Converters/Civil3d/Speckle.Converters.Civil3dShared/ToSpeckle/Properties/GeneralPropertiesExtractor.cs
@@ -292,7 +292,7 @@ public class GeneralPropertiesExtractor
       };
       speedsCount++;
     }
-    designCriteriaDict["Design Speeds"] = designSpeedsDict;
+
     if (designSpeedsDict.Count > 0)
     {
       designCriteriaDict["Design Speeds"] = designSpeedsDict;


### PR DESCRIPTION
For any entity with a basecurve but no display value, adds the basecurves to the display value property instead. The intention is so the parent object is selected in the viewer (instead of the basecurve curve).
sample commit: https://latest.speckle.systems/projects/3f895e614f/models/88370f10da@6fdefc5bc7