### PR TITLE
Fix for Autocad receive speed

### DIFF
--- a/Connectors/Autocad/Speckle.Connectors.AutocadShared/HostApp/AutocadColorBaker.cs
+++ b/Connectors/Autocad/Speckle.Connectors.AutocadShared/HostApp/AutocadColorBaker.cs
@@ -29,10 +29,7 @@ public class AutocadColorBaker
   /// </summary>
   /// <param name="colorProxies"></param>
   /// <param name="onOperationProgressed"></param>
-  public async Task ParseColors(
-    IReadOnlyCollection<ColorProxy> colorProxies,
-    IProgress<CardProgress> onOperationProgressed
-  )
+  public void ParseColors(IReadOnlyCollection<ColorProxy> colorProxies, IProgress<CardProgress> onOperationProgressed)
   {
     var count = 0;
     foreach (ColorProxy colorProxy in colorProxies)
@@ -64,8 +61,6 @@ public class AutocadColorBaker
       {
         _logger.LogError(ex, "Failed parsing color proxy");
       }
-
-      await Task.Yield();
     }
   }
 

--- a/Connectors/Autocad/Speckle.Connectors.AutocadShared/HostApp/AutocadInstanceBaker.cs
+++ b/Connectors/Autocad/Speckle.Connectors.AutocadShared/HostApp/AutocadInstanceBaker.cs
@@ -49,7 +49,7 @@ public class AutocadInstanceBaker : IInstanceBaker<List<Entity>>
   }
 
   [SuppressMessage("Maintainability", "CA1506:Avoid excessive class coupling")]
-  public async Task<BakeResult> BakeInstances(
+  public BakeResult BakeInstances(
     IReadOnlyCollection<(Collection[] collectionPath, IInstanceComponent obj)> instanceComponents,
     Dictionary<string, List<Entity>> applicationIdMap,
     string baseLayerName,
@@ -167,7 +167,6 @@ public class AutocadInstanceBaker : IInstanceBaker<List<Entity>>
     }
 
     transaction.Commit();
-    await Task.Yield();
     return new(createdObjectIds, consumedObjectIds, conversionResults);
   }
 

--- a/Connectors/Autocad/Speckle.Connectors.AutocadShared/HostApp/AutocadMaterialBaker.cs
+++ b/Connectors/Autocad/Speckle.Connectors.AutocadShared/HostApp/AutocadMaterialBaker.cs
@@ -91,7 +91,7 @@ public class AutocadMaterialBaker
     transaction.Commit();
   }
 
-  public async Task ParseAndBakeRenderMaterials(
+  public void ParseAndBakeRenderMaterials(
     List<RenderMaterialProxy> materialProxies,
     string baseLayerPrefix,
     IProgress<CardProgress> onOperationProgressed
@@ -140,7 +140,6 @@ public class AutocadMaterialBaker
     }
 
     transaction.Commit();
-    await Task.Yield();
   }
 
   private (ObjectId, ReceiveConversionResult) BakeMaterial(

--- a/Connectors/Autocad/Speckle.Connectors.AutocadShared/Operations/Receive/AutocadHostObjectBuilder.cs
+++ b/Connectors/Autocad/Speckle.Connectors.AutocadShared/Operations/Receive/AutocadHostObjectBuilder.cs
@@ -127,10 +127,13 @@ public class AutocadHostObjectBuilder : IHostObjectBuilder
     {
       string objectId = atomicObject.applicationId ?? atomicObject.id;
       onOperationProgressed.Report(new("Converting objects", (double)++count / atomicObjects.Count));
+      if (count % 50 == 0)
+      {
+        await Task.Delay(10).ConfigureAwait(true);
+      }
       try
       {
-        List<Entity> convertedObjects = await ConvertObject(atomicObject, layerPath, baseLayerPrefix)
-          .ConfigureAwait(true);
+        List<Entity> convertedObjects = ConvertObject(atomicObject, layerPath, baseLayerPrefix);
 
         applicationIdMap[objectId] = convertedObjects;
 
@@ -181,7 +184,7 @@ public class AutocadHostObjectBuilder : IHostObjectBuilder
     _materialBaker.PurgeMaterials(baseLayerPrefix);
   }
 
-  private async Task<List<Entity>> ConvertObject(Base obj, Collection[] layerPath, string baseLayerNamePrefix)
+  private List<Entity> ConvertObject(Base obj, Collection[] layerPath, string baseLayerNamePrefix)
   {
     string layerName = _layerBaker.CreateLayerForReceive(layerPath, baseLayerNamePrefix);
     var convertedEntities = new List<Entity>();
@@ -204,7 +207,6 @@ public class AutocadHostObjectBuilder : IHostObjectBuilder
     }
 
     tr.Commit();
-    await Task.Delay(10).ConfigureAwait(true);
     return convertedEntities;
   }
 

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/HostApp/RhinoInstanceBaker.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/HostApp/RhinoInstanceBaker.cs
@@ -42,7 +42,7 @@ public class RhinoInstanceBaker : IInstanceBaker<List<string>>
   /// <param name="instanceComponents">Instance definitions and instances that need creating.</param>
   /// <param name="applicationIdMap">A dict mapping { original application id -> [resulting application ids post conversion] }</param>
   /// <param name="onOperationProgressed"></param>
-  public async Task<BakeResult> BakeInstances(
+  public BakeResult BakeInstances(
     IReadOnlyCollection<(Collection[] collectionPath, IInstanceComponent obj)> instanceComponents,
     Dictionary<string, List<string>> applicationIdMap,
     string baseLayerName,
@@ -153,7 +153,6 @@ public class RhinoInstanceBaker : IInstanceBaker<List<string>>
       }
     }
 
-    await Task.Yield();
     return new(createdObjectIds, consumedObjectIds, conversionResults);
   }
 

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/Operations/Receive/RhinoHostObjectBuilder.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/Operations/Receive/RhinoHostObjectBuilder.cs
@@ -55,7 +55,7 @@ public class RhinoHostObjectBuilder : IHostObjectBuilder
   }
 
 #pragma warning disable CA1506
