### PR TITLE
fix(civil3d/rhino): adds correct curves to displayvalue and receiving arcs as fallback in rhino

### DIFF
--- a/Converters/Civil3d/Speckle.Converters.Civil3dShared/Helpers/DisplayValueExtractor.cs
+++ b/Converters/Civil3d/Speckle.Converters.Civil3dShared/Helpers/DisplayValueExtractor.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.Logging;
 using Speckle.Converters.Common;
 using Speckle.Converters.Common.Objects;
+using Speckle.Objects;
 using Speckle.Sdk.Models;
 
 namespace Speckle.Converters.Civil3dShared.Helpers;
@@ -62,5 +63,43 @@ public sealed class DisplayValueExtractor
       default:
         return null;
     }
+  }
+
+  /// <summary>
+  /// Processes a list of ICurves for suitable display value curves.
+  /// </summary>
+  /// <param name="iCurves"></param>
+  /// <returns>
+  /// List of simple curves: lines, polylines, and arcs.
+  /// Null if no suitable display curves were found.
+  /// </returns>
+  public List<Base>? ProcessICurvesForDisplay(List<ICurve>? iCurves)
+  {
+    if (iCurves is null)
+    {
+      return null;
+    }
+
+    List<Base> result = new();
+    foreach (ICurve curve in iCurves)
+    {
+      switch (curve)
+      {
+        case SOG.Line:
+        case SOG.Polyline:
+        case SOG.Arc:
+          result.Add((Base)curve);
+          break;
+        case SOG.Polycurve polycurve:
+          List<Base>? processedSegments = ProcessICurvesForDisplay(polycurve.segments);
+          if (processedSegments is not null)
+          {
+            result.AddRange(processedSegments);
+          }
+          break;
+      }
+    }
+
+    return result.Count > 0 ? result : null;
   }
 }

--- a/Converters/Civil3d/Speckle.Converters.Civil3dShared/ToSpeckle/BuiltElements/CivilEntityToSpeckleTopLevelConverter.cs
+++ b/Converters/Civil3d/Speckle.Converters.Civil3dShared/ToSpeckle/BuiltElements/CivilEntityToSpeckleTopLevelConverter.cs
@@ -61,7 +61,8 @@ public class CivilEntityToSpeckleTopLevelConverter : IToSpeckleTopLevelConverter
 
     // extract display value.
     // If object has no display but has basecurves, use basecurves for display instead (for viewer selection)
-    List<Base>? display = _displayValueExtractor.GetDisplayValue(target) ?? baseCurves?.Select(o => (Base)o).ToList();
+    List<Base>? display =
+      _displayValueExtractor.GetDisplayValue(target) ?? _displayValueExtractor.ProcessICurvesForDisplay(baseCurves);
     if (display is not null)
     {
       civilObject["displayValue"] = display;

--- a/Converters/Rhino/Speckle.Converters.RhinoShared/ToHost/TopLevel/FallbackToHostTopLevelConverter.cs
+++ b/Converters/Rhino/Speckle.Converters.RhinoShared/ToHost/TopLevel/FallbackToHostTopLevelConverter.cs
@@ -1,4 +1,4 @@
-﻿using Speckle.Converters.Common;
+using Speckle.Converters.Common;
 using Speckle.Converters.Common.Objects;
 using Speckle.Sdk.Common;
 using Speckle.Sdk.Common.Exceptions;
@@ -14,6 +14,7 @@ public class FallbackToHostTopLevelConverter
   private readonly ITypedConverter<SOG.Point, RG.Point> _pointConverter;
   private readonly ITypedConverter<SOG.Line, RG.LineCurve> _lineConverter;
   private readonly ITypedConverter<SOG.Polyline, RG.PolylineCurve> _polylineConverter;
+  private readonly ITypedConverter<SOG.Arc, RG.ArcCurve> _arcConverter;
   private readonly ITypedConverter<SOG.Mesh, RG.Mesh> _meshConverter;
   private readonly IConverterSettingsStore<RhinoConversionSettings> _settingsStore;
 
@@ -21,6 +22,7 @@ public class FallbackToHostTopLevelConverter
     ITypedConverter<SOG.Point, RG.Point> pointConverter,
     ITypedConverter<SOG.Line, RG.LineCurve> lineConverter,
     ITypedConverter<SOG.Polyline, RG.PolylineCurve> polylineConverter,
+    ITypedConverter<SOG.Arc, RG.ArcCurve> arcConverter,
     ITypedConverter<SOG.Mesh, RG.Mesh> meshConverter,
     IConverterSettingsStore<RhinoConversionSettings> settingsStore
   )
@@ -28,6 +30,7 @@ public class FallbackToHostTopLevelConverter
     _pointConverter = pointConverter;
     _lineConverter = lineConverter;
     _polylineConverter = polylineConverter;
+    _arcConverter = arcConverter;
     _meshConverter = meshConverter;
     _settingsStore = settingsStore;
   }
@@ -43,6 +46,7 @@ public class FallbackToHostTopLevelConverter
       {
         SOG.Line line => _lineConverter.Convert(line),
         SOG.Polyline polyline => _polylineConverter.Convert(polyline),
+        SOG.Arc arc => _arcConverter.Convert(arc),
         SOG.Mesh mesh => _meshConverter.Convert(mesh),
         SOG.Point point => _pointConverter.Convert(point),
         _ => throw new ConversionException($"Found unsupported fallback geometry: {item.GetType()}")


### PR DESCRIPTION
Fixes issue in receiving Civil3d elements with curves in their display value in rhino.
This was done by: 
- prefiltering list of ICurve in Civil3d to only include lines, polylines, and arcs to be used as display values.
- adding arcs to the supported types of fallback geometry in rhino

sample commit: https://latest.speckle.systems/projects/3f895e614f/models/1737754fb4@1d2b032ba5

received in rhino:
![{589AE953-792B-480C-B158-47E66C07B06B}](https://github.com/user-attachments/assets/41fdd72d-f3bd-40fb-9679-fde0c16f40f2)

extra check received in autocad:
![{3C905819-DC10-4CBA-872D-F0D7FDB23134}](https://github.com/user-attachments/assets/a842c33f-c464-4ab4-8e67-273e8c301672)

