### PR TITLE
Fix(tekla): Read write model cards to/from appdata + fixes double UI

### DIFF
--- a/Connectors/Tekla/Speckle.Connector.TeklaShared/Bindings/TeklaBasicConnectorBinding.cs
+++ b/Connectors/Tekla/Speckle.Connector.TeklaShared/Bindings/TeklaBasicConnectorBinding.cs
@@ -12,6 +12,7 @@ namespace Speckle.Connector.Tekla2024.Bindings;
 
 public class TeklaBasicConnectorBinding : IBasicConnectorBinding
 {
+  public BasicConnectorBindingCommands Commands { get; }
   private readonly ISpeckleApplication _speckleApplication;
   private readonly DocumentModelStore _store;
   public string Name => "baseBinding";
@@ -32,6 +33,12 @@ public class TeklaBasicConnectorBinding : IBasicConnectorBinding
     Parent = parent;
     _logger = logger;
     _model = model;
+    Commands = new BasicConnectorBindingCommands(parent);
+    _store.DocumentChanged += (_, _) =>
+      parent.TopLevelExceptionHandler.FireAndForget(async () =>
+      {
+        await Commands.NotifyDocumentChanged().ConfigureAwait(false);
+      });
   }
 
   public string GetSourceApplicationName() => _speckleApplication.Slug;
@@ -141,6 +148,4 @@ public class TeklaBasicConnectorBinding : IBasicConnectorBinding
       _logger.LogError(ex, "Failed to highlight objects");
     }
   }
-
-  public BasicConnectorBindingCommands Commands { get; }
 }

--- a/Connectors/Tekla/Speckle.Connector.TeklaShared/HostApp/TeklaDocumentModelStore.cs
+++ b/Connectors/Tekla/Speckle.Connector.TeklaShared/HostApp/TeklaDocumentModelStore.cs
@@ -1,17 +1,100 @@
-﻿using Speckle.Connectors.DUI.Models;
+﻿using System.IO;
+using Microsoft.Extensions.Logging;
+using Speckle.Connectors.DUI.Models;
 using Speckle.Newtonsoft.Json;
+using Speckle.Sdk;
+using Speckle.Sdk.Helpers;
+using Speckle.Sdk.Logging;
 
 namespace Speckle.Connector.Tekla2024.HostApp;
 
 public class TeklaDocumentModelStore : DocumentModelStore
 {
+  private readonly ISpeckleApplication _speckleApplication;
+  private readonly ILogger<TeklaDocumentModelStore> _logger;
+  private readonly TSM.Model _model;
+  private readonly TSM.Events _events;
+  private string HostAppUserDataPath { get; set; }
+  private string DocumentStateFile { get; set; }
+  private string ModelPathHash { get; set; }
+
   public TeklaDocumentModelStore(
-    JsonSerializerSettings jsonSerializerSettings
-  // ITopLevelExceptionHandler topLevelExceptionHandler
+    JsonSerializerSettings jsonSerializerSettings,
+    ISpeckleApplication speckleApplication,
+    ILogger<TeklaDocumentModelStore> logger
   )
-    : base(jsonSerializerSettings, true) { }
+    : base(jsonSerializerSettings, true)
+  {
+    _speckleApplication = speckleApplication;
+    _logger = logger;
+    _model = new TSM.Model();
+    SetPaths();
+    _events = new TSM.Events();
+    _events.ModelLoad += () =>
+    {
+      SetPaths();
+      ReadFromFile();
+      OnDocumentChanged();
+    };
+    _events.Register();
+    if (SpeckleTeklaPanelHost.IsInitialized)
+    {
+      ReadFromFile();
+      OnDocumentChanged();
+    }
+  }
 
-  public override void WriteToFile() { }
+  private void SetPaths()
+  {
+    ModelPathHash = Crypt.Md5(_model.GetInfo().ModelPath, length: 32);
+    HostAppUserDataPath = Path.Combine(
+      SpecklePathProvider.UserSpeckleFolderPath,
+      "Connectors",
+      _speckleApplication.Slug
+    );
+    DocumentStateFile = Path.Combine(HostAppUserDataPath, $"{ModelPathHash}.json");
+  }
 
-  public override void ReadFromFile() { }
+  public override void WriteToFile()
+  {
+    string serializedState = Serialize();
+    try
+    {
+      if (!Directory.Exists(HostAppUserDataPath))
+      {
+        Directory.CreateDirectory(HostAppUserDataPath);
+      }
+      File.WriteAllText(DocumentStateFile, serializedState);
+    }
+    catch (Exception ex) when (!ex.IsFatal())
+    {
+      _logger.LogError(ex.Message);
+    }
+  }
+
+  public override void ReadFromFile()
+  {
+    try
+    {
+      if (!Directory.Exists(HostAppUserDataPath))
+      {
+        Models = new();
+        return;
+      }
+
+      if (!File.Exists(DocumentStateFile))
+      {
+        Models = new();
+        return;
+      }
+
+      string serializedState = File.ReadAllText(DocumentStateFile);
+      Models = Deserialize(serializedState) ?? new();
+    }
+    catch (Exception ex) when (!ex.IsFatal())
+    {
+      Models = new();
+      _logger.LogError(ex.Message);
+    }
+  }
 }

