### PR TITLE
feat(rhino): adds names to all objects on bake

### DIFF
--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/Operations/Receive/RhinoHostObjectBuilder.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/Operations/Receive/RhinoHostObjectBuilder.cs
@@ -130,7 +130,7 @@ public class RhinoHostObjectBuilder : IHostObjectBuilder
           try
           {
             // 0: get the name of the incoming obj if any
-            string? name = obj["name"] as string;
+            string name = obj["name"] as string ?? "";
 
             // 1: get pre-created layer from cache in layer baker
             int layerIndex = _layerBaker.GetAndCreateLayerFromPath(path, baseLayerName);
@@ -256,9 +256,9 @@ public class RhinoHostObjectBuilder : IHostObjectBuilder
     _groupBaker.PurgeGroups(baseLayerName);
   }
 
-  private Guid BakeObject(GeometryBase obj, Base originalObject, int layerIndex, string? name = null)
+  private Guid BakeObject(GeometryBase obj, Base originalObject, int layerIndex, string name = "")
   {
-    ObjectAttributes atts = new() { LayerIndex = layerIndex };
+    ObjectAttributes atts = new() { LayerIndex = layerIndex, Name = name };
     var objectId = originalObject.applicationId ?? originalObject.id;
 
     if (_materialBaker.ObjectIdAndMaterialIndexMap.TryGetValue(objectId, out int mIndex))
@@ -273,11 +273,6 @@ public class RhinoHostObjectBuilder : IHostObjectBuilder
       atts.ColorSource = color.Item2;
     }
 
-    if (name is not null)
-    {
-      atts.Name = name;
-    }
-
     return _converterSettings.Current.Document.Objects.Add(obj, atts);
   }
 
@@ -286,7 +281,7 @@ public class RhinoHostObjectBuilder : IHostObjectBuilder
     Base originatingObject,
     int layerIndex,
     string baseLayerName,
-    string? name = null
+    string name = ""
   )
   {
     List<Guid> objectIds = new();

--- a/Converters/Rhino/Speckle.Converters.RhinoShared/ToSpeckle/TopLevel/RhinoObjectToSpeckleTopLevelConverter.cs
+++ b/Converters/Rhino/Speckle.Converters.RhinoShared/ToSpeckle/TopLevel/RhinoObjectToSpeckleTopLevelConverter.cs
@@ -1,4 +1,4 @@
-﻿using Speckle.Converters.Common.Objects;
+using Speckle.Converters.Common.Objects;
 using Speckle.Sdk.Models;
 using RhinoObject = Rhino.DocObjects.RhinoObject;
 
@@ -28,6 +28,10 @@ public abstract class RhinoObjectToSpeckleTopLevelConverter<TTopLevelIn, TInRaw,
 
     // POC: Any common operations for all RhinoObjects should be done here, not on the specific implementer
     // Things like user-dictionaries and other user-defined metadata.
+    if (!string.IsNullOrEmpty(typedTarget.Attributes.Name))
+    {
+      result["name"] = typedTarget.Attributes.Name;
+    }
 
     return result;
   }


### PR DESCRIPTION
Looks for a `name` property on incoming atomic objects, and bakes rhino objects with a name if one exists.
Motivation: while the name is nice to preserve for multiplayer flows, this property helps a lot when receiving fallback geometry from other apps (esp civil and revit) that would help identify what the original object was.

Also adds `name` property to all rhino objects on send.