### PR TITLE
Dimitrie/cnx 643 arcs in blocks are not received

### DIFF
--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Receive/RevitHostObjectBuilder.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Receive/RevitHostObjectBuilder.cs
@@ -180,7 +180,7 @@ internal sealed class RevitHostObjectBuilder : IHostObjectBuilder, IDisposable
       {
         using var activity = _activityFactory.Start("BakeObject");
 
-        // POC hack of the ages: try to pre transform curves before baking
+        // POC hack of the ages: try to pre transform curves, points and meshes before baking
         // we need to bypass the local to global converter as there we don't have access to what we want. that service will/should stop existing.
         if (
           localToGlobalMap.AtomicObject is ITransformable transformable // and ICurve

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Receive/RevitHostObjectBuilder.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Receive/RevitHostObjectBuilder.cs
@@ -183,7 +183,7 @@ internal sealed class RevitHostObjectBuilder : IHostObjectBuilder, IDisposable
         // POC hack of the ages: try to pre transform curves before baking
         // we need to bypass the local to global converter as there we don't have access to what we want. that service will/should stop existing.
         if (
-          localToGlobalMap.AtomicObject is ITransformable transformable and ICurve
+          localToGlobalMap.AtomicObject is ITransformable transformable // and ICurve
           && localToGlobalMap.Matrix.Count > 0
           && localToGlobalMap.AtomicObject["units"] is string units
         )


### PR DESCRIPTION
Fixes/improves some lingering issues around blocks to revit: 
- Improves [CNX-647: Rhino2Revit - Incorrect Block Transformation (or something else)](https://linear.app/speckle/issue/CNX-647/rhino2revit-incorrect-block-transformation-or-something-else)
- Fixes [CNX-641: Receiving points in blocks silently fails](https://linear.app/speckle/issue/CNX-641/receiving-points-in-blocks-silently-fails)


TLDR, some limitations still apply and most likely will be there for a while:
- arcs and circles from blocks will not be scalable
- breps in blocks will not be scalable

