### PR TITLE
top level exception handler give a better exception when toasts fail

### DIFF
--- a/DUI3/Speckle.Connectors.DUI/Bridge/TopLevelExceptionHandler.cs
+++ b/DUI3/Speckle.Connectors.DUI/Bridge/TopLevelExceptionHandler.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.Logging;
 using Speckle.Connectors.DUI.Bindings;
 using Speckle.InterfaceGenerator;
@@ -69,6 +70,11 @@ public sealed class TopLevelExceptionHandler : ITopLevelExceptionHandler
   }
 
   ///<inheritdoc cref="CatchUnhandled{T}(Func{T})"/>
+  [SuppressMessage(
+    "Design",
+    "CA1031:Do not catch general exception types",
+    Justification = "Top level exception handler"
+  )]
   public async Task<Result<T>> CatchUnhandledAsync<T>(Func<Task<T>> function)
   {
     try
@@ -79,14 +85,7 @@ public sealed class TopLevelExceptionHandler : ITopLevelExceptionHandler
       }
       catch (Exception ex) when (!ex.IsFatal())
       {
-        _logger.LogError(ex, UNHANDLED_LOGGER_TEMPLATE);
-        await SetGlobalNotification(
-            ToastNotificationType.DANGER,
-            "Unhandled Exception Occured",
-            ex.ToFormattedString(),
-            false
-          )
-          .ConfigureAwait(false);
+        await HandleException(ex).ConfigureAwait(false);
         return new(ex);
       }
     }
@@ -94,6 +93,33 @@ public sealed class TopLevelExceptionHandler : ITopLevelExceptionHandler
     {
       _logger.LogCritical(ex, UNHANDLED_LOGGER_TEMPLATE);
       throw;
+    }
+  }
+
+  private async Task HandleException(Exception ex)
+  {
+    _logger.LogError(ex, UNHANDLED_LOGGER_TEMPLATE);
+
+    try
+    {
+      await SetGlobalNotification(
+          ToastNotificationType.DANGER,
+          "Unhandled Exception Occured",
+          ex.ToFormattedString(),
+          false
+        )
+        .ConfigureAwait(false);
+    }
+    catch (Exception toastEx)
+    {
+      // Not only was a top level exception caught, but our attempt to display a toast failed!
+      // Toasts can fail if the BrowserBridge is not yet associated with a binding
+      // For this reason, binding authors should avoid doing anything in
+      // the constructors of bindings that may try and use the bridge!
+      AggregateException aggregateException =
+        new("An Unhandled top level exception was caught, and the toast failed to display it!", [toastEx, ex]);
+
+      throw aggregateException;
     }
   }
 

--- a/DUI3/Speckle.Connectors.DUI/Bridge/TopLevelExceptionHandler.cs
+++ b/DUI3/Speckle.Connectors.DUI/Bridge/TopLevelExceptionHandler.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.Logging;
 using Speckle.Connectors.DUI.Bindings;
 using Speckle.InterfaceGenerator;
@@ -70,11 +69,6 @@ public sealed class TopLevelExceptionHandler : ITopLevelExceptionHandler
   }
 
   ///<inheritdoc cref="CatchUnhandled{T}(Func{T})"/>
-  [SuppressMessage(
-    "Design",
-    "CA1031:Do not catch general exception types",
-    Justification = "Top level exception handler"
-  )]
   public async Task<Result<T>> CatchUnhandledAsync<T>(Func<Task<T>> function)
   {
     try


### PR DESCRIPTION
When Top level exception toasts fail to display, the exception message is lost

Here, I've adjusted the top level exception handler behaviour to handle toast faliures with an aggregate exception, and provide a better exception message when this occurs.