--- a/Connectors/Tekla/Speckle.Connector.TeklaShared/SpeckleTeklaPanelHost.cs
+++ b/Connectors/Tekla/Speckle.Connector.TeklaShared/SpeckleTeklaPanelHost.cs
@@ -1,4 +1,6 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Drawing;
+using System.Runtime.InteropServices;
 using System.Windows.Forms;
 using System.Windows.Forms.Integration;
 using Microsoft.Extensions.DependencyInjection;
@@ -20,6 +22,13 @@ public class SpeckleTeklaPanelHost : PluginFormBase
   public static new ServiceProvider? Container { get; private set; }
   public static bool IsFirst { get; private set; } = true;
   public static bool IsInitialized { get; private set; }
+
+  //window owner call
+  [DllImport("user32.dll", SetLastError = true)]
+  [SuppressMessage("Security", "CA5392:Use DefaultDllImportSearchPaths attribute for P/Invokes")]
+  private static extern IntPtr SetWindowLongPtr(IntPtr hWnd, int nIndex, IntPtr value);
+
+  private const int GWL_HWNDPARENT = -8;
 
   public SpeckleTeklaPanelHost()
   {
@@ -92,6 +101,7 @@ public class SpeckleTeklaPanelHost : PluginFormBase
     Operation.DisplayPrompt("Speckle connector initialized.");
 
     this.TopLevel = true;
+    SetWindowLongPtr(Handle, GWL_HWNDPARENT, MainWindow.Frame.Handle);
     Show();
     Activate();
     Focus();

--- a/Connectors/Tekla/Speckle.Connector.TeklaShared/SpeckleTeklaPanelHost.cs
+++ b/Connectors/Tekla/Speckle.Connector.TeklaShared/SpeckleTeklaPanelHost.cs
@@ -20,7 +20,13 @@ public class SpeckleTeklaPanelHost : PluginFormBase
   private ElementHost Host { get; set; }
   public Model Model { get; private set; }
   public static new ServiceProvider? Container { get; private set; }
-  public static bool IsFirst { get; private set; } = true;
+
+  // NOTE: Somehow tekla triggers this class twice at the beginning and on first dialog our webview appears
+  // with small size of render in Host even if we set it as Dock.Fill. But on second trigger dialog initializes as expected.
+  // So, we do not init our plugin at first attempt, we just close it at first.
+  // On second, we init plugin and mark plugin as 'Initialized' to handle later init attempts nicely.
+  // We make 'IsInitialized' as 'false' only whenever our main dialog is closed explicitly by user.
+  private static bool IsFirst { get; set; } = true;
   public static bool IsInitialized { get; private set; }
 
   //window owner call


### PR DESCRIPTION
- Double UI
A bit dancing with WPF and triggering `Close` explicitly on unnecessary dialogs helped on not having weird UIs. We also have another `IsInitialized` state that we make it `false` again when the original UI is closed.

- Parenting the dialog 
Connect handle of Plugin dialog to Tekla window which they work together now and our dialog is visible on top of Tekla!

![rider64_OawfwyIzNV](https://github.com/user-attachments/assets/a9142121-ee33-4150-9603-6c637236f7ba)

- Document change
We do not necessarily need to close dialogs, just watching document changed event (`ModelLoad`) and trigger UI to refetch state after we read model state as explained below.

- Read/Write model cards
Seems like Tekla API is not friendly on saving things on file. I've introduced new way to handle it and it works as expected so far. @didimitrie was mentioning yesterday we might need similar logic for other connectors too.

![image](https://github.com/user-attachments/assets/065be180-4127-45d9-a8b7-9ae85e0a7888)
