### PR TITLE
fix(rhino): more lenient creation for failed/partial instances

### DIFF
--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/HostApp/RhinoInstanceBaker.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/HostApp/RhinoInstanceBaker.cs
@@ -81,6 +81,12 @@ public class RhinoInstanceBaker : IInstanceBaker<List<string>>
           foreach (var id in currentApplicationObjectsIds)
           {
             var docObject = doc.Objects.FindId(new Guid(id));
+            // NOTE: we're here being lenient on incomplete block creation. If a block contains unsupported elements that somehow threw/didn't manage to get baked as atomic objects,
+            // we just continue rather than throw on a null when accessing the docObject's Geometry.
+            if (docObject is null)
+            {
+              continue;
+            }
             definitionGeometryList.Add(docObject.Geometry);
             attributes.Add(docObject.Attributes);
           }


### PR DESCRIPTION
Treats the issue described in the linear ticket, but the root cause of the problem is most likely somewhere on the creation side of things (sketchup) OR in rhino's mesh to host converter. 

This is a welcome addition (viewer behaves the same way), where we don't fail instance creation if one object from its definition is missing. 