### PR TITLE
Bjorn/cnx 798 rendermaterialproxy owerritten

### DIFF
--- a/Connectors/Tekla/Speckle.Connector.TeklaShared/Extensions/ModelObjectExtension.cs
+++ b/Connectors/Tekla/Speckle.Connector.TeklaShared/Extensions/ModelObjectExtension.cs
@@ -6,7 +6,8 @@ public static class ModelObjectExtensions
   {
     typeof(TSM.ControlPoint),
     typeof(TSM.Weld),
-    typeof(TSM.Fitting)
+    typeof(TSM.Fitting),
+    typeof(TSM.BooleanPart)
   };
 
   public static IEnumerable<TSM.ModelObject> GetSupportedChildren(this TSM.ModelObject modelObject)

--- a/Connectors/Tekla/Speckle.Connector.TeklaShared/HostApp/TeklaMaterialUnpacker.cs
+++ b/Connectors/Tekla/Speckle.Connector.TeklaShared/HostApp/TeklaMaterialUnpacker.cs
@@ -8,48 +8,67 @@ public class TeklaMaterialUnpacker
 {
   public List<RenderMaterialProxy> UnpackRenderMaterial(List<TSM.ModelObject> atomicObjects)
   {
-    Dictionary<string, RenderMaterialProxy> renderMaterialProxies = new();
-
-    var flattenedAtomicObjects = new List<TSM.ModelObject>();
+    int counter = 0;
+    var renderMaterialProxies = new Dictionary<string, RenderMaterialProxy>();
+    var processedObjects = new HashSet<string>();
 
     foreach (var atomicObject in atomicObjects)
     {
-      flattenedAtomicObjects.Add(atomicObject);
-      flattenedAtomicObjects.AddRange(atomicObject.GetSupportedChildren().ToList());
-    }
-
-    foreach (TSM.ModelObject flattenedAtomicObject in flattenedAtomicObjects)
-    {
-      var color = new TSMUI.Color();
-      TSMUI.ModelObjectVisualization.GetRepresentation(flattenedAtomicObject, ref color);
-      int r = (int)(color.Red * 255);
-      int g = (int)(color.Green * 255);
-      int b = (int)(color.Blue * 255);
-      int a = (int)(color.Transparency * 255);
-      int argb = (a << 24) | (r << 16) | (g << 8) | b;
-
-      Color systemColor = Color.FromArgb(argb);
-
-      var colorId = color.GetSpeckleApplicationId();
-      var objectId = flattenedAtomicObject.GetSpeckleApplicationId();
-      if (renderMaterialProxies.TryGetValue(colorId, out RenderMaterialProxy? value))
-      {
-        value.objects.Add(objectId);
-      }
-      else
-      {
-        var renderMaterial = new RenderMaterial() { name = colorId, diffuse = systemColor.ToArgb() };
-        RenderMaterialProxy proxyRenderMaterial =
-          new()
-          {
-            value = renderMaterial,
-            objects = [objectId],
-            applicationId = colorId
-          };
-        renderMaterialProxies[colorId] = proxyRenderMaterial;
-      }
+      ProcessModelObject(atomicObject, renderMaterialProxies, processedObjects, ref counter);
     }
 
     return renderMaterialProxies.Values.ToList();
+  }
+
+  // NOTE: Why this function? Previously, if multiple atomicObjects had the same color, the RenderMaterialProxy was overwritten
+  private void ProcessModelObject(
+    TSM.ModelObject modelObject,
+    Dictionary<string, RenderMaterialProxy> renderMaterialProxies,
+    HashSet<string> processedObjects,
+    ref int duplicateCounter
+  )
+  {
+    // Prevent processing the same object multiple times
+    var objectId = modelObject.GetSpeckleApplicationId();
+    Type teklaType = modelObject.GetType();
+    Console.WriteLine($"Processing model object: {teklaType}");
+    if (processedObjects.Contains(objectId))
+    {
+      duplicateCounter++;
+      return;
+    }
+
+    processedObjects.Add(objectId);
+
+    var color = new TSMUI.Color();
+    TSMUI.ModelObjectVisualization.GetRepresentation(modelObject, ref color);
+    int r = (int)(color.Red * 255);
+    int g = (int)(color.Green * 255);
+    int b = (int)(color.Blue * 255);
+    int a = (int)(color.Transparency * 255);
+    int argb = (a << 24) | (r << 16) | (g << 8) | b;
+
+    Color systemColor = Color.FromArgb(argb);
+    var colorId = color.GetSpeckleApplicationId();
+
+    // Ensure unique RenderMaterialProxy for each color
+    if (!renderMaterialProxies.TryGetValue(colorId, out RenderMaterialProxy? renderMaterialProxy))
+    {
+      renderMaterialProxy = new RenderMaterialProxy
+      {
+        value = new RenderMaterial { name = colorId, diffuse = systemColor.ToArgb() },
+        objects = new List<string>(),
+        applicationId = colorId
+      };
+      renderMaterialProxies[colorId] = renderMaterialProxy;
+    }
+
+    renderMaterialProxy.objects.Add(objectId);
+
+    // Recursively process children
+    foreach (var child in modelObject.GetSupportedChildren())
+    {
+      ProcessModelObject(child, renderMaterialProxies, processedObjects, ref duplicateCounter);
+    }
   }
 }


### PR DESCRIPTION
## Description & motivation

- Related to [CNX-798](https://linear.app/speckle/issue/CNX-798/rendermaterialproxy-owerritten)
- `TSM.BooleanPart` contained `objectId`s of elements part of boolean operations. These were unpacked as child objects, which created a circular reference of ids problem.
- This caused `renderMaterial` being overwritten in the viewer and sometimes affecting the load in e.g. Rhino

## Changes:

- Exclude `BooleanPart` as part of `s_excludedTypes`
- Supplement `UnpackRenderMaterial` with a `ProcessModelObject` function to keep track of processed objects (w.r.t. Ids)
- Add `_logger` to catch duplicates, should the problem be related to **not only** the `BooleanPart`

## To-do before merge:

- Check on another model apart from `Basic Steel Model`
- Send to Viewer, inspect for no overwriting of `renderMaterial` and receive in Rhino (check proper rendering colors in the viewer as well as display preview in Rhino Speckle Connector and Rhino model with rendered display mode)

## Validation of changes:

### Before

When `BooleanPart` was still being processed as part of an objects `GetSupportedChildren()`, a simple counter found many "duplicate" ids:

![counter before fix](https://github.com/user-attachments/assets/b450d09c-ce1a-402f-aac2-089cfc7bfb7e)

In the viewer, `renderMaterial` overwritten:

![renderMaterial before fix](https://github.com/user-attachments/assets/5528c304-6797-4c7e-9693-ba73a4ca6e7d)

### After

With `BooleanPart` excluded in the `GetSupportedChildren()`, the counter found no duplicated ids being referenced:

<img width="1280" alt="counter after fix" src="https://github.com/user-attachments/assets/587b6f8e-557f-4462-b583-b41b3656aa40">

In the viewer, no more overwriting of `renderMaterial`:

<img width="702" alt="renderMaterial after fix" src="https://github.com/user-attachments/assets/b99f00bd-ad70-47a5-98b7-b37cb9e82d7b">

Rhino import correct:

<img width="699" alt="rhino after fix" src="https://github.com/user-attachments/assets/7c63c9e0-8503-4ca7-af2b-15226f5c236e">

## Checklist:

- [x] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [x] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] My code follows a similar style to existing code.
- [ ] I have added appropriate tests.
- [x] I have updated or added relevant documentation.
