### PR TITLE
Fix(dui3): do not pass selectedobjectids from idmap

### DIFF
--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Bindings/BasicConnectorBindingRevit.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Bindings/BasicConnectorBindingRevit.cs
@@ -126,7 +126,7 @@ internal sealed class BasicConnectorBindingRevit : IBasicConnectorBinding
         return;
       }
 
-      var selectedObjects = senderModelCard.SendFilter.NotNull().IdMap.NotNull().Values;
+      var selectedObjects = senderModelCard.SendFilter.NotNull().SelectedObjectIds;
 
       elementIds = selectedObjects
         .Select(uid => ElementIdHelper.GetElementIdFromUniqueId(activeUIDoc.Document, uid))

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Bindings/RevitSendBinding.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Bindings/RevitSendBinding.cs
@@ -190,14 +190,16 @@ internal sealed class RevitSendBinding : RevitBaseBinding, ISendBinding
 
     if (modelCard.SendFilter is not null && modelCard.SendFilter.IdMap is not null)
     {
+      var newSelectedObjectIds = new List<string>();
       foreach (Element element in elements)
       {
         modelCard.SendFilter.IdMap[element.Id.ToString()] = element.UniqueId;
+        newSelectedObjectIds.Add(element.UniqueId);
       }
 
       // We update the state on the UI SenderModelCard to prevent potential inconsistencies between hostApp IdMap in sendfilters.
       await Commands
-        .SetFilterObjectIds(modelCard.ModelCardId.NotNull(), modelCard.SendFilter.IdMap)
+        .SetFilterObjectIds(modelCard.ModelCardId.NotNull(), modelCard.SendFilter.IdMap, newSelectedObjectIds)
         .ConfigureAwait(false);
     }
 

--- a/DUI3/Speckle.Connectors.DUI/Bindings/SendBindingUICommands.cs
+++ b/DUI3/Speckle.Connectors.DUI/Bindings/SendBindingUICommands.cs
@@ -18,8 +18,22 @@ public class SendBindingUICommands(IBrowserBridge bridge) : BasicConnectorBindin
   public async Task SetModelsExpired(IEnumerable<string> expiredModelIds) =>
     await Bridge.Send(SET_MODELS_EXPIRED_UI_COMMAND_NAME, expiredModelIds).ConfigureAwait(false);
 
-  public async Task SetFilterObjectIds(string modelCardId, Dictionary<string, string> idMap, List<string> newSelectedObjectIds) =>
-    await Bridge.Send(SET_ID_MAP_COMMAND_NAME, new { modelCardId, idMap, newSelectedObjectIds }).ConfigureAwait(false);
+  public async Task SetFilterObjectIds(
+    string modelCardId,
+    Dictionary<string, string> idMap,
+    List<string> newSelectedObjectIds
+  ) =>
+    await Bridge
+      .Send(
+        SET_ID_MAP_COMMAND_NAME,
+        new
+        {
+          modelCardId,
+          idMap,
+          newSelectedObjectIds
+        }
+      )
+      .ConfigureAwait(false);
 
   public async Task SetModelSendResult(
     string modelCardId,

--- a/DUI3/Speckle.Connectors.DUI/Bindings/SendBindingUICommands.cs
+++ b/DUI3/Speckle.Connectors.DUI/Bindings/SendBindingUICommands.cs
@@ -18,8 +18,8 @@ public class SendBindingUICommands(IBrowserBridge bridge) : BasicConnectorBindin
   public async Task SetModelsExpired(IEnumerable<string> expiredModelIds) =>
     await Bridge.Send(SET_MODELS_EXPIRED_UI_COMMAND_NAME, expiredModelIds).ConfigureAwait(false);
 
-  public async Task SetFilterObjectIds(string modelCardId, Dictionary<string, string> idMap) =>
-    await Bridge.Send(SET_ID_MAP_COMMAND_NAME, new { modelCardId, idMap }).ConfigureAwait(false);
+  public async Task SetFilterObjectIds(string modelCardId, Dictionary<string, string> idMap, List<string> newSelectedObjectIds) =>
+    await Bridge.Send(SET_ID_MAP_COMMAND_NAME, new { modelCardId, idMap, newSelectedObjectIds }).ConfigureAwait(false);
 
   public async Task SetModelSendResult(
     string modelCardId,


### PR DESCRIPTION
We were mutating the selectedObjectIds from IdMap. IdMap is a accumulated dictionary that we shouldn't set SelectedObjectIds from it.