### PR TITLE
Fix sending caching

### DIFF
--- a/Connectors/ArcGIS/Speckle.Connectors.ArcGIS3/packages.lock.json
+++ b/Connectors/ArcGIS/Speckle.Connectors.ArcGIS3/packages.lock.json
@@ -231,9 +231,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.212, )",
-          "Speckle.Sdk": "[3.1.0-dev.212, )",
-          "Speckle.Sdk.Dependencies": "[3.1.0-dev.212, )"
+          "Speckle.Objects": "[3.1.0-dev.215, )",
+          "Speckle.Sdk": "[3.1.0-dev.215, )",
+          "Speckle.Sdk.Dependencies": "[3.1.0-dev.215, )"
         }
       },
       "speckle.connectors.dui": {
@@ -241,8 +241,8 @@
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
           "Speckle.Connectors.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[3.1.0-dev.212, )",
-          "Speckle.Sdk.Dependencies": "[3.1.0-dev.212, )",
+          "Speckle.Sdk": "[3.1.0-dev.215, )",
+          "Speckle.Sdk.Dependencies": "[3.1.0-dev.215, )",
           "System.Threading.Tasks.Dataflow": "[6.0.0, )"
         }
       },
@@ -267,7 +267,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.1.0-dev.212, )"
+          "Speckle.Objects": "[3.1.0-dev.215, )"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -299,18 +299,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "n0NUmrZKDSgMDnKrlTpJk8sH7Kse/8O6M1qkBmw02ux6LhOIpQhdlHo3SY/xS0yV6HQnaFuzI75o1zByTnxGng==",
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "NNiTR3dp1/4WNIv2WRHm87pr4WQztt9vVRALqULEUTcYrvb34xwnKwPwt3Ah5iXW1g3qkecXto5V7Ex+IIzeRQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.1.0-dev.212"
+          "Speckle.Sdk": "3.1.0-dev.215"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "hyBvk2Vq0MPVBM3r48TVJc4ERwcZpuCstIpfebrekLLbCH+wk/vfCD9VMKWqALYjTuYg7hFwrKGw6Z/G23n5jw==",
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "YMb7xdELiza88RSCUWcqmKJlrnoqjxlc1+Z1gEQSCfvFV0Ibvfjz08YAMkOWFc/ZaY9nBUZvshHEWYIskEk5cg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -320,14 +320,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.0.1",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.1.0-dev.212"
+          "Speckle.Sdk.Dependencies": "3.1.0-dev.215"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "b6nJAUSYixTWwZMjff1uPkrKXKp8ehoO6Nfw/eQxLpXdwaF4xdk1/sOXwFeGWaWId9E41Jf2jq4YHcxPEnDjYA=="
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "cT5HRu+pRBvfKTRJIvQBgdX2X5eeTebHe7zmNz82tFT0p65RsK9K7Ap9RjvMndbEPqFtt8/sCNa5RHyfrf+IUg=="
       },
       "System.Threading.Tasks.Dataflow": {
         "type": "CentralTransitive",

--- a/Connectors/Autocad/Speckle.Connectors.Autocad2022/packages.lock.json
+++ b/Connectors/Autocad/Speckle.Connectors.Autocad2022/packages.lock.json
@@ -264,9 +264,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.212, )",
-          "Speckle.Sdk": "[3.1.0-dev.212, )",
-          "Speckle.Sdk.Dependencies": "[3.1.0-dev.212, )"
+          "Speckle.Objects": "[3.1.0-dev.215, )",
+          "Speckle.Sdk": "[3.1.0-dev.215, )",
+          "Speckle.Sdk.Dependencies": "[3.1.0-dev.215, )"
         }
       },
       "speckle.connectors.dui": {
@@ -274,8 +274,8 @@
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
           "Speckle.Connectors.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[3.1.0-dev.212, )",
-          "Speckle.Sdk.Dependencies": "[3.1.0-dev.212, )",
+          "Speckle.Sdk": "[3.1.0-dev.215, )",
+          "Speckle.Sdk.Dependencies": "[3.1.0-dev.215, )",
           "System.Threading.Tasks.Dataflow": "[6.0.0, )"
         }
       },
@@ -300,7 +300,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.1.0-dev.212, )"
+          "Speckle.Objects": "[3.1.0-dev.215, )"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -338,18 +338,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "n0NUmrZKDSgMDnKrlTpJk8sH7Kse/8O6M1qkBmw02ux6LhOIpQhdlHo3SY/xS0yV6HQnaFuzI75o1zByTnxGng==",
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "NNiTR3dp1/4WNIv2WRHm87pr4WQztt9vVRALqULEUTcYrvb34xwnKwPwt3Ah5iXW1g3qkecXto5V7Ex+IIzeRQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.1.0-dev.212"
+          "Speckle.Sdk": "3.1.0-dev.215"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "hyBvk2Vq0MPVBM3r48TVJc4ERwcZpuCstIpfebrekLLbCH+wk/vfCD9VMKWqALYjTuYg7hFwrKGw6Z/G23n5jw==",
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "YMb7xdELiza88RSCUWcqmKJlrnoqjxlc1+Z1gEQSCfvFV0Ibvfjz08YAMkOWFc/ZaY9nBUZvshHEWYIskEk5cg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -359,14 +359,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.0.1",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.1.0-dev.212"
+          "Speckle.Sdk.Dependencies": "3.1.0-dev.215"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "b6nJAUSYixTWwZMjff1uPkrKXKp8ehoO6Nfw/eQxLpXdwaF4xdk1/sOXwFeGWaWId9E41Jf2jq4YHcxPEnDjYA=="
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "cT5HRu+pRBvfKTRJIvQBgdX2X5eeTebHe7zmNz82tFT0p65RsK9K7Ap9RjvMndbEPqFtt8/sCNa5RHyfrf+IUg=="
       },
       "System.Threading.Tasks.Dataflow": {
         "type": "CentralTransitive",

--- a/Connectors/Autocad/Speckle.Connectors.Autocad2023/packages.lock.json
+++ b/Connectors/Autocad/Speckle.Connectors.Autocad2023/packages.lock.json
@@ -264,9 +264,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.212, )",
-          "Speckle.Sdk": "[3.1.0-dev.212, )",
-          "Speckle.Sdk.Dependencies": "[3.1.0-dev.212, )"
+          "Speckle.Objects": "[3.1.0-dev.215, )",
+          "Speckle.Sdk": "[3.1.0-dev.215, )",
+          "Speckle.Sdk.Dependencies": "[3.1.0-dev.215, )"
         }
       },
       "speckle.connectors.dui": {
@@ -274,8 +274,8 @@
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
           "Speckle.Connectors.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[3.1.0-dev.212, )",
-          "Speckle.Sdk.Dependencies": "[3.1.0-dev.212, )",
+          "Speckle.Sdk": "[3.1.0-dev.215, )",
+          "Speckle.Sdk.Dependencies": "[3.1.0-dev.215, )",
           "System.Threading.Tasks.Dataflow": "[6.0.0, )"
         }
       },
@@ -300,7 +300,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.1.0-dev.212, )"
+          "Speckle.Objects": "[3.1.0-dev.215, )"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -338,18 +338,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "n0NUmrZKDSgMDnKrlTpJk8sH7Kse/8O6M1qkBmw02ux6LhOIpQhdlHo3SY/xS0yV6HQnaFuzI75o1zByTnxGng==",
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "NNiTR3dp1/4WNIv2WRHm87pr4WQztt9vVRALqULEUTcYrvb34xwnKwPwt3Ah5iXW1g3qkecXto5V7Ex+IIzeRQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.1.0-dev.212"
+          "Speckle.Sdk": "3.1.0-dev.215"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "hyBvk2Vq0MPVBM3r48TVJc4ERwcZpuCstIpfebrekLLbCH+wk/vfCD9VMKWqALYjTuYg7hFwrKGw6Z/G23n5jw==",
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "YMb7xdELiza88RSCUWcqmKJlrnoqjxlc1+Z1gEQSCfvFV0Ibvfjz08YAMkOWFc/ZaY9nBUZvshHEWYIskEk5cg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -359,14 +359,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.0.1",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.1.0-dev.212"
+          "Speckle.Sdk.Dependencies": "3.1.0-dev.215"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "b6nJAUSYixTWwZMjff1uPkrKXKp8ehoO6Nfw/eQxLpXdwaF4xdk1/sOXwFeGWaWId9E41Jf2jq4YHcxPEnDjYA=="
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "cT5HRu+pRBvfKTRJIvQBgdX2X5eeTebHe7zmNz82tFT0p65RsK9K7Ap9RjvMndbEPqFtt8/sCNa5RHyfrf+IUg=="
       },
       "System.Threading.Tasks.Dataflow": {
         "type": "CentralTransitive",

--- a/Connectors/Autocad/Speckle.Connectors.Autocad2024/packages.lock.json
+++ b/Connectors/Autocad/Speckle.Connectors.Autocad2024/packages.lock.json
@@ -264,9 +264,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.212, )",
-          "Speckle.Sdk": "[3.1.0-dev.212, )",
-          "Speckle.Sdk.Dependencies": "[3.1.0-dev.212, )"
+          "Speckle.Objects": "[3.1.0-dev.215, )",
+          "Speckle.Sdk": "[3.1.0-dev.215, )",
+          "Speckle.Sdk.Dependencies": "[3.1.0-dev.215, )"
         }
       },
       "speckle.connectors.dui": {
@@ -274,8 +274,8 @@
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
           "Speckle.Connectors.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[3.1.0-dev.212, )",
-          "Speckle.Sdk.Dependencies": "[3.1.0-dev.212, )",
+          "Speckle.Sdk": "[3.1.0-dev.215, )",
+          "Speckle.Sdk.Dependencies": "[3.1.0-dev.215, )",
           "System.Threading.Tasks.Dataflow": "[6.0.0, )"
         }
       },
@@ -301,7 +301,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.1.0-dev.212, )"
+          "Speckle.Objects": "[3.1.0-dev.215, )"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -339,18 +339,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "n0NUmrZKDSgMDnKrlTpJk8sH7Kse/8O6M1qkBmw02ux6LhOIpQhdlHo3SY/xS0yV6HQnaFuzI75o1zByTnxGng==",
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "NNiTR3dp1/4WNIv2WRHm87pr4WQztt9vVRALqULEUTcYrvb34xwnKwPwt3Ah5iXW1g3qkecXto5V7Ex+IIzeRQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.1.0-dev.212"
+          "Speckle.Sdk": "3.1.0-dev.215"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "hyBvk2Vq0MPVBM3r48TVJc4ERwcZpuCstIpfebrekLLbCH+wk/vfCD9VMKWqALYjTuYg7hFwrKGw6Z/G23n5jw==",
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "YMb7xdELiza88RSCUWcqmKJlrnoqjxlc1+Z1gEQSCfvFV0Ibvfjz08YAMkOWFc/ZaY9nBUZvshHEWYIskEk5cg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -360,14 +360,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.0.1",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.1.0-dev.212"
+          "Speckle.Sdk.Dependencies": "3.1.0-dev.215"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "b6nJAUSYixTWwZMjff1uPkrKXKp8ehoO6Nfw/eQxLpXdwaF4xdk1/sOXwFeGWaWId9E41Jf2jq4YHcxPEnDjYA=="
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "cT5HRu+pRBvfKTRJIvQBgdX2X5eeTebHe7zmNz82tFT0p65RsK9K7Ap9RjvMndbEPqFtt8/sCNa5RHyfrf+IUg=="
       },
       "System.Threading.Tasks.Dataflow": {
         "type": "CentralTransitive",

--- a/Connectors/Autocad/Speckle.Connectors.Autocad2025/packages.lock.json
+++ b/Connectors/Autocad/Speckle.Connectors.Autocad2025/packages.lock.json
@@ -220,9 +220,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.212, )",
-          "Speckle.Sdk": "[3.1.0-dev.212, )",
-          "Speckle.Sdk.Dependencies": "[3.1.0-dev.212, )"
+          "Speckle.Objects": "[3.1.0-dev.215, )",
+          "Speckle.Sdk": "[3.1.0-dev.215, )",
+          "Speckle.Sdk.Dependencies": "[3.1.0-dev.215, )"
         }
       },
       "speckle.connectors.dui": {
@@ -230,8 +230,8 @@
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
           "Speckle.Connectors.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[3.1.0-dev.212, )",
-          "Speckle.Sdk.Dependencies": "[3.1.0-dev.212, )",
+          "Speckle.Sdk": "[3.1.0-dev.215, )",
+          "Speckle.Sdk.Dependencies": "[3.1.0-dev.215, )",
           "System.Threading.Tasks.Dataflow": "[6.0.0, )"
         }
       },
@@ -257,7 +257,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.1.0-dev.212, )"
+          "Speckle.Objects": "[3.1.0-dev.215, )"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -295,18 +295,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "n0NUmrZKDSgMDnKrlTpJk8sH7Kse/8O6M1qkBmw02ux6LhOIpQhdlHo3SY/xS0yV6HQnaFuzI75o1zByTnxGng==",
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "NNiTR3dp1/4WNIv2WRHm87pr4WQztt9vVRALqULEUTcYrvb34xwnKwPwt3Ah5iXW1g3qkecXto5V7Ex+IIzeRQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.1.0-dev.212"
+          "Speckle.Sdk": "3.1.0-dev.215"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "hyBvk2Vq0MPVBM3r48TVJc4ERwcZpuCstIpfebrekLLbCH+wk/vfCD9VMKWqALYjTuYg7hFwrKGw6Z/G23n5jw==",
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "YMb7xdELiza88RSCUWcqmKJlrnoqjxlc1+Z1gEQSCfvFV0Ibvfjz08YAMkOWFc/ZaY9nBUZvshHEWYIskEk5cg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -315,14 +315,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.0.1",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.1.0-dev.212"
+          "Speckle.Sdk.Dependencies": "3.1.0-dev.215"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "b6nJAUSYixTWwZMjff1uPkrKXKp8ehoO6Nfw/eQxLpXdwaF4xdk1/sOXwFeGWaWId9E41Jf2jq4YHcxPEnDjYA=="
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "cT5HRu+pRBvfKTRJIvQBgdX2X5eeTebHe7zmNz82tFT0p65RsK9K7Ap9RjvMndbEPqFtt8/sCNa5RHyfrf+IUg=="
       },
       "System.Threading.Tasks.Dataflow": {
         "type": "CentralTransitive",

--- a/Connectors/Autocad/Speckle.Connectors.Civil3d2022/packages.lock.json
+++ b/Connectors/Autocad/Speckle.Connectors.Civil3d2022/packages.lock.json
@@ -273,9 +273,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.212, )",
-          "Speckle.Sdk": "[3.1.0-dev.212, )",
-          "Speckle.Sdk.Dependencies": "[3.1.0-dev.212, )"
+          "Speckle.Objects": "[3.1.0-dev.215, )",
+          "Speckle.Sdk": "[3.1.0-dev.215, )",
+          "Speckle.Sdk.Dependencies": "[3.1.0-dev.215, )"
         }
       },
       "speckle.connectors.dui": {
@@ -283,8 +283,8 @@
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
           "Speckle.Connectors.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[3.1.0-dev.212, )",
-          "Speckle.Sdk.Dependencies": "[3.1.0-dev.212, )",
+          "Speckle.Sdk": "[3.1.0-dev.215, )",
+          "Speckle.Sdk.Dependencies": "[3.1.0-dev.215, )",
           "System.Threading.Tasks.Dataflow": "[6.0.0, )"
         }
       },
