### PR TITLE
fix(autocad): arc to host conversions fixed to remove dependency on incoming arc plane and angle props

### DIFF
--- a/Converters/Autocad/Speckle.Converters.AutocadShared/AutocadRootToSpeckleConverter.cs
+++ b/Converters/Autocad/Speckle.Converters.AutocadShared/AutocadRootToSpeckleConverter.cs
@@ -7,12 +7,12 @@ using Speckle.Sdk.Models;
 
 namespace Speckle.Converters.Autocad;
 
-public class AutocadRootToHostConverter : IRootToSpeckleConverter
+public class AutocadRootToSpeckleConverter : IRootToSpeckleConverter
 {
   private readonly IConverterManager<IToSpeckleTopLevelConverter> _toSpeckle;
   private readonly IConverterSettingsStore<AutocadConversionSettings> _settingsStore;
 
-  public AutocadRootToHostConverter(
+  public AutocadRootToSpeckleConverter(
     IConverterManager<IToSpeckleTopLevelConverter> toSpeckle,
     IConverterSettingsStore<AutocadConversionSettings> settingsStore
   )

--- a/Converters/Autocad/Speckle.Converters.AutocadShared/ServiceRegistration.cs
+++ b/Converters/Autocad/Speckle.Converters.AutocadShared/ServiceRegistration.cs
@@ -14,7 +14,7 @@ public static class ServiceRegistration
     //register types by default
     serviceCollection.AddMatchingInterfacesAsTransient(converterAssembly);
     // add single root converter
-    serviceCollection.AddRootCommon<AutocadRootToHostConverter>(converterAssembly);
+    serviceCollection.AddRootCommon<AutocadRootToSpeckleConverter>(converterAssembly);
 
     // add application converters and context stack
     serviceCollection.AddApplicationConverters<AutocadToSpeckleUnitConverter, ADB.UnitsValue>(converterAssembly);

--- a/Converters/Autocad/Speckle.Converters.AutocadShared/ServiceRegistration.cs
+++ b/Converters/Autocad/Speckle.Converters.AutocadShared/ServiceRegistration.cs
@@ -1,4 +1,4 @@
-﻿using System.Reflection;
+using System.Reflection;
 using Microsoft.Extensions.DependencyInjection;
 using Speckle.Converters.Common;
 using Speckle.Converters.Common.Registration;

--- a/Converters/Autocad/Speckle.Converters.AutocadShared/Speckle.Converters.AutocadShared.projitems
+++ b/Converters/Autocad/Speckle.Converters.AutocadShared/Speckle.Converters.AutocadShared.projitems
@@ -11,7 +11,7 @@
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)AutocadConversionSettings.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)AutocadConversionSettingsFactory.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)AutocadRootToHostConverter.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)AutocadRootToSpeckleConverter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)AutocadConversionContextStack.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)AutocadToSpeckleUnitConverter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\EntityExtensions.cs" />

--- a/Converters/Autocad/Speckle.Converters.AutocadShared/ToHost/Geometry/ArcToHostConverter.cs
+++ b/Converters/Autocad/Speckle.Converters.AutocadShared/ToHost/Geometry/ArcToHostConverter.cs
@@ -31,11 +31,13 @@ public class ArcToHostConverter : IToHostTopLevelConverter, ITypedConverter<SOG.
     AG.CircularArc3d circularArc = _arcConverter.Convert(target);
 
     // calculate adjusted start and end angles from circularArc reference
-    AG.Plane plane = _planeConverter.Convert(target.plane);
-    double angle = circularArc.ReferenceVector.AngleOnPlane(plane);
-    double startAngle = circularArc.StartAngle + angle;
-    double endAngle = circularArc.EndAngle + angle;
+    // for some reason, if just the circular arc start and end angle props are used, this moves the endpoints of the created arc
+    // so we need to calculate the adjusted start and end angles from the circularArc reference vector.
+    AG.Plane plane = new(circularArc.Center, circularArc.Normal);
+    double angleOnPlane = circularArc.ReferenceVector.AngleOnPlane(plane);
+    double adjustedStartAngle = circularArc.StartAngle + angleOnPlane;
+    double adjustEndAngle = circularArc.EndAngle + angleOnPlane;
 
-    return new(circularArc.Center, circularArc.Normal, circularArc.Radius, startAngle, endAngle);
+    return new(circularArc.Center, circularArc.Normal, circularArc.Radius, adjustedStartAngle, adjustEndAngle);
   }
 }

--- a/Converters/Autocad/Speckle.Converters.AutocadShared/ToHost/Raw/ArcToHostRawConverter.cs
+++ b/Converters/Autocad/Speckle.Converters.AutocadShared/ToHost/Raw/ArcToHostRawConverter.cs
@@ -27,16 +27,6 @@ public class ArcToHostRowConverter : ITypedConverter<SOG.Arc, AG.CircularArc3d>
     AG.Point3d end = _pointConverter.Convert(target.endPoint);
     AG.Point3d mid = _pointConverter.Convert(target.midPoint);
     AG.CircularArc3d arc = new(start, mid, end);
-
-    AG.Vector3d normal = _vectorConverter.Convert(target.plane.normal);
-    AG.Vector3d xdir = _vectorConverter.Convert(target.plane.xdir);
-    arc.SetAxes(normal, xdir);
-
-    if (target.startAngle is double startAngle && target.endAngle is double endAngle)
-    {
-      arc.SetAngles(startAngle, endAngle);
-    }
-
     return arc;
   }
 }


### PR DESCRIPTION
We were previously depending on the speckle arc's plane and start/end angle props to create autocad arcs. Since these props can't be guaranteed to be calculated "correctly" to autocad convention (eg when sent from civil), these dependencies have been removed and recalculated internally.

before:
![image](https://github.com/user-attachments/assets/7890b252-ec1e-4b18-b709-8a2b4afcf482)

result: 
![{5F794467-D0CD-49A8-AE7E-AFF716004C6B}](https://github.com/user-attachments/assets/703d4b8a-dd75-44f2-8e89-1651b8ba5af7)