-  public async Task<HostObjectBuilderResult> Build(
+  public Task<HostObjectBuilderResult> Build(
 #pragma warning restore CA1506
     Base rootObject,
     string projectName,
@@ -207,9 +207,12 @@ public class RhinoHostObjectBuilder : IHostObjectBuilder
     // 6 - Convert instances
     using (var _ = _activityFactory.Start("Converting instances"))
     {
-      var (createdInstanceIds, consumedObjectIds, instanceConversionResults) = await _instanceBaker
-        .BakeInstances(instanceComponentsWithPath, applicationIdMap, baseLayerName, onOperationProgressed)
-        .ConfigureAwait(false);
+      var (createdInstanceIds, consumedObjectIds, instanceConversionResults) = _instanceBaker.BakeInstances(
+        instanceComponentsWithPath,
+        applicationIdMap,
+        baseLayerName,
+        onOperationProgressed
+      );
 
       bakedObjectIds.RemoveAll(id => consumedObjectIds.Contains(id)); // remove all objects that have been "consumed"
       bakedObjectIds.AddRange(createdInstanceIds); // add instance ids
@@ -224,7 +227,7 @@ public class RhinoHostObjectBuilder : IHostObjectBuilder
     }
 
     _converterSettings.Current.Document.Views.Redraw();
-    return new HostObjectBuilderResult(bakedObjectIds, conversionResults);
+    return Task.FromResult(new HostObjectBuilderResult(bakedObjectIds, conversionResults));
   }
 
   private void PreReceiveDeepClean(string baseLayerName)

--- a/DUI3/Speckle.Connectors.DUI.WebView/DUI3ControlWebView.xaml.cs
+++ b/DUI3/Speckle.Connectors.DUI.WebView/DUI3ControlWebView.xaml.cs
@@ -26,7 +26,7 @@ public sealed partial class DUI3ControlWebView : UserControl, IBrowserScriptExec
 
   public object BrowserElement => Browser;
 
-  public  Task ExecuteScriptAsyncMethod(string script, CancellationToken cancellationToken)
+  public Task ExecuteScriptAsyncMethod(string script, CancellationToken cancellationToken)
   {
     if (!Browser.IsInitialized)
     {
@@ -34,20 +34,20 @@ public sealed partial class DUI3ControlWebView : UserControl, IBrowserScriptExec
     }
 
     bool isAlreadyMainThread = Browser.Dispatcher.CheckAccess();
-   if (isAlreadyMainThread)
-   {
-     //fire and forget
-     Browser.ExecuteScriptAsync(script);
-   }
-   else
-   {
-     Browser.Dispatcher.Invoke(
-       //fire and forget
-       () => Browser.ExecuteScriptAsync(script),
-       DispatcherPriority.Background
-     );
-   }
-   return Task.CompletedTask;
+    if (isAlreadyMainThread)
+    {
+      //fire and forget
+      Browser.ExecuteScriptAsync(script);
+    }
+    else
+    {
+      Browser.Dispatcher.Invoke(
+        //fire and forget
+        () => Browser.ExecuteScriptAsync(script),
+        DispatcherPriority.Background
+      );
+    }
+    return Task.CompletedTask;
   }
 
   private void OnInitialized(object? sender, CoreWebView2InitializationCompletedEventArgs e)

--- a/DUI3/Speckle.Connectors.DUI.WebView/DUI3ControlWebView.xaml.cs
+++ b/DUI3/Speckle.Connectors.DUI.WebView/DUI3ControlWebView.xaml.cs
@@ -26,57 +26,28 @@ public sealed partial class DUI3ControlWebView : UserControl, IBrowserScriptExec
 
   public object BrowserElement => Browser;
 
-  // {
-  //   if (!Browser.IsInitialized)
-  //   {
-  //     throw new InvalidOperationException("Failed to execute script, Webview2 is not initialized yet.");
-  //   }
-  //
-  //   var t = Browser.Dispatcher.Invoke(
-  //     async () =>
-  //     {
-  //       var res = await Browser.ExecuteScriptAsync(script).ConfigureAwait(true);
-  //       await Task.Delay(100).ConfigureAwait(true);
-  //       return res;
-  //     },
-  //     DispatcherPriority.Background
-  //   );
-  //
-  //   _ = t.IsCompleted;
-
-  // bool isAlreadyMainThread = Browser.Dispatcher.CheckAccess();
-  // if (isAlreadyMainThread)
-  // {
-  //   Browser.ExecuteScriptAsync(script);
-  // }
-  // else
-  // {
-  //   Browser.Dispatcher.Invoke(
-  //     () =>
-  //     {
-  //       return Browser.ExecuteScriptAsync(script);
-  //     },
-  //     DispatcherPriority.Background
-  //   );
-  // }
-  // }
-
-  public async Task ExecuteScriptAsyncMethod(string script, CancellationToken cancellationToken)
+  public  Task ExecuteScriptAsyncMethod(string script, CancellationToken cancellationToken)
   {
     if (!Browser.IsInitialized)
     {
       throw new InvalidOperationException("Failed to execute script, Webview2 is not initialized yet.");
     }
 
-    var callbackTask = await Browser
-      .Dispatcher.InvokeAsync(
-        async () => await Browser.ExecuteScriptAsync(script).ConfigureAwait(false),
-        DispatcherPriority.Background,
-        cancellationToken
-      )
-      .Task.ConfigureAwait(false);
-
-    _ = await callbackTask.ConfigureAwait(false);
+    bool isAlreadyMainThread = Browser.Dispatcher.CheckAccess();
+   if (isAlreadyMainThread)
+   {
+     //fire and forget
+     Browser.ExecuteScriptAsync(script);
+   }
+   else
+   {
+     Browser.Dispatcher.Invoke(
+       //fire and forget
+       () => Browser.ExecuteScriptAsync(script),
+       DispatcherPriority.Background
+     );
+   }
+   return Task.CompletedTask;
   }
 
   private void OnInitialized(object? sender, CoreWebView2InitializationCompletedEventArgs e)

--- a/DUI3/Speckle.Connectors.DUI.WebView/DUI3ControlWebView.xaml.cs
+++ b/DUI3/Speckle.Connectors.DUI.WebView/DUI3ControlWebView.xaml.cs
@@ -33,20 +33,12 @@ public sealed partial class DUI3ControlWebView : UserControl, IBrowserScriptExec
       throw new InvalidOperationException("Failed to execute script, Webview2 is not initialized yet.");
     }
 