@@ -310,7 +310,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.1.0-dev.212, )"
+          "Speckle.Objects": "[3.1.0-dev.215, )"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -348,18 +348,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "n0NUmrZKDSgMDnKrlTpJk8sH7Kse/8O6M1qkBmw02ux6LhOIpQhdlHo3SY/xS0yV6HQnaFuzI75o1zByTnxGng==",
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "NNiTR3dp1/4WNIv2WRHm87pr4WQztt9vVRALqULEUTcYrvb34xwnKwPwt3Ah5iXW1g3qkecXto5V7Ex+IIzeRQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.1.0-dev.212"
+          "Speckle.Sdk": "3.1.0-dev.215"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "hyBvk2Vq0MPVBM3r48TVJc4ERwcZpuCstIpfebrekLLbCH+wk/vfCD9VMKWqALYjTuYg7hFwrKGw6Z/G23n5jw==",
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "YMb7xdELiza88RSCUWcqmKJlrnoqjxlc1+Z1gEQSCfvFV0Ibvfjz08YAMkOWFc/ZaY9nBUZvshHEWYIskEk5cg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -369,14 +369,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.0.1",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.1.0-dev.212"
+          "Speckle.Sdk.Dependencies": "3.1.0-dev.215"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "b6nJAUSYixTWwZMjff1uPkrKXKp8ehoO6Nfw/eQxLpXdwaF4xdk1/sOXwFeGWaWId9E41Jf2jq4YHcxPEnDjYA=="
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "cT5HRu+pRBvfKTRJIvQBgdX2X5eeTebHe7zmNz82tFT0p65RsK9K7Ap9RjvMndbEPqFtt8/sCNa5RHyfrf+IUg=="
       },
       "System.Threading.Tasks.Dataflow": {
         "type": "CentralTransitive",

--- a/Connectors/Autocad/Speckle.Connectors.Civil3d2023/packages.lock.json
+++ b/Connectors/Autocad/Speckle.Connectors.Civil3d2023/packages.lock.json
@@ -273,9 +273,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.212, )",
-          "Speckle.Sdk": "[3.1.0-dev.212, )",
-          "Speckle.Sdk.Dependencies": "[3.1.0-dev.212, )"
+          "Speckle.Objects": "[3.1.0-dev.215, )",
+          "Speckle.Sdk": "[3.1.0-dev.215, )",
+          "Speckle.Sdk.Dependencies": "[3.1.0-dev.215, )"
         }
       },
       "speckle.connectors.dui": {
@@ -283,8 +283,8 @@
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
           "Speckle.Connectors.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[3.1.0-dev.212, )",
-          "Speckle.Sdk.Dependencies": "[3.1.0-dev.212, )",
+          "Speckle.Sdk": "[3.1.0-dev.215, )",
+          "Speckle.Sdk.Dependencies": "[3.1.0-dev.215, )",
           "System.Threading.Tasks.Dataflow": "[6.0.0, )"
         }
       },
@@ -310,7 +310,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.1.0-dev.212, )"
+          "Speckle.Objects": "[3.1.0-dev.215, )"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -348,18 +348,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "n0NUmrZKDSgMDnKrlTpJk8sH7Kse/8O6M1qkBmw02ux6LhOIpQhdlHo3SY/xS0yV6HQnaFuzI75o1zByTnxGng==",
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "NNiTR3dp1/4WNIv2WRHm87pr4WQztt9vVRALqULEUTcYrvb34xwnKwPwt3Ah5iXW1g3qkecXto5V7Ex+IIzeRQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.1.0-dev.212"
+          "Speckle.Sdk": "3.1.0-dev.215"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "hyBvk2Vq0MPVBM3r48TVJc4ERwcZpuCstIpfebrekLLbCH+wk/vfCD9VMKWqALYjTuYg7hFwrKGw6Z/G23n5jw==",
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "YMb7xdELiza88RSCUWcqmKJlrnoqjxlc1+Z1gEQSCfvFV0Ibvfjz08YAMkOWFc/ZaY9nBUZvshHEWYIskEk5cg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -369,14 +369,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.0.1",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.1.0-dev.212"
+          "Speckle.Sdk.Dependencies": "3.1.0-dev.215"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "b6nJAUSYixTWwZMjff1uPkrKXKp8ehoO6Nfw/eQxLpXdwaF4xdk1/sOXwFeGWaWId9E41Jf2jq4YHcxPEnDjYA=="
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "cT5HRu+pRBvfKTRJIvQBgdX2X5eeTebHe7zmNz82tFT0p65RsK9K7Ap9RjvMndbEPqFtt8/sCNa5RHyfrf+IUg=="
       },
       "System.Threading.Tasks.Dataflow": {
         "type": "CentralTransitive",

--- a/Connectors/Autocad/Speckle.Connectors.Civil3d2024/packages.lock.json
+++ b/Connectors/Autocad/Speckle.Connectors.Civil3d2024/packages.lock.json
@@ -273,9 +273,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.212, )",
-          "Speckle.Sdk": "[3.1.0-dev.212, )",
-          "Speckle.Sdk.Dependencies": "[3.1.0-dev.212, )"
+          "Speckle.Objects": "[3.1.0-dev.215, )",
+          "Speckle.Sdk": "[3.1.0-dev.215, )",
+          "Speckle.Sdk.Dependencies": "[3.1.0-dev.215, )"
         }
       },
       "speckle.connectors.dui": {
@@ -283,8 +283,8 @@
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
           "Speckle.Connectors.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[3.1.0-dev.212, )",
-          "Speckle.Sdk.Dependencies": "[3.1.0-dev.212, )",
+          "Speckle.Sdk": "[3.1.0-dev.215, )",
+          "Speckle.Sdk.Dependencies": "[3.1.0-dev.215, )",
           "System.Threading.Tasks.Dataflow": "[6.0.0, )"
         }
       },
@@ -310,7 +310,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.1.0-dev.212, )"
+          "Speckle.Objects": "[3.1.0-dev.215, )"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -348,18 +348,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "n0NUmrZKDSgMDnKrlTpJk8sH7Kse/8O6M1qkBmw02ux6LhOIpQhdlHo3SY/xS0yV6HQnaFuzI75o1zByTnxGng==",
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "NNiTR3dp1/4WNIv2WRHm87pr4WQztt9vVRALqULEUTcYrvb34xwnKwPwt3Ah5iXW1g3qkecXto5V7Ex+IIzeRQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.1.0-dev.212"
+          "Speckle.Sdk": "3.1.0-dev.215"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "hyBvk2Vq0MPVBM3r48TVJc4ERwcZpuCstIpfebrekLLbCH+wk/vfCD9VMKWqALYjTuYg7hFwrKGw6Z/G23n5jw==",
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "YMb7xdELiza88RSCUWcqmKJlrnoqjxlc1+Z1gEQSCfvFV0Ibvfjz08YAMkOWFc/ZaY9nBUZvshHEWYIskEk5cg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -369,14 +369,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.0.1",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.1.0-dev.212"
+          "Speckle.Sdk.Dependencies": "3.1.0-dev.215"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "b6nJAUSYixTWwZMjff1uPkrKXKp8ehoO6Nfw/eQxLpXdwaF4xdk1/sOXwFeGWaWId9E41Jf2jq4YHcxPEnDjYA=="
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "cT5HRu+pRBvfKTRJIvQBgdX2X5eeTebHe7zmNz82tFT0p65RsK9K7Ap9RjvMndbEPqFtt8/sCNa5RHyfrf+IUg=="
       },
       "System.Threading.Tasks.Dataflow": {
         "type": "CentralTransitive",

--- a/Connectors/Autocad/Speckle.Connectors.Civil3d2025/packages.lock.json
+++ b/Connectors/Autocad/Speckle.Connectors.Civil3d2025/packages.lock.json
@@ -229,9 +229,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.212, )",
-          "Speckle.Sdk": "[3.1.0-dev.212, )",
-          "Speckle.Sdk.Dependencies": "[3.1.0-dev.212, )"
+          "Speckle.Objects": "[3.1.0-dev.215, )",
+          "Speckle.Sdk": "[3.1.0-dev.215, )",
+          "Speckle.Sdk.Dependencies": "[3.1.0-dev.215, )"
         }
       },
       "speckle.connectors.dui": {
@@ -239,8 +239,8 @@
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
           "Speckle.Connectors.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[3.1.0-dev.212, )",
-          "Speckle.Sdk.Dependencies": "[3.1.0-dev.212, )",
+          "Speckle.Sdk": "[3.1.0-dev.215, )",
+          "Speckle.Sdk.Dependencies": "[3.1.0-dev.215, )",
           "System.Threading.Tasks.Dataflow": "[6.0.0, )"
         }
       },
@@ -267,7 +267,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.1.0-dev.212, )"
+          "Speckle.Objects": "[3.1.0-dev.215, )"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -305,18 +305,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "n0NUmrZKDSgMDnKrlTpJk8sH7Kse/8O6M1qkBmw02ux6LhOIpQhdlHo3SY/xS0yV6HQnaFuzI75o1zByTnxGng==",
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "NNiTR3dp1/4WNIv2WRHm87pr4WQztt9vVRALqULEUTcYrvb34xwnKwPwt3Ah5iXW1g3qkecXto5V7Ex+IIzeRQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.1.0-dev.212"
+          "Speckle.Sdk": "3.1.0-dev.215"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "hyBvk2Vq0MPVBM3r48TVJc4ERwcZpuCstIpfebrekLLbCH+wk/vfCD9VMKWqALYjTuYg7hFwrKGw6Z/G23n5jw==",
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "YMb7xdELiza88RSCUWcqmKJlrnoqjxlc1+Z1gEQSCfvFV0Ibvfjz08YAMkOWFc/ZaY9nBUZvshHEWYIskEk5cg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -325,14 +325,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.0.1",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.1.0-dev.212"
+          "Speckle.Sdk.Dependencies": "3.1.0-dev.215"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "b6nJAUSYixTWwZMjff1uPkrKXKp8ehoO6Nfw/eQxLpXdwaF4xdk1/sOXwFeGWaWId9E41Jf2jq4YHcxPEnDjYA=="
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "cT5HRu+pRBvfKTRJIvQBgdX2X5eeTebHe7zmNz82tFT0p65RsK9K7Ap9RjvMndbEPqFtt8/sCNa5RHyfrf+IUg=="
       },
       "System.Threading.Tasks.Dataflow": {
         "type": "CentralTransitive",

--- a/Connectors/CSi/Speckle.Connectors.ETABS21/packages.lock.json
+++ b/Connectors/CSi/Speckle.Connectors.ETABS21/packages.lock.json
@@ -264,9 +264,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.212, )",
-          "Speckle.Sdk": "[3.1.0-dev.212, )",
-          "Speckle.Sdk.Dependencies": "[3.1.0-dev.212, )"
+          "Speckle.Objects": "[3.1.0-dev.215, )",
+          "Speckle.Sdk": "[3.1.0-dev.215, )",
+          "Speckle.Sdk.Dependencies": "[3.1.0-dev.215, )"
         }
       },
       "speckle.connectors.dui": {
@@ -274,8 +274,8 @@
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
           "Speckle.Connectors.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[3.1.0-dev.212, )",
-          "Speckle.Sdk.Dependencies": "[3.1.0-dev.212, )",
+          "Speckle.Sdk": "[3.1.0-dev.215, )",
+          "Speckle.Sdk.Dependencies": "[3.1.0-dev.215, )",
           "System.Threading.Tasks.Dataflow": "[6.0.0, )"
         }
       },
@@ -293,7 +293,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.1.0-dev.212, )"
+          "Speckle.Objects": "[3.1.0-dev.215, )"
         }
       },
       "speckle.converters.etabs21": {
@@ -337,18 +337,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "n0NUmrZKDSgMDnKrlTpJk8sH7Kse/8O6M1qkBmw02ux6LhOIpQhdlHo3SY/xS0yV6HQnaFuzI75o1zByTnxGng==",
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "NNiTR3dp1/4WNIv2WRHm87pr4WQztt9vVRALqULEUTcYrvb34xwnKwPwt3Ah5iXW1g3qkecXto5V7Ex+IIzeRQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.1.0-dev.212"
+          "Speckle.Sdk": "3.1.0-dev.215"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "hyBvk2Vq0MPVBM3r48TVJc4ERwcZpuCstIpfebrekLLbCH+wk/vfCD9VMKWqALYjTuYg7hFwrKGw6Z/G23n5jw==",
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "YMb7xdELiza88RSCUWcqmKJlrnoqjxlc1+Z1gEQSCfvFV0Ibvfjz08YAMkOWFc/ZaY9nBUZvshHEWYIskEk5cg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -358,14 +358,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.0.1",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.1.0-dev.212"
+          "Speckle.Sdk.Dependencies": "3.1.0-dev.215"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "b6nJAUSYixTWwZMjff1uPkrKXKp8ehoO6Nfw/eQxLpXdwaF4xdk1/sOXwFeGWaWId9E41Jf2jq4YHcxPEnDjYA=="
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "cT5HRu+pRBvfKTRJIvQBgdX2X5eeTebHe7zmNz82tFT0p65RsK9K7Ap9RjvMndbEPqFtt8/sCNa5RHyfrf+IUg=="
       },
       "System.Threading.Tasks.Dataflow": {
         "type": "CentralTransitive",

--- a/Connectors/CSi/Speckle.Connectors.ETABS22/packages.lock.json
+++ b/Connectors/CSi/Speckle.Connectors.ETABS22/packages.lock.json
@@ -220,9 +220,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.212, )",
-          "Speckle.Sdk": "[3.1.0-dev.212, )",
-          "Speckle.Sdk.Dependencies": "[3.1.0-dev.212, )"
+          "Speckle.Objects": "[3.1.0-dev.215, )",
+          "Speckle.Sdk": "[3.1.0-dev.215, )",
+          "Speckle.Sdk.Dependencies": "[3.1.0-dev.215, )"
         }
       },
       "speckle.connectors.dui": {
@@ -230,8 +230,8 @@
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
           "Speckle.Connectors.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[3.1.0-dev.212, )",
-          "Speckle.Sdk.Dependencies": "[3.1.0-dev.212, )",
+          "Speckle.Sdk": "[3.1.0-dev.215, )",
+          "Speckle.Sdk.Dependencies": "[3.1.0-dev.215, )",
           "System.Threading.Tasks.Dataflow": "[6.0.0, )"
         }
       },
@@ -249,7 +249,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.1.0-dev.212, )"
+          "Speckle.Objects": "[3.1.0-dev.215, )"
         }
       },
       "speckle.converters.etabs22": {
@@ -293,18 +293,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "n0NUmrZKDSgMDnKrlTpJk8sH7Kse/8O6M1qkBmw02ux6LhOIpQhdlHo3SY/xS0yV6HQnaFuzI75o1zByTnxGng==",
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "NNiTR3dp1/4WNIv2WRHm87pr4WQztt9vVRALqULEUTcYrvb34xwnKwPwt3Ah5iXW1g3qkecXto5V7Ex+IIzeRQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.1.0-dev.212"
+          "Speckle.Sdk": "3.1.0-dev.215"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "hyBvk2Vq0MPVBM3r48TVJc4ERwcZpuCstIpfebrekLLbCH+wk/vfCD9VMKWqALYjTuYg7hFwrKGw6Z/G23n5jw==",
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "YMb7xdELiza88RSCUWcqmKJlrnoqjxlc1+Z1gEQSCfvFV0Ibvfjz08YAMkOWFc/ZaY9nBUZvshHEWYIskEk5cg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -313,14 +313,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.0.1",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.1.0-dev.212"
+          "Speckle.Sdk.Dependencies": "3.1.0-dev.215"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "b6nJAUSYixTWwZMjff1uPkrKXKp8ehoO6Nfw/eQxLpXdwaF4xdk1/sOXwFeGWaWId9E41Jf2jq4YHcxPEnDjYA=="
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "cT5HRu+pRBvfKTRJIvQBgdX2X5eeTebHe7zmNz82tFT0p65RsK9K7Ap9RjvMndbEPqFtt8/sCNa5RHyfrf+IUg=="
       },
       "System.Threading.Tasks.Dataflow": {
         "type": "CentralTransitive",

--- a/Connectors/Revit/Speckle.Connectors.Revit2022/packages.lock.json
+++ b/Connectors/Revit/Speckle.Connectors.Revit2022/packages.lock.json
@@ -292,9 +292,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.212, )",
-          "Speckle.Sdk": "[3.1.0-dev.212, )",
-          "Speckle.Sdk.Dependencies": "[3.1.0-dev.212, )"
+          "Speckle.Objects": "[3.1.0-dev.215, )",
+          "Speckle.Sdk": "[3.1.0-dev.215, )",
+          "Speckle.Sdk.Dependencies": "[3.1.0-dev.215, )"
         }
       },
       "speckle.connectors.dui": {
@@ -302,8 +302,8 @@
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
           "Speckle.Connectors.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[3.1.0-dev.212, )",
-          "Speckle.Sdk.Dependencies": "[3.1.0-dev.212, )",
+          "Speckle.Sdk": "[3.1.0-dev.215, )",
+          "Speckle.Sdk.Dependencies": "[3.1.0-dev.215, )",
           "System.Threading.Tasks.Dataflow": "[6.0.0, )"
         }
       },
