### PR TITLE
Dimitrie/cnx 634 some elements are received as generic models ignoring

### DIFF
--- a/Converters/Revit/Speckle.Converters.RevitShared/RevitRootToSpeckleConverter.cs
+++ b/Converters/Revit/Speckle.Converters.RevitShared/RevitRootToSpeckleConverter.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Logging;
 using Speckle.Converters.Common;
 using Speckle.Converters.Common.Objects;
 using Speckle.Converters.Common.Registration;
+using Speckle.Converters.RevitShared.Extensions;
 using Speckle.Converters.RevitShared.Settings;
 using Speckle.Converters.RevitShared.ToSpeckle;
 using Speckle.Sdk;
@@ -58,6 +59,7 @@ public class RevitRootToSpeckleConverter : IRootToSpeckleConverter
     if (target is not DB.DirectShape)
     {
       result["category"] = element.Category?.Name;
+      result["builtinCategory"] = element.Category?.GetBuiltInCategory().ToString();
     }
 
     try

--- a/Converters/Revit/Speckle.Converters.RevitShared/Speckle.Converters.RevitShared.projitems
+++ b/Converters/Revit/Speckle.Converters.RevitShared/Speckle.Converters.RevitShared.projitems
@@ -89,6 +89,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)ToSpeckle\TopLevel\FootPrintRoofToSpeckleTopLevelConverter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ToSpeckle\TopLevel\HostedElementConversionToSpeckle.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ToSpeckle\TopLevel\ModelCurveToSpeckleTopLevelConverter.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)ToSpeckle\TopLevel\RailingTopLevelConverterToSpeckle.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ToSpeckle\TopLevel\RoofBaseToSpeckleTopLevelTopLevelConverter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ToSpeckle\TopLevel\RoomTopLevelConverterToSpeckle.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ToSpeckle\TopLevel\TopographyTopLevelConverterToSpeckle.cs" />

--- a/Converters/Revit/Speckle.Converters.RevitShared/ToHost/Raw/LocalToGlobalToDirectShapeConverter.cs
+++ b/Converters/Revit/Speckle.Converters.RevitShared/ToHost/Raw/LocalToGlobalToDirectShapeConverter.cs
@@ -29,11 +29,11 @@ public class LocalToGlobalToDirectShapeConverter
   public DB.DirectShape Convert((Base atomicObject, List<Matrix4x4> matrix) target)
   {
     // 1- set ds category
-    var category = target.atomicObject["category"] as string;
+    var category = target.atomicObject["builtinCategory"] as string;
     var dsCategory = DB.BuiltInCategory.OST_GenericModel;
     if (category is not null)
     {
-      var res = Enum.TryParse($"OST_{category}", out DB.BuiltInCategory cat);
+      var res = Enum.TryParse(category, out DB.BuiltInCategory cat);
       if (res)
       {
         var c = DB.Category.GetCategory(_converterSettings.Current.Document, cat);

--- a/Converters/Revit/Speckle.Converters.RevitShared/ToSpeckle/TopLevel/RailingTopLevelConverterToSpeckle.cs
+++ b/Converters/Revit/Speckle.Converters.RevitShared/ToSpeckle/TopLevel/RailingTopLevelConverterToSpeckle.cs
@@ -1,18 +1,17 @@
 using Speckle.Converters.Common;
 using Speckle.Converters.RevitShared.Helpers;
 using Speckle.Converters.RevitShared.Settings;
-using Speckle.Objects.BuiltElements.Revit;
+using Speckle.Converters.RevitShared.ToSpeckle;
 
-namespace Speckle.Converters.RevitShared.ToSpeckle;
+namespace Speckle.Converters.Revit2023.ToSpeckle.TopLevel;
 
-// POC: used as placeholder for revit instances
-[NameAndRankValue(nameof(DB.Element), 0)]
-public class ElementTopLevelConverterToSpeckle : BaseTopLevelConverterToSpeckle<DB.Element, RevitElement>
+[NameAndRankValue(nameof(DBA.Railing), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
+public class RailingTopLevelConverterToSpeckle : BaseTopLevelConverterToSpeckle<DBA.Railing, SOBR.RevitElement>
 {
   private readonly DisplayValueExtractor _displayValueExtractor;
   private readonly IConverterSettingsStore<RevitConversionSettings> _converterSettings;
 
-  public ElementTopLevelConverterToSpeckle(
+  public RailingTopLevelConverterToSpeckle(
     DisplayValueExtractor displayValueExtractor,
     IConverterSettingsStore<RevitConversionSettings> converterSettings
   )
@@ -21,15 +20,20 @@ public class ElementTopLevelConverterToSpeckle : BaseTopLevelConverterToSpeckle<
     _converterSettings = converterSettings;
   }
 
-  public override RevitElement Convert(DB.Element target)
+  public override SOBR.RevitElement Convert(DBA.Railing target)
   {
     string family = target.Document.GetElement(target.GetTypeId()) is DB.FamilySymbol symbol
       ? symbol.FamilyName
       : "no family";
     string category = target.Category?.Name ?? "no category";
-    List<Objects.Geometry.Mesh> displayValue = _displayValueExtractor.GetDisplayValue(target);
+    var displayValue = _displayValueExtractor.GetDisplayValue(target);
 
-    RevitElement speckleElement =
+    var topRail = _converterSettings.Current.Document.GetElement(target.TopRail);
+    var topRailDisplayValue = _displayValueExtractor.GetDisplayValue(topRail);
+
+    displayValue.AddRange(topRailDisplayValue);
+
+    SOBR.RevitElement speckleElement =
       new()
       {
         type = target.Name,


### PR DESCRIPTION
Fixes [CNX-634: Some elements are received as Generic Models (ignoring categories assigned to them)](https://linear.app/speckle/issue/CNX-634/some-elements-are-received-as-generic-models-ignoring-categories)