### PR TITLE
removing redundant loop

### DIFF
--- a/Connectors/ArcGIS/Speckle.Connectors.ArcGIS3/Bindings/ArcGISSelectionBinding.cs
+++ b/Connectors/ArcGIS/Speckle.Connectors.ArcGIS3/Bindings/ArcGISSelectionBinding.cs
@@ -53,11 +53,8 @@ public class ArcGISSelectionBinding : ISelectionBinding
     selectedMembers.AddRange(mapView.GetSelectedStandaloneTables());
 
     List<MapMember> allNestedMembers = new();
-    foreach (MapMember member in selectedMembers)
-    {
-      var layerMapMembers = _mapMemberUtils.UnpackMapLayers(selectedMembers);
-      allNestedMembers.AddRange(layerMapMembers);
-    }
+    var layerMapMembers = _mapMemberUtils.UnpackMapLayers(selectedMembers);
+    allNestedMembers.AddRange(layerMapMembers);
 
     List<string> objectTypes = allNestedMembers
       .Select(o => o.GetType().ToString().Split(".").Last())


### PR DESCRIPTION
The loop was designed to iterate through each selected layer, but the function has change to take the list of all layers together. So the loop is redundant and duplicating the results. 