@@ -314,7 +314,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.1.0-dev.212, )"
+          "Speckle.Objects": "[3.1.0-dev.215, )"
         }
       },
       "speckle.converters.revit2022": {
@@ -353,11 +353,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "n0NUmrZKDSgMDnKrlTpJk8sH7Kse/8O6M1qkBmw02ux6LhOIpQhdlHo3SY/xS0yV6HQnaFuzI75o1zByTnxGng==",
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "NNiTR3dp1/4WNIv2WRHm87pr4WQztt9vVRALqULEUTcYrvb34xwnKwPwt3Ah5iXW1g3qkecXto5V7Ex+IIzeRQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.1.0-dev.212"
+          "Speckle.Sdk": "3.1.0-dev.215"
         }
       },
       "Speckle.Revit.API": {
@@ -368,9 +368,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "hyBvk2Vq0MPVBM3r48TVJc4ERwcZpuCstIpfebrekLLbCH+wk/vfCD9VMKWqALYjTuYg7hFwrKGw6Z/G23n5jw==",
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "YMb7xdELiza88RSCUWcqmKJlrnoqjxlc1+Z1gEQSCfvFV0Ibvfjz08YAMkOWFc/ZaY9nBUZvshHEWYIskEk5cg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -380,14 +380,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.0.1",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.1.0-dev.212"
+          "Speckle.Sdk.Dependencies": "3.1.0-dev.215"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "b6nJAUSYixTWwZMjff1uPkrKXKp8ehoO6Nfw/eQxLpXdwaF4xdk1/sOXwFeGWaWId9E41Jf2jq4YHcxPEnDjYA=="
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "cT5HRu+pRBvfKTRJIvQBgdX2X5eeTebHe7zmNz82tFT0p65RsK9K7Ap9RjvMndbEPqFtt8/sCNa5RHyfrf+IUg=="
       },
       "System.Threading.Tasks.Dataflow": {
         "type": "CentralTransitive",

--- a/Connectors/Revit/Speckle.Connectors.Revit2023/packages.lock.json
+++ b/Connectors/Revit/Speckle.Connectors.Revit2023/packages.lock.json
@@ -292,9 +292,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.212, )",
-          "Speckle.Sdk": "[3.1.0-dev.212, )",
-          "Speckle.Sdk.Dependencies": "[3.1.0-dev.212, )"
+          "Speckle.Objects": "[3.1.0-dev.215, )",
+          "Speckle.Sdk": "[3.1.0-dev.215, )",
+          "Speckle.Sdk.Dependencies": "[3.1.0-dev.215, )"
         }
       },
       "speckle.connectors.dui": {
@@ -302,8 +302,8 @@
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
           "Speckle.Connectors.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[3.1.0-dev.212, )",
-          "Speckle.Sdk.Dependencies": "[3.1.0-dev.212, )",
+          "Speckle.Sdk": "[3.1.0-dev.215, )",
+          "Speckle.Sdk.Dependencies": "[3.1.0-dev.215, )",
           "System.Threading.Tasks.Dataflow": "[6.0.0, )"
         }
       },
@@ -314,7 +314,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.1.0-dev.212, )"
+          "Speckle.Objects": "[3.1.0-dev.215, )"
         }
       },
       "speckle.converters.revit2023": {
@@ -353,11 +353,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "n0NUmrZKDSgMDnKrlTpJk8sH7Kse/8O6M1qkBmw02ux6LhOIpQhdlHo3SY/xS0yV6HQnaFuzI75o1zByTnxGng==",
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "NNiTR3dp1/4WNIv2WRHm87pr4WQztt9vVRALqULEUTcYrvb34xwnKwPwt3Ah5iXW1g3qkecXto5V7Ex+IIzeRQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.1.0-dev.212"
+          "Speckle.Sdk": "3.1.0-dev.215"
         }
       },
       "Speckle.Revit.API": {
@@ -368,9 +368,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "hyBvk2Vq0MPVBM3r48TVJc4ERwcZpuCstIpfebrekLLbCH+wk/vfCD9VMKWqALYjTuYg7hFwrKGw6Z/G23n5jw==",
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "YMb7xdELiza88RSCUWcqmKJlrnoqjxlc1+Z1gEQSCfvFV0Ibvfjz08YAMkOWFc/ZaY9nBUZvshHEWYIskEk5cg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -380,14 +380,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.0.1",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.1.0-dev.212"
+          "Speckle.Sdk.Dependencies": "3.1.0-dev.215"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "b6nJAUSYixTWwZMjff1uPkrKXKp8ehoO6Nfw/eQxLpXdwaF4xdk1/sOXwFeGWaWId9E41Jf2jq4YHcxPEnDjYA=="
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "cT5HRu+pRBvfKTRJIvQBgdX2X5eeTebHe7zmNz82tFT0p65RsK9K7Ap9RjvMndbEPqFtt8/sCNa5RHyfrf+IUg=="
       },
       "System.Threading.Tasks.Dataflow": {
         "type": "CentralTransitive",

--- a/Connectors/Revit/Speckle.Connectors.Revit2024/packages.lock.json
+++ b/Connectors/Revit/Speckle.Connectors.Revit2024/packages.lock.json
@@ -292,9 +292,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.212, )",
-          "Speckle.Sdk": "[3.1.0-dev.212, )",
-          "Speckle.Sdk.Dependencies": "[3.1.0-dev.212, )"
+          "Speckle.Objects": "[3.1.0-dev.215, )",
+          "Speckle.Sdk": "[3.1.0-dev.215, )",
+          "Speckle.Sdk.Dependencies": "[3.1.0-dev.215, )"
         }
       },
       "speckle.connectors.dui": {
@@ -302,8 +302,8 @@
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
           "Speckle.Connectors.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[3.1.0-dev.212, )",
-          "Speckle.Sdk.Dependencies": "[3.1.0-dev.212, )",
+          "Speckle.Sdk": "[3.1.0-dev.215, )",
+          "Speckle.Sdk.Dependencies": "[3.1.0-dev.215, )",
           "System.Threading.Tasks.Dataflow": "[6.0.0, )"
         }
       },
@@ -314,7 +314,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.1.0-dev.212, )"
+          "Speckle.Objects": "[3.1.0-dev.215, )"
         }
       },
       "speckle.converters.revit2024": {
@@ -353,11 +353,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "n0NUmrZKDSgMDnKrlTpJk8sH7Kse/8O6M1qkBmw02ux6LhOIpQhdlHo3SY/xS0yV6HQnaFuzI75o1zByTnxGng==",
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "NNiTR3dp1/4WNIv2WRHm87pr4WQztt9vVRALqULEUTcYrvb34xwnKwPwt3Ah5iXW1g3qkecXto5V7Ex+IIzeRQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.1.0-dev.212"
+          "Speckle.Sdk": "3.1.0-dev.215"
         }
       },
       "Speckle.Revit.API": {
@@ -368,9 +368,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "hyBvk2Vq0MPVBM3r48TVJc4ERwcZpuCstIpfebrekLLbCH+wk/vfCD9VMKWqALYjTuYg7hFwrKGw6Z/G23n5jw==",
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "YMb7xdELiza88RSCUWcqmKJlrnoqjxlc1+Z1gEQSCfvFV0Ibvfjz08YAMkOWFc/ZaY9nBUZvshHEWYIskEk5cg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -380,14 +380,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.0.1",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.1.0-dev.212"
+          "Speckle.Sdk.Dependencies": "3.1.0-dev.215"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "b6nJAUSYixTWwZMjff1uPkrKXKp8ehoO6Nfw/eQxLpXdwaF4xdk1/sOXwFeGWaWId9E41Jf2jq4YHcxPEnDjYA=="
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "cT5HRu+pRBvfKTRJIvQBgdX2X5eeTebHe7zmNz82tFT0p65RsK9K7Ap9RjvMndbEPqFtt8/sCNa5RHyfrf+IUg=="
       },
       "System.Threading.Tasks.Dataflow": {
         "type": "CentralTransitive",

--- a/Connectors/Revit/Speckle.Connectors.Revit2025/packages.lock.json
+++ b/Connectors/Revit/Speckle.Connectors.Revit2025/packages.lock.json
@@ -242,9 +242,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.212, )",
-          "Speckle.Sdk": "[3.1.0-dev.212, )",
-          "Speckle.Sdk.Dependencies": "[3.1.0-dev.212, )"
+          "Speckle.Objects": "[3.1.0-dev.215, )",
+          "Speckle.Sdk": "[3.1.0-dev.215, )",
+          "Speckle.Sdk.Dependencies": "[3.1.0-dev.215, )"
         }
       },
       "speckle.connectors.dui": {
@@ -252,8 +252,8 @@
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
           "Speckle.Connectors.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[3.1.0-dev.212, )",
-          "Speckle.Sdk.Dependencies": "[3.1.0-dev.212, )",
+          "Speckle.Sdk": "[3.1.0-dev.215, )",
+          "Speckle.Sdk.Dependencies": "[3.1.0-dev.215, )",
           "System.Threading.Tasks.Dataflow": "[6.0.0, )"
         }
       },
@@ -271,7 +271,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.1.0-dev.212, )"
+          "Speckle.Objects": "[3.1.0-dev.215, )"
         }
       },
       "speckle.converters.revit2025": {
@@ -316,11 +316,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "n0NUmrZKDSgMDnKrlTpJk8sH7Kse/8O6M1qkBmw02ux6LhOIpQhdlHo3SY/xS0yV6HQnaFuzI75o1zByTnxGng==",
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "NNiTR3dp1/4WNIv2WRHm87pr4WQztt9vVRALqULEUTcYrvb34xwnKwPwt3Ah5iXW1g3qkecXto5V7Ex+IIzeRQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.1.0-dev.212"
+          "Speckle.Sdk": "3.1.0-dev.215"
         }
       },
       "Speckle.Revit.API": {
@@ -331,9 +331,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "hyBvk2Vq0MPVBM3r48TVJc4ERwcZpuCstIpfebrekLLbCH+wk/vfCD9VMKWqALYjTuYg7hFwrKGw6Z/G23n5jw==",
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "YMb7xdELiza88RSCUWcqmKJlrnoqjxlc1+Z1gEQSCfvFV0Ibvfjz08YAMkOWFc/ZaY9nBUZvshHEWYIskEk5cg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -342,14 +342,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.0.1",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.1.0-dev.212"
+          "Speckle.Sdk.Dependencies": "3.1.0-dev.215"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "b6nJAUSYixTWwZMjff1uPkrKXKp8ehoO6Nfw/eQxLpXdwaF4xdk1/sOXwFeGWaWId9E41Jf2jq4YHcxPEnDjYA=="
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "cT5HRu+pRBvfKTRJIvQBgdX2X5eeTebHe7zmNz82tFT0p65RsK9K7Ap9RjvMndbEPqFtt8/sCNa5RHyfrf+IUg=="
       },
       "System.Threading.Tasks.Dataflow": {
         "type": "CentralTransitive",

--- a/Connectors/Rhino/Speckle.Connectors.Rhino7/packages.lock.json
+++ b/Connectors/Rhino/Speckle.Connectors.Rhino7/packages.lock.json
@@ -273,9 +273,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.212, )",
-          "Speckle.Sdk": "[3.1.0-dev.212, )",
-          "Speckle.Sdk.Dependencies": "[3.1.0-dev.212, )"
+          "Speckle.Objects": "[3.1.0-dev.215, )",
+          "Speckle.Sdk": "[3.1.0-dev.215, )",
+          "Speckle.Sdk.Dependencies": "[3.1.0-dev.215, )"
         }
       },
       "speckle.connectors.dui": {
@@ -283,8 +283,8 @@
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
           "Speckle.Connectors.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[3.1.0-dev.212, )",
-          "Speckle.Sdk.Dependencies": "[3.1.0-dev.212, )",
+          "Speckle.Sdk": "[3.1.0-dev.215, )",
+          "Speckle.Sdk.Dependencies": "[3.1.0-dev.215, )",
           "System.Threading.Tasks.Dataflow": "[6.0.0, )"
         }
       },
@@ -302,7 +302,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.1.0-dev.212, )"
+          "Speckle.Objects": "[3.1.0-dev.215, )"
         }
       },
       "speckle.converters.rhino7": {
@@ -347,18 +347,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "n0NUmrZKDSgMDnKrlTpJk8sH7Kse/8O6M1qkBmw02ux6LhOIpQhdlHo3SY/xS0yV6HQnaFuzI75o1zByTnxGng==",
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "NNiTR3dp1/4WNIv2WRHm87pr4WQztt9vVRALqULEUTcYrvb34xwnKwPwt3Ah5iXW1g3qkecXto5V7Ex+IIzeRQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.1.0-dev.212"
+          "Speckle.Sdk": "3.1.0-dev.215"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "hyBvk2Vq0MPVBM3r48TVJc4ERwcZpuCstIpfebrekLLbCH+wk/vfCD9VMKWqALYjTuYg7hFwrKGw6Z/G23n5jw==",
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "YMb7xdELiza88RSCUWcqmKJlrnoqjxlc1+Z1gEQSCfvFV0Ibvfjz08YAMkOWFc/ZaY9nBUZvshHEWYIskEk5cg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -368,14 +368,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.0.1",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.1.0-dev.212"
+          "Speckle.Sdk.Dependencies": "3.1.0-dev.215"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "b6nJAUSYixTWwZMjff1uPkrKXKp8ehoO6Nfw/eQxLpXdwaF4xdk1/sOXwFeGWaWId9E41Jf2jq4YHcxPEnDjYA=="
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "cT5HRu+pRBvfKTRJIvQBgdX2X5eeTebHe7zmNz82tFT0p65RsK9K7Ap9RjvMndbEPqFtt8/sCNa5RHyfrf+IUg=="
       },
       "System.Threading.Tasks.Dataflow": {
         "type": "CentralTransitive",

--- a/Connectors/Rhino/Speckle.Connectors.Rhino8/packages.lock.json
+++ b/Connectors/Rhino/Speckle.Connectors.Rhino8/packages.lock.json
@@ -273,9 +273,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.212, )",
-          "Speckle.Sdk": "[3.1.0-dev.212, )",
-          "Speckle.Sdk.Dependencies": "[3.1.0-dev.212, )"
+          "Speckle.Objects": "[3.1.0-dev.215, )",
+          "Speckle.Sdk": "[3.1.0-dev.215, )",
+          "Speckle.Sdk.Dependencies": "[3.1.0-dev.215, )"
         }
       },
       "speckle.connectors.dui": {
@@ -283,8 +283,8 @@
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
           "Speckle.Connectors.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[3.1.0-dev.212, )",
-          "Speckle.Sdk.Dependencies": "[3.1.0-dev.212, )",
+          "Speckle.Sdk": "[3.1.0-dev.215, )",
+          "Speckle.Sdk.Dependencies": "[3.1.0-dev.215, )",
           "System.Threading.Tasks.Dataflow": "[6.0.0, )"
         }
       },
