### PR TITLE
Fix(revit): Clear token after every operation to prevent annoying message

### DIFF
--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Bindings/RevitReceiveBinding.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Bindings/RevitReceiveBinding.cs
@@ -102,5 +102,10 @@ internal sealed class RevitReceiveBinding : IReceiveBinding
       _logger.LogModelCardHandledError(ex);
       await Commands.SetModelError(modelCardId, ex).ConfigureAwait(false);
     }
+    finally
+    {
+      // otherwise the id of the operation persists on the cancellation manager and triggers 'Operations cancelled because of document swap!' message to UI.
+      _cancellationManager.CancelOperation(modelCardId);
+    }
   }
 }

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Bindings/RevitSendBinding.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Bindings/RevitSendBinding.cs
@@ -167,6 +167,11 @@ internal sealed class RevitSendBinding : RevitBaseBinding, ISendBinding
       _logger.LogModelCardHandledError(ex);
       await Commands.SetModelError(modelCardId, ex).ConfigureAwait(false);
     }
+    finally
+    {
+      // otherwise the id of the operation persists on the cancellation manager and triggers 'Operations cancelled because of document swap!' message to UI.
+      _cancellationManager.CancelOperation(modelCardId);
+    }
   }
 
   private async Task<List<Element>> RefreshElementsOnSender(SenderModelCard modelCard)


### PR DESCRIPTION
No more annoying error

![image](https://github.com/user-attachments/assets/4c5f3359-5591-4c70-ae3f-0056f9a1bef5)

https://github.com/user-attachments/assets/c68c61bc-9a3c-4de7-a185-2875b4757701

