### PR TITLE
CNX-818: Greyscaled Objects in the Viewer

### DIFF
--- a/Converters/Tekla/Speckle.Converters.TeklaShared/ToSpeckle/TopLevel/ModelObjectToSpeckleConverter.cs
+++ b/Converters/Tekla/Speckle.Converters.TeklaShared/ToSpeckle/TopLevel/ModelObjectToSpeckleConverter.cs
@@ -91,6 +91,16 @@ public class ModelObjectToSpeckleConverter : IToSpeckleTopLevelConverter
     {
       var child = Convert(childObject);
       child.applicationId = childObject.GetSpeckleApplicationId();
+
+      // NOTE: Only assigning applicationIds to result and not children resulted in greyed components in the viewer
+      if (child["displayValue"] is List<Base> displayValues)
+      {
+        foreach (var displayValueObject in displayValues)
+        {
+          displayValueObject.applicationId = childObject.GetSpeckleApplicationId();
+        }
+      }
+
       children.Add(child);
     }
 


### PR DESCRIPTION
## Description & motivation

- We attached `applicationId` to `mesh` of `parent` but not `child`.
- Same fix applied in #385, but also for children


## Validation of changes:

### Before

<img width="640" alt="image" src="https://github.com/user-attachments/assets/e0449d0d-30e8-41fc-b709-2adc4dc11028">

### After

<img width="640" alt="image" src="https://github.com/user-attachments/assets/d6c79a6a-5f2e-4450-991d-e36053e8e30d">

<img width="640" alt="image" src="https://github.com/user-attachments/assets/1422a2bf-31ce-447c-805a-082bfdd6af59">


## Checklist:

- [x] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [x] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] My code follows a similar style to existing code.
- [ ] I have added appropriate tests.
- [x] I have updated or added relevant documentation.