@@ -302,7 +302,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.1.0-dev.212, )"
+          "Speckle.Objects": "[3.1.0-dev.215, )"
         }
       },
       "speckle.converters.rhino8": {
@@ -347,18 +347,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "n0NUmrZKDSgMDnKrlTpJk8sH7Kse/8O6M1qkBmw02ux6LhOIpQhdlHo3SY/xS0yV6HQnaFuzI75o1zByTnxGng==",
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "NNiTR3dp1/4WNIv2WRHm87pr4WQztt9vVRALqULEUTcYrvb34xwnKwPwt3Ah5iXW1g3qkecXto5V7Ex+IIzeRQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.1.0-dev.212"
+          "Speckle.Sdk": "3.1.0-dev.215"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "hyBvk2Vq0MPVBM3r48TVJc4ERwcZpuCstIpfebrekLLbCH+wk/vfCD9VMKWqALYjTuYg7hFwrKGw6Z/G23n5jw==",
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "YMb7xdELiza88RSCUWcqmKJlrnoqjxlc1+Z1gEQSCfvFV0Ibvfjz08YAMkOWFc/ZaY9nBUZvshHEWYIskEk5cg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -368,14 +368,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.0.1",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.1.0-dev.212"
+          "Speckle.Sdk.Dependencies": "3.1.0-dev.215"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "b6nJAUSYixTWwZMjff1uPkrKXKp8ehoO6Nfw/eQxLpXdwaF4xdk1/sOXwFeGWaWId9E41Jf2jq4YHcxPEnDjYA=="
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "cT5HRu+pRBvfKTRJIvQBgdX2X5eeTebHe7zmNz82tFT0p65RsK9K7Ap9RjvMndbEPqFtt8/sCNa5RHyfrf+IUg=="
       },
       "System.Threading.Tasks.Dataflow": {
         "type": "CentralTransitive",

--- a/Connectors/Tekla/Speckle.Connector.Tekla2023/packages.lock.json
+++ b/Connectors/Tekla/Speckle.Connector.Tekla2023/packages.lock.json
@@ -35,11 +35,11 @@
       },
       "Speckle.Objects": {
         "type": "Direct",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "n0NUmrZKDSgMDnKrlTpJk8sH7Kse/8O6M1qkBmw02ux6LhOIpQhdlHo3SY/xS0yV6HQnaFuzI75o1zByTnxGng==",
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "NNiTR3dp1/4WNIv2WRHm87pr4WQztt9vVRALqULEUTcYrvb34xwnKwPwt3Ah5iXW1g3qkecXto5V7Ex+IIzeRQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.1.0-dev.212"
+          "Speckle.Sdk": "3.1.0-dev.215"
         }
       },
       "Tekla.Structures.Dialog": {
@@ -332,9 +332,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.212, )",
-          "Speckle.Sdk": "[3.1.0-dev.212, )",
-          "Speckle.Sdk.Dependencies": "[3.1.0-dev.212, )"
+          "Speckle.Objects": "[3.1.0-dev.215, )",
+          "Speckle.Sdk": "[3.1.0-dev.215, )",
+          "Speckle.Sdk.Dependencies": "[3.1.0-dev.215, )"
         }
       },
       "speckle.connectors.dui": {
@@ -342,8 +342,8 @@
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
           "Speckle.Connectors.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[3.1.0-dev.212, )",
-          "Speckle.Sdk.Dependencies": "[3.1.0-dev.212, )",
+          "Speckle.Sdk": "[3.1.0-dev.215, )",
+          "Speckle.Sdk.Dependencies": "[3.1.0-dev.215, )",
           "System.Threading.Tasks.Dataflow": "[6.0.0, )"
         }
       },
@@ -369,7 +369,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.1.0-dev.212, )"
+          "Speckle.Objects": "[3.1.0-dev.215, )"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -407,9 +407,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "hyBvk2Vq0MPVBM3r48TVJc4ERwcZpuCstIpfebrekLLbCH+wk/vfCD9VMKWqALYjTuYg7hFwrKGw6Z/G23n5jw==",
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "YMb7xdELiza88RSCUWcqmKJlrnoqjxlc1+Z1gEQSCfvFV0Ibvfjz08YAMkOWFc/ZaY9nBUZvshHEWYIskEk5cg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -419,14 +419,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.0.1",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.1.0-dev.212"
+          "Speckle.Sdk.Dependencies": "3.1.0-dev.215"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "b6nJAUSYixTWwZMjff1uPkrKXKp8ehoO6Nfw/eQxLpXdwaF4xdk1/sOXwFeGWaWId9E41Jf2jq4YHcxPEnDjYA=="
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "cT5HRu+pRBvfKTRJIvQBgdX2X5eeTebHe7zmNz82tFT0p65RsK9K7Ap9RjvMndbEPqFtt8/sCNa5RHyfrf+IUg=="
       },
       "System.Threading.Tasks.Dataflow": {
         "type": "CentralTransitive",

--- a/Connectors/Tekla/Speckle.Connector.Tekla2024/packages.lock.json
+++ b/Connectors/Tekla/Speckle.Connector.Tekla2024/packages.lock.json
@@ -35,11 +35,11 @@
       },
       "Speckle.Objects": {
         "type": "Direct",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "n0NUmrZKDSgMDnKrlTpJk8sH7Kse/8O6M1qkBmw02ux6LhOIpQhdlHo3SY/xS0yV6HQnaFuzI75o1zByTnxGng==",
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "NNiTR3dp1/4WNIv2WRHm87pr4WQztt9vVRALqULEUTcYrvb34xwnKwPwt3Ah5iXW1g3qkecXto5V7Ex+IIzeRQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.1.0-dev.212"
+          "Speckle.Sdk": "3.1.0-dev.215"
         }
       },
       "Tekla.Structures.Dialog": {
@@ -413,9 +413,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.212, )",
-          "Speckle.Sdk": "[3.1.0-dev.212, )",
-          "Speckle.Sdk.Dependencies": "[3.1.0-dev.212, )"
+          "Speckle.Objects": "[3.1.0-dev.215, )",
+          "Speckle.Sdk": "[3.1.0-dev.215, )",
+          "Speckle.Sdk.Dependencies": "[3.1.0-dev.215, )"
         }
       },
       "speckle.connectors.dui": {
@@ -423,8 +423,8 @@
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
           "Speckle.Connectors.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[3.1.0-dev.212, )",
-          "Speckle.Sdk.Dependencies": "[3.1.0-dev.212, )",
+          "Speckle.Sdk": "[3.1.0-dev.215, )",
+          "Speckle.Sdk.Dependencies": "[3.1.0-dev.215, )",
           "System.Threading.Tasks.Dataflow": "[6.0.0, )"
         }
       },
@@ -450,7 +450,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.1.0-dev.212, )"
+          "Speckle.Objects": "[3.1.0-dev.215, )"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -488,9 +488,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "hyBvk2Vq0MPVBM3r48TVJc4ERwcZpuCstIpfebrekLLbCH+wk/vfCD9VMKWqALYjTuYg7hFwrKGw6Z/G23n5jw==",
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "YMb7xdELiza88RSCUWcqmKJlrnoqjxlc1+Z1gEQSCfvFV0Ibvfjz08YAMkOWFc/ZaY9nBUZvshHEWYIskEk5cg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -500,14 +500,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.0.1",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.1.0-dev.212"
+          "Speckle.Sdk.Dependencies": "3.1.0-dev.215"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "b6nJAUSYixTWwZMjff1uPkrKXKp8ehoO6Nfw/eQxLpXdwaF4xdk1/sOXwFeGWaWId9E41Jf2jq4YHcxPEnDjYA=="
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "cT5HRu+pRBvfKTRJIvQBgdX2X5eeTebHe7zmNz82tFT0p65RsK9K7Ap9RjvMndbEPqFtt8/sCNa5RHyfrf+IUg=="
       },
       "System.Threading.Tasks.Dataflow": {
         "type": "CentralTransitive",

--- a/Converters/ArcGIS/Speckle.Converters.ArcGIS3/packages.lock.json
+++ b/Converters/ArcGIS/Speckle.Converters.ArcGIS3/packages.lock.json
@@ -224,7 +224,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.1.0-dev.212, )"
+          "Speckle.Objects": "[3.1.0-dev.215, )"
         }
       },
       "Microsoft.Extensions.Logging": {
@@ -247,18 +247,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "n0NUmrZKDSgMDnKrlTpJk8sH7Kse/8O6M1qkBmw02ux6LhOIpQhdlHo3SY/xS0yV6HQnaFuzI75o1zByTnxGng==",
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "NNiTR3dp1/4WNIv2WRHm87pr4WQztt9vVRALqULEUTcYrvb34xwnKwPwt3Ah5iXW1g3qkecXto5V7Ex+IIzeRQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.1.0-dev.212"
+          "Speckle.Sdk": "3.1.0-dev.215"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "hyBvk2Vq0MPVBM3r48TVJc4ERwcZpuCstIpfebrekLLbCH+wk/vfCD9VMKWqALYjTuYg7hFwrKGw6Z/G23n5jw==",
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "YMb7xdELiza88RSCUWcqmKJlrnoqjxlc1+Z1gEQSCfvFV0Ibvfjz08YAMkOWFc/ZaY9nBUZvshHEWYIskEk5cg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -268,14 +268,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.0.1",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.1.0-dev.212"
+          "Speckle.Sdk.Dependencies": "3.1.0-dev.215"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "b6nJAUSYixTWwZMjff1uPkrKXKp8ehoO6Nfw/eQxLpXdwaF4xdk1/sOXwFeGWaWId9E41Jf2jq4YHcxPEnDjYA=="
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "cT5HRu+pRBvfKTRJIvQBgdX2X5eeTebHe7zmNz82tFT0p65RsK9K7Ap9RjvMndbEPqFtt8/sCNa5RHyfrf+IUg=="
       }
     }
   }

--- a/Converters/Autocad/Speckle.Converters.Autocad2022/packages.lock.json
+++ b/Converters/Autocad/Speckle.Converters.Autocad2022/packages.lock.json
@@ -263,7 +263,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.1.0-dev.212, )"
+          "Speckle.Objects": "[3.1.0-dev.215, )"
         }
       },
       "Microsoft.Extensions.Logging": {
@@ -286,18 +286,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "n0NUmrZKDSgMDnKrlTpJk8sH7Kse/8O6M1qkBmw02ux6LhOIpQhdlHo3SY/xS0yV6HQnaFuzI75o1zByTnxGng==",
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "NNiTR3dp1/4WNIv2WRHm87pr4WQztt9vVRALqULEUTcYrvb34xwnKwPwt3Ah5iXW1g3qkecXto5V7Ex+IIzeRQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.1.0-dev.212"
+          "Speckle.Sdk": "3.1.0-dev.215"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "hyBvk2Vq0MPVBM3r48TVJc4ERwcZpuCstIpfebrekLLbCH+wk/vfCD9VMKWqALYjTuYg7hFwrKGw6Z/G23n5jw==",
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "YMb7xdELiza88RSCUWcqmKJlrnoqjxlc1+Z1gEQSCfvFV0Ibvfjz08YAMkOWFc/ZaY9nBUZvshHEWYIskEk5cg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -307,14 +307,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.0.1",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.1.0-dev.212"
+          "Speckle.Sdk.Dependencies": "3.1.0-dev.215"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "b6nJAUSYixTWwZMjff1uPkrKXKp8ehoO6Nfw/eQxLpXdwaF4xdk1/sOXwFeGWaWId9E41Jf2jq4YHcxPEnDjYA=="
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "cT5HRu+pRBvfKTRJIvQBgdX2X5eeTebHe7zmNz82tFT0p65RsK9K7Ap9RjvMndbEPqFtt8/sCNa5RHyfrf+IUg=="
       }
     }
   }

--- a/Converters/Autocad/Speckle.Converters.Autocad2023/packages.lock.json
+++ b/Converters/Autocad/Speckle.Converters.Autocad2023/packages.lock.json
@@ -263,7 +263,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.1.0-dev.212, )"
+          "Speckle.Objects": "[3.1.0-dev.215, )"
         }
       },
       "Microsoft.Extensions.Logging": {
@@ -286,18 +286,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "n0NUmrZKDSgMDnKrlTpJk8sH7Kse/8O6M1qkBmw02ux6LhOIpQhdlHo3SY/xS0yV6HQnaFuzI75o1zByTnxGng==",
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "NNiTR3dp1/4WNIv2WRHm87pr4WQztt9vVRALqULEUTcYrvb34xwnKwPwt3Ah5iXW1g3qkecXto5V7Ex+IIzeRQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.1.0-dev.212"
+          "Speckle.Sdk": "3.1.0-dev.215"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "hyBvk2Vq0MPVBM3r48TVJc4ERwcZpuCstIpfebrekLLbCH+wk/vfCD9VMKWqALYjTuYg7hFwrKGw6Z/G23n5jw==",
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "YMb7xdELiza88RSCUWcqmKJlrnoqjxlc1+Z1gEQSCfvFV0Ibvfjz08YAMkOWFc/ZaY9nBUZvshHEWYIskEk5cg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -307,14 +307,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.0.1",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.1.0-dev.212"
+          "Speckle.Sdk.Dependencies": "3.1.0-dev.215"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "b6nJAUSYixTWwZMjff1uPkrKXKp8ehoO6Nfw/eQxLpXdwaF4xdk1/sOXwFeGWaWId9E41Jf2jq4YHcxPEnDjYA=="
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "cT5HRu+pRBvfKTRJIvQBgdX2X5eeTebHe7zmNz82tFT0p65RsK9K7Ap9RjvMndbEPqFtt8/sCNa5RHyfrf+IUg=="
       }
     }
   }

--- a/Converters/Autocad/Speckle.Converters.Autocad2024/packages.lock.json
+++ b/Converters/Autocad/Speckle.Converters.Autocad2024/packages.lock.json
@@ -264,9 +264,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.212, )",
-          "Speckle.Sdk": "[3.1.0-dev.212, )",
-          "Speckle.Sdk.Dependencies": "[3.1.0-dev.212, )"
+          "Speckle.Objects": "[3.1.0-dev.215, )",
+          "Speckle.Sdk": "[3.1.0-dev.215, )",
+          "Speckle.Sdk.Dependencies": "[3.1.0-dev.215, )"
         }
       },
       "speckle.connectors.dui": {
@@ -274,8 +274,8 @@
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
           "Speckle.Connectors.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[3.1.0-dev.212, )",
-          "Speckle.Sdk.Dependencies": "[3.1.0-dev.212, )",
+          "Speckle.Sdk": "[3.1.0-dev.215, )",
+          "Speckle.Sdk.Dependencies": "[3.1.0-dev.215, )",
           "System.Threading.Tasks.Dataflow": "[6.0.0, )"
         }
       },
