### PR TITLE
Use of obsolete members now generates warning

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -255,8 +255,6 @@ dotnet_diagnostic.ca1509.severity = warning # Invalid entry in code metrics conf
 dotnet_diagnostic.ca1861.severity = none # Prefer 'static readonly' fields over constant array arguments if the called method is called repeatedly and is not mutating the passed array (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1861)
 
 dotnet_diagnostic.cs8618.severity = suggestion # nullable problem
-dotnet_diagnostic.CS0809.severity = suggestion # obsolete errors
-dotnet_diagnostic.CS0618.severity = suggestion # obsolete errors
 
 
 # Performance rules

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/ElementIdHelper.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/ElementIdHelper.cs
@@ -12,10 +12,17 @@ public static class ElementIdHelper
 
   public static ElementId? GetElementId(string elementId)
   {
+#if REVIT2024_OR_GREATER
+    if (long.TryParse(elementId, out long elementIdInt))
+    {
+      return new ElementId(elementIdInt);
+    }
+#else
     if (int.TryParse(elementId, out int elementIdInt))
     {
       return new ElementId(elementIdInt);
     }
+#endif
     else
     {
       return null;

--- a/Connectors/Rhino/Speckle.Connectors.Rhino8/Speckle.Connectors.Rhino8.csproj
+++ b/Connectors/Rhino/Speckle.Connectors.Rhino8/Speckle.Connectors.Rhino8.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>net48</TargetFramework>
     <Configurations>Debug;Release;Local</Configurations>
     <RhinoVersion>8</RhinoVersion>
-    <DefineConstants>$(DefineConstants);RHINO8;RHINO7_OR_GREATER;RHIN08_OR_GREATER</DefineConstants>
+    <DefineConstants>$(DefineConstants);RHINO8;RHINO7_OR_GREATER;RHINO8_OR_GREATER</DefineConstants>
     <TargetExt>.rhp</TargetExt>
     <StartProgram>$(ProgramFiles)\Rhino $(RhinoVersion)\System\Rhino.exe</StartProgram>
     <EnableWindowsTargeting>true</EnableWindowsTargeting>

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/HostApp/RhinoLayerBaker.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/HostApp/RhinoLayerBaker.cs
@@ -16,6 +16,13 @@ public class RhinoLayerBaker : TraversalContextUnpacker
   private readonly RhinoColorBaker _colorBaker;
   private readonly Dictionary<string, int> _hostLayerCache = new();
 
+  private static readonly string s_pathSeparator =
+#if RHINO8_OR_GREATER
+  ModelComponent.NamePathSeparator;
+#else
+  Layer.PathSeparator;
+#endif
+
   public RhinoLayerBaker(RhinoMaterialBaker materialBaker, RhinoColorBaker colorBaker)
   {
     _materialBaker = materialBaker;
@@ -68,7 +75,7 @@ public class RhinoLayerBaker : TraversalContextUnpacker
       .Select(o => string.IsNullOrWhiteSpace(o.name) ? "unnamed" : o.name)
       .Prepend(baseLayerName);
 
-    var layerFullName = string.Join(Layer.PathSeparator, layerPath);
+    var layerFullName = string.Join(s_pathSeparator, layerPath);
 
     if (_hostLayerCache.TryGetValue(layerFullName, out int existingLayerIndex))
     {
@@ -91,7 +98,7 @@ public class RhinoLayerBaker : TraversalContextUnpacker
     Layer? previousLayer = currentDocument.Layers.FindName(currentLayerName);
     foreach (Collection collection in collectionPath)
     {
-      currentLayerName += Layer.PathSeparator + collection.name;
+      currentLayerName += s_pathSeparator + collection.name;
       currentLayerName = currentLayerName.Replace("{", "").Replace("}", ""); // Rhino specific cleanup for gh (see RemoveInvalidRhinoChars)
       if (_hostLayerCache.TryGetValue(currentLayerName, out int value))
       {

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/HostApp/RhinoLayerUnpacker.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/HostApp/RhinoLayerUnpacker.cs
@@ -2,6 +2,10 @@ using Rhino;
 using Speckle.Sdk.Models.Collections;
 using Layer = Rhino.DocObjects.Layer;
 using SpeckleLayer = Speckle.Sdk.Models.Collections.Layer;
+#if RHINO8_OR_GREATER
+using Rhino.DocObjects;
+#endif
+
 
 namespace Speckle.Connectors.Rhino.HostApp;
 
@@ -11,6 +15,14 @@ namespace Speckle.Connectors.Rhino.HostApp;
 public class RhinoLayerUnpacker
 {
   private readonly Dictionary<int, Collection> _layerCollectionCache = new();
+
+  private static readonly string s_pathSeparator =
+#if RHINO8_OR_GREATER
+  ModelComponent.NamePathSeparator;
+#else
+  Layer.PathSeparator;
+#endif
+  private static readonly string[] s_pathSeparatorSplit = [s_pathSeparator];
 
   /// <summary>
   /// <para>Use this method to construct the root commit object while converting objects.</para>
@@ -26,7 +38,7 @@ public class RhinoLayerUnpacker
       return value;
     }
 
-    var names = layer.FullPath.Split(new[] { Layer.PathSeparator }, StringSplitOptions.None);
+    var names = layer.FullPath.Split(s_pathSeparatorSplit, StringSplitOptions.None);
     var path = names[0];
     var index = 0;
     var previousCollection = rootObjectCollection;
@@ -53,7 +65,7 @@ public class RhinoLayerUnpacker
 
       if (index < names.Length - 1)
       {
-        path += Layer.PathSeparator + names[index + 1];
+        path += s_pathSeparator + names[index + 1];
       }
 
       index++;

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/HostApp/RhinoLayerUnpacker.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/HostApp/RhinoLayerUnpacker.cs
@@ -6,7 +6,6 @@ using SpeckleLayer = Speckle.Sdk.Models.Collections.Layer;
 using Rhino.DocObjects;
 #endif
 
-
 namespace Speckle.Connectors.Rhino.HostApp;
 
 /// <summary>

--- a/Converters/Civil3d/Speckle.Converters.Civil3dShared/Helpers/CorridorHandler.cs
+++ b/Converters/Civil3d/Speckle.Converters.Civil3dShared/Helpers/CorridorHandler.cs
@@ -45,7 +45,12 @@ public sealed class CorridorHandler
     List<Base> baselines = new(corridor.Baselines.Count);
     foreach (CDB.Baseline baseline in corridor.Baselines)
     {
+#if CIVIL3D2025_OR_GREATER
+      string baselineGuid = baseline.BaselineGuid.ToString();
+#else
       string baselineGuid = baseline.baselineGUID.ToString();
+
+#endif
 
       Base convertedBaseline =
         new()

--- a/Converters/Civil3d/Speckle.Converters.Civil3dShared/ToSpeckle/Properties/ClassPropertiesExtractor.cs
+++ b/Converters/Civil3d/Speckle.Converters.Civil3dShared/ToSpeckle/Properties/ClassPropertiesExtractor.cs
@@ -174,7 +174,9 @@ public class ClassPropertiesExtractor
         ["innerHeight"] = pipe.InnerHeight,
         ["slope"] = pipe.Slope,
         ["shape"] = pipe.CrossSectionalShape.ToString(),
-        ["length2d"] = pipe.Length2D,
+#pragma warning disable CS0618 // Type or member is obsolete
+        ["length2d"] = pipe.Length2D, //Length2D was un-obsoleted in 2023, but is still marked obsolete in 2022
+#pragma warning restore CS0618 // Type or member is obsolete
         ["minimumCover"] = pipe.MinimumCover,
         ["maximumCover"] = pipe.MaximumCover,
         ["junctionLoss"] = pipe.JunctionLoss,

--- a/Converters/Revit/Speckle.Converters.RevitShared/Extensions/CategoryExtensions.cs
+++ b/Converters/Revit/Speckle.Converters.RevitShared/Extensions/CategoryExtensions.cs
@@ -26,7 +26,11 @@ public static class CategoryExtensions
 
   public static BuiltInCategory GetBuiltInCategory(this Category category)
   {
+#if REVIT2024_OR_GREATER
+    return (BuiltInCategory)category.Id.Value;
+#else
     return (BuiltInCategory)category.Id.IntegerValue;
+#endif
   }
 
   public static string GetBuiltInFromSchemaBuilderCategory(this SOBR.RevitCategory c)

--- a/Converters/Revit/Speckle.Converters.RevitShared/Helpers/RevitCategoryInfo.cs
+++ b/Converters/Revit/Speckle.Converters.RevitShared/Helpers/RevitCategoryInfo.cs
@@ -29,7 +29,11 @@ public class RevitCategoryInfo
 
   public bool ContainsRevitCategory(Category category)
   {
+#if REVIT2024_OR_GREATER
+    return BuiltInCategories.Select(x => (long)x).Contains(category.Id.Value);
+#else
     return BuiltInCategories.Select(x => (int)x).Contains(category.Id.IntegerValue);
+#endif
   }
 
   public List<ElementType> GetElementTypes(Document document)

--- a/Converters/Rhino/Speckle.Converters.Rhino8/Speckle.Converters.Rhino8.csproj
+++ b/Converters/Rhino/Speckle.Converters.Rhino8/Speckle.Converters.Rhino8.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <Configurations>Debug;Release;Local</Configurations>
-    <DefineConstants>$(DefineConstants);RHINO8;RHINO7_OR_GREATER;RHIN08_OR_GREATER</DefineConstants>
+    <DefineConstants>$(DefineConstants);RHINO8;RHINO7_OR_GREATER;RHINO8_OR_GREATER</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
I noticed that we had several obsolete warnings erroneously supressed

This caused a minor incident, where a function was made `Obsolete` in the SDK and we didn't realise we'd missed updating several connectors to use it.

---
This PR re-enables those warnings about using obsolete members
Additionally, I've resolved several violations against host app API members that were made obsolete.

I'm willing to accept us supressing some of these warnings (like in the case of civil, where a member was marked obsolete in 2022, but then was no longer obsolete in 2023).
Host app APIs don't tend to be quite as dev friendly as we'd always like. But for the cases here where there genuine reason to update to avoid obsolete API functions, lets keep on top of it!