-    bool isAlreadyMainThread = Browser.Dispatcher.CheckAccess();
-    if (isAlreadyMainThread)
-    {
+    //always invoke even on the main thread because it's better somehow
+    Browser.Dispatcher.Invoke(
       //fire and forget
-      Browser.ExecuteScriptAsync(script);
-    }
-    else
-    {
-      Browser.Dispatcher.Invoke(
-        //fire and forget
-        () => Browser.ExecuteScriptAsync(script),
-        DispatcherPriority.Background
-      );
-    }
+      () => Browser.ExecuteScriptAsync(script),
+      DispatcherPriority.Background
+    );
     return Task.CompletedTask;
   }
 

--- a/Sdk/Speckle.Connectors.Common/Instances/IInstanceBaker.cs
+++ b/Sdk/Speckle.Connectors.Common/Instances/IInstanceBaker.cs
@@ -14,7 +14,7 @@ public interface IInstanceBaker<TAppIdMapValueType>
   /// <param name="baseLayerName"></param>
   /// <param name="onOperationProgressed"></param>
   /// <returns></returns>
-  Task<BakeResult> BakeInstances(
+  BakeResult BakeInstances(
     IReadOnlyCollection<(Collection[] collectionPath, IInstanceComponent obj)> instanceComponents,
     Dictionary<string, TAppIdMapValueType> applicationIdMap,
     string baseLayerName,


### PR DESCRIPTION
There's no way around having to yield to the UI thread to get a status update.  However, we can reduce the number of times we do so.  This is a quick way to have some updates (factor of 50 reduction) but we could do something more inteligent.

Event binding should be reviewing.  This reduces the allocations of the exception handler tasks.  Needs further work though.

https://linear.app/speckle/issue/CNX-854/autocad-receive-performance-totally-tanked