@@ -293,7 +293,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.1.0-dev.212, )"
+          "Speckle.Objects": "[3.1.0-dev.215, )"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -331,18 +331,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "n0NUmrZKDSgMDnKrlTpJk8sH7Kse/8O6M1qkBmw02ux6LhOIpQhdlHo3SY/xS0yV6HQnaFuzI75o1zByTnxGng==",
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "NNiTR3dp1/4WNIv2WRHm87pr4WQztt9vVRALqULEUTcYrvb34xwnKwPwt3Ah5iXW1g3qkecXto5V7Ex+IIzeRQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.1.0-dev.212"
+          "Speckle.Sdk": "3.1.0-dev.215"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "hyBvk2Vq0MPVBM3r48TVJc4ERwcZpuCstIpfebrekLLbCH+wk/vfCD9VMKWqALYjTuYg7hFwrKGw6Z/G23n5jw==",
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "YMb7xdELiza88RSCUWcqmKJlrnoqjxlc1+Z1gEQSCfvFV0Ibvfjz08YAMkOWFc/ZaY9nBUZvshHEWYIskEk5cg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -352,14 +352,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.0.1",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.1.0-dev.212"
+          "Speckle.Sdk.Dependencies": "3.1.0-dev.215"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "b6nJAUSYixTWwZMjff1uPkrKXKp8ehoO6Nfw/eQxLpXdwaF4xdk1/sOXwFeGWaWId9E41Jf2jq4YHcxPEnDjYA=="
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "cT5HRu+pRBvfKTRJIvQBgdX2X5eeTebHe7zmNz82tFT0p65RsK9K7Ap9RjvMndbEPqFtt8/sCNa5RHyfrf+IUg=="
       },
       "System.Threading.Tasks.Dataflow": {
         "type": "CentralTransitive",

--- a/Converters/Autocad/Speckle.Converters.Autocad2025/packages.lock.json
+++ b/Converters/Autocad/Speckle.Converters.Autocad2025/packages.lock.json
@@ -220,9 +220,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.212, )",
-          "Speckle.Sdk": "[3.1.0-dev.212, )",
-          "Speckle.Sdk.Dependencies": "[3.1.0-dev.212, )"
+          "Speckle.Objects": "[3.1.0-dev.215, )",
+          "Speckle.Sdk": "[3.1.0-dev.215, )",
+          "Speckle.Sdk.Dependencies": "[3.1.0-dev.215, )"
         }
       },
       "speckle.connectors.dui": {
@@ -230,8 +230,8 @@
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
           "Speckle.Connectors.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[3.1.0-dev.212, )",
-          "Speckle.Sdk.Dependencies": "[3.1.0-dev.212, )",
+          "Speckle.Sdk": "[3.1.0-dev.215, )",
+          "Speckle.Sdk.Dependencies": "[3.1.0-dev.215, )",
           "System.Threading.Tasks.Dataflow": "[6.0.0, )"
         }
       },
@@ -249,7 +249,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.1.0-dev.212, )"
+          "Speckle.Objects": "[3.1.0-dev.215, )"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -287,18 +287,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "n0NUmrZKDSgMDnKrlTpJk8sH7Kse/8O6M1qkBmw02ux6LhOIpQhdlHo3SY/xS0yV6HQnaFuzI75o1zByTnxGng==",
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "NNiTR3dp1/4WNIv2WRHm87pr4WQztt9vVRALqULEUTcYrvb34xwnKwPwt3Ah5iXW1g3qkecXto5V7Ex+IIzeRQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.1.0-dev.212"
+          "Speckle.Sdk": "3.1.0-dev.215"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "hyBvk2Vq0MPVBM3r48TVJc4ERwcZpuCstIpfebrekLLbCH+wk/vfCD9VMKWqALYjTuYg7hFwrKGw6Z/G23n5jw==",
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "YMb7xdELiza88RSCUWcqmKJlrnoqjxlc1+Z1gEQSCfvFV0Ibvfjz08YAMkOWFc/ZaY9nBUZvshHEWYIskEk5cg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -307,14 +307,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.0.1",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.1.0-dev.212"
+          "Speckle.Sdk.Dependencies": "3.1.0-dev.215"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "b6nJAUSYixTWwZMjff1uPkrKXKp8ehoO6Nfw/eQxLpXdwaF4xdk1/sOXwFeGWaWId9E41Jf2jq4YHcxPEnDjYA=="
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "cT5HRu+pRBvfKTRJIvQBgdX2X5eeTebHe7zmNz82tFT0p65RsK9K7Ap9RjvMndbEPqFtt8/sCNa5RHyfrf+IUg=="
       },
       "System.Threading.Tasks.Dataflow": {
         "type": "CentralTransitive",

--- a/Converters/CSi/Speckle.Converters.ETABS21/packages.lock.json
+++ b/Converters/CSi/Speckle.Converters.ETABS21/packages.lock.json
@@ -263,7 +263,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.1.0-dev.212, )"
+          "Speckle.Objects": "[3.1.0-dev.215, )"
         }
       },
       "Microsoft.Extensions.Logging": {
@@ -286,18 +286,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "n0NUmrZKDSgMDnKrlTpJk8sH7Kse/8O6M1qkBmw02ux6LhOIpQhdlHo3SY/xS0yV6HQnaFuzI75o1zByTnxGng==",
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "NNiTR3dp1/4WNIv2WRHm87pr4WQztt9vVRALqULEUTcYrvb34xwnKwPwt3Ah5iXW1g3qkecXto5V7Ex+IIzeRQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.1.0-dev.212"
+          "Speckle.Sdk": "3.1.0-dev.215"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "hyBvk2Vq0MPVBM3r48TVJc4ERwcZpuCstIpfebrekLLbCH+wk/vfCD9VMKWqALYjTuYg7hFwrKGw6Z/G23n5jw==",
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "YMb7xdELiza88RSCUWcqmKJlrnoqjxlc1+Z1gEQSCfvFV0Ibvfjz08YAMkOWFc/ZaY9nBUZvshHEWYIskEk5cg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -307,14 +307,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.0.1",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.1.0-dev.212"
+          "Speckle.Sdk.Dependencies": "3.1.0-dev.215"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "b6nJAUSYixTWwZMjff1uPkrKXKp8ehoO6Nfw/eQxLpXdwaF4xdk1/sOXwFeGWaWId9E41Jf2jq4YHcxPEnDjYA=="
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "cT5HRu+pRBvfKTRJIvQBgdX2X5eeTebHe7zmNz82tFT0p65RsK9K7Ap9RjvMndbEPqFtt8/sCNa5RHyfrf+IUg=="
       }
     }
   }

--- a/Converters/CSi/Speckle.Converters.ETABS22/packages.lock.json
+++ b/Converters/CSi/Speckle.Converters.ETABS22/packages.lock.json
@@ -219,7 +219,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.1.0-dev.212, )"
+          "Speckle.Objects": "[3.1.0-dev.215, )"
         }
       },
       "Microsoft.Extensions.Logging": {
@@ -242,18 +242,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "n0NUmrZKDSgMDnKrlTpJk8sH7Kse/8O6M1qkBmw02ux6LhOIpQhdlHo3SY/xS0yV6HQnaFuzI75o1zByTnxGng==",
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "NNiTR3dp1/4WNIv2WRHm87pr4WQztt9vVRALqULEUTcYrvb34xwnKwPwt3Ah5iXW1g3qkecXto5V7Ex+IIzeRQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.1.0-dev.212"
+          "Speckle.Sdk": "3.1.0-dev.215"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "hyBvk2Vq0MPVBM3r48TVJc4ERwcZpuCstIpfebrekLLbCH+wk/vfCD9VMKWqALYjTuYg7hFwrKGw6Z/G23n5jw==",
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "YMb7xdELiza88RSCUWcqmKJlrnoqjxlc1+Z1gEQSCfvFV0Ibvfjz08YAMkOWFc/ZaY9nBUZvshHEWYIskEk5cg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -262,14 +262,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.0.1",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.1.0-dev.212"
+          "Speckle.Sdk.Dependencies": "3.1.0-dev.215"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "b6nJAUSYixTWwZMjff1uPkrKXKp8ehoO6Nfw/eQxLpXdwaF4xdk1/sOXwFeGWaWId9E41Jf2jq4YHcxPEnDjYA=="
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "cT5HRu+pRBvfKTRJIvQBgdX2X5eeTebHe7zmNz82tFT0p65RsK9K7Ap9RjvMndbEPqFtt8/sCNa5RHyfrf+IUg=="
       }
     }
   }

--- a/Converters/Civil3d/Speckle.Converters.Civil3d2022/packages.lock.json
+++ b/Converters/Civil3d/Speckle.Converters.Civil3d2022/packages.lock.json
@@ -272,7 +272,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.1.0-dev.212, )"
+          "Speckle.Objects": "[3.1.0-dev.215, )"
         }
       },
       "Microsoft.Extensions.Logging": {
@@ -295,18 +295,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "n0NUmrZKDSgMDnKrlTpJk8sH7Kse/8O6M1qkBmw02ux6LhOIpQhdlHo3SY/xS0yV6HQnaFuzI75o1zByTnxGng==",
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "NNiTR3dp1/4WNIv2WRHm87pr4WQztt9vVRALqULEUTcYrvb34xwnKwPwt3Ah5iXW1g3qkecXto5V7Ex+IIzeRQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.1.0-dev.212"
+          "Speckle.Sdk": "3.1.0-dev.215"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "hyBvk2Vq0MPVBM3r48TVJc4ERwcZpuCstIpfebrekLLbCH+wk/vfCD9VMKWqALYjTuYg7hFwrKGw6Z/G23n5jw==",
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "YMb7xdELiza88RSCUWcqmKJlrnoqjxlc1+Z1gEQSCfvFV0Ibvfjz08YAMkOWFc/ZaY9nBUZvshHEWYIskEk5cg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -316,14 +316,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.0.1",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.1.0-dev.212"
+          "Speckle.Sdk.Dependencies": "3.1.0-dev.215"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "b6nJAUSYixTWwZMjff1uPkrKXKp8ehoO6Nfw/eQxLpXdwaF4xdk1/sOXwFeGWaWId9E41Jf2jq4YHcxPEnDjYA=="
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "cT5HRu+pRBvfKTRJIvQBgdX2X5eeTebHe7zmNz82tFT0p65RsK9K7Ap9RjvMndbEPqFtt8/sCNa5RHyfrf+IUg=="
       }
     }
   }

--- a/Converters/Civil3d/Speckle.Converters.Civil3d2023/packages.lock.json
+++ b/Converters/Civil3d/Speckle.Converters.Civil3d2023/packages.lock.json
@@ -272,7 +272,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.1.0-dev.212, )"
+          "Speckle.Objects": "[3.1.0-dev.215, )"
         }
       },
       "Microsoft.Extensions.Logging": {
@@ -295,18 +295,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "n0NUmrZKDSgMDnKrlTpJk8sH7Kse/8O6M1qkBmw02ux6LhOIpQhdlHo3SY/xS0yV6HQnaFuzI75o1zByTnxGng==",
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "NNiTR3dp1/4WNIv2WRHm87pr4WQztt9vVRALqULEUTcYrvb34xwnKwPwt3Ah5iXW1g3qkecXto5V7Ex+IIzeRQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.1.0-dev.212"
+          "Speckle.Sdk": "3.1.0-dev.215"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "hyBvk2Vq0MPVBM3r48TVJc4ERwcZpuCstIpfebrekLLbCH+wk/vfCD9VMKWqALYjTuYg7hFwrKGw6Z/G23n5jw==",
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "YMb7xdELiza88RSCUWcqmKJlrnoqjxlc1+Z1gEQSCfvFV0Ibvfjz08YAMkOWFc/ZaY9nBUZvshHEWYIskEk5cg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -316,14 +316,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.0.1",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.1.0-dev.212"
+          "Speckle.Sdk.Dependencies": "3.1.0-dev.215"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "b6nJAUSYixTWwZMjff1uPkrKXKp8ehoO6Nfw/eQxLpXdwaF4xdk1/sOXwFeGWaWId9E41Jf2jq4YHcxPEnDjYA=="
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "cT5HRu+pRBvfKTRJIvQBgdX2X5eeTebHe7zmNz82tFT0p65RsK9K7Ap9RjvMndbEPqFtt8/sCNa5RHyfrf+IUg=="
       }
     }
   }

--- a/Converters/Civil3d/Speckle.Converters.Civil3d2024/packages.lock.json
+++ b/Converters/Civil3d/Speckle.Converters.Civil3d2024/packages.lock.json
@@ -272,7 +272,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.1.0-dev.212, )"
+          "Speckle.Objects": "[3.1.0-dev.215, )"
         }
       },
       "Microsoft.Extensions.Logging": {
@@ -295,18 +295,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "n0NUmrZKDSgMDnKrlTpJk8sH7Kse/8O6M1qkBmw02ux6LhOIpQhdlHo3SY/xS0yV6HQnaFuzI75o1zByTnxGng==",
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "NNiTR3dp1/4WNIv2WRHm87pr4WQztt9vVRALqULEUTcYrvb34xwnKwPwt3Ah5iXW1g3qkecXto5V7Ex+IIzeRQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.1.0-dev.212"
+          "Speckle.Sdk": "3.1.0-dev.215"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "hyBvk2Vq0MPVBM3r48TVJc4ERwcZpuCstIpfebrekLLbCH+wk/vfCD9VMKWqALYjTuYg7hFwrKGw6Z/G23n5jw==",
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "YMb7xdELiza88RSCUWcqmKJlrnoqjxlc1+Z1gEQSCfvFV0Ibvfjz08YAMkOWFc/ZaY9nBUZvshHEWYIskEk5cg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -316,14 +316,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.0.1",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.1.0-dev.212"
+          "Speckle.Sdk.Dependencies": "3.1.0-dev.215"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "b6nJAUSYixTWwZMjff1uPkrKXKp8ehoO6Nfw/eQxLpXdwaF4xdk1/sOXwFeGWaWId9E41Jf2jq4YHcxPEnDjYA=="
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "cT5HRu+pRBvfKTRJIvQBgdX2X5eeTebHe7zmNz82tFT0p65RsK9K7Ap9RjvMndbEPqFtt8/sCNa5RHyfrf+IUg=="
       }
     }
   }

--- a/Converters/Civil3d/Speckle.Converters.Civil3d2025/packages.lock.json
+++ b/Converters/Civil3d/Speckle.Converters.Civil3d2025/packages.lock.json
@@ -229,9 +229,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.212, )",
-          "Speckle.Sdk": "[3.1.0-dev.212, )",
-          "Speckle.Sdk.Dependencies": "[3.1.0-dev.212, )"
+          "Speckle.Objects": "[3.1.0-dev.215, )",
+          "Speckle.Sdk": "[3.1.0-dev.215, )",
+          "Speckle.Sdk.Dependencies": "[3.1.0-dev.215, )"
         }
       },
       "speckle.connectors.dui": {
@@ -239,8 +239,8 @@
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
           "Speckle.Connectors.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[3.1.0-dev.212, )",
-          "Speckle.Sdk.Dependencies": "[3.1.0-dev.212, )",
+          "Speckle.Sdk": "[3.1.0-dev.215, )",
+          "Speckle.Sdk.Dependencies": "[3.1.0-dev.215, )",
           "System.Threading.Tasks.Dataflow": "[6.0.0, )"
         }
       },
@@ -258,7 +258,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.1.0-dev.212, )"
+          "Speckle.Objects": "[3.1.0-dev.215, )"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -296,18 +296,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "n0NUmrZKDSgMDnKrlTpJk8sH7Kse/8O6M1qkBmw02ux6LhOIpQhdlHo3SY/xS0yV6HQnaFuzI75o1zByTnxGng==",
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "NNiTR3dp1/4WNIv2WRHm87pr4WQztt9vVRALqULEUTcYrvb34xwnKwPwt3Ah5iXW1g3qkecXto5V7Ex+IIzeRQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.1.0-dev.212"
+          "Speckle.Sdk": "3.1.0-dev.215"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "hyBvk2Vq0MPVBM3r48TVJc4ERwcZpuCstIpfebrekLLbCH+wk/vfCD9VMKWqALYjTuYg7hFwrKGw6Z/G23n5jw==",
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "YMb7xdELiza88RSCUWcqmKJlrnoqjxlc1+Z1gEQSCfvFV0Ibvfjz08YAMkOWFc/ZaY9nBUZvshHEWYIskEk5cg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -316,14 +316,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.0.1",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.1.0-dev.212"
+          "Speckle.Sdk.Dependencies": "3.1.0-dev.215"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "b6nJAUSYixTWwZMjff1uPkrKXKp8ehoO6Nfw/eQxLpXdwaF4xdk1/sOXwFeGWaWId9E41Jf2jq4YHcxPEnDjYA=="
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "cT5HRu+pRBvfKTRJIvQBgdX2X5eeTebHe7zmNz82tFT0p65RsK9K7Ap9RjvMndbEPqFtt8/sCNa5RHyfrf+IUg=="
       },
       "System.Threading.Tasks.Dataflow": {
         "type": "CentralTransitive",

--- a/Converters/Revit/Speckle.Converters.Revit2022.Tests/packages.lock.json
+++ b/Converters/Revit/Speckle.Converters.Revit2022.Tests/packages.lock.json
@@ -345,7 +345,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.1.0-dev.212, )"
+          "Speckle.Objects": "[3.1.0-dev.215, )"
         }
       },
       "speckle.testing": {
@@ -375,18 +375,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "n0NUmrZKDSgMDnKrlTpJk8sH7Kse/8O6M1qkBmw02ux6LhOIpQhdlHo3SY/xS0yV6HQnaFuzI75o1zByTnxGng==",
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "NNiTR3dp1/4WNIv2WRHm87pr4WQztt9vVRALqULEUTcYrvb34xwnKwPwt3Ah5iXW1g3qkecXto5V7Ex+IIzeRQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.1.0-dev.212"
+          "Speckle.Sdk": "3.1.0-dev.215"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "hyBvk2Vq0MPVBM3r48TVJc4ERwcZpuCstIpfebrekLLbCH+wk/vfCD9VMKWqALYjTuYg7hFwrKGw6Z/G23n5jw==",
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "YMb7xdELiza88RSCUWcqmKJlrnoqjxlc1+Z1gEQSCfvFV0Ibvfjz08YAMkOWFc/ZaY9nBUZvshHEWYIskEk5cg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -395,14 +395,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.0.1",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.1.0-dev.212"
+          "Speckle.Sdk.Dependencies": "3.1.0-dev.215"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "b6nJAUSYixTWwZMjff1uPkrKXKp8ehoO6Nfw/eQxLpXdwaF4xdk1/sOXwFeGWaWId9E41Jf2jq4YHcxPEnDjYA=="
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "cT5HRu+pRBvfKTRJIvQBgdX2X5eeTebHe7zmNz82tFT0p65RsK9K7Ap9RjvMndbEPqFtt8/sCNa5RHyfrf+IUg=="
       }
     }
   }

--- a/Converters/Revit/Speckle.Converters.Revit2022/packages.lock.json
+++ b/Converters/Revit/Speckle.Converters.Revit2022/packages.lock.json
@@ -263,7 +263,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.1.0-dev.212, )"
+          "Speckle.Objects": "[3.1.0-dev.215, )"
         }
       },
       "Microsoft.Extensions.Logging": {
@@ -286,18 +286,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "n0NUmrZKDSgMDnKrlTpJk8sH7Kse/8O6M1qkBmw02ux6LhOIpQhdlHo3SY/xS0yV6HQnaFuzI75o1zByTnxGng==",
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "NNiTR3dp1/4WNIv2WRHm87pr4WQztt9vVRALqULEUTcYrvb34xwnKwPwt3Ah5iXW1g3qkecXto5V7Ex+IIzeRQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.1.0-dev.212"
+          "Speckle.Sdk": "3.1.0-dev.215"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "hyBvk2Vq0MPVBM3r48TVJc4ERwcZpuCstIpfebrekLLbCH+wk/vfCD9VMKWqALYjTuYg7hFwrKGw6Z/G23n5jw==",
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "YMb7xdELiza88RSCUWcqmKJlrnoqjxlc1+Z1gEQSCfvFV0Ibvfjz08YAMkOWFc/ZaY9nBUZvshHEWYIskEk5cg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -307,14 +307,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.0.1",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.1.0-dev.212"
+          "Speckle.Sdk.Dependencies": "3.1.0-dev.215"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "b6nJAUSYixTWwZMjff1uPkrKXKp8ehoO6Nfw/eQxLpXdwaF4xdk1/sOXwFeGWaWId9E41Jf2jq4YHcxPEnDjYA=="
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "cT5HRu+pRBvfKTRJIvQBgdX2X5eeTebHe7zmNz82tFT0p65RsK9K7Ap9RjvMndbEPqFtt8/sCNa5RHyfrf+IUg=="
       }
     }
   }

--- a/Converters/Revit/Speckle.Converters.Revit2023.Tests/packages.lock.json
+++ b/Converters/Revit/Speckle.Converters.Revit2023.Tests/packages.lock.json
@@ -345,7 +345,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.1.0-dev.212, )"
+          "Speckle.Objects": "[3.1.0-dev.215, )"
         }
       },
       "speckle.testing": {
@@ -375,18 +375,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "n0NUmrZKDSgMDnKrlTpJk8sH7Kse/8O6M1qkBmw02ux6LhOIpQhdlHo3SY/xS0yV6HQnaFuzI75o1zByTnxGng==",
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "NNiTR3dp1/4WNIv2WRHm87pr4WQztt9vVRALqULEUTcYrvb34xwnKwPwt3Ah5iXW1g3qkecXto5V7Ex+IIzeRQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.1.0-dev.212"
+          "Speckle.Sdk": "3.1.0-dev.215"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "hyBvk2Vq0MPVBM3r48TVJc4ERwcZpuCstIpfebrekLLbCH+wk/vfCD9VMKWqALYjTuYg7hFwrKGw6Z/G23n5jw==",
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "YMb7xdELiza88RSCUWcqmKJlrnoqjxlc1+Z1gEQSCfvFV0Ibvfjz08YAMkOWFc/ZaY9nBUZvshHEWYIskEk5cg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -395,14 +395,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.0.1",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.1.0-dev.212"
+          "Speckle.Sdk.Dependencies": "3.1.0-dev.215"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "b6nJAUSYixTWwZMjff1uPkrKXKp8ehoO6Nfw/eQxLpXdwaF4xdk1/sOXwFeGWaWId9E41Jf2jq4YHcxPEnDjYA=="
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "cT5HRu+pRBvfKTRJIvQBgdX2X5eeTebHe7zmNz82tFT0p65RsK9K7Ap9RjvMndbEPqFtt8/sCNa5RHyfrf+IUg=="
       }
     }
   }

--- a/Converters/Revit/Speckle.Converters.Revit2023/packages.lock.json
+++ b/Converters/Revit/Speckle.Converters.Revit2023/packages.lock.json
@@ -263,7 +263,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.1.0-dev.212, )"
+          "Speckle.Objects": "[3.1.0-dev.215, )"
         }
       },
       "Microsoft.Extensions.Logging": {
@@ -286,18 +286,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "n0NUmrZKDSgMDnKrlTpJk8sH7Kse/8O6M1qkBmw02ux6LhOIpQhdlHo3SY/xS0yV6HQnaFuzI75o1zByTnxGng==",
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "NNiTR3dp1/4WNIv2WRHm87pr4WQztt9vVRALqULEUTcYrvb34xwnKwPwt3Ah5iXW1g3qkecXto5V7Ex+IIzeRQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.1.0-dev.212"
+          "Speckle.Sdk": "3.1.0-dev.215"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "hyBvk2Vq0MPVBM3r48TVJc4ERwcZpuCstIpfebrekLLbCH+wk/vfCD9VMKWqALYjTuYg7hFwrKGw6Z/G23n5jw==",
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "YMb7xdELiza88RSCUWcqmKJlrnoqjxlc1+Z1gEQSCfvFV0Ibvfjz08YAMkOWFc/ZaY9nBUZvshHEWYIskEk5cg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -307,14 +307,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.0.1",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.1.0-dev.212"
+          "Speckle.Sdk.Dependencies": "3.1.0-dev.215"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "b6nJAUSYixTWwZMjff1uPkrKXKp8ehoO6Nfw/eQxLpXdwaF4xdk1/sOXwFeGWaWId9E41Jf2jq4YHcxPEnDjYA=="
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "cT5HRu+pRBvfKTRJIvQBgdX2X5eeTebHe7zmNz82tFT0p65RsK9K7Ap9RjvMndbEPqFtt8/sCNa5RHyfrf+IUg=="
       }
     }
   }

--- a/Converters/Revit/Speckle.Converters.Revit2024.Tests/packages.lock.json
+++ b/Converters/Revit/Speckle.Converters.Revit2024.Tests/packages.lock.json
@@ -345,7 +345,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.1.0-dev.212, )"
+          "Speckle.Objects": "[3.1.0-dev.215, )"
         }
       },
       "speckle.testing": {
@@ -375,18 +375,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "n0NUmrZKDSgMDnKrlTpJk8sH7Kse/8O6M1qkBmw02ux6LhOIpQhdlHo3SY/xS0yV6HQnaFuzI75o1zByTnxGng==",
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "NNiTR3dp1/4WNIv2WRHm87pr4WQztt9vVRALqULEUTcYrvb34xwnKwPwt3Ah5iXW1g3qkecXto5V7Ex+IIzeRQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.1.0-dev.212"
+          "Speckle.Sdk": "3.1.0-dev.215"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "hyBvk2Vq0MPVBM3r48TVJc4ERwcZpuCstIpfebrekLLbCH+wk/vfCD9VMKWqALYjTuYg7hFwrKGw6Z/G23n5jw==",
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "YMb7xdELiza88RSCUWcqmKJlrnoqjxlc1+Z1gEQSCfvFV0Ibvfjz08YAMkOWFc/ZaY9nBUZvshHEWYIskEk5cg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -395,14 +395,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.0.1",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.1.0-dev.212"
+          "Speckle.Sdk.Dependencies": "3.1.0-dev.215"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "b6nJAUSYixTWwZMjff1uPkrKXKp8ehoO6Nfw/eQxLpXdwaF4xdk1/sOXwFeGWaWId9E41Jf2jq4YHcxPEnDjYA=="
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "cT5HRu+pRBvfKTRJIvQBgdX2X5eeTebHe7zmNz82tFT0p65RsK9K7Ap9RjvMndbEPqFtt8/sCNa5RHyfrf+IUg=="
       }
     }
   }

--- a/Converters/Revit/Speckle.Converters.Revit2024/packages.lock.json
+++ b/Converters/Revit/Speckle.Converters.Revit2024/packages.lock.json
@@ -263,7 +263,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.1.0-dev.212, )"
+          "Speckle.Objects": "[3.1.0-dev.215, )"
         }
       },
       "Microsoft.Extensions.Logging": {
@@ -286,18 +286,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "n0NUmrZKDSgMDnKrlTpJk8sH7Kse/8O6M1qkBmw02ux6LhOIpQhdlHo3SY/xS0yV6HQnaFuzI75o1zByTnxGng==",
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "NNiTR3dp1/4WNIv2WRHm87pr4WQztt9vVRALqULEUTcYrvb34xwnKwPwt3Ah5iXW1g3qkecXto5V7Ex+IIzeRQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.1.0-dev.212"
+          "Speckle.Sdk": "3.1.0-dev.215"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "hyBvk2Vq0MPVBM3r48TVJc4ERwcZpuCstIpfebrekLLbCH+wk/vfCD9VMKWqALYjTuYg7hFwrKGw6Z/G23n5jw==",
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "YMb7xdELiza88RSCUWcqmKJlrnoqjxlc1+Z1gEQSCfvFV0Ibvfjz08YAMkOWFc/ZaY9nBUZvshHEWYIskEk5cg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -307,14 +307,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.0.1",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.1.0-dev.212"
+          "Speckle.Sdk.Dependencies": "3.1.0-dev.215"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "b6nJAUSYixTWwZMjff1uPkrKXKp8ehoO6Nfw/eQxLpXdwaF4xdk1/sOXwFeGWaWId9E41Jf2jq4YHcxPEnDjYA=="
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "cT5HRu+pRBvfKTRJIvQBgdX2X5eeTebHe7zmNz82tFT0p65RsK9K7Ap9RjvMndbEPqFtt8/sCNa5RHyfrf+IUg=="
       }
     }
   }

--- a/Converters/Revit/Speckle.Converters.Revit2025/packages.lock.json
+++ b/Converters/Revit/Speckle.Converters.Revit2025/packages.lock.json
@@ -219,7 +219,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.1.0-dev.212, )"
+          "Speckle.Objects": "[3.1.0-dev.215, )"
         }
       },
       "Microsoft.Extensions.Logging": {
@@ -242,18 +242,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "n0NUmrZKDSgMDnKrlTpJk8sH7Kse/8O6M1qkBmw02ux6LhOIpQhdlHo3SY/xS0yV6HQnaFuzI75o1zByTnxGng==",
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "NNiTR3dp1/4WNIv2WRHm87pr4WQztt9vVRALqULEUTcYrvb34xwnKwPwt3Ah5iXW1g3qkecXto5V7Ex+IIzeRQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.1.0-dev.212"
+          "Speckle.Sdk": "3.1.0-dev.215"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "hyBvk2Vq0MPVBM3r48TVJc4ERwcZpuCstIpfebrekLLbCH+wk/vfCD9VMKWqALYjTuYg7hFwrKGw6Z/G23n5jw==",
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "YMb7xdELiza88RSCUWcqmKJlrnoqjxlc1+Z1gEQSCfvFV0Ibvfjz08YAMkOWFc/ZaY9nBUZvshHEWYIskEk5cg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -262,14 +262,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.0.1",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.1.0-dev.212"
+          "Speckle.Sdk.Dependencies": "3.1.0-dev.215"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "b6nJAUSYixTWwZMjff1uPkrKXKp8ehoO6Nfw/eQxLpXdwaF4xdk1/sOXwFeGWaWId9E41Jf2jq4YHcxPEnDjYA=="
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "cT5HRu+pRBvfKTRJIvQBgdX2X5eeTebHe7zmNz82tFT0p65RsK9K7Ap9RjvMndbEPqFtt8/sCNa5RHyfrf+IUg=="
       }
     }
   }

--- a/Converters/Rhino/Speckle.Converters.Rhino7.Tests/packages.lock.json
+++ b/Converters/Rhino/Speckle.Converters.Rhino7.Tests/packages.lock.json
@@ -345,7 +345,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.1.0-dev.212, )"
+          "Speckle.Objects": "[3.1.0-dev.215, )"
         }
       },
       "speckle.testing": {
@@ -375,18 +375,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "n0NUmrZKDSgMDnKrlTpJk8sH7Kse/8O6M1qkBmw02ux6LhOIpQhdlHo3SY/xS0yV6HQnaFuzI75o1zByTnxGng==",
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "NNiTR3dp1/4WNIv2WRHm87pr4WQztt9vVRALqULEUTcYrvb34xwnKwPwt3Ah5iXW1g3qkecXto5V7Ex+IIzeRQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.1.0-dev.212"
+          "Speckle.Sdk": "3.1.0-dev.215"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "hyBvk2Vq0MPVBM3r48TVJc4ERwcZpuCstIpfebrekLLbCH+wk/vfCD9VMKWqALYjTuYg7hFwrKGw6Z/G23n5jw==",
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "YMb7xdELiza88RSCUWcqmKJlrnoqjxlc1+Z1gEQSCfvFV0Ibvfjz08YAMkOWFc/ZaY9nBUZvshHEWYIskEk5cg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -395,14 +395,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.0.1",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.1.0-dev.212"
+          "Speckle.Sdk.Dependencies": "3.1.0-dev.215"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "b6nJAUSYixTWwZMjff1uPkrKXKp8ehoO6Nfw/eQxLpXdwaF4xdk1/sOXwFeGWaWId9E41Jf2jq4YHcxPEnDjYA=="
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "cT5HRu+pRBvfKTRJIvQBgdX2X5eeTebHe7zmNz82tFT0p65RsK9K7Ap9RjvMndbEPqFtt8/sCNa5RHyfrf+IUg=="
       }
     }
   }

--- a/Converters/Rhino/Speckle.Converters.Rhino7/packages.lock.json
+++ b/Converters/Rhino/Speckle.Converters.Rhino7/packages.lock.json
@@ -263,7 +263,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.1.0-dev.212, )"
+          "Speckle.Objects": "[3.1.0-dev.215, )"
         }
       },
       "Microsoft.Extensions.Logging": {
@@ -286,18 +286,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "n0NUmrZKDSgMDnKrlTpJk8sH7Kse/8O6M1qkBmw02ux6LhOIpQhdlHo3SY/xS0yV6HQnaFuzI75o1zByTnxGng==",
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "NNiTR3dp1/4WNIv2WRHm87pr4WQztt9vVRALqULEUTcYrvb34xwnKwPwt3Ah5iXW1g3qkecXto5V7Ex+IIzeRQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.1.0-dev.212"
+          "Speckle.Sdk": "3.1.0-dev.215"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "hyBvk2Vq0MPVBM3r48TVJc4ERwcZpuCstIpfebrekLLbCH+wk/vfCD9VMKWqALYjTuYg7hFwrKGw6Z/G23n5jw==",
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "YMb7xdELiza88RSCUWcqmKJlrnoqjxlc1+Z1gEQSCfvFV0Ibvfjz08YAMkOWFc/ZaY9nBUZvshHEWYIskEk5cg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -307,14 +307,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.0.1",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.1.0-dev.212"
+          "Speckle.Sdk.Dependencies": "3.1.0-dev.215"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "b6nJAUSYixTWwZMjff1uPkrKXKp8ehoO6Nfw/eQxLpXdwaF4xdk1/sOXwFeGWaWId9E41Jf2jq4YHcxPEnDjYA=="
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "cT5HRu+pRBvfKTRJIvQBgdX2X5eeTebHe7zmNz82tFT0p65RsK9K7Ap9RjvMndbEPqFtt8/sCNa5RHyfrf+IUg=="
       }
     }
   }

--- a/Converters/Rhino/Speckle.Converters.Rhino8/packages.lock.json
+++ b/Converters/Rhino/Speckle.Converters.Rhino8/packages.lock.json
@@ -263,7 +263,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.1.0-dev.212, )"
+          "Speckle.Objects": "[3.1.0-dev.215, )"
         }
       },
       "Microsoft.Extensions.Logging": {
@@ -286,18 +286,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "n0NUmrZKDSgMDnKrlTpJk8sH7Kse/8O6M1qkBmw02ux6LhOIpQhdlHo3SY/xS0yV6HQnaFuzI75o1zByTnxGng==",
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "NNiTR3dp1/4WNIv2WRHm87pr4WQztt9vVRALqULEUTcYrvb34xwnKwPwt3Ah5iXW1g3qkecXto5V7Ex+IIzeRQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.1.0-dev.212"
+          "Speckle.Sdk": "3.1.0-dev.215"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "hyBvk2Vq0MPVBM3r48TVJc4ERwcZpuCstIpfebrekLLbCH+wk/vfCD9VMKWqALYjTuYg7hFwrKGw6Z/G23n5jw==",
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "YMb7xdELiza88RSCUWcqmKJlrnoqjxlc1+Z1gEQSCfvFV0Ibvfjz08YAMkOWFc/ZaY9nBUZvshHEWYIskEk5cg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -307,14 +307,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.0.1",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.1.0-dev.212"
+          "Speckle.Sdk.Dependencies": "3.1.0-dev.215"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "b6nJAUSYixTWwZMjff1uPkrKXKp8ehoO6Nfw/eQxLpXdwaF4xdk1/sOXwFeGWaWId9E41Jf2jq4YHcxPEnDjYA=="
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "cT5HRu+pRBvfKTRJIvQBgdX2X5eeTebHe7zmNz82tFT0p65RsK9K7Ap9RjvMndbEPqFtt8/sCNa5RHyfrf+IUg=="
       }
     }
   }

--- a/Converters/Tekla/Speckle.Converter.Tekla2023/packages.lock.json
+++ b/Converters/Tekla/Speckle.Converter.Tekla2023/packages.lock.json
@@ -300,7 +300,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.1.0-dev.212, )"
+          "Speckle.Objects": "[3.1.0-dev.215, )"
         }
       },
       "Microsoft.Extensions.Logging": {
@@ -323,18 +323,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "n0NUmrZKDSgMDnKrlTpJk8sH7Kse/8O6M1qkBmw02ux6LhOIpQhdlHo3SY/xS0yV6HQnaFuzI75o1zByTnxGng==",
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "NNiTR3dp1/4WNIv2WRHm87pr4WQztt9vVRALqULEUTcYrvb34xwnKwPwt3Ah5iXW1g3qkecXto5V7Ex+IIzeRQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.1.0-dev.212"
+          "Speckle.Sdk": "3.1.0-dev.215"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "hyBvk2Vq0MPVBM3r48TVJc4ERwcZpuCstIpfebrekLLbCH+wk/vfCD9VMKWqALYjTuYg7hFwrKGw6Z/G23n5jw==",
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "YMb7xdELiza88RSCUWcqmKJlrnoqjxlc1+Z1gEQSCfvFV0Ibvfjz08YAMkOWFc/ZaY9nBUZvshHEWYIskEk5cg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -344,14 +344,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.0.1",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.1.0-dev.212"
+          "Speckle.Sdk.Dependencies": "3.1.0-dev.215"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "b6nJAUSYixTWwZMjff1uPkrKXKp8ehoO6Nfw/eQxLpXdwaF4xdk1/sOXwFeGWaWId9E41Jf2jq4YHcxPEnDjYA=="
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "cT5HRu+pRBvfKTRJIvQBgdX2X5eeTebHe7zmNz82tFT0p65RsK9K7Ap9RjvMndbEPqFtt8/sCNa5RHyfrf+IUg=="
       },
       "Tekla.Structures.Dialog": {
         "type": "CentralTransitive",

--- a/Converters/Tekla/Speckle.Converter.Tekla2024/packages.lock.json
+++ b/Converters/Tekla/Speckle.Converter.Tekla2024/packages.lock.json
@@ -341,7 +341,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.1.0-dev.212, )"
+          "Speckle.Objects": "[3.1.0-dev.215, )"
         }
       },
       "Microsoft.Extensions.Logging": {
@@ -364,18 +364,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "n0NUmrZKDSgMDnKrlTpJk8sH7Kse/8O6M1qkBmw02ux6LhOIpQhdlHo3SY/xS0yV6HQnaFuzI75o1zByTnxGng==",
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "NNiTR3dp1/4WNIv2WRHm87pr4WQztt9vVRALqULEUTcYrvb34xwnKwPwt3Ah5iXW1g3qkecXto5V7Ex+IIzeRQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.1.0-dev.212"
+          "Speckle.Sdk": "3.1.0-dev.215"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "hyBvk2Vq0MPVBM3r48TVJc4ERwcZpuCstIpfebrekLLbCH+wk/vfCD9VMKWqALYjTuYg7hFwrKGw6Z/G23n5jw==",
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "YMb7xdELiza88RSCUWcqmKJlrnoqjxlc1+Z1gEQSCfvFV0Ibvfjz08YAMkOWFc/ZaY9nBUZvshHEWYIskEk5cg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -385,14 +385,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.0.1",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.1.0-dev.212"
+          "Speckle.Sdk.Dependencies": "3.1.0-dev.215"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "b6nJAUSYixTWwZMjff1uPkrKXKp8ehoO6Nfw/eQxLpXdwaF4xdk1/sOXwFeGWaWId9E41Jf2jq4YHcxPEnDjYA=="
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "cT5HRu+pRBvfKTRJIvQBgdX2X5eeTebHe7zmNz82tFT0p65RsK9K7Ap9RjvMndbEPqFtt8/sCNa5RHyfrf+IUg=="
       },
       "Tekla.Structures.Plugins": {
         "type": "CentralTransitive",

--- a/DUI3/Speckle.Connectors.DUI.Tests/packages.lock.json
+++ b/DUI3/Speckle.Connectors.DUI.Tests/packages.lock.json
@@ -324,9 +324,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.212, )",
-          "Speckle.Sdk": "[3.1.0-dev.212, )",
-          "Speckle.Sdk.Dependencies": "[3.1.0-dev.212, )"
+          "Speckle.Objects": "[3.1.0-dev.215, )",
+          "Speckle.Sdk": "[3.1.0-dev.215, )",
+          "Speckle.Sdk.Dependencies": "[3.1.0-dev.215, )"
         }
       },
       "speckle.connectors.dui": {
@@ -334,8 +334,8 @@
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
           "Speckle.Connectors.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[3.1.0-dev.212, )",
-          "Speckle.Sdk.Dependencies": "[3.1.0-dev.212, )",
+          "Speckle.Sdk": "[3.1.0-dev.215, )",
+          "Speckle.Sdk.Dependencies": "[3.1.0-dev.215, )",
           "System.Threading.Tasks.Dataflow": "[6.0.0, )"
         }
       },
@@ -378,18 +378,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "n0NUmrZKDSgMDnKrlTpJk8sH7Kse/8O6M1qkBmw02ux6LhOIpQhdlHo3SY/xS0yV6HQnaFuzI75o1zByTnxGng==",
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "NNiTR3dp1/4WNIv2WRHm87pr4WQztt9vVRALqULEUTcYrvb34xwnKwPwt3Ah5iXW1g3qkecXto5V7Ex+IIzeRQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.1.0-dev.212"
+          "Speckle.Sdk": "3.1.0-dev.215"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "hyBvk2Vq0MPVBM3r48TVJc4ERwcZpuCstIpfebrekLLbCH+wk/vfCD9VMKWqALYjTuYg7hFwrKGw6Z/G23n5jw==",
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "YMb7xdELiza88RSCUWcqmKJlrnoqjxlc1+Z1gEQSCfvFV0Ibvfjz08YAMkOWFc/ZaY9nBUZvshHEWYIskEk5cg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -398,14 +398,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.0.1",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.1.0-dev.212"
+          "Speckle.Sdk.Dependencies": "3.1.0-dev.215"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "b6nJAUSYixTWwZMjff1uPkrKXKp8ehoO6Nfw/eQxLpXdwaF4xdk1/sOXwFeGWaWId9E41Jf2jq4YHcxPEnDjYA=="
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "cT5HRu+pRBvfKTRJIvQBgdX2X5eeTebHe7zmNz82tFT0p65RsK9K7Ap9RjvMndbEPqFtt8/sCNa5RHyfrf+IUg=="
       },
       "System.Threading.Tasks.Dataflow": {
         "type": "CentralTransitive",

--- a/DUI3/Speckle.Connectors.DUI.WebView/packages.lock.json
+++ b/DUI3/Speckle.Connectors.DUI.WebView/packages.lock.json
@@ -264,9 +264,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.212, )",
-          "Speckle.Sdk": "[3.1.0-dev.212, )",
-          "Speckle.Sdk.Dependencies": "[3.1.0-dev.212, )"
+          "Speckle.Objects": "[3.1.0-dev.215, )",
+          "Speckle.Sdk": "[3.1.0-dev.215, )",
+          "Speckle.Sdk.Dependencies": "[3.1.0-dev.215, )"
         }
       },
       "speckle.connectors.dui": {
@@ -274,8 +274,8 @@
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
           "Speckle.Connectors.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[3.1.0-dev.212, )",
-          "Speckle.Sdk.Dependencies": "[3.1.0-dev.212, )",
+          "Speckle.Sdk": "[3.1.0-dev.215, )",
+          "Speckle.Sdk.Dependencies": "[3.1.0-dev.215, )",
           "System.Threading.Tasks.Dataflow": "[6.0.0, )"
         }
       },
@@ -311,18 +311,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "n0NUmrZKDSgMDnKrlTpJk8sH7Kse/8O6M1qkBmw02ux6LhOIpQhdlHo3SY/xS0yV6HQnaFuzI75o1zByTnxGng==",
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "NNiTR3dp1/4WNIv2WRHm87pr4WQztt9vVRALqULEUTcYrvb34xwnKwPwt3Ah5iXW1g3qkecXto5V7Ex+IIzeRQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.1.0-dev.212"
+          "Speckle.Sdk": "3.1.0-dev.215"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "hyBvk2Vq0MPVBM3r48TVJc4ERwcZpuCstIpfebrekLLbCH+wk/vfCD9VMKWqALYjTuYg7hFwrKGw6Z/G23n5jw==",
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "YMb7xdELiza88RSCUWcqmKJlrnoqjxlc1+Z1gEQSCfvFV0Ibvfjz08YAMkOWFc/ZaY9nBUZvshHEWYIskEk5cg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -332,14 +332,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.0.1",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.1.0-dev.212"
+          "Speckle.Sdk.Dependencies": "3.1.0-dev.215"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "b6nJAUSYixTWwZMjff1uPkrKXKp8ehoO6Nfw/eQxLpXdwaF4xdk1/sOXwFeGWaWId9E41Jf2jq4YHcxPEnDjYA=="
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "cT5HRu+pRBvfKTRJIvQBgdX2X5eeTebHe7zmNz82tFT0p65RsK9K7Ap9RjvMndbEPqFtt8/sCNa5RHyfrf+IUg=="
       },
       "System.Threading.Tasks.Dataflow": {
         "type": "CentralTransitive",
@@ -572,9 +572,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.212, )",
-          "Speckle.Sdk": "[3.1.0-dev.212, )",
-          "Speckle.Sdk.Dependencies": "[3.1.0-dev.212, )"
+          "Speckle.Objects": "[3.1.0-dev.215, )",
+          "Speckle.Sdk": "[3.1.0-dev.215, )",
+          "Speckle.Sdk.Dependencies": "[3.1.0-dev.215, )"
         }
       },
       "speckle.connectors.dui": {
@@ -582,8 +582,8 @@
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
           "Speckle.Connectors.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[3.1.0-dev.212, )",
-          "Speckle.Sdk.Dependencies": "[3.1.0-dev.212, )",
+          "Speckle.Sdk": "[3.1.0-dev.215, )",
+          "Speckle.Sdk.Dependencies": "[3.1.0-dev.215, )",
           "System.Threading.Tasks.Dataflow": "[6.0.0, )"
         }
       },
@@ -619,18 +619,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "n0NUmrZKDSgMDnKrlTpJk8sH7Kse/8O6M1qkBmw02ux6LhOIpQhdlHo3SY/xS0yV6HQnaFuzI75o1zByTnxGng==",
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "NNiTR3dp1/4WNIv2WRHm87pr4WQztt9vVRALqULEUTcYrvb34xwnKwPwt3Ah5iXW1g3qkecXto5V7Ex+IIzeRQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.1.0-dev.212"
+          "Speckle.Sdk": "3.1.0-dev.215"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "hyBvk2Vq0MPVBM3r48TVJc4ERwcZpuCstIpfebrekLLbCH+wk/vfCD9VMKWqALYjTuYg7hFwrKGw6Z/G23n5jw==",
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "YMb7xdELiza88RSCUWcqmKJlrnoqjxlc1+Z1gEQSCfvFV0Ibvfjz08YAMkOWFc/ZaY9nBUZvshHEWYIskEk5cg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -640,14 +640,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.0.1",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.1.0-dev.212"
+          "Speckle.Sdk.Dependencies": "3.1.0-dev.215"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "b6nJAUSYixTWwZMjff1uPkrKXKp8ehoO6Nfw/eQxLpXdwaF4xdk1/sOXwFeGWaWId9E41Jf2jq4YHcxPEnDjYA=="
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "cT5HRu+pRBvfKTRJIvQBgdX2X5eeTebHe7zmNz82tFT0p65RsK9K7Ap9RjvMndbEPqFtt8/sCNa5RHyfrf+IUg=="
       },
       "System.Threading.Tasks.Dataflow": {
         "type": "CentralTransitive",

--- a/DUI3/Speckle.Connectors.DUI/packages.lock.json
+++ b/DUI3/Speckle.Connectors.DUI/packages.lock.json
@@ -50,9 +50,9 @@
       },
       "Speckle.Sdk": {
         "type": "Direct",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "hyBvk2Vq0MPVBM3r48TVJc4ERwcZpuCstIpfebrekLLbCH+wk/vfCD9VMKWqALYjTuYg7hFwrKGw6Z/G23n5jw==",
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "YMb7xdELiza88RSCUWcqmKJlrnoqjxlc1+Z1gEQSCfvFV0Ibvfjz08YAMkOWFc/ZaY9nBUZvshHEWYIskEk5cg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -62,14 +62,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.0.1",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.1.0-dev.212"
+          "Speckle.Sdk.Dependencies": "3.1.0-dev.215"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Direct",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "b6nJAUSYixTWwZMjff1uPkrKXKp8ehoO6Nfw/eQxLpXdwaF4xdk1/sOXwFeGWaWId9E41Jf2jq4YHcxPEnDjYA=="
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "cT5HRu+pRBvfKTRJIvQBgdX2X5eeTebHe7zmNz82tFT0p65RsK9K7Ap9RjvMndbEPqFtt8/sCNa5RHyfrf+IUg=="
       },
       "System.Threading.Tasks.Dataflow": {
         "type": "Direct",
@@ -320,9 +320,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.212, )",
-          "Speckle.Sdk": "[3.1.0-dev.212, )",
-          "Speckle.Sdk.Dependencies": "[3.1.0-dev.212, )"
+          "Speckle.Objects": "[3.1.0-dev.215, )",
+          "Speckle.Sdk": "[3.1.0-dev.215, )",
+          "Speckle.Sdk.Dependencies": "[3.1.0-dev.215, )"
         }
       },
       "speckle.connectors.logging": {
@@ -351,11 +351,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "n0NUmrZKDSgMDnKrlTpJk8sH7Kse/8O6M1qkBmw02ux6LhOIpQhdlHo3SY/xS0yV6HQnaFuzI75o1zByTnxGng==",
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "NNiTR3dp1/4WNIv2WRHm87pr4WQztt9vVRALqULEUTcYrvb34xwnKwPwt3Ah5iXW1g3qkecXto5V7Ex+IIzeRQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.1.0-dev.212"
+          "Speckle.Sdk": "3.1.0-dev.215"
         }
       }
     }

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -40,9 +40,9 @@
     <PackageVersion Include="Speckle.Revit2023.Fakes" Version="0.3.1" />
     <PackageVersion Include="Speckle.Revit2024.Fakes" Version="0.3.1" />
     <PackageVersion Include="Speckle.Rhino7.Fakes" Version="0.3.1" />
-    <PackageVersion Include="Speckle.Objects" Version="3.1.0-dev.212" />
-    <PackageVersion Include="Speckle.Sdk" Version="3.1.0-dev.212" />
-    <PackageVersion Include="Speckle.Sdk.Dependencies" Version="3.1.0-dev.212" />
+    <PackageVersion Include="Speckle.Objects" Version="3.1.0-dev.215" />
+    <PackageVersion Include="Speckle.Sdk" Version="3.1.0-dev.215" />
+    <PackageVersion Include="Speckle.Sdk.Dependencies" Version="3.1.0-dev.215" />
     <PackageVersion Include="SimpleExec" Version="12.0.0" />
     <PackageVersion Include="System.Threading.Tasks.Dataflow" Version="6.0.0" />
     <GlobalPackageReference Include="PolySharp" Version="1.14.1" />

--- a/Sdk/Speckle.Connectors.Common/Operations/PassthroughProgress.cs
+++ b/Sdk/Speckle.Connectors.Common/Operations/PassthroughProgress.cs
@@ -2,6 +2,7 @@
 
 namespace Speckle.Connectors.Common.Operations;
 
+//this aggregates speed across all SDK uploads and passes it to the main thread
 public class PassthroughProgress : IProgress<ProgressArgs>
 {
   private readonly Action<ProgressArgs> _progressCallback;
@@ -18,7 +19,7 @@ public class PassthroughProgress : IProgress<ProgressArgs>
 
   public void Report(ProgressArgs value)
   {
-    if (value.ProgressEvent == ProgressEvent.DownloadBytes)
+    if (value.ProgressEvent == ProgressEvent.DownloadBytes || value.ProgressEvent == ProgressEvent.UploadBytes)
     {
       long totalBytes;
       lock (_totals)

--- a/Sdk/Speckle.Connectors.Common/Operations/SendProgress.cs
+++ b/Sdk/Speckle.Connectors.Common/Operations/SendProgress.cs
@@ -45,7 +45,9 @@ public class SendProgress(IProgressDisplayManager progressDisplayManager) : ISen
         {
           return;
         }
-        onOperationProgressed.Report(new($"Caching... ({args.Count} objects)", null));
+        onOperationProgressed.Report(
+          new($"Caching... ({args.Count} objects)", progressDisplayManager.CalculatePercentage(args))
+        );
         break;
       case ProgressEvent.UploadBytes:
         if (!_serializeIsDone)
@@ -55,7 +57,7 @@ public class SendProgress(IProgressDisplayManager progressDisplayManager) : ISen
         onOperationProgressed.Report(new($"Uploading... ({_previousSpeed})", null));
         break;
       case ProgressEvent.FromCacheOrSerialized:
-        var message = $"Serializing... ({_serialized} done / {_total} found objects)";
+        var message = $"Serializing... ({_serialized} / {_total} found objects)";
         onOperationProgressed.Report(new(message, progressDisplayManager.CalculatePercentage(args)));
         break;
     }

--- a/Sdk/Speckle.Connectors.Common/Operations/SendProgress.cs
+++ b/Sdk/Speckle.Connectors.Common/Operations/SendProgress.cs
@@ -56,9 +56,7 @@ public class SendProgress(IProgressDisplayManager progressDisplayManager) : ISen
         break;
       case ProgressEvent.FromCacheOrSerialized:
         var message = $"Serializing... ({_serialized} done / {_total} found objects)";
-        onOperationProgressed.Report(
-          new(message, progressDisplayManager.CalculatePercentage(args))
-        );
+        onOperationProgressed.Report(new(message, progressDisplayManager.CalculatePercentage(args)));
         break;
     }
   }

--- a/Sdk/Speckle.Connectors.Common/Operations/SendProgress.cs
+++ b/Sdk/Speckle.Connectors.Common/Operations/SendProgress.cs
@@ -7,12 +7,24 @@ namespace Speckle.Connectors.Common.Operations;
 public class SendProgress(IProgressDisplayManager progressDisplayManager) : ISendProgress
 {
   private string? _previousSpeed;
+  private bool _serializeIsDone;
+  private long _serialized;
+  private long _total;
 
   public void Begin() => progressDisplayManager.Begin();
 
   public void Report(IProgress<CardProgress> onOperationProgressed, ProgressArgs args)
   {
-    if (args.ProgressEvent == ProgressEvent.UploadBytes)
+    if (args.ProgressEvent == ProgressEvent.FromCacheOrSerialized)
+    {
+      _serialized = args.Count;
+      _serializeIsDone = args.Count >= args.Total;
+    }
+    else if (args.ProgressEvent == ProgressEvent.FindingChildren)
+    {
+      _total = args.Count;
+    }
+    else if (args.ProgressEvent == ProgressEvent.UploadBytes)
     {
       switch (args.ProgressEvent)
       {
@@ -29,14 +41,23 @@ public class SendProgress(IProgressDisplayManager progressDisplayManager) : ISen
     switch (args.ProgressEvent)
     {
       case ProgressEvent.CachedToLocal:
-        onOperationProgressed.Report(new($"Caching... ({args.Count} total objects)", null));
+        if (!_serializeIsDone)
+        {
+          return;
+        }
+        onOperationProgressed.Report(new($"Caching... ({args.Count} objects)", null));
         break;
       case ProgressEvent.UploadBytes:
+        if (!_serializeIsDone)
+        {
+          return;
+        }
         onOperationProgressed.Report(new($"Uploading... ({_previousSpeed})", null));
         break;
       case ProgressEvent.FromCacheOrSerialized:
+        var message = $"Serializing... ({_serialized} done / {_total} found objects)";
         onOperationProgressed.Report(
-          new("Loading cache and Serializing...", progressDisplayManager.CalculatePercentage(args))
+          new(message, progressDisplayManager.CalculatePercentage(args))
         );
         break;
     }

--- a/Sdk/Speckle.Connectors.Common/packages.lock.json
+++ b/Sdk/Speckle.Connectors.Common/packages.lock.json
@@ -53,18 +53,18 @@
       },
       "Speckle.Objects": {
         "type": "Direct",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "n0NUmrZKDSgMDnKrlTpJk8sH7Kse/8O6M1qkBmw02ux6LhOIpQhdlHo3SY/xS0yV6HQnaFuzI75o1zByTnxGng==",
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "NNiTR3dp1/4WNIv2WRHm87pr4WQztt9vVRALqULEUTcYrvb34xwnKwPwt3Ah5iXW1g3qkecXto5V7Ex+IIzeRQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.1.0-dev.212"
+          "Speckle.Sdk": "3.1.0-dev.215"
         }
       },
       "Speckle.Sdk": {
         "type": "Direct",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "hyBvk2Vq0MPVBM3r48TVJc4ERwcZpuCstIpfebrekLLbCH+wk/vfCD9VMKWqALYjTuYg7hFwrKGw6Z/G23n5jw==",
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "YMb7xdELiza88RSCUWcqmKJlrnoqjxlc1+Z1gEQSCfvFV0Ibvfjz08YAMkOWFc/ZaY9nBUZvshHEWYIskEk5cg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -74,14 +74,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.0.1",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.1.0-dev.212"
+          "Speckle.Sdk.Dependencies": "3.1.0-dev.215"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Direct",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "b6nJAUSYixTWwZMjff1uPkrKXKp8ehoO6Nfw/eQxLpXdwaF4xdk1/sOXwFeGWaWId9E41Jf2jq4YHcxPEnDjYA=="
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "cT5HRu+pRBvfKTRJIvQBgdX2X5eeTebHe7zmNz82tFT0p65RsK9K7Ap9RjvMndbEPqFtt8/sCNa5RHyfrf+IUg=="
       },
       "GraphQL.Client": {
         "type": "Transitive",

--- a/Sdk/Speckle.Connectors.Tests/packages.lock.json
+++ b/Sdk/Speckle.Connectors.Tests/packages.lock.json
@@ -324,9 +324,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.1.0-dev.212, )",
-          "Speckle.Sdk": "[3.1.0-dev.212, )",
-          "Speckle.Sdk.Dependencies": "[3.1.0-dev.212, )"
+          "Speckle.Objects": "[3.1.0-dev.215, )",
+          "Speckle.Sdk": "[3.1.0-dev.215, )",
+          "Speckle.Sdk.Dependencies": "[3.1.0-dev.215, )"
         }
       },
       "speckle.connectors.logging": {
@@ -368,18 +368,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "n0NUmrZKDSgMDnKrlTpJk8sH7Kse/8O6M1qkBmw02ux6LhOIpQhdlHo3SY/xS0yV6HQnaFuzI75o1zByTnxGng==",
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "NNiTR3dp1/4WNIv2WRHm87pr4WQztt9vVRALqULEUTcYrvb34xwnKwPwt3Ah5iXW1g3qkecXto5V7Ex+IIzeRQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.1.0-dev.212"
+          "Speckle.Sdk": "3.1.0-dev.215"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "hyBvk2Vq0MPVBM3r48TVJc4ERwcZpuCstIpfebrekLLbCH+wk/vfCD9VMKWqALYjTuYg7hFwrKGw6Z/G23n5jw==",
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "YMb7xdELiza88RSCUWcqmKJlrnoqjxlc1+Z1gEQSCfvFV0Ibvfjz08YAMkOWFc/ZaY9nBUZvshHEWYIskEk5cg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -388,14 +388,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.0.1",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.1.0-dev.212"
+          "Speckle.Sdk.Dependencies": "3.1.0-dev.215"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "b6nJAUSYixTWwZMjff1uPkrKXKp8ehoO6Nfw/eQxLpXdwaF4xdk1/sOXwFeGWaWId9E41Jf2jq4YHcxPEnDjYA=="
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "cT5HRu+pRBvfKTRJIvQBgdX2X5eeTebHe7zmNz82tFT0p65RsK9K7Ap9RjvMndbEPqFtt8/sCNa5RHyfrf+IUg=="
       }
     }
   }

--- a/Sdk/Speckle.Converters.Common.Tests/packages.lock.json
+++ b/Sdk/Speckle.Converters.Common.Tests/packages.lock.json
@@ -332,7 +332,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.1.0-dev.212, )"
+          "Speckle.Objects": "[3.1.0-dev.215, )"
         }
       },
       "speckle.testing": {
@@ -362,18 +362,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "n0NUmrZKDSgMDnKrlTpJk8sH7Kse/8O6M1qkBmw02ux6LhOIpQhdlHo3SY/xS0yV6HQnaFuzI75o1zByTnxGng==",
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "NNiTR3dp1/4WNIv2WRHm87pr4WQztt9vVRALqULEUTcYrvb34xwnKwPwt3Ah5iXW1g3qkecXto5V7Ex+IIzeRQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.1.0-dev.212"
+          "Speckle.Sdk": "3.1.0-dev.215"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "hyBvk2Vq0MPVBM3r48TVJc4ERwcZpuCstIpfebrekLLbCH+wk/vfCD9VMKWqALYjTuYg7hFwrKGw6Z/G23n5jw==",
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "YMb7xdELiza88RSCUWcqmKJlrnoqjxlc1+Z1gEQSCfvFV0Ibvfjz08YAMkOWFc/ZaY9nBUZvshHEWYIskEk5cg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -382,14 +382,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.0.1",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.1.0-dev.212"
+          "Speckle.Sdk.Dependencies": "3.1.0-dev.215"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "b6nJAUSYixTWwZMjff1uPkrKXKp8ehoO6Nfw/eQxLpXdwaF4xdk1/sOXwFeGWaWId9E41Jf2jq4YHcxPEnDjYA=="
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "cT5HRu+pRBvfKTRJIvQBgdX2X5eeTebHe7zmNz82tFT0p65RsK9K7Ap9RjvMndbEPqFtt8/sCNa5RHyfrf+IUg=="
       }
     }
   }

--- a/Sdk/Speckle.Converters.Common/packages.lock.json
+++ b/Sdk/Speckle.Converters.Common/packages.lock.json
@@ -50,11 +50,11 @@
       },
       "Speckle.Objects": {
         "type": "Direct",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "n0NUmrZKDSgMDnKrlTpJk8sH7Kse/8O6M1qkBmw02ux6LhOIpQhdlHo3SY/xS0yV6HQnaFuzI75o1zByTnxGng==",
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "NNiTR3dp1/4WNIv2WRHm87pr4WQztt9vVRALqULEUTcYrvb34xwnKwPwt3Ah5iXW1g3qkecXto5V7Ex+IIzeRQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.1.0-dev.212"
+          "Speckle.Sdk": "3.1.0-dev.215"
         }
       },
       "GraphQL.Client": {
@@ -309,9 +309,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "hyBvk2Vq0MPVBM3r48TVJc4ERwcZpuCstIpfebrekLLbCH+wk/vfCD9VMKWqALYjTuYg7hFwrKGw6Z/G23n5jw==",
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "YMb7xdELiza88RSCUWcqmKJlrnoqjxlc1+Z1gEQSCfvFV0Ibvfjz08YAMkOWFc/ZaY9nBUZvshHEWYIskEk5cg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -321,14 +321,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.0.1",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.1.0-dev.212"
+          "Speckle.Sdk.Dependencies": "3.1.0-dev.215"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.1.0-dev.212, )",
-        "resolved": "3.1.0-dev.212",
-        "contentHash": "b6nJAUSYixTWwZMjff1uPkrKXKp8ehoO6Nfw/eQxLpXdwaF4xdk1/sOXwFeGWaWId9E41Jf2jq4YHcxPEnDjYA=="
+        "requested": "[3.1.0-dev.215, )",
+        "resolved": "3.1.0-dev.215",
+        "contentHash": "cT5HRu+pRBvfKTRJIvQBgdX2X5eeTebHe7zmNz82tFT0p65RsK9K7Ap9RjvMndbEPqFtt8/sCNa5RHyfrf+IUg=="
       }
     }
   }


### PR DESCRIPTION
Part of https://linear.app/speckle/issue/CXPLA-143/sdk-slow-on-caching-and-general-sending

Fixed:
- calculation of upload speed

Changed:
- how progress looks: do all of serialize first and calculate tree ASAP.  Then show upload/caching left only when serialization is done