### PR TITLE
Use Result objects to have less exceptions in converters

### DIFF
--- a/Connectors/ArcGIS/Speckle.Connectors.ArcGIS3/Operations/Receive/ArcGISHostObjectBuilder.cs
+++ b/Connectors/ArcGIS/Speckle.Connectors.ArcGIS3/Operations/Receive/ArcGISHostObjectBuilder.cs
@@ -54,7 +54,9 @@ public class ArcGISHostObjectBuilder : IHostObjectBuilder
     _colorManager = colorManager;
   }
 
+#pragma warning disable CA1506
   public async Task<HostObjectBuilderResult> Build(
+#pragma warning restore CA1506
     Base rootObject,
     string projectName,
     string modelName,

--- a/Connectors/Autocad/Speckle.Connectors.AutocadShared/Operations/Receive/AutocadHostObjectBuilder.cs
+++ b/Connectors/Autocad/Speckle.Connectors.AutocadShared/Operations/Receive/AutocadHostObjectBuilder.cs
@@ -198,8 +198,12 @@ public class AutocadHostObjectBuilder : IHostObjectBuilder
     using var tr = Application.DocumentManager.CurrentDocument.Database.TransactionManager.StartTransaction();
 
     // 1: convert
-    var converted = _converter.Convert(obj);
-
+    var result = _converter.Convert(obj);
+    if (result.IsFailure)
+    {
+      return [];
+    }
+    var converted = result.Host;
     // 2: handle result
     if (converted is Entity entity)
     {
@@ -211,7 +215,6 @@ public class AutocadHostObjectBuilder : IHostObjectBuilder
       var bakedFallbackEntities = BakeObjectsAsGroup(fallbackConversionResult, obj, layerName, baseLayerNamePrefix);
       convertedEntities.UnionWith(bakedFallbackEntities);
     }
-
     tr.Commit();
     return convertedEntities.Freeze();
   }

--- a/Connectors/Autocad/Speckle.Connectors.AutocadShared/Operations/Send/AutocadRootObjectBaseBuilder.cs
+++ b/Connectors/Autocad/Speckle.Connectors.AutocadShared/Operations/Send/AutocadRootObjectBaseBuilder.cs
@@ -176,12 +176,17 @@ public abstract class AutocadRootObjectBaseBuilder : IRootObjectBuilder<AutocadR
       }
       else
       {
-        converted = _converter.Convert(entity);
+        var result = _converter.Convert(entity);
+        if (result.IsFailure)
+        {
+          return new(Status.ERROR, applicationId, sourceType, result.Message);
+        }
+        converted = result.Value;
         converted.applicationId = applicationId;
       }
 
       collectionHost.elements.Add(converted);
-      return new(Status.SUCCESS, applicationId, sourceType, converted);
+      return new(Status.SUCCESS, applicationId, sourceType, converted, null);
     }
     catch (Exception ex) when (!ex.IsFatal())
     {

--- a/Connectors/CSi/Speckle.Connectors.CSiShared/Operations/Send/CsiRootObjectBuilder.cs
+++ b/Connectors/CSi/Speckle.Connectors.CSiShared/Operations/Send/CsiRootObjectBuilder.cs
@@ -96,14 +96,20 @@ public class CsiRootObjectBuilder : IRootObjectBuilder<ICsiWrapper>
       }
       else
       {
-        converted = _rootToSpeckleConverter.Convert(csiObject);
+        var result = _rootToSpeckleConverter.Convert(csiObject);
+        if (result.IsFailure)
+        {
+          return new(Status.ERROR, applicationId, sourceType, result.Message);
+        }
+
+        converted = result.Value;
       }
 
       var collection = _sendCollectionManager.AddObjectCollectionToRoot(converted, typeCollection);
       collection.elements ??= new List<Base>();
       collection.elements.Add(converted);
 
-      return new(Status.SUCCESS, applicationId, sourceType, converted);
+      return new(Status.SUCCESS, applicationId, sourceType, converted, null);
     }
     catch (Exception ex) when (!ex.IsFatal())
     {

--- a/Connectors/Navisworks/Speckle.Connectors.NavisworksShared/Operations/Send/NavisworksRootObjectBuilder.cs
+++ b/Connectors/Navisworks/Speckle.Connectors.NavisworksShared/Operations/Send/NavisworksRootObjectBuilder.cs
@@ -166,13 +166,12 @@ public class NavisworksRootObjectBuilder(
     try
     {
       var result = sendConversionCache.TryGetValue(applicationId, sendInfo.ProjectId, out ObjectReference? cached)
-        ? BaseResult.Success( cached)
+        ? BaseResult.Success(cached)
         : rootToSpeckleConverter.Convert(navisworksItem);
 
       if (result.IsFailure)
       {
         return new SendConversionResult(Status.ERROR, applicationId, "ModelItem", result.Message);
-        
       }
       var converted = result.Value;
       convertedBases[applicationId] = converted;

--- a/Connectors/Navisworks/Speckle.Connectors.NavisworksShared/Operations/Send/NavisworksRootObjectBuilder.cs
+++ b/Connectors/Navisworks/Speckle.Connectors.NavisworksShared/Operations/Send/NavisworksRootObjectBuilder.cs
@@ -7,7 +7,6 @@ using Speckle.Connectors.Common.Conversion;
 using Speckle.Connectors.Common.Operations;
 using Speckle.Converter.Navisworks.Settings;
 using Speckle.Converters.Common;
-using Speckle.Converters.Common.Registration;
 using Speckle.Objects.Data;
 using Speckle.Sdk;
 using Speckle.Sdk.Logging;

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Receive/RevitHostObjectBuilder.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Receive/RevitHostObjectBuilder.cs
@@ -236,7 +236,13 @@ internal sealed class RevitHostObjectBuilder : IHostObjectBuilder, IDisposable
         }
         else
         {
-          conversionResults.Add(new(Status.ERROR, localToGlobalMap.AtomicObject, $"Failed to cast {result?.GetType()} to direct shape definition wrapper."));
+          conversionResults.Add(
+            new(
+              Status.ERROR,
+              localToGlobalMap.AtomicObject,
+              $"Failed to cast {result?.GetType()} to direct shape definition wrapper."
+            )
+          );
         }
       }
       catch (Exception ex) when (!ex.IsFatal())

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/RevitRootObjectBuilder.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/RevitRootObjectBuilder.cs
@@ -117,14 +117,20 @@ public class RevitRootObjectBuilder : IRootObjectBuilder<ElementId>
         }
         else
         {
-          converted = _converter.Convert(revitElement);
+          var conversionResult = _converter.Convert(revitElement);
+          if (conversionResult.IsFailure)
+          {
+            results.Add(new(Status.ERROR, applicationId,sourceType,  conversionResult.Message));
+            continue;
+          }
+          converted = conversionResult.Value;
           converted.applicationId = applicationId;
         }
 
         var collection = _sendCollectionManager.GetAndCreateObjectHostCollection(revitElement, rootObject);
 
         collection.elements.Add(converted);
-        results.Add(new(Status.SUCCESS, applicationId, sourceType, converted));
+        results.Add(new(Status.SUCCESS, applicationId, sourceType, converted, null));
       }
       catch (Exception ex) when (!ex.IsFatal())
       {

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/RevitRootObjectBuilder.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/RevitRootObjectBuilder.cs
@@ -120,7 +120,7 @@ public class RevitRootObjectBuilder : IRootObjectBuilder<ElementId>
           var conversionResult = _converter.Convert(revitElement);
           if (conversionResult.IsFailure)
           {
-            results.Add(new(Status.ERROR, applicationId,sourceType,  conversionResult.Message));
+            results.Add(new(Status.ERROR, applicationId, sourceType, conversionResult.Message));
             continue;
           }
           converted = conversionResult.Value;

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/Operations/Receive/RhinoHostObjectBuilder.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/Operations/Receive/RhinoHostObjectBuilder.cs
@@ -149,7 +149,7 @@ public class RhinoHostObjectBuilder : IHostObjectBuilder
             var result = _converter.Convert(obj);
             if (!result.IsSuccess)
             {
-              conversionResults.Add(new(Status.ERROR, obj,  result.Message.NotNull()));
+              conversionResults.Add(new(Status.ERROR, obj, result.Message.NotNull()));
               convertActivity?.SetStatus(SdkActivityStatusCode.Error);
               continue;
             }

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/Operations/Send/RhinoRootObjectBuilder.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/Operations/Send/RhinoRootObjectBuilder.cs
@@ -11,6 +11,7 @@ using Speckle.Connectors.Rhino.HostApp;
 using Speckle.Converters.Common;
 using Speckle.Converters.Rhino;
 using Speckle.Sdk;
+using Speckle.Sdk.Common;
 using Speckle.Sdk.Logging;
 using Speckle.Sdk.Models;
 using Speckle.Sdk.Models.Collections;
@@ -159,8 +160,17 @@ public class RhinoRootObjectBuilder : IRootObjectBuilder<RhinoObject>
       }
       else
       {
-        converted = _rootToSpeckleConverter.Convert(rhinoObject);
-        converted.applicationId = applicationId;
+        var result  = _rootToSpeckleConverter.Convert(rhinoObject);
+        if (result.IsSuccess)
+        {
+          converted = result.Base.NotNull();
+          converted.applicationId = applicationId;
+        }
+        else
+        {
+          _logger.LogSendConversionError(sourceType, result.Message.NotNull());
+          return new(Status.ERROR, applicationId, sourceType);
+        }
       }
 
       // add to host

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/Operations/Send/RhinoRootObjectBuilder.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/Operations/Send/RhinoRootObjectBuilder.cs
@@ -160,7 +160,7 @@ public class RhinoRootObjectBuilder : IRootObjectBuilder<RhinoObject>
       }
       else
       {
-        var result  = _rootToSpeckleConverter.Convert(rhinoObject);
+        var result = _rootToSpeckleConverter.Convert(rhinoObject);
         if (result.IsSuccess)
         {
           converted = result.Base.NotNull();

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/Operations/Send/RhinoRootObjectBuilder.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/Operations/Send/RhinoRootObjectBuilder.cs
@@ -169,14 +169,14 @@ public class RhinoRootObjectBuilder : IRootObjectBuilder<RhinoObject>
         else
         {
           _logger.LogSendConversionError(sourceType, result.Message.NotNull());
-          return new(Status.ERROR, applicationId, sourceType);
+          return new(Status.ERROR, applicationId, sourceType, null);
         }
       }
 
       // add to host
       collectionHost.elements.Add(converted);
 
-      return new(Status.SUCCESS, applicationId, sourceType, converted);
+      return new(Status.SUCCESS, applicationId, sourceType, converted, null);
     }
     catch (Exception ex) when (!ex.IsFatal())
     {

--- a/Connectors/Tekla/Speckle.Connector.TeklaShared/Operations/Send/TeklaRootObjectBuilder.cs
+++ b/Connectors/Tekla/Speckle.Connector.TeklaShared/Operations/Send/TeklaRootObjectBuilder.cs
@@ -110,7 +110,13 @@ public class TeklaRootObjectBuilder : IRootObjectBuilder<TSM.ModelObject>
       }
       else
       {
-        converted = _rootToSpeckleConverter.Convert(teklaObject);
+        var result = _rootToSpeckleConverter.Convert(teklaObject);
+        if (result.IsFailure)
+        {
+          return new(Status.ERROR, applicationId, sourceType, result.Message);
+        }
+
+        converted = result.Value;
       }
 
       var collection = _sendCollectionManager.GetAndCreateObjectHostCollection(teklaObject, collectionHost);
@@ -118,7 +124,7 @@ public class TeklaRootObjectBuilder : IRootObjectBuilder<TSM.ModelObject>
       // Add to host collection
       collection.elements.Add(converted);
 
-      return new(Status.SUCCESS, applicationId, sourceType, converted);
+      return new(Status.SUCCESS, applicationId, sourceType, converted, null);
     }
     catch (Exception ex) when (!ex.IsFatal())
     {

--- a/Converters/ArcGIS/Speckle.Converters.ArcGIS3/ToHost/TopLevel/ArcToHostConverter.cs
+++ b/Converters/ArcGIS/Speckle.Converters.ArcGIS3/ToHost/TopLevel/ArcToHostConverter.cs
@@ -1,6 +1,5 @@
 using Speckle.Converters.Common;
 using Speckle.Converters.Common.Objects;
-using Speckle.Converters.Common.Registration;
 using Speckle.Sdk.Models;
 
 namespace Speckle.Converters.ArcGIS3.ToHost.TopLevel;

--- a/Converters/ArcGIS/Speckle.Converters.ArcGIS3/ToHost/TopLevel/ArcToHostConverter.cs
+++ b/Converters/ArcGIS/Speckle.Converters.ArcGIS3/ToHost/TopLevel/ArcToHostConverter.cs
@@ -1,5 +1,6 @@
 using Speckle.Converters.Common;
 using Speckle.Converters.Common.Objects;
+using Speckle.Converters.Common.Registration;
 using Speckle.Sdk.Models;
 
 namespace Speckle.Converters.ArcGIS3.ToHost.TopLevel;
@@ -19,7 +20,7 @@ public class ArcToHostConverter : IToHostTopLevelConverter, ITypedConverter<SOG.
     _settingsStore = settingsStore;
   }
 
-  public object Convert(Base target) => Convert((SOG.Arc)target);
+  public HostResult Convert(Base target) => HostResult.Success(Convert((SOG.Arc)target));
 
   public ACG.Polyline Convert(SOG.Arc target)
   {

--- a/Converters/ArcGIS/Speckle.Converters.ArcGIS3/ToHost/TopLevel/CircleToHostConverter.cs
+++ b/Converters/ArcGIS/Speckle.Converters.ArcGIS3/ToHost/TopLevel/CircleToHostConverter.cs
@@ -20,7 +20,7 @@ public class CircleToHostConverter : IToHostTopLevelConverter, ITypedConverter<S
     _settingsStore = settingsStore;
   }
 
-  public HostResult Convert(Base target) => HostResult.Success(  Convert((SOG.Circle)target));
+  public HostResult Convert(Base target) => HostResult.Success(Convert((SOG.Circle)target));
 
   public ACG.Polyline Convert(SOG.Circle target)
   {

--- a/Converters/ArcGIS/Speckle.Converters.ArcGIS3/ToHost/TopLevel/CircleToHostConverter.cs
+++ b/Converters/ArcGIS/Speckle.Converters.ArcGIS3/ToHost/TopLevel/CircleToHostConverter.cs
@@ -1,5 +1,6 @@
 using Speckle.Converters.Common;
 using Speckle.Converters.Common.Objects;
+using Speckle.Converters.Common.Registration;
 using Speckle.Sdk.Common;
 using Speckle.Sdk.Models;
 
@@ -20,7 +21,7 @@ public class CircleToHostConverter : IToHostTopLevelConverter, ITypedConverter<S
     _settingsStore = settingsStore;
   }
 
-  public object Convert(Base target) => Convert((SOG.Circle)target);
+  public HostResult Convert(Base target) => HostResult.Success(  Convert((SOG.Circle)target));
 
   public ACG.Polyline Convert(SOG.Circle target)
   {

--- a/Converters/ArcGIS/Speckle.Converters.ArcGIS3/ToHost/TopLevel/CircleToHostConverter.cs
+++ b/Converters/ArcGIS/Speckle.Converters.ArcGIS3/ToHost/TopLevel/CircleToHostConverter.cs
@@ -1,6 +1,5 @@
 using Speckle.Converters.Common;
 using Speckle.Converters.Common.Objects;
-using Speckle.Converters.Common.Registration;
 using Speckle.Sdk.Common;
 using Speckle.Sdk.Models;
 

--- a/Converters/ArcGIS/Speckle.Converters.ArcGIS3/ToHost/TopLevel/EllipseToHostConverter.cs
+++ b/Converters/ArcGIS/Speckle.Converters.ArcGIS3/ToHost/TopLevel/EllipseToHostConverter.cs
@@ -1,5 +1,6 @@
 using Speckle.Converters.Common;
 using Speckle.Converters.Common.Objects;
+using Speckle.Converters.Common.Registration;
 using Speckle.Sdk.Common;
 using Speckle.Sdk.Models;
 
@@ -20,7 +21,7 @@ public class EllipseToHostConverter : IToHostTopLevelConverter, ITypedConverter<
     _settingsStore = settingsStore;
   }
 
-  public object Convert(Base target) => Convert((SOG.Ellipse)target);
+  public HostResult Convert(Base target) => HostResult.Success(Convert((SOG.Ellipse)target));
 
   public ACG.Polyline Convert(SOG.Ellipse target)
   {

--- a/Converters/ArcGIS/Speckle.Converters.ArcGIS3/ToHost/TopLevel/EllipseToHostConverter.cs
+++ b/Converters/ArcGIS/Speckle.Converters.ArcGIS3/ToHost/TopLevel/EllipseToHostConverter.cs
@@ -1,6 +1,5 @@
 using Speckle.Converters.Common;
 using Speckle.Converters.Common.Objects;
-using Speckle.Converters.Common.Registration;
 using Speckle.Sdk.Common;
 using Speckle.Sdk.Models;
 

--- a/Converters/ArcGIS/Speckle.Converters.ArcGIS3/ToHost/TopLevel/FallbackToHostConverter.cs
+++ b/Converters/ArcGIS/Speckle.Converters.ArcGIS3/ToHost/TopLevel/FallbackToHostConverter.cs
@@ -24,7 +24,7 @@ public class FallbackToHostConverter : IToHostTopLevelConverter, ITypedConverter
     _pointListConverter = pointListConverter;
   }
 
-  public HostResult Convert(Base target) => HostResult.Success( Convert((DisplayableObject)target));
+  public HostResult Convert(Base target) => HostResult.Success(Convert((DisplayableObject)target));
 
   public ACG.Geometry Convert(DisplayableObject target)
   {

--- a/Converters/ArcGIS/Speckle.Converters.ArcGIS3/ToHost/TopLevel/FallbackToHostConverter.cs
+++ b/Converters/ArcGIS/Speckle.Converters.ArcGIS3/ToHost/TopLevel/FallbackToHostConverter.cs
@@ -1,6 +1,5 @@
 ﻿using Speckle.Converters.Common;
 using Speckle.Converters.Common.Objects;
-using Speckle.Converters.Common.Registration;
 using Speckle.Objects;
 using Speckle.Sdk.Common.Exceptions;
 using Speckle.Sdk.Models;

--- a/Converters/ArcGIS/Speckle.Converters.ArcGIS3/ToHost/TopLevel/FallbackToHostConverter.cs
+++ b/Converters/ArcGIS/Speckle.Converters.ArcGIS3/ToHost/TopLevel/FallbackToHostConverter.cs
@@ -1,5 +1,6 @@
 ﻿using Speckle.Converters.Common;
 using Speckle.Converters.Common.Objects;
+using Speckle.Converters.Common.Registration;
 using Speckle.Objects;
 using Speckle.Sdk.Common.Exceptions;
 using Speckle.Sdk.Models;
@@ -24,7 +25,7 @@ public class FallbackToHostConverter : IToHostTopLevelConverter, ITypedConverter
     _pointListConverter = pointListConverter;
   }
 
-  public object Convert(Base target) => Convert((DisplayableObject)target);
+  public HostResult Convert(Base target) => HostResult.Success( Convert((DisplayableObject)target));
 
   public ACG.Geometry Convert(DisplayableObject target)
   {

--- a/Converters/ArcGIS/Speckle.Converters.ArcGIS3/ToHost/TopLevel/LineToHostConverter.cs
+++ b/Converters/ArcGIS/Speckle.Converters.ArcGIS3/ToHost/TopLevel/LineToHostConverter.cs
@@ -19,7 +19,7 @@ public class LineSingleToHostConverter : IToHostTopLevelConverter, ITypedConvert
     _settingsStore = settingsStore;
   }
 
-  public HostResult Convert(Base target) => HostResult.Success( Convert((SOG.Line)target));
+  public HostResult Convert(Base target) => HostResult.Success(Convert((SOG.Line)target));
 
   public ACG.Polyline Convert(SOG.Line target)
   {

--- a/Converters/ArcGIS/Speckle.Converters.ArcGIS3/ToHost/TopLevel/LineToHostConverter.cs
+++ b/Converters/ArcGIS/Speckle.Converters.ArcGIS3/ToHost/TopLevel/LineToHostConverter.cs
@@ -1,6 +1,5 @@
 using Speckle.Converters.Common;
 using Speckle.Converters.Common.Objects;
-using Speckle.Converters.Common.Registration;
 using Speckle.Sdk.Models;
 
 namespace Speckle.Converters.ArcGIS3.ToHost.TopLevel;

--- a/Converters/ArcGIS/Speckle.Converters.ArcGIS3/ToHost/TopLevel/LineToHostConverter.cs
+++ b/Converters/ArcGIS/Speckle.Converters.ArcGIS3/ToHost/TopLevel/LineToHostConverter.cs
@@ -1,5 +1,6 @@
 using Speckle.Converters.Common;
 using Speckle.Converters.Common.Objects;
+using Speckle.Converters.Common.Registration;
 using Speckle.Sdk.Models;
 
 namespace Speckle.Converters.ArcGIS3.ToHost.TopLevel;
@@ -19,7 +20,7 @@ public class LineSingleToHostConverter : IToHostTopLevelConverter, ITypedConvert
     _settingsStore = settingsStore;
   }
 
-  public object Convert(Base target) => Convert((SOG.Line)target);
+  public HostResult Convert(Base target) => HostResult.Success( Convert((SOG.Line)target));
 
   public ACG.Polyline Convert(SOG.Line target)
   {

--- a/Converters/ArcGIS/Speckle.Converters.ArcGIS3/ToHost/TopLevel/MeshToHostConverter.cs
+++ b/Converters/ArcGIS/Speckle.Converters.ArcGIS3/ToHost/TopLevel/MeshToHostConverter.cs
@@ -14,7 +14,7 @@ public class MeshToHostConverter : IToHostTopLevelConverter, ITypedConverter<SOG
     _meshConverter = meshConverter;
   }
 
-  public HostResult Convert(Base target) => HostResult.Success(  Convert((SOG.Mesh)target));
+  public HostResult Convert(Base target) => HostResult.Success(Convert((SOG.Mesh)target));
 
   public ACG.Multipatch Convert(SOG.Mesh target)
   {

--- a/Converters/ArcGIS/Speckle.Converters.ArcGIS3/ToHost/TopLevel/MeshToHostConverter.cs
+++ b/Converters/ArcGIS/Speckle.Converters.ArcGIS3/ToHost/TopLevel/MeshToHostConverter.cs
@@ -1,5 +1,6 @@
 using Speckle.Converters.Common;
 using Speckle.Converters.Common.Objects;
+using Speckle.Converters.Common.Registration;
 using Speckle.Sdk.Models;
 
 namespace Speckle.Converters.ArcGIS3.ToHost.TopLevel;
@@ -14,7 +15,7 @@ public class MeshToHostConverter : IToHostTopLevelConverter, ITypedConverter<SOG
     _meshConverter = meshConverter;
   }
 
-  public object Convert(Base target) => Convert((SOG.Mesh)target);
+  public HostResult Convert(Base target) => HostResult.Success(  Convert((SOG.Mesh)target));
 
   public ACG.Multipatch Convert(SOG.Mesh target)
   {

--- a/Converters/ArcGIS/Speckle.Converters.ArcGIS3/ToHost/TopLevel/MeshToHostConverter.cs
+++ b/Converters/ArcGIS/Speckle.Converters.ArcGIS3/ToHost/TopLevel/MeshToHostConverter.cs
@@ -1,6 +1,5 @@
 using Speckle.Converters.Common;
 using Speckle.Converters.Common.Objects;
-using Speckle.Converters.Common.Registration;
 using Speckle.Sdk.Models;
 
 namespace Speckle.Converters.ArcGIS3.ToHost.TopLevel;

--- a/Converters/ArcGIS/Speckle.Converters.ArcGIS3/ToHost/TopLevel/PointToHostConverter.cs
+++ b/Converters/ArcGIS/Speckle.Converters.ArcGIS3/ToHost/TopLevel/PointToHostConverter.cs
@@ -14,5 +14,6 @@ public class PointToHostConverter : IToHostTopLevelConverter
     _pointConverter = pointConverter;
   }
 
-  public HostResult Convert(Base target) => HostResult.Success(  _pointConverter.Convert(new List<SOG.Point> { (SOG.Point)target }));
+  public HostResult Convert(Base target) =>
+    HostResult.Success(_pointConverter.Convert(new List<SOG.Point> { (SOG.Point)target }));
 }

--- a/Converters/ArcGIS/Speckle.Converters.ArcGIS3/ToHost/TopLevel/PointToHostConverter.cs
+++ b/Converters/ArcGIS/Speckle.Converters.ArcGIS3/ToHost/TopLevel/PointToHostConverter.cs
@@ -1,5 +1,6 @@
 using Speckle.Converters.Common;
 using Speckle.Converters.Common.Objects;
+using Speckle.Converters.Common.Registration;
 using Speckle.Sdk.Models;
 
 namespace Speckle.Converters.ArcGIS3.ToHost.TopLevel;
@@ -14,5 +15,5 @@ public class PointToHostConverter : IToHostTopLevelConverter
     _pointConverter = pointConverter;
   }
 
-  public object Convert(Base target) => _pointConverter.Convert(new List<SOG.Point> { (SOG.Point)target });
+  public HostResult Convert(Base target) => HostResult.Success(  _pointConverter.Convert(new List<SOG.Point> { (SOG.Point)target }));
 }

--- a/Converters/ArcGIS/Speckle.Converters.ArcGIS3/ToHost/TopLevel/PointToHostConverter.cs
+++ b/Converters/ArcGIS/Speckle.Converters.ArcGIS3/ToHost/TopLevel/PointToHostConverter.cs
@@ -1,6 +1,5 @@
 using Speckle.Converters.Common;
 using Speckle.Converters.Common.Objects;
-using Speckle.Converters.Common.Registration;
 using Speckle.Sdk.Models;
 
 namespace Speckle.Converters.ArcGIS3.ToHost.TopLevel;

--- a/Converters/ArcGIS/Speckle.Converters.ArcGIS3/ToHost/TopLevel/PolycurveToHostConverter.cs
+++ b/Converters/ArcGIS/Speckle.Converters.ArcGIS3/ToHost/TopLevel/PolycurveToHostConverter.cs
@@ -1,5 +1,7 @@
 using Speckle.Converters.Common;
 using Speckle.Converters.Common.Objects;
+using Speckle.Converters.Common.Registration;
+using Speckle.Sdk.Common;
 using Speckle.Sdk.Common.Exceptions;
 using Speckle.Sdk.Models;
 
@@ -20,7 +22,7 @@ public class PolycurveToHostConverter : IToHostTopLevelConverter, ITypedConverte
     _settingsStore = settingsStore;
   }
 
-  public object Convert(Base target) => Convert((SOG.Polycurve)target);
+  public HostResult Convert(Base target) => HostResult.Success( Convert((SOG.Polycurve)target));
 
   public ACG.Polyline Convert(SOG.Polycurve target)
   {
@@ -29,7 +31,7 @@ public class PolycurveToHostConverter : IToHostTopLevelConverter, ITypedConverte
 
     foreach (var segment in target.segments)
     {
-      ACG.Polyline converted = (ACG.Polyline)_converter.Convert((Base)segment); //CurveConverter.NotNull().Convert(segment);
+      ACG.Polyline converted = (ACG.Polyline)_converter.Convert((Base)segment).Host.NotNull(); 
       List<ACG.MapPoint> segmentPts = converted.Points.ToList();
 
       if (

--- a/Converters/ArcGIS/Speckle.Converters.ArcGIS3/ToHost/TopLevel/PolycurveToHostConverter.cs
+++ b/Converters/ArcGIS/Speckle.Converters.ArcGIS3/ToHost/TopLevel/PolycurveToHostConverter.cs
@@ -1,6 +1,5 @@
 using Speckle.Converters.Common;
 using Speckle.Converters.Common.Objects;
-using Speckle.Converters.Common.Registration;
 using Speckle.Sdk.Common;
 using Speckle.Sdk.Common.Exceptions;
 using Speckle.Sdk.Models;

--- a/Converters/ArcGIS/Speckle.Converters.ArcGIS3/ToHost/TopLevel/PolycurveToHostConverter.cs
+++ b/Converters/ArcGIS/Speckle.Converters.ArcGIS3/ToHost/TopLevel/PolycurveToHostConverter.cs
@@ -21,7 +21,7 @@ public class PolycurveToHostConverter : IToHostTopLevelConverter, ITypedConverte
     _settingsStore = settingsStore;
   }
 
-  public HostResult Convert(Base target) => HostResult.Success( Convert((SOG.Polycurve)target));
+  public HostResult Convert(Base target) => HostResult.Success(Convert((SOG.Polycurve)target));
 
   public ACG.Polyline Convert(SOG.Polycurve target)
   {
@@ -30,7 +30,7 @@ public class PolycurveToHostConverter : IToHostTopLevelConverter, ITypedConverte
 
     foreach (var segment in target.segments)
     {
-      ACG.Polyline converted = (ACG.Polyline)_converter.Convert((Base)segment).Host.NotNull(); 
+      ACG.Polyline converted = (ACG.Polyline)_converter.Convert((Base)segment).Host.NotNull();
       List<ACG.MapPoint> segmentPts = converted.Points.ToList();
 
       if (

--- a/Converters/ArcGIS/Speckle.Converters.ArcGIS3/ToHost/TopLevel/PolylineToHostConverter.cs
+++ b/Converters/ArcGIS/Speckle.Converters.ArcGIS3/ToHost/TopLevel/PolylineToHostConverter.cs
@@ -1,6 +1,5 @@
 using Speckle.Converters.Common;
 using Speckle.Converters.Common.Objects;
-using Speckle.Converters.Common.Registration;
 using Speckle.Sdk.Models;
 
 namespace Speckle.Converters.ArcGIS3.ToHost.TopLevel;

--- a/Converters/ArcGIS/Speckle.Converters.ArcGIS3/ToHost/TopLevel/PolylineToHostConverter.cs
+++ b/Converters/ArcGIS/Speckle.Converters.ArcGIS3/ToHost/TopLevel/PolylineToHostConverter.cs
@@ -1,5 +1,6 @@
 using Speckle.Converters.Common;
 using Speckle.Converters.Common.Objects;
+using Speckle.Converters.Common.Registration;
 using Speckle.Sdk.Models;
 
 namespace Speckle.Converters.ArcGIS3.ToHost.TopLevel;
@@ -19,7 +20,7 @@ public class PolylineToHostConverter : IToHostTopLevelConverter, ITypedConverter
     _settingsStore = settingsStore;
   }
 
-  public object Convert(Base target) => Convert((SOG.Polyline)target);
+  public HostResult Convert(Base target) => HostResult.Success(  Convert((SOG.Polyline)target));
 
   public ACG.Polyline Convert(SOG.Polyline target)
   {

--- a/Converters/ArcGIS/Speckle.Converters.ArcGIS3/ToHost/TopLevel/PolylineToHostConverter.cs
+++ b/Converters/ArcGIS/Speckle.Converters.ArcGIS3/ToHost/TopLevel/PolylineToHostConverter.cs
@@ -19,7 +19,7 @@ public class PolylineToHostConverter : IToHostTopLevelConverter, ITypedConverter
     _settingsStore = settingsStore;
   }
 
-  public HostResult Convert(Base target) => HostResult.Success(  Convert((SOG.Polyline)target));
+  public HostResult Convert(Base target) => HostResult.Success(Convert((SOG.Polyline)target));
 
   public ACG.Polyline Convert(SOG.Polyline target)
   {

--- a/Converters/ArcGIS/Speckle.Converters.ArcGIS3/ToSpeckle/TopLevel/CoreObjectsBaseToSpeckleTopLevelConverter.cs
+++ b/Converters/ArcGIS/Speckle.Converters.ArcGIS3/ToSpeckle/TopLevel/CoreObjectsBaseToSpeckleTopLevelConverter.cs
@@ -1,7 +1,6 @@
 using Speckle.Converters.ArcGIS3.ToSpeckle.Helpers;
 using Speckle.Converters.Common;
 using Speckle.Converters.Common.Objects;
-using Speckle.Converters.Common.Registration;
 using Speckle.Objects.Data;
 using Speckle.Sdk.Models;
 

--- a/Converters/ArcGIS/Speckle.Converters.ArcGIS3/ToSpeckle/TopLevel/CoreObjectsBaseToSpeckleTopLevelConverter.cs
+++ b/Converters/ArcGIS/Speckle.Converters.ArcGIS3/ToSpeckle/TopLevel/CoreObjectsBaseToSpeckleTopLevelConverter.cs
@@ -1,6 +1,7 @@
 using Speckle.Converters.ArcGIS3.ToSpeckle.Helpers;
 using Speckle.Converters.Common;
 using Speckle.Converters.Common.Objects;
+using Speckle.Converters.Common.Registration;
 using Speckle.Objects.Data;
 using Speckle.Sdk.Models;
 
@@ -24,7 +25,7 @@ public class CoreObjectsBaseToSpeckleTopLevelConverter : IToSpeckleTopLevelConve
     _settingsStore = settingsStore;
   }
 
-  public Base Convert(object target) => Convert((AC.CoreObjectsBase)target);
+  public BaseResult Convert(object target) => BaseResult.Success( Convert((AC.CoreObjectsBase)target));
 
   private ArcgisObject Convert(AC.CoreObjectsBase target)
   {

--- a/Converters/ArcGIS/Speckle.Converters.ArcGIS3/ToSpeckle/TopLevel/CoreObjectsBaseToSpeckleTopLevelConverter.cs
+++ b/Converters/ArcGIS/Speckle.Converters.ArcGIS3/ToSpeckle/TopLevel/CoreObjectsBaseToSpeckleTopLevelConverter.cs
@@ -24,7 +24,7 @@ public class CoreObjectsBaseToSpeckleTopLevelConverter : IToSpeckleTopLevelConve
     _settingsStore = settingsStore;
   }
 
-  public BaseResult Convert(object target) => BaseResult.Success( Convert((AC.CoreObjectsBase)target));
+  public BaseResult Convert(object target) => BaseResult.Success(Convert((AC.CoreObjectsBase)target));
 
   private ArcgisObject Convert(AC.CoreObjectsBase target)
   {

--- a/Converters/Autocad/Speckle.Converters.AutocadShared/AutocadRootToSpeckleConverter.cs
+++ b/Converters/Autocad/Speckle.Converters.AutocadShared/AutocadRootToSpeckleConverter.cs
@@ -3,7 +3,6 @@ using Speckle.Converters.Common;
 using Speckle.Converters.Common.Objects;
 using Speckle.Converters.Common.Registration;
 using Speckle.Sdk.Common.Exceptions;
-using Speckle.Sdk.Models;
 
 namespace Speckle.Converters.Autocad;
 
@@ -21,7 +20,7 @@ public class AutocadRootToSpeckleConverter : IRootToSpeckleConverter
     _settingsStore = settingsStore;
   }
 
-  public Base Convert(object target)
+  public BaseResult Convert(object target)
   {
     if (target is not DBObject dbObject)
     {
@@ -36,9 +35,12 @@ public class AutocadRootToSpeckleConverter : IRootToSpeckleConverter
     {
       using (var tr = _settingsStore.Current.Document.Database.TransactionManager.StartTransaction())
       {
-        var objectConverter = _toSpeckle.ResolveConverter(type);
-
-        var convertedObject = objectConverter.Convert(dbObject);
+        var result = _toSpeckle.ResolveConverter(type);
+        if (result.IsFailure)
+        {
+          return BaseResult.Failure(result);
+        }
+        var convertedObject = result.Converter.Convert(dbObject);
         tr.Commit();
         return convertedObject;
       }

--- a/Converters/Autocad/Speckle.Converters.AutocadShared/ToHost/Geometry/ArcToHostConverter.cs
+++ b/Converters/Autocad/Speckle.Converters.AutocadShared/ToHost/Geometry/ArcToHostConverter.cs
@@ -22,7 +22,7 @@ public class ArcToHostConverter : IToHostTopLevelConverter, ITypedConverter<SOG.
     _settingsStore = settingsStore;
   }
 
-  public object Convert(Base target) => Convert((SOG.Arc)target);
+  public HostResult Convert(Base target) => HostResult.Success(Convert((SOG.Arc)target));
 
   public ADB.Arc Convert(SOG.Arc target)
   {

--- a/Converters/Autocad/Speckle.Converters.AutocadShared/ToHost/Geometry/AutocadPolycurveToHostConverter.cs
+++ b/Converters/Autocad/Speckle.Converters.AutocadShared/ToHost/Geometry/AutocadPolycurveToHostConverter.cs
@@ -1,6 +1,5 @@
 using Speckle.Converters.Common;
 using Speckle.Converters.Common.Objects;
-using Speckle.Sdk.Common.Exceptions;
 using Speckle.Sdk.Models;
 
 namespace Speckle.Converters.Autocad2023.ToHost.Geometry;
@@ -23,28 +22,28 @@ public class AutocadPolycurveToHostConverter : IToHostTopLevelConverter
     _polyline3dConverter = polyline3dConverter;
   }
 
-  public object Convert(Base target)
+  public HostResult Convert(Base target)
   {
     SOG.Autocad.AutocadPolycurve polycurve = (SOG.Autocad.AutocadPolycurve)target;
 
     switch (polycurve.polyType)
     {
       case SOG.Autocad.AutocadPolyType.Light:
-        return _polylineConverter.Convert(polycurve);
+        return HostResult.Success( _polylineConverter.Convert(polycurve));
 
       case SOG.Autocad.AutocadPolyType.Simple2d:
       case SOG.Autocad.AutocadPolyType.FitCurve2d:
       case SOG.Autocad.AutocadPolyType.CubicSpline2d:
       case SOG.Autocad.AutocadPolyType.QuadSpline2d:
-        return _polyline2dConverter.Convert(polycurve);
+        return HostResult.Success( _polyline2dConverter.Convert(polycurve));
 
       case SOG.Autocad.AutocadPolyType.Simple3d:
       case SOG.Autocad.AutocadPolyType.CubicSpline3d:
       case SOG.Autocad.AutocadPolyType.QuadSpline3d:
-        return _polyline3dConverter.Convert(polycurve);
+        return HostResult.Success( _polyline3dConverter.Convert(polycurve));
 
       default:
-        throw new ValidationException("Unknown poly type for AutocadPolycurve");
+        return HostResult.NoConversion("Unknown poly type for AutocadPolycurve");
     }
   }
 }

--- a/Converters/Autocad/Speckle.Converters.AutocadShared/ToHost/Geometry/AutocadPolycurveToHostConverter.cs
+++ b/Converters/Autocad/Speckle.Converters.AutocadShared/ToHost/Geometry/AutocadPolycurveToHostConverter.cs
@@ -29,18 +29,18 @@ public class AutocadPolycurveToHostConverter : IToHostTopLevelConverter
     switch (polycurve.polyType)
     {
       case SOG.Autocad.AutocadPolyType.Light:
-        return HostResult.Success( _polylineConverter.Convert(polycurve));
+        return HostResult.Success(_polylineConverter.Convert(polycurve));
 
       case SOG.Autocad.AutocadPolyType.Simple2d:
       case SOG.Autocad.AutocadPolyType.FitCurve2d:
       case SOG.Autocad.AutocadPolyType.CubicSpline2d:
       case SOG.Autocad.AutocadPolyType.QuadSpline2d:
-        return HostResult.Success( _polyline2dConverter.Convert(polycurve));
+        return HostResult.Success(_polyline2dConverter.Convert(polycurve));
 
       case SOG.Autocad.AutocadPolyType.Simple3d:
       case SOG.Autocad.AutocadPolyType.CubicSpline3d:
       case SOG.Autocad.AutocadPolyType.QuadSpline3d:
-        return HostResult.Success( _polyline3dConverter.Convert(polycurve));
+        return HostResult.Success(_polyline3dConverter.Convert(polycurve));
 
       default:
         return HostResult.NoConversion("Unknown poly type for AutocadPolycurve");

--- a/Converters/Autocad/Speckle.Converters.AutocadShared/ToHost/Geometry/CircleToHostConverter.cs
+++ b/Converters/Autocad/Speckle.Converters.AutocadShared/ToHost/Geometry/CircleToHostConverter.cs
@@ -23,7 +23,7 @@ public class CircleToHostConverter : IToHostTopLevelConverter, ITypedConverter<S
     _settingsStore = settingsStore;
   }
 
-  public object Convert(Base target) => Convert((SOG.Circle)target);
+  public HostResult Convert(Base target) => HostResult.Success(Convert((SOG.Circle)target));
 
   public ADB.Circle Convert(SOG.Circle target)
   {

--- a/Converters/Autocad/Speckle.Converters.AutocadShared/ToHost/Geometry/CurveToHostConverter.cs
+++ b/Converters/Autocad/Speckle.Converters.AutocadShared/ToHost/Geometry/CurveToHostConverter.cs
@@ -14,7 +14,7 @@ public class CurveToHostConverter : IToHostTopLevelConverter, ITypedConverter<SO
     _curveConverter = curveConverter;
   }
 
-  public object Convert(Base target) => Convert((SOG.Curve)target);
+  public HostResult Convert(Base target) => HostResult.Success(Convert((SOG.Curve)target));
 
   public ADB.Curve Convert(SOG.Curve target) => ADB.Curve.CreateFromGeCurve(_curveConverter.Convert(target));
 }

--- a/Converters/Autocad/Speckle.Converters.AutocadShared/ToHost/Geometry/EllipseToHostConverter.cs
+++ b/Converters/Autocad/Speckle.Converters.AutocadShared/ToHost/Geometry/EllipseToHostConverter.cs
@@ -23,7 +23,7 @@ public class EllipseToHostConverter : IToHostTopLevelConverter, ITypedConverter<
     _settingsStore = settingsStore;
   }
 
-  public object Convert(Base target) => Convert((SOG.Ellipse)target);
+  public HostResult Convert(Base target) => HostResult.Success(Convert((SOG.Ellipse)target));
 
   /// <exception cref="ArgumentNullException"> Throws if any ellipse radius value is null.</exception>
   public ADB.Ellipse Convert(SOG.Ellipse target)

--- a/Converters/Autocad/Speckle.Converters.AutocadShared/ToHost/Geometry/LineToHostConverter.cs
+++ b/Converters/Autocad/Speckle.Converters.AutocadShared/ToHost/Geometry/LineToHostConverter.cs
@@ -14,7 +14,7 @@ public class LineToHostConverter : IToHostTopLevelConverter, ITypedConverter<SOG
     _pointConverter = pointConverter;
   }
 
-  public object Convert(Base target) => Convert((SOG.Line)target);
+  public HostResult Convert(Base target) => HostResult.Success(Convert((SOG.Line)target));
 
   public ADB.Line Convert(SOG.Line target) =>
     new(_pointConverter.Convert(target.start), _pointConverter.Convert(target.end));

--- a/Converters/Autocad/Speckle.Converters.AutocadShared/ToHost/Geometry/MeshToHostConverter.cs
+++ b/Converters/Autocad/Speckle.Converters.AutocadShared/ToHost/Geometry/MeshToHostConverter.cs
@@ -21,7 +21,7 @@ public class MeshToHostConverter : IToHostTopLevelConverter, ITypedConverter<SOG
     _settingsStore = settingsStore;
   }
 
-  public object Convert(Base target) => Convert((SOG.Mesh)target);
+  public HostResult Convert(Base target) => HostResult.Success(Convert((SOG.Mesh)target));
 
   /// <remarks>
   /// Mesh conversion requires transaction since it's vertices needed to be added into database in advance..

--- a/Converters/Autocad/Speckle.Converters.AutocadShared/ToHost/Geometry/PointToHostConverter.cs
+++ b/Converters/Autocad/Speckle.Converters.AutocadShared/ToHost/Geometry/PointToHostConverter.cs
@@ -14,7 +14,7 @@ public class PointToHostConverter : IToHostTopLevelConverter, ITypedConverter<SO
     _pointConverter = pointConverter;
   }
 
-  public object Convert(Base target) => Convert((SOG.Point)target);
+  public HostResult Convert(Base target) => HostResult.Success(Convert((SOG.Point)target));
 
   public ADB.DBPoint Convert(SOG.Point target) => new(_pointConverter.Convert(target));
 }

--- a/Converters/Autocad/Speckle.Converters.AutocadShared/ToHost/Geometry/PolycurveToHostConverter.cs
+++ b/Converters/Autocad/Speckle.Converters.AutocadShared/ToHost/Geometry/PolycurveToHostConverter.cs
@@ -24,7 +24,7 @@ public class PolycurveToHostConverter : IToHostTopLevelConverter
     _splineConverter = splineConverter;
   }
 
-  public object Convert(Base target)
+  public HostResult Convert(Base target)
   {
     SOG.Polycurve polycurve = (SOG.Polycurve)target;
     bool convertAsSpline = polycurve.segments.Any(s => s is not SOG.Line and not SOG.Arc);
@@ -32,11 +32,11 @@ public class PolycurveToHostConverter : IToHostTopLevelConverter
 
     if (convertAsSpline || !isPlanar)
     {
-      return _splineConverter.Convert(polycurve);
+      return HostResult.Success(_splineConverter.Convert(polycurve));
     }
     else
     {
-      return _polylineConverter.Convert(polycurve);
+      return HostResult.Success(_polylineConverter.Convert(polycurve));
     }
   }
 

--- a/Converters/Autocad/Speckle.Converters.AutocadShared/ToHost/Geometry/PolylineToHostConverter.cs
+++ b/Converters/Autocad/Speckle.Converters.AutocadShared/ToHost/Geometry/PolylineToHostConverter.cs
@@ -14,7 +14,7 @@ public class PolylineToHostConverter : IToHostTopLevelConverter, ITypedConverter
     _pointConverter = pointConverter;
   }
 
-  public object Convert(Base target) => Convert((SOG.Polyline)target);
+  public HostResult Convert(Base target) => HostResult.Success(Convert((SOG.Polyline)target));
 
   public ADB.Polyline3d Convert(SOG.Polyline target)
   {

--- a/Converters/Autocad/Speckle.Converters.AutocadShared/ToHost/Geometry/SpeckleFallbackToHostConversion.cs
+++ b/Converters/Autocad/Speckle.Converters.AutocadShared/ToHost/Geometry/SpeckleFallbackToHostConversion.cs
@@ -31,7 +31,7 @@ public class SpeckleFallbackToAutocadTopLevelConverter
     _pointConverter = pointConverter;
   }
 
-  public object Convert(Base target) => Convert((DisplayableObject)target);
+  public HostResult Convert(Base target) => HostResult.Success(Convert((DisplayableObject)target));
 
   public List<ADB.Entity> Convert(DisplayableObject target)
   {

--- a/Converters/Autocad/Speckle.Converters.AutocadShared/ToSpeckle/Geometry/ArcToSpeckleConverter.cs
+++ b/Converters/Autocad/Speckle.Converters.AutocadShared/ToSpeckle/Geometry/ArcToSpeckleConverter.cs
@@ -1,6 +1,5 @@
 using Speckle.Converters.Common;
 using Speckle.Converters.Common.Objects;
-using Speckle.Sdk.Models;
 
 namespace Speckle.Converters.Autocad.ToSpeckle.Geometry;
 
@@ -14,7 +13,7 @@ public class DBArcToSpeckleConverter : IToSpeckleTopLevelConverter
     _arcConverter = arcConverter;
   }
 
-  public Base Convert(object target) => Convert((ADB.Arc)target);
 
+  public BaseResult Convert(object target) => BaseResult.Success(Convert((ADB.Arc)target));
   public SOG.Arc Convert(ADB.Arc target) => _arcConverter.Convert(target);
 }

--- a/Converters/Autocad/Speckle.Converters.AutocadShared/ToSpeckle/Geometry/ArcToSpeckleConverter.cs
+++ b/Converters/Autocad/Speckle.Converters.AutocadShared/ToSpeckle/Geometry/ArcToSpeckleConverter.cs
@@ -13,7 +13,7 @@ public class DBArcToSpeckleConverter : IToSpeckleTopLevelConverter
     _arcConverter = arcConverter;
   }
 
-
   public BaseResult Convert(object target) => BaseResult.Success(Convert((ADB.Arc)target));
+
   public SOG.Arc Convert(ADB.Arc target) => _arcConverter.Convert(target);
 }

--- a/Converters/Autocad/Speckle.Converters.AutocadShared/ToSpeckle/Geometry/CircleToSpeckleConverter.cs
+++ b/Converters/Autocad/Speckle.Converters.AutocadShared/ToSpeckle/Geometry/CircleToSpeckleConverter.cs
@@ -1,6 +1,5 @@
 using Speckle.Converters.Common;
 using Speckle.Converters.Common.Objects;
-using Speckle.Sdk.Models;
 
 namespace Speckle.Converters.Autocad.ToSpeckle.Geometry;
 
@@ -14,7 +13,7 @@ public class DBCircleToSpeckleConverter : IToSpeckleTopLevelConverter
     _circleConverter = circleConverter;
   }
 
-  public Base Convert(object target) => RawConvert((ADB.Circle)target);
+  public BaseResult Convert(object target) => BaseResult.Success(RawConvert((ADB.Circle)target));
 
   public SOG.Circle RawConvert(ADB.Circle target) => _circleConverter.Convert(target);
 }

--- a/Converters/Autocad/Speckle.Converters.AutocadShared/ToSpeckle/Geometry/EllipseToSpeckleConverter.cs
+++ b/Converters/Autocad/Speckle.Converters.AutocadShared/ToSpeckle/Geometry/EllipseToSpeckleConverter.cs
@@ -1,6 +1,5 @@
 using Speckle.Converters.Common;
 using Speckle.Converters.Common.Objects;
-using Speckle.Sdk.Models;
 
 namespace Speckle.Converters.Autocad.ToSpeckle.Geometry;
 
@@ -14,7 +13,7 @@ public class DBEllipseToSpeckleConverter : IToSpeckleTopLevelConverter
     _ellipseConverter = ellipseConverter;
   }
 
-  public Base Convert(object target) => RawConvert((ADB.Ellipse)target);
+  public BaseResult Convert(object target) => BaseResult.Success(RawConvert((ADB.Ellipse)target));
 
   public SOG.Ellipse RawConvert(ADB.Ellipse target) => _ellipseConverter.Convert(target);
 }

--- a/Converters/Autocad/Speckle.Converters.AutocadShared/ToSpeckle/Geometry/LineToSpeckleConverter.cs
+++ b/Converters/Autocad/Speckle.Converters.AutocadShared/ToSpeckle/Geometry/LineToSpeckleConverter.cs
@@ -1,6 +1,5 @@
 using Speckle.Converters.Common;
 using Speckle.Converters.Common.Objects;
-using Speckle.Sdk.Models;
 
 namespace Speckle.Converters.Autocad.ToSpeckle.Geometry;
 
@@ -14,7 +13,7 @@ public class LineToSpeckleConverter : IToSpeckleTopLevelConverter
     _lineConverter = lineConverter;
   }
 
-  public Base Convert(object target) => Convert((ADB.Line)target);
+  public BaseResult Convert(object target) => BaseResult.Success(Convert((ADB.Line)target));
 
   public SOG.Line Convert(ADB.Line target) => _lineConverter.Convert(target);
 }

--- a/Converters/Autocad/Speckle.Converters.AutocadShared/ToSpeckle/Geometry/PointToSpeckleConverter.cs
+++ b/Converters/Autocad/Speckle.Converters.AutocadShared/ToSpeckle/Geometry/PointToSpeckleConverter.cs
@@ -1,6 +1,5 @@
 using Speckle.Converters.Common;
 using Speckle.Converters.Common.Objects;
-using Speckle.Sdk.Models;
 
 namespace Speckle.Converters.Autocad.ToSpeckle.Geometry;
 
@@ -14,7 +13,7 @@ public class PointToSpeckleConverter : IToSpeckleTopLevelConverter
     _pointConverter = pointConverter;
   }
 
-  public Base Convert(object target) => RawConvert((ADB.DBPoint)target);
+  public BaseResult Convert(object target) => BaseResult.Success(RawConvert((ADB.DBPoint)target));
 
   public SOG.Point RawConvert(ADB.DBPoint target) => _pointConverter.Convert(target.Position);
 }

--- a/Converters/Autocad/Speckle.Converters.AutocadShared/ToSpeckle/Geometry/PolyfaceMeshToSpeckleConverter.cs
+++ b/Converters/Autocad/Speckle.Converters.AutocadShared/ToSpeckle/Geometry/PolyfaceMeshToSpeckleConverter.cs
@@ -1,7 +1,6 @@
 using Autodesk.AutoCAD.Geometry;
 using Speckle.Converters.Common;
 using Speckle.Converters.Common.Objects;
-using Speckle.Sdk.Models;
 
 namespace Speckle.Converters.Autocad.Geometry;
 
@@ -29,7 +28,7 @@ public class DBPolyfaceMeshToSpeckleConverter : IToSpeckleTopLevelConverter
     _settingsStore = settingsStore;
   }
 
-  public Base Convert(object target) => RawConvert((ADB.PolyFaceMesh)target);
+  public BaseResult Convert(object target) => BaseResult.Success(RawConvert((ADB.PolyFaceMesh)target));
 
   public SOG.Mesh RawConvert(ADB.PolyFaceMesh target)
   {

--- a/Converters/Autocad/Speckle.Converters.AutocadShared/ToSpeckle/Geometry/Polyline2dToSpeckleConverter.cs
+++ b/Converters/Autocad/Speckle.Converters.AutocadShared/ToSpeckle/Geometry/Polyline2dToSpeckleConverter.cs
@@ -1,7 +1,6 @@
 using Speckle.Converters.Autocad.Extensions;
 using Speckle.Converters.Common;
 using Speckle.Converters.Common.Objects;
-using Speckle.Sdk.Models;
 
 namespace Speckle.Converters.Autocad.Geometry;
 
@@ -46,7 +45,7 @@ public class Polyline2dToSpeckleConverter
     _settingsStore = settingsStore;
   }
 
-  public Base Convert(object target) => Convert((ADB.Polyline2d)target);
+  public BaseResult Convert(object target) => BaseResult.Success(Convert((ADB.Polyline2d)target));
 
   public SOG.Autocad.AutocadPolycurve Convert(ADB.Polyline2d target)
   {

--- a/Converters/Autocad/Speckle.Converters.AutocadShared/ToSpeckle/Geometry/Polyline3dToSpeckleConverter.cs
+++ b/Converters/Autocad/Speckle.Converters.AutocadShared/ToSpeckle/Geometry/Polyline3dToSpeckleConverter.cs
@@ -1,7 +1,6 @@
 using Speckle.Converters.Autocad.Extensions;
 using Speckle.Converters.Common;
 using Speckle.Converters.Common.Objects;
-using Speckle.Sdk.Models;
 
 namespace Speckle.Converters.Autocad.Geometry;
 
@@ -36,7 +35,7 @@ public class Polyline3dToSpeckleConverter
     _settingsStore = settingsStore;
   }
 
-  public Base Convert(object target) => Convert((ADB.Polyline3d)target);
+  public BaseResult Convert(object target) => BaseResult.Success(Convert((ADB.Polyline3d)target));
 
   public SOG.Autocad.AutocadPolycurve Convert(ADB.Polyline3d target)
   {

--- a/Converters/Autocad/Speckle.Converters.AutocadShared/ToSpeckle/Geometry/PolylineToSpeckleConverter.cs
+++ b/Converters/Autocad/Speckle.Converters.AutocadShared/ToSpeckle/Geometry/PolylineToSpeckleConverter.cs
@@ -1,6 +1,5 @@
 using Speckle.Converters.Common;
 using Speckle.Converters.Common.Objects;
-using Speckle.Sdk.Models;
 
 namespace Speckle.Converters.Autocad.Geometry;
 
@@ -36,7 +35,7 @@ public class PolylineToSpeckleConverter
     _settingsStore = settingsStore;
   }
 
-  public Base Convert(object target) => Convert((ADB.Polyline)target);
+  public BaseResult Convert(object target) => BaseResult.Success(Convert((ADB.Polyline)target));
 
   public SOG.Autocad.AutocadPolycurve Convert(ADB.Polyline target)
   {

--- a/Converters/Autocad/Speckle.Converters.AutocadShared/ToSpeckle/Geometry/RegionToSpeckleConverter.cs
+++ b/Converters/Autocad/Speckle.Converters.AutocadShared/ToSpeckle/Geometry/RegionToSpeckleConverter.cs
@@ -1,7 +1,6 @@
 using Speckle.Converters.Common;
 using Speckle.Converters.Common.Objects;
 using Speckle.Sdk.Common.Exceptions;
-using Speckle.Sdk.Models;
 
 namespace Speckle.Converters.Autocad.Geometry;
 
@@ -15,7 +14,7 @@ public class RegionToSpeckleConverter : IToSpeckleTopLevelConverter, ITypedConve
     _brepConverter = brepConverter;
   }
 
-  public Base Convert(object target) => Convert((ADB.Region)target);
+  public BaseResult Convert(object target) => BaseResult.Success(Convert((ADB.Region)target));
 
   public SOG.Mesh Convert(ADB.Region target)
   {

--- a/Converters/Autocad/Speckle.Converters.AutocadShared/ToSpeckle/Geometry/Solid3dToSpeckleConverter.cs
+++ b/Converters/Autocad/Speckle.Converters.AutocadShared/ToSpeckle/Geometry/Solid3dToSpeckleConverter.cs
@@ -1,6 +1,5 @@
 using Speckle.Converters.Common;
 using Speckle.Converters.Common.Objects;
-using Speckle.Sdk.Models;
 
 namespace Speckle.Converters.Autocad.Geometry;
 
@@ -14,7 +13,7 @@ public class Solid3dToSpeckleConverter : IToSpeckleTopLevelConverter
     _solidConverter = solidConverter;
   }
 
-  public Base Convert(object target) => RawConvert((ADB.Solid3d)target);
+  public BaseResult Convert(object target) => BaseResult.Success(RawConvert((ADB.Solid3d)target));
 
   public SOG.Mesh RawConvert(ADB.Solid3d target)
   {

--- a/Converters/Autocad/Speckle.Converters.AutocadShared/ToSpeckle/Geometry/SplineToSpeckleConverter.cs
+++ b/Converters/Autocad/Speckle.Converters.AutocadShared/ToSpeckle/Geometry/SplineToSpeckleConverter.cs
@@ -1,6 +1,5 @@
 using Speckle.Converters.Common;
 using Speckle.Converters.Common.Objects;
-using Speckle.Sdk.Models;
 
 namespace Speckle.Converters.Autocad.ToSpeckle.Geometry;
 
@@ -14,7 +13,7 @@ public class SplineToSpeckleConverter : IToSpeckleTopLevelConverter
     _splineConverter = splineConverter;
   }
 
-  public Base Convert(object target) => Convert((ADB.Spline)target);
+  public BaseResult Convert(object target) => BaseResult.Success(Convert((ADB.Spline)target));
 
   public SOG.Curve Convert(ADB.Spline target) => _splineConverter.Convert(target);
 }

--- a/Converters/Autocad/Speckle.Converters.AutocadShared/ToSpeckle/Geometry/SubDMeshToSpeckleConverter.cs
+++ b/Converters/Autocad/Speckle.Converters.AutocadShared/ToSpeckle/Geometry/SubDMeshToSpeckleConverter.cs
@@ -1,7 +1,6 @@
 using Speckle.Converters.Common;
 using Speckle.Converters.Common.Objects;
 using Speckle.Sdk;
-using Speckle.Sdk.Models;
 
 namespace Speckle.Converters.Autocad.Geometry;
 
@@ -15,7 +14,7 @@ public class DBSubDMeshToSpeckleConverter : IToSpeckleTopLevelConverter
     _settingsStore = settingsStore;
   }
 
-  public Base Convert(object target) => RawConvert((ADB.SubDMesh)target);
+  public BaseResult Convert(object target) => BaseResult.Success(RawConvert((ADB.SubDMesh)target));
 
   public SOG.Mesh RawConvert(ADB.SubDMesh target)
   {

--- a/Converters/Autocad/Speckle.Converters.AutocadShared/ToSpeckle/Geometry/SurfaceToSpeckleConverter.cs
+++ b/Converters/Autocad/Speckle.Converters.AutocadShared/ToSpeckle/Geometry/SurfaceToSpeckleConverter.cs
@@ -1,7 +1,6 @@
 using Speckle.Converters.Common;
 using Speckle.Converters.Common.Objects;
 using Speckle.Sdk.Common.Exceptions;
-using Speckle.Sdk.Models;
 
 namespace Speckle.Converters.Autocad.Geometry;
 
@@ -15,7 +14,7 @@ public class SurfaceToSpeckleConverter : IToSpeckleTopLevelConverter, ITypedConv
     _brepConverter = brepConverter;
   }
 
-  public Base Convert(object target) => Convert((ADB.Surface)target);
+  public BaseResult Convert(object target) => BaseResult.Success(Convert((ADB.Surface)target));
 
   public SOG.Mesh Convert(ADB.Surface target)
   {

--- a/Converters/CSi/Speckle.Converters.CSiShared/CsiRootToSpeckleConverter.cs
+++ b/Converters/CSi/Speckle.Converters.CSiShared/CsiRootToSpeckleConverter.cs
@@ -2,8 +2,7 @@ using Microsoft.Extensions.Logging;
 using Speckle.Converters.Common;
 using Speckle.Converters.Common.Objects;
 using Speckle.Converters.Common.Registration;
-using Speckle.Sdk.Common.Exceptions;
-using Speckle.Sdk.Models;
+using Speckle.Sdk.Common;
 
 namespace Speckle.Converters.CSiShared;
 
@@ -24,17 +23,21 @@ public class CsiRootToSpeckleConverter : IRootToSpeckleConverter
     _logger = logger;
   }
 
-  public Base Convert(object target)
+  public BaseResult Convert(object target)
   {
     if (target is not ICsiWrapper)
     {
-      throw new ValidationException($"Target object is not a CSiWrapper. It's a ${target.GetType()}");
+      return BaseResult.NoConversion($"Target object is not a CSiWrapper. It's a ${target.GetType()}");
     }
 
     Type type = target.GetType();
-    var objectConverter = _toSpeckle.ResolveConverter(type, true);
+    var converterResult = _toSpeckle.ResolveConverter(type, true);
+    if (converterResult.IsFailure)
+    {
+      return BaseResult.NoConverter(converterResult.Message);
+    }
 
-    Base result = objectConverter.Convert(target);
+    var result = converterResult.Converter.NotNull().Convert(target);
 
     return result;
   }

--- a/Converters/CSi/Speckle.Converters.CSiShared/ToSpeckle/TopLevel/CsiObjectToSpeckleConverterBase.cs
+++ b/Converters/CSi/Speckle.Converters.CSiShared/ToSpeckle/TopLevel/CsiObjectToSpeckleConverterBase.cs
@@ -1,5 +1,6 @@
 using Speckle.Converters.Common;
 using Speckle.Converters.Common.Objects;
+using Speckle.Converters.Common.Registration;
 using Speckle.Converters.CSiShared.ToSpeckle.Helpers;
 using Speckle.Objects;
 using Speckle.Sdk.Models;
@@ -37,9 +38,9 @@ public abstract class CsiObjectToSpeckleConverterBase : IToSpeckleTopLevelConver
     _applicationPropertiesExtractor = applicationPropertiesExtractor;
   }
 
-  public Base Convert(object target) => Convert((CsiWrapperBase)target);
+  public BaseResult Convert(object target) => Convert((CsiWrapperBase)target);
 
-  public Base Convert(CsiWrapperBase wrapper)
+  public BaseResult Convert(CsiWrapperBase wrapper)
   {
     var displayValue = _displayValueExtractor.GetDisplayValue(wrapper).ToList();
     var objectData = _applicationPropertiesExtractor.ExtractProperties(wrapper);
@@ -54,7 +55,7 @@ public abstract class CsiObjectToSpeckleConverterBase : IToSpeckleTopLevelConver
       objectData.ApplicationId
     );
 
-    return baseObject;
+    return BaseResult.Success(baseObject);
   }
 
   protected abstract Base CreateTargetObject(

--- a/Converters/CSi/Speckle.Converters.CSiShared/ToSpeckle/TopLevel/CsiObjectToSpeckleConverterBase.cs
+++ b/Converters/CSi/Speckle.Converters.CSiShared/ToSpeckle/TopLevel/CsiObjectToSpeckleConverterBase.cs
@@ -1,6 +1,5 @@
 using Speckle.Converters.Common;
 using Speckle.Converters.Common.Objects;
-using Speckle.Converters.Common.Registration;
 using Speckle.Converters.CSiShared.ToSpeckle.Helpers;
 using Speckle.Objects;
 using Speckle.Sdk.Models;

--- a/Converters/Civil3d/Speckle.Converters.Civil3dShared/Civil3dRootToSpeckleConverter.cs
+++ b/Converters/Civil3d/Speckle.Converters.Civil3dShared/Civil3dRootToSpeckleConverter.cs
@@ -44,15 +44,15 @@ public class Civil3dRootToSpeckleConverter : IRootToSpeckleConverter
       return BaseResult.Failure(converterResult);
     }
 
-      using (var l = _settingsStore.Current.Document.LockDocument())
+    using (var l = _settingsStore.Current.Document.LockDocument())
+    {
+      using (var tr = _settingsStore.Current.Document.Database.TransactionManager.StartTransaction())
       {
-        using (var tr = _settingsStore.Current.Document.Database.TransactionManager.StartTransaction())
-        {
-          var result = converterResult.Converter.Convert(objectToConvert);
+        var result = converterResult.Converter.Convert(objectToConvert);
 
-          tr.Commit();
-          return result;
-        }
+        tr.Commit();
+        return result;
       }
+    }
   }
 }

--- a/Converters/Civil3d/Speckle.Converters.Civil3dShared/ToSpeckle/TopLevel/CivilEntityToSpeckleTopLevelConverter.cs
+++ b/Converters/Civil3d/Speckle.Converters.Civil3dShared/ToSpeckle/TopLevel/CivilEntityToSpeckleTopLevelConverter.cs
@@ -36,7 +36,7 @@ public class CivilEntityToSpeckleTopLevelConverter : IToSpeckleTopLevelConverter
     _corridorHandler = corridorHandler;
   }
 
-  public Base Convert(object target) => Convert((CDB.Entity)target);
+  public BaseResult Convert(object target) => BaseResult.Success(Convert((CDB.Entity)target));
 
   public Civil3dObject Convert(CDB.Entity target)
   {

--- a/Converters/Navisworks/Speckle.Converters.NavisworksShared/ToSpeckle/TopLevel/ModelItemTopLevelConverterToSpeckle.cs
+++ b/Converters/Navisworks/Speckle.Converters.NavisworksShared/ToSpeckle/TopLevel/ModelItemTopLevelConverterToSpeckle.cs
@@ -2,6 +2,7 @@
 using Speckle.Converter.Navisworks.ToSpeckle.PropertyHandlers;
 using Speckle.Converters.Common;
 using Speckle.Converters.Common.Objects;
+using Speckle.Converters.Common.Registration;
 using Speckle.Sdk.Models;
 using Speckle.Sdk.Models.Collections;
 
@@ -36,7 +37,7 @@ public class ModelItemToToSpeckleConverter : IToSpeckleTopLevelConverter
   /// </summary>
   /// <param name="target">The object to convert.</param>
   /// <returns>The converted Speckle Base object.</returns>
-  public Base Convert(object target)
+  public BaseResult Convert(object target)
   {
     if (target == null)
     {
@@ -47,7 +48,7 @@ public class ModelItemToToSpeckleConverter : IToSpeckleTopLevelConverter
   }
 
   // Converts a Navisworks ModelItem into a Speckle Base object
-  private Base Convert(NAV.ModelItem target)
+  private BaseResult Convert(NAV.ModelItem target)
   {
     var name = GetObjectName(target);
 
@@ -59,7 +60,7 @@ public class ModelItemToToSpeckleConverter : IToSpeckleTopLevelConverter
       handler.AssignProperties(navisworksObject, target);
     }
 
-    return navisworksObject;
+    return  BaseResult.Success(navisworksObject);
   }
 
   /// <summary>

--- a/Converters/Navisworks/Speckle.Converters.NavisworksShared/ToSpeckle/TopLevel/ModelItemTopLevelConverterToSpeckle.cs
+++ b/Converters/Navisworks/Speckle.Converters.NavisworksShared/ToSpeckle/TopLevel/ModelItemTopLevelConverterToSpeckle.cs
@@ -59,7 +59,7 @@ public class ModelItemToToSpeckleConverter : IToSpeckleTopLevelConverter
       handler.AssignProperties(navisworksObject, target);
     }
 
-    return  BaseResult.Success(navisworksObject);
+    return BaseResult.Success(navisworksObject);
   }
 
   /// <summary>

--- a/Converters/Navisworks/Speckle.Converters.NavisworksShared/ToSpeckle/TopLevel/ModelItemTopLevelConverterToSpeckle.cs
+++ b/Converters/Navisworks/Speckle.Converters.NavisworksShared/ToSpeckle/TopLevel/ModelItemTopLevelConverterToSpeckle.cs
@@ -2,7 +2,6 @@
 using Speckle.Converter.Navisworks.ToSpeckle.PropertyHandlers;
 using Speckle.Converters.Common;
 using Speckle.Converters.Common.Objects;
-using Speckle.Converters.Common.Registration;
 using Speckle.Sdk.Models;
 using Speckle.Sdk.Models.Collections;
 

--- a/Converters/Revit/Speckle.Converters.RevitShared/RevitRootToHostConverter.cs
+++ b/Converters/Revit/Speckle.Converters.RevitShared/RevitRootToHostConverter.cs
@@ -11,8 +11,8 @@ public record DirectShapeDefinitionWrapper(string DefinitionId, List<GeometryObj
 
 public class RevitRootToHostConverter(
   ITypedConverter<Base, List<DB.GeometryObject>> baseToGeometryConverter,
-  IConverterSettingsStore<RevitConversionSettings> converterSettings)
-  : IRootToHostConverter
+  IConverterSettingsStore<RevitConversionSettings> converterSettings
+) : IRootToHostConverter
 {
   public HostResult Convert(Base target)
   {

--- a/Converters/Revit/Speckle.Converters.RevitShared/RevitRootToHostConverter.cs
+++ b/Converters/Revit/Speckle.Converters.RevitShared/RevitRootToHostConverter.cs
@@ -1,7 +1,6 @@
 using Autodesk.Revit.DB;
 using Speckle.Converters.Common;
 using Speckle.Converters.Common.Objects;
-using Speckle.Converters.Common.Registration;
 using Speckle.Converters.RevitShared.Settings;
 using Speckle.Sdk.Common;
 using Speckle.Sdk.Models;

--- a/Converters/Revit/Speckle.Converters.RevitShared/RevitRootToSpeckleConverter.cs
+++ b/Converters/Revit/Speckle.Converters.RevitShared/RevitRootToSpeckleConverter.cs
@@ -60,6 +60,6 @@ public class RevitRootToSpeckleConverter : IRootToSpeckleConverter
     }
     result["worksetName"] = worksetName;
 
-    return  BaseResult.Success(result);
+    return BaseResult.Success(result);
   }
 }

--- a/Converters/Revit/Speckle.Converters.RevitShared/ToSpeckle/TopLevel/ModelCurveToSpeckleTopLevelConverter.cs
+++ b/Converters/Revit/Speckle.Converters.RevitShared/ToSpeckle/TopLevel/ModelCurveToSpeckleTopLevelConverter.cs
@@ -1,5 +1,6 @@
 using Speckle.Converters.Common;
 using Speckle.Converters.Common.Objects;
+using Speckle.Converters.Common.Registration;
 using Speckle.Objects;
 using Speckle.Sdk.Models;
 
@@ -16,12 +17,12 @@ public class ModelCurveToSpeckleTopLevelConverter : IToSpeckleTopLevelConverter
     _curveConverter = curveConverter;
   }
 
-  public Base Convert(object target) => Convert((DB.ModelCurve)target);
+  public BaseResult Convert(object target) => Convert((DB.ModelCurve)target);
 
-  public Base Convert(DB.ModelCurve target)
+  public BaseResult Convert(DB.ModelCurve target)
   {
     var curve = (Base)_curveConverter.Convert(target.GeometryCurve);
     curve["category"] = target.Category?.Name;
-    return curve;
+    return BaseResult.Success(curve);
   }
 }

--- a/Converters/Revit/Speckle.Converters.RevitShared/ToSpeckle/TopLevel/ModelCurveToSpeckleTopLevelConverter.cs
+++ b/Converters/Revit/Speckle.Converters.RevitShared/ToSpeckle/TopLevel/ModelCurveToSpeckleTopLevelConverter.cs
@@ -1,6 +1,5 @@
 using Speckle.Converters.Common;
 using Speckle.Converters.Common.Objects;
-using Speckle.Converters.Common.Registration;
 using Speckle.Objects;
 using Speckle.Sdk.Models;
 

--- a/Converters/Revit/Speckle.Converters.RevitShared/ToSpeckle/TopLevel/PointcloudTopLevelConverterToSpeckle.cs
+++ b/Converters/Revit/Speckle.Converters.RevitShared/ToSpeckle/TopLevel/PointcloudTopLevelConverterToSpeckle.cs
@@ -1,6 +1,5 @@
 using Speckle.Converters.Common;
 using Speckle.Converters.Common.Objects;
-using Speckle.Converters.Common.Registration;
 using Speckle.Converters.RevitShared.Settings;
 
 namespace Speckle.Converters.RevitShared.ToSpeckle;

--- a/Converters/Revit/Speckle.Converters.RevitShared/ToSpeckle/TopLevel/PointcloudTopLevelConverterToSpeckle.cs
+++ b/Converters/Revit/Speckle.Converters.RevitShared/ToSpeckle/TopLevel/PointcloudTopLevelConverterToSpeckle.cs
@@ -1,7 +1,7 @@
 using Speckle.Converters.Common;
 using Speckle.Converters.Common.Objects;
+using Speckle.Converters.Common.Registration;
 using Speckle.Converters.RevitShared.Settings;
-using Speckle.Sdk.Models;
 
 namespace Speckle.Converters.RevitShared.ToSpeckle;
 
@@ -23,9 +23,9 @@ public sealed class PointcloudTopLevelConverterToSpeckle : IToSpeckleTopLevelCon
     _boundingBoxConverter = boundingBoxConverter;
   }
 
-  public Base Convert(object target) => Convert((DB.PointCloudInstance)target);
+  public BaseResult Convert(object target) => Convert((DB.PointCloudInstance)target);
 
-  public SOG.Pointcloud Convert(DB.PointCloudInstance target)
+  public BaseResult Convert(DB.PointCloudInstance target)
   {
     var boundingBox = target.get_BoundingBox(null!);
     using DB.Transform transform = target.GetTransform();
@@ -48,7 +48,7 @@ public sealed class PointcloudTopLevelConverterToSpeckle : IToSpeckleTopLevelCon
 
       specklePointCloud["category"] = target.Category?.Name;
 
-      return specklePointCloud;
+      return BaseResult.Success(specklePointCloud);
     }
   }
 }

--- a/Converters/Revit/Speckle.Converters.RevitShared/ToSpeckle/TopLevel/RevitElementTopLevelConverterToSpeckle.cs
+++ b/Converters/Revit/Speckle.Converters.RevitShared/ToSpeckle/TopLevel/RevitElementTopLevelConverterToSpeckle.cs
@@ -1,6 +1,5 @@
 using Speckle.Converters.Common;
 using Speckle.Converters.Common.Objects;
-using Speckle.Converters.Common.Registration;
 using Speckle.Converters.RevitShared.Extensions;
 using Speckle.Converters.RevitShared.Helpers;
 using Speckle.Converters.RevitShared.Settings;

--- a/Converters/Rhino/Speckle.Converters.RhinoShared/SpeckleToHostGeometryBaseTopLevelConverter.cs
+++ b/Converters/Rhino/Speckle.Converters.RhinoShared/SpeckleToHostGeometryBaseTopLevelConverter.cs
@@ -1,6 +1,5 @@
 ﻿using Speckle.Converters.Common;
 using Speckle.Converters.Common.Objects;
-using Speckle.Converters.Common.Registration;
 using Speckle.Sdk.Common;
 using Speckle.Sdk.Common.Exceptions;
 using Speckle.Sdk.Models;

--- a/Converters/Rhino/Speckle.Converters.RhinoShared/SpeckleToHostGeometryBaseTopLevelConverter.cs
+++ b/Converters/Rhino/Speckle.Converters.RhinoShared/SpeckleToHostGeometryBaseTopLevelConverter.cs
@@ -1,5 +1,6 @@
 ﻿using Speckle.Converters.Common;
 using Speckle.Converters.Common.Objects;
+using Speckle.Converters.Common.Registration;
 using Speckle.Sdk.Common;
 using Speckle.Sdk.Common.Exceptions;
 using Speckle.Sdk.Models;
@@ -21,7 +22,7 @@ public abstract class SpeckleToHostGeometryBaseTopLevelConverter<TIn, TOut> : IT
     _geometryBaseConverter = geometryBaseConverter;
   }
 
-  public object Convert(Base target)
+  public HostResult Convert(Base target)
   {
     var castedBase = (TIn)target;
     var result = _geometryBaseConverter.Convert(castedBase);
@@ -37,7 +38,7 @@ public abstract class SpeckleToHostGeometryBaseTopLevelConverter<TIn, TOut> : IT
     if (result is RG.GeometryBase geometryBase && units is not null)
     {
       geometryBase.Transform(GetScaleTransform(units));
-      return geometryBase;
+      return HostResult.Success(geometryBase);
     }
 
     if (result is List<RG.GeometryBase> geometryBases && units is not null)
@@ -48,10 +49,10 @@ public abstract class SpeckleToHostGeometryBaseTopLevelConverter<TIn, TOut> : IT
         gb.Transform(t);
       }
 
-      return geometryBases;
+      return HostResult.Success(geometryBases);
     }
 
-    return result;
+    return HostResult.Success(result);
   }
 
   private RG.Transform GetScaleTransform(string from)

--- a/Converters/Rhino/Speckle.Converters.RhinoShared/ToHost/TopLevel/FallbackToHostTopLevelConverter.cs
+++ b/Converters/Rhino/Speckle.Converters.RhinoShared/ToHost/TopLevel/FallbackToHostTopLevelConverter.cs
@@ -1,6 +1,5 @@
 using Speckle.Converters.Common;
 using Speckle.Converters.Common.Objects;
-using Speckle.Converters.Common.Registration;
 using Speckle.Sdk.Common;
 using Speckle.Sdk.Common.Exceptions;
 using Speckle.Sdk.Models;

--- a/Converters/Rhino/Speckle.Converters.RhinoShared/ToHost/TopLevel/FallbackToHostTopLevelConverter.cs
+++ b/Converters/Rhino/Speckle.Converters.RhinoShared/ToHost/TopLevel/FallbackToHostTopLevelConverter.cs
@@ -1,5 +1,6 @@
 using Speckle.Converters.Common;
 using Speckle.Converters.Common.Objects;
+using Speckle.Converters.Common.Registration;
 using Speckle.Sdk.Common;
 using Speckle.Sdk.Common.Exceptions;
 using Speckle.Sdk.Models;
@@ -35,7 +36,7 @@ public class FallbackToHostTopLevelConverter
     _settingsStore = settingsStore;
   }
 
-  public object Convert(Base target) => Convert((DisplayableObject)target);
+  public HostResult Convert(Base target) => HostResult.Success(Convert((DisplayableObject)target));
 
   public List<RG.GeometryBase> Convert(DisplayableObject target)
   {

--- a/Converters/Rhino/Speckle.Converters.RhinoShared/ToSpeckle/TopLevel/BrepObjectToSpeckleTopLevelConverter.cs
+++ b/Converters/Rhino/Speckle.Converters.RhinoShared/ToSpeckle/TopLevel/BrepObjectToSpeckleTopLevelConverter.cs
@@ -1,9 +1,9 @@
 ﻿using Rhino.DocObjects;
 using Speckle.Converters.Common;
 using Speckle.Converters.Common.Objects;
+using Speckle.Converters.Common.Registration;
 using Speckle.Converters.Rhino.ToSpeckle.Encoding;
 using Speckle.Converters.Rhino.ToSpeckle.Meshing;
-using Speckle.Sdk.Models;
 
 namespace Speckle.Converters.Rhino.ToSpeckle.TopLevel;
 
@@ -22,7 +22,7 @@ public class BrepObjectToSpeckleTopLevelConverter : IToSpeckleTopLevelConverter
     _settingsStore = settingsStore;
   }
 
-  public Base Convert(object target)
+  public BaseResult Convert(object target)
   {
     var brepObject = (BrepObject)target;
     var brepEncoding = RawEncodingCreator.Encode(brepObject.Geometry, _settingsStore.Current.Document);
@@ -37,6 +37,6 @@ public class BrepObjectToSpeckleTopLevelConverter : IToSpeckleTopLevelConverter
       units = _settingsStore.Current.SpeckleUnits
     };
 
-    return bx;
+    return BaseResult.Success(bx);
   }
 }

--- a/Converters/Rhino/Speckle.Converters.RhinoShared/ToSpeckle/TopLevel/BrepObjectToSpeckleTopLevelConverter.cs
+++ b/Converters/Rhino/Speckle.Converters.RhinoShared/ToSpeckle/TopLevel/BrepObjectToSpeckleTopLevelConverter.cs
@@ -1,7 +1,6 @@
 ﻿using Rhino.DocObjects;
 using Speckle.Converters.Common;
 using Speckle.Converters.Common.Objects;
-using Speckle.Converters.Common.Registration;
 using Speckle.Converters.Rhino.ToSpeckle.Encoding;
 using Speckle.Converters.Rhino.ToSpeckle.Meshing;
 

--- a/Converters/Rhino/Speckle.Converters.RhinoShared/ToSpeckle/TopLevel/ExtrusionObjectToSpeckleTopLevelConverter.cs
+++ b/Converters/Rhino/Speckle.Converters.RhinoShared/ToSpeckle/TopLevel/ExtrusionObjectToSpeckleTopLevelConverter.cs
@@ -1,9 +1,9 @@
 ﻿using Rhino.DocObjects;
 using Speckle.Converters.Common;
 using Speckle.Converters.Common.Objects;
+using Speckle.Converters.Common.Registration;
 using Speckle.Converters.Rhino.ToSpeckle.Encoding;
 using Speckle.Converters.Rhino.ToSpeckle.Meshing;
-using Speckle.Sdk.Models;
 
 namespace Speckle.Converters.Rhino.ToSpeckle.TopLevel;
 
@@ -22,7 +22,7 @@ public class ExtrusionObjectToSpeckleTopLevelConverter : IToSpeckleTopLevelConve
     _settingsStore = settingsStore;
   }
 
-  public Base Convert(object target)
+  public BaseResult Convert(object target)
   {
     var extrusionObject = (ExtrusionObject)target;
     var extrusionEncoding = RawEncodingCreator.Encode(extrusionObject.Geometry, _settingsStore.Current.Document);
@@ -37,6 +37,6 @@ public class ExtrusionObjectToSpeckleTopLevelConverter : IToSpeckleTopLevelConve
       units = _settingsStore.Current.SpeckleUnits
     };
 
-    return bx;
+    return BaseResult.Success(bx);
   }
 }

--- a/Converters/Rhino/Speckle.Converters.RhinoShared/ToSpeckle/TopLevel/ExtrusionObjectToSpeckleTopLevelConverter.cs
+++ b/Converters/Rhino/Speckle.Converters.RhinoShared/ToSpeckle/TopLevel/ExtrusionObjectToSpeckleTopLevelConverter.cs
@@ -1,7 +1,6 @@
 ﻿using Rhino.DocObjects;
 using Speckle.Converters.Common;
 using Speckle.Converters.Common.Objects;
-using Speckle.Converters.Common.Registration;
 using Speckle.Converters.Rhino.ToSpeckle.Encoding;
 using Speckle.Converters.Rhino.ToSpeckle.Meshing;
 

--- a/Converters/Rhino/Speckle.Converters.RhinoShared/ToSpeckle/TopLevel/RhinoObjectToSpeckleTopLevelConverter.cs
+++ b/Converters/Rhino/Speckle.Converters.RhinoShared/ToSpeckle/TopLevel/RhinoObjectToSpeckleTopLevelConverter.cs
@@ -1,5 +1,5 @@
+using Speckle.Converters.Common;
 using Speckle.Converters.Common.Objects;
-using Speckle.Converters.Common.Registration;
 using Speckle.Sdk.Models;
 using RhinoObject = Rhino.DocObjects.RhinoObject;
 

--- a/Converters/Rhino/Speckle.Converters.RhinoShared/ToSpeckle/TopLevel/RhinoObjectToSpeckleTopLevelConverter.cs
+++ b/Converters/Rhino/Speckle.Converters.RhinoShared/ToSpeckle/TopLevel/RhinoObjectToSpeckleTopLevelConverter.cs
@@ -1,4 +1,5 @@
 using Speckle.Converters.Common.Objects;
+using Speckle.Converters.Common.Registration;
 using Speckle.Sdk.Models;
 using RhinoObject = Rhino.DocObjects.RhinoObject;
 
@@ -19,7 +20,7 @@ public abstract class RhinoObjectToSpeckleTopLevelConverter<TTopLevelIn, TInRaw,
   // POC: IIndex would fix this as I would just request the type from `RhinoObject.Geometry` directly.
   protected abstract TInRaw GetTypedGeometry(TTopLevelIn input);
 
-  public virtual Base Convert(object target)
+  public  BaseResult Convert(object target)
   {
     var typedTarget = (TTopLevelIn)target;
     var typedGeometry = GetTypedGeometry(typedTarget);
@@ -33,6 +34,6 @@ public abstract class RhinoObjectToSpeckleTopLevelConverter<TTopLevelIn, TInRaw,
       result["name"] = typedTarget.Attributes.Name;
     }
 
-    return result;
+    return BaseResult.Success( result);
   }
 }

--- a/Converters/Rhino/Speckle.Converters.RhinoShared/ToSpeckle/TopLevel/RhinoObjectToSpeckleTopLevelConverter.cs
+++ b/Converters/Rhino/Speckle.Converters.RhinoShared/ToSpeckle/TopLevel/RhinoObjectToSpeckleTopLevelConverter.cs
@@ -20,7 +20,7 @@ public abstract class RhinoObjectToSpeckleTopLevelConverter<TTopLevelIn, TInRaw,
   // POC: IIndex would fix this as I would just request the type from `RhinoObject.Geometry` directly.
   protected abstract TInRaw GetTypedGeometry(TTopLevelIn input);
 
-  public  BaseResult Convert(object target)
+  public BaseResult Convert(object target)
   {
     var typedTarget = (TTopLevelIn)target;
     var typedGeometry = GetTypedGeometry(typedTarget);
@@ -34,6 +34,6 @@ public abstract class RhinoObjectToSpeckleTopLevelConverter<TTopLevelIn, TInRaw,
       result["name"] = typedTarget.Attributes.Name;
     }
 
-    return BaseResult.Success( result);
+    return BaseResult.Success(result);
   }
 }

--- a/Converters/Rhino/Speckle.Converters.RhinoShared/ToSpeckle/TopLevel/SubDObjectToSpeckleTopLevelConverter.cs
+++ b/Converters/Rhino/Speckle.Converters.RhinoShared/ToSpeckle/TopLevel/SubDObjectToSpeckleTopLevelConverter.cs
@@ -1,9 +1,9 @@
 ﻿using Rhino.DocObjects;
 using Speckle.Converters.Common;
 using Speckle.Converters.Common.Objects;
+using Speckle.Converters.Common.Registration;
 using Speckle.Converters.Rhino.ToSpeckle.Encoding;
 using Speckle.Converters.Rhino.ToSpeckle.Meshing;
-using Speckle.Sdk.Models;
 
 namespace Speckle.Converters.Rhino.ToSpeckle.TopLevel;
 
@@ -22,7 +22,7 @@ public class SubDObjectToSpeckleTopLevelConverter : IToSpeckleTopLevelConverter
     _settingsStore = settingsStore;
   }
 
-  public Base Convert(object target)
+  public BaseResult Convert(object target)
   {
     var subDObject = (SubDObject)target;
     var subdEncoding = RawEncodingCreator.Encode(subDObject.Geometry, _settingsStore.Current.Document);
@@ -37,6 +37,6 @@ public class SubDObjectToSpeckleTopLevelConverter : IToSpeckleTopLevelConverter
       units = _settingsStore.Current.SpeckleUnits
     };
 
-    return bx;
+    return BaseResult.Success(bx);
   }
 }

--- a/Converters/Rhino/Speckle.Converters.RhinoShared/ToSpeckle/TopLevel/SubDObjectToSpeckleTopLevelConverter.cs
+++ b/Converters/Rhino/Speckle.Converters.RhinoShared/ToSpeckle/TopLevel/SubDObjectToSpeckleTopLevelConverter.cs
@@ -1,7 +1,6 @@
 ﻿using Rhino.DocObjects;
 using Speckle.Converters.Common;
 using Speckle.Converters.Common.Objects;
-using Speckle.Converters.Common.Registration;
 using Speckle.Converters.Rhino.ToSpeckle.Encoding;
 using Speckle.Converters.Rhino.ToSpeckle.Meshing;
 

--- a/Converters/Tekla/Speckle.Converters.TeklaShared/ToSpeckle/TopLevel/ModelObjectToSpeckleConverter.cs
+++ b/Converters/Tekla/Speckle.Converters.TeklaShared/ToSpeckle/TopLevel/ModelObjectToSpeckleConverter.cs
@@ -1,6 +1,5 @@
 using Speckle.Converters.Common;
 using Speckle.Converters.Common.Objects;
-using Speckle.Converters.Common.Registration;
 using Speckle.Converters.TeklaShared.Extensions;
 using Speckle.Converters.TeklaShared.ToSpeckle.Helpers;
 using Speckle.Objects.Data;

--- a/Converters/Tekla/Speckle.Converters.TeklaShared/ToSpeckle/TopLevel/ModelObjectToSpeckleConverter.cs
+++ b/Converters/Tekla/Speckle.Converters.TeklaShared/ToSpeckle/TopLevel/ModelObjectToSpeckleConverter.cs
@@ -1,5 +1,6 @@
 using Speckle.Converters.Common;
 using Speckle.Converters.Common.Objects;
+using Speckle.Converters.Common.Registration;
 using Speckle.Converters.TeklaShared.Extensions;
 using Speckle.Converters.TeklaShared.ToSpeckle.Helpers;
 using Speckle.Objects.Data;
@@ -28,7 +29,7 @@ public class ModelObjectToSpeckleConverter : IToSpeckleTopLevelConverter
     _classPropertyExtractor = classPropertyExtractor;
   }
 
-  public Base Convert(object target) => Convert((TSM.ModelObject)target);
+  public BaseResult Convert(object target) => BaseResult.Success(Convert((TSM.ModelObject)target));
 
   private TeklaObject Convert(TSM.ModelObject target)
   {

--- a/Sdk/Speckle.Connectors.Common/Conversion/ReportResult.cs
+++ b/Sdk/Speckle.Connectors.Common/Conversion/ReportResult.cs
@@ -55,12 +55,8 @@ public sealed class ReceiveConversionResult : ConversionResult
     ResultType = resultType;
     Error = FormatError(exception);
   }
-  
-  public ReceiveConversionResult(
-    Status status,
-    Base source,
-    string exception
-  )
+
+  public ReceiveConversionResult(Status status, Base source, string exception)
   {
     Status = status;
     SourceId = source.id.NotNull();

--- a/Sdk/Speckle.Connectors.Common/Conversion/ReportResult.cs
+++ b/Sdk/Speckle.Connectors.Common/Conversion/ReportResult.cs
@@ -25,8 +25,8 @@ public sealed class SendConversionResult : ConversionResult
     Status status,
     string sourceId,
     string sourceType,
-    Base? result = null,
-    Exception? exception = null
+    Base? result,
+    Exception? exception
   )
   {
     Status = status;
@@ -35,6 +35,16 @@ public sealed class SendConversionResult : ConversionResult
     ResultId = result?.id;
     ResultType = result?.speckle_type;
     Error = FormatError(exception);
+  }
+  
+  public SendConversionResult(Status status, 
+    string sourceId,
+    string sourceType, string? message)
+  {
+    Status = status;
+    SourceId = sourceId;
+    SourceType = sourceType;
+    Error = new ErrorWrapper() { Message = message.NotNull(), StackTrace = "" };
   }
 }
 
@@ -56,12 +66,12 @@ public sealed class ReceiveConversionResult : ConversionResult
     Error = FormatError(exception);
   }
 
-  public ReceiveConversionResult(Status status, Base source, string exception)
+  public ReceiveConversionResult(Status status, Base source, string? message)
   {
     Status = status;
     SourceId = source.id.NotNull();
     SourceType = source.speckle_type; // Note: we'll parse it nicely in FE
-    Error = new ErrorWrapper() { Message = exception, StackTrace = "" };
+    Error = new ErrorWrapper() { Message = message.NotNull(), StackTrace = "" };
   }
 }
 

--- a/Sdk/Speckle.Connectors.Common/Conversion/ReportResult.cs
+++ b/Sdk/Speckle.Connectors.Common/Conversion/ReportResult.cs
@@ -21,13 +21,7 @@ public enum Status
 
 public sealed class SendConversionResult : ConversionResult
 {
-  public SendConversionResult(
-    Status status,
-    string sourceId,
-    string sourceType,
-    Base? result,
-    Exception? exception
-  )
+  public SendConversionResult(Status status, string sourceId, string sourceType, Base? result, Exception? exception)
   {
     Status = status;
     SourceId = sourceId;
@@ -36,10 +30,8 @@ public sealed class SendConversionResult : ConversionResult
     ResultType = result?.speckle_type;
     Error = FormatError(exception);
   }
-  
-  public SendConversionResult(Status status, 
-    string sourceId,
-    string sourceType, string? message)
+
+  public SendConversionResult(Status status, string sourceId, string sourceType, string? message)
   {
     Status = status;
     SourceId = sourceId;

--- a/Sdk/Speckle.Connectors.Common/Conversion/ReportResult.cs
+++ b/Sdk/Speckle.Connectors.Common/Conversion/ReportResult.cs
@@ -55,6 +55,18 @@ public sealed class ReceiveConversionResult : ConversionResult
     ResultType = resultType;
     Error = FormatError(exception);
   }
+  
+  public ReceiveConversionResult(
+    Status status,
+    Base source,
+    string exception
+  )
+  {
+    Status = status;
+    SourceId = source.id.NotNull();
+    SourceType = source.speckle_type; // Note: we'll parse it nicely in FE
+    Error = new ErrorWrapper() { Message = exception, StackTrace = "" };
+  }
 }
 
 /// <summary>

--- a/Sdk/Speckle.Connectors.Common/Extensions/RootObjectBuilderExtensions.cs
+++ b/Sdk/Speckle.Connectors.Common/Extensions/RootObjectBuilderExtensions.cs
@@ -20,7 +20,7 @@ public static class RootObjectBuilderExtensions
 
     logger.Log(logLevel, ex, "Conversion of object {objectType} was not successful", objectType);
   }
-  
+
   public static void LogSendConversionError<T>(
     this ILogger<IRootObjectBuilder<T>> logger,
     string objectType,

--- a/Sdk/Speckle.Connectors.Common/Extensions/RootObjectBuilderExtensions.cs
+++ b/Sdk/Speckle.Connectors.Common/Extensions/RootObjectBuilderExtensions.cs
@@ -20,4 +20,13 @@ public static class RootObjectBuilderExtensions
 
     logger.Log(logLevel, ex, "Conversion of object {objectType} was not successful", objectType);
   }
+  
+  public static void LogSendConversionError<T>(
+    this ILogger<IRootObjectBuilder<T>> logger,
+    string objectType,
+    string message
+  )
+  {
+    logger.Log(LogLevel.Information, "Conversion of object {objectType} was not successful:" + message, objectType);
+  }
 }

--- a/Sdk/Speckle.Converters.Common.Tests/ConverterManagerTests.cs
+++ b/Sdk/Speckle.Converters.Common.Tests/ConverterManagerTests.cs
@@ -3,7 +3,6 @@ using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using NUnit.Framework;
 using Speckle.Converters.Common.Registration;
-using Speckle.Sdk.Common.Exceptions;
 
 namespace Speckle.Converters.Common.Tests;
 
@@ -30,29 +29,37 @@ public class ConverterManagerTests
   public void Test_Null()
   {
     var sut = SetupManager("Test", typeof(TestConverter));
-    Assert.Throws<ConversionNotSupportedException>(() => sut.ResolveConverter(typeof(string), false));
+    var result = sut.ResolveConverter(typeof(string), false);
+    result.IsFailure.Should().BeTrue();
   }
 
   [Test]
   public void Test_NoFallback()
   {
     var sut = SetupManager("String", typeof(TestConverter));
-    var converter = sut.ResolveConverter(typeof(string), false);
-    converter.Should().NotBeNull();
+    var result = sut.ResolveConverter(typeof(string), false);
+    result.Should().NotBeNull();
+    result.IsSuccess.Should().BeTrue();
+    result.IsFailure.Should().BeFalse();
+    result.Converter.Should().NotBeNull();
   }
 
   [Test]
   public void Test_Fallback()
   {
     var sut = SetupManager("Object", typeof(TestConverter));
-    var converter = sut.ResolveConverter(typeof(string), true);
-    converter.Should().NotBeNull();
+    var result = sut.ResolveConverter(typeof(string), true);
+    result.Should().NotBeNull();
+    result.IsSuccess.Should().BeTrue();
+    result.IsFailure.Should().BeFalse();
+    result.Converter.Should().NotBeNull();
   }
 
   [Test]
   public void Test_Fallback_Null()
   {
     var sut = SetupManager("Object", typeof(TestConverter));
-    Assert.Throws<ConversionNotSupportedException>(() => sut.ResolveConverter(typeof(string), false));
+    var result = sut.ResolveConverter(typeof(string), false);
+    result.IsFailure.Should().BeTrue();
   }
 }

--- a/Sdk/Speckle.Converters.Common/Extensions/ToHostTopLevelConverterExtension.cs
+++ b/Sdk/Speckle.Converters.Common/Extensions/ToHostTopLevelConverterExtension.cs
@@ -1,8 +1,6 @@
 ﻿using Microsoft.Extensions.Logging;
 using Speckle.Converters.Common.Objects;
-using Speckle.Converters.Common.Registration;
 using Speckle.Sdk;
-using Speckle.Sdk.Common;
 using Speckle.Sdk.Models;
 
 namespace Speckle.Converters.Common.Extensions;
@@ -19,7 +17,7 @@ public static class ToHostTopLevelConverterExtension
     {
       if (converter.IsSuccess)
       {
-        return converter.Converter.NotNull().Convert(target);
+        return converter.Converter.Convert(target);
       }
 
       logger.Log(

--- a/Sdk/Speckle.Converters.Common/Extensions/ToHostTopLevelConverterExtension.cs
+++ b/Sdk/Speckle.Converters.Common/Extensions/ToHostTopLevelConverterExtension.cs
@@ -1,13 +1,54 @@
 ﻿using Microsoft.Extensions.Logging;
 using Speckle.Converters.Common.Objects;
+using Speckle.Converters.Common.Registration;
 using Speckle.Sdk;
+using Speckle.Sdk.Common;
 using Speckle.Sdk.Models;
 
 namespace Speckle.Converters.Common.Extensions;
 
 public static class ToHostTopLevelConverterExtension
 {
-  public static object ConvertAndLog(this IToHostTopLevelConverter converter, Base target, ILogger logger)
+  public static HostResult ConvertAndLog(this ConverterResult<IToHostTopLevelConverter> converter, Base target, ILogger logger)
+  {
+    try
+    {
+      if (converter.IsSuccess)
+      {
+        return converter.Converter.NotNull().Convert(target);
+      }
+
+      logger.Log(
+        LogLevel.Information,
+        "Conversion of object {target} using {converter} was not successful",
+        target.GetType(),
+        converter.GetType()
+      );
+      return HostResult.NoConverter(converter.Message);
+    }
+#pragma warning disable CA1031
+    catch (Exception ex)
+#pragma warning restore CA1031
+    {
+      //SpeckleExceptions are expected, if a converter throws anything else, its considered an error that we should investigate and fix
+      LogLevel logLevel = ex switch
+      {
+        SpeckleException => LogLevel.Information, //If it's too noisy, we could demote to LogLevel.Debug
+        _ => LogLevel.Error
+      };
+
+      logger.Log(
+        logLevel,
+        ex,
+        "Conversion of object {target} using {converter} was not successful",
+        target.GetType(),
+        converter.GetType()
+      );
+
+      return HostResult.NoConversion($"Conversion of object {target} using {converter} was not successful: " + ex.Message);
+    }
+  }
+  public static HostResult ConvertAndLog(this IToHostTopLevelConverter converter, Base target, ILogger logger)
   {
     try
     {

--- a/Sdk/Speckle.Converters.Common/Extensions/ToHostTopLevelConverterExtension.cs
+++ b/Sdk/Speckle.Converters.Common/Extensions/ToHostTopLevelConverterExtension.cs
@@ -9,7 +9,11 @@ namespace Speckle.Converters.Common.Extensions;
 
 public static class ToHostTopLevelConverterExtension
 {
-  public static HostResult ConvertAndLog(this ConverterResult<IToHostTopLevelConverter> converter, Base target, ILogger logger)
+  public static HostResult ConvertAndLog(
+    this ConverterResult<IToHostTopLevelConverter> converter,
+    Base target,
+    ILogger logger
+  )
   {
     try
     {
@@ -45,9 +49,12 @@ public static class ToHostTopLevelConverterExtension
         converter.GetType()
       );
 
-      return HostResult.NoConversion($"Conversion of object {target} using {converter} was not successful: " + ex.Message);
+      return HostResult.NoConversion(
+        $"Conversion of object {target} using {converter} was not successful: " + ex.Message
+      );
     }
   }
+
   public static HostResult ConvertAndLog(this IToHostTopLevelConverter converter, Base target, ILogger logger)
   {
     try

--- a/Sdk/Speckle.Converters.Common/IConversionResult.cs
+++ b/Sdk/Speckle.Converters.Common/IConversionResult.cs
@@ -26,7 +26,7 @@ public readonly record struct ConverterResult<T>(
 {
   public bool IsSuccess => ConversionStatus == ConversionStatus.Success;
   public bool IsFailure => ConversionStatus != ConversionStatus.Success;
-  
+
   public T Converter
   {
     get

--- a/Sdk/Speckle.Converters.Common/IRootToHostConverter.cs
+++ b/Sdk/Speckle.Converters.Common/IRootToHostConverter.cs
@@ -1,8 +1,9 @@
+using Speckle.Converters.Common.Registration;
 using Speckle.Sdk.Models;
 
 namespace Speckle.Converters.Common;
 
 public interface IRootToHostConverter
 {
-  object Convert(Base target);
+  HostResult Convert(Base target);
 }

--- a/Sdk/Speckle.Converters.Common/IRootToHostConverter.cs
+++ b/Sdk/Speckle.Converters.Common/IRootToHostConverter.cs
@@ -1,4 +1,3 @@
-using Speckle.Converters.Common.Registration;
 using Speckle.Sdk.Models;
 
 namespace Speckle.Converters.Common;

--- a/Sdk/Speckle.Converters.Common/Objects/IToHostTopLevelConverter.cs
+++ b/Sdk/Speckle.Converters.Common/Objects/IToHostTopLevelConverter.cs
@@ -1,4 +1,3 @@
-using Speckle.Converters.Common.Registration;
 using Speckle.Sdk.Models;
 
 namespace Speckle.Converters.Common.Objects;

--- a/Sdk/Speckle.Converters.Common/Objects/IToHostTopLevelConverter.cs
+++ b/Sdk/Speckle.Converters.Common/Objects/IToHostTopLevelConverter.cs
@@ -1,8 +1,9 @@
+using Speckle.Converters.Common.Registration;
 using Speckle.Sdk.Models;
 
 namespace Speckle.Converters.Common.Objects;
 
 public interface IToHostTopLevelConverter
 {
-  object Convert(Base target);
+  HostResult Convert(Base target);
 }

--- a/Sdk/Speckle.Converters.Common/Objects/IToSpeckleTopLevelConverter.cs
+++ b/Sdk/Speckle.Converters.Common/Objects/IToSpeckleTopLevelConverter.cs
@@ -1,8 +1,8 @@
-using Speckle.Sdk.Models;
+using Speckle.Converters.Common.Registration;
 
 namespace Speckle.Converters.Common.Objects;
 
 public interface IToSpeckleTopLevelConverter
 {
-  Base Convert(object target);
+  BaseResult Convert(object target);
 }

--- a/Sdk/Speckle.Converters.Common/Objects/IToSpeckleTopLevelConverter.cs
+++ b/Sdk/Speckle.Converters.Common/Objects/IToSpeckleTopLevelConverter.cs
@@ -1,5 +1,3 @@
-using Speckle.Converters.Common.Registration;
-
 namespace Speckle.Converters.Common.Objects;
 
 public interface IToSpeckleTopLevelConverter

--- a/Sdk/Speckle.Converters.Common/Registration/ConverterManager.cs
+++ b/Sdk/Speckle.Converters.Common/Registration/ConverterManager.cs
@@ -3,7 +3,6 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace Speckle.Converters.Common.Registration;
 
-
 public class ConverterManager<T>(ConcurrentDictionary<string, Type> converterTypes, IServiceProvider serviceProvider)
   : IConverterManager<T>
 {
@@ -23,7 +22,10 @@ public class ConverterManager<T>(ConcurrentDictionary<string, Type> converterTyp
 
         if (currentType == null)
         {
-          return new ConverterResult<T>(ConversionStatus.NoConverter, Message: $"No conversion found for {type.Name} or any of its base types");
+          return new ConverterResult<T>(
+            ConversionStatus.NoConverter,
+            Message: $"No conversion found for {type.Name} or any of its base types"
+          );
         }
       }
       else if (converter is null)
@@ -32,7 +34,6 @@ public class ConverterManager<T>(ConcurrentDictionary<string, Type> converterTyp
       }
       else
       {
-         
         return new ConverterResult<T>(ConversionStatus.Success, converter);
       }
     }

--- a/Sdk/Speckle.Converters.Common/Registration/ConverterManager.cs
+++ b/Sdk/Speckle.Converters.Common/Registration/ConverterManager.cs
@@ -1,15 +1,15 @@
 using System.Collections.Concurrent;
 using Microsoft.Extensions.DependencyInjection;
-using Speckle.Sdk.Common.Exceptions;
 
 namespace Speckle.Converters.Common.Registration;
+
 
 public class ConverterManager<T>(ConcurrentDictionary<string, Type> converterTypes, IServiceProvider serviceProvider)
   : IConverterManager<T>
 {
   public string Name => typeof(T).Name;
 
-  public T ResolveConverter(Type type, bool recursive = true)
+  public ConverterResult<T> ResolveConverter(Type type, bool recursive = true)
   {
     var currentType = type;
     while (true)
@@ -23,16 +23,17 @@ public class ConverterManager<T>(ConcurrentDictionary<string, Type> converterTyp
 
         if (currentType == null)
         {
-          throw new ConversionNotSupportedException($"No conversion found for {type.Name} or any of its base types");
+          return new ConverterResult<T>(ConversionStatus.NoConverter, Message: $"No conversion found for {type.Name} or any of its base types");
         }
       }
       else if (converter is null)
       {
-        throw new ConversionNotSupportedException($"No conversion found for {type.Name}");
+        return new ConverterResult<T>(ConversionStatus.NoConverter, Message: $"No conversion found for {type.Name}");
       }
       else
       {
-        return converter;
+         
+        return new ConverterResult<T>(ConversionStatus.Success, converter);
       }
     }
   }

--- a/Sdk/Speckle.Converters.Common/Registration/IConversionResult.cs
+++ b/Sdk/Speckle.Converters.Common/Registration/IConversionResult.cs
@@ -1,0 +1,39 @@
+﻿using Speckle.Sdk.Models;
+
+namespace Speckle.Converters.Common.Registration;
+
+public interface IConversionResult
+{
+  ConversionStatus ConversionStatus { get; }
+  string? Message { get; }
+  bool IsSuccess { get; }
+}
+
+public enum ConversionStatus
+{
+  Success,
+  NoConverter,
+  NoConversion
+}
+
+public readonly record struct ConverterResult<T>(ConversionStatus ConversionStatus, T? Converter = default, string? Message = null) : IConversionResult
+{
+  public bool IsSuccess => ConversionStatus == ConversionStatus.Success;
+}
+
+public readonly record struct BaseResult(ConversionStatus ConversionStatus, Base? Base = null, string? Message = null) : IConversionResult
+{
+  public bool IsSuccess => ConversionStatus == ConversionStatus.Success;
+  
+  public static BaseResult Success(Base baseObject) => new(ConversionStatus.Success, baseObject);
+  public static BaseResult NoConverter(string? message) => new(ConversionStatus.NoConverter, Message: message);
+}
+
+public readonly record struct HostResult(ConversionStatus ConversionStatus, object? Host = null, string? Message = null) : IConversionResult
+{
+  public bool IsSuccess => ConversionStatus == ConversionStatus.Success;
+  
+  public static HostResult Success(object obj) => new(ConversionStatus.Success, obj);
+  public static HostResult NoConverter(string? message) => new(ConversionStatus.NoConverter, Message: message);
+  public static HostResult NoConversion(string? message) => new(ConversionStatus.NoConversion, Message: message);
+}

--- a/Sdk/Speckle.Converters.Common/Registration/IConversionResult.cs
+++ b/Sdk/Speckle.Converters.Common/Registration/IConversionResult.cs
@@ -16,24 +16,33 @@ public enum ConversionStatus
   NoConversion
 }
 
-public readonly record struct ConverterResult<T>(ConversionStatus ConversionStatus, T? Converter = default, string? Message = null) : IConversionResult
+public readonly record struct ConverterResult<T>(
+  ConversionStatus ConversionStatus,
+  T? Converter = default,
+  string? Message = null
+) : IConversionResult
 {
   public bool IsSuccess => ConversionStatus == ConversionStatus.Success;
 }
 
-public readonly record struct BaseResult(ConversionStatus ConversionStatus, Base? Base = null, string? Message = null) : IConversionResult
+public readonly record struct BaseResult(ConversionStatus ConversionStatus, Base? Base = null, string? Message = null)
+  : IConversionResult
 {
   public bool IsSuccess => ConversionStatus == ConversionStatus.Success;
-  
+
   public static BaseResult Success(Base baseObject) => new(ConversionStatus.Success, baseObject);
+
   public static BaseResult NoConverter(string? message) => new(ConversionStatus.NoConverter, Message: message);
 }
 
-public readonly record struct HostResult(ConversionStatus ConversionStatus, object? Host = null, string? Message = null) : IConversionResult
+public readonly record struct HostResult(ConversionStatus ConversionStatus, object? Host = null, string? Message = null)
+  : IConversionResult
 {
   public bool IsSuccess => ConversionStatus == ConversionStatus.Success;
-  
+
   public static HostResult Success(object obj) => new(ConversionStatus.Success, obj);
+
   public static HostResult NoConverter(string? message) => new(ConversionStatus.NoConverter, Message: message);
+
   public static HostResult NoConversion(string? message) => new(ConversionStatus.NoConversion, Message: message);
 }

--- a/Sdk/Speckle.Converters.Common/Registration/IConversionResult.cs
+++ b/Sdk/Speckle.Converters.Common/Registration/IConversionResult.cs
@@ -1,4 +1,5 @@
-﻿using Speckle.Sdk.Models;
+﻿using Speckle.Sdk;
+using Speckle.Sdk.Models;
 
 namespace Speckle.Converters.Common.Registration;
 
@@ -7,6 +8,7 @@ public interface IConversionResult
   ConversionStatus ConversionStatus { get; }
   string? Message { get; }
   bool IsSuccess { get; }
+  bool IsFailure { get; }
 }
 
 public enum ConversionStatus
@@ -23,22 +25,41 @@ public readonly record struct ConverterResult<T>(
 ) : IConversionResult
 {
   public bool IsSuccess => ConversionStatus == ConversionStatus.Success;
+  public bool IsFailure => ConversionStatus != ConversionStatus.Success;
 }
 
 public readonly record struct BaseResult(ConversionStatus ConversionStatus, Base? Base = null, string? Message = null)
   : IConversionResult
 {
   public bool IsSuccess => ConversionStatus == ConversionStatus.Success;
+  public bool IsFailure => ConversionStatus != ConversionStatus.Success;
+
+  public Base Value
+  {
+    get
+    {
+      if (IsSuccess)
+      {
+        return Base ?? throw new InvalidOperationException("Base was null");
+      }
+#pragma warning disable CA1065
+      throw new SpeckleException("Conversion wasn't successful: " + Message);
+#pragma warning restore CA1065
+    }
+  } 
 
   public static BaseResult Success(Base baseObject) => new(ConversionStatus.Success, baseObject);
 
   public static BaseResult NoConverter(string? message) => new(ConversionStatus.NoConverter, Message: message);
+
+  public static BaseResult NoConversion(string? message) => new(ConversionStatus.NoConversion, Message: message);
 }
 
 public readonly record struct HostResult(ConversionStatus ConversionStatus, object? Host = null, string? Message = null)
   : IConversionResult
 {
   public bool IsSuccess => ConversionStatus == ConversionStatus.Success;
+  public bool IsFailure => ConversionStatus != ConversionStatus.Success;
 
   public static HostResult Success(object obj) => new(ConversionStatus.Success, obj);
 

--- a/Sdk/Speckle.Converters.Common/Registration/IConverterManager.cs
+++ b/Sdk/Speckle.Converters.Common/Registration/IConverterManager.cs
@@ -3,5 +3,5 @@ namespace Speckle.Converters.Common.Registration;
 public interface IConverterManager<T>
 {
   public string Name { get; }
-  public T ResolveConverter(Type type, bool recursive = true);
+  public ConverterResult<T> ResolveConverter(Type type, bool recursive = true);
 }

--- a/Sdk/Speckle.Converters.Common/RootToSpeckleConverter.cs
+++ b/Sdk/Speckle.Converters.Common/RootToSpeckleConverter.cs
@@ -1,28 +1,24 @@
 using Speckle.Converters.Common.Objects;
 using Speckle.Converters.Common.Registration;
 using Speckle.InterfaceGenerator;
-using Speckle.Sdk.Models;
+using Speckle.Sdk.Common;
 
 namespace Speckle.Converters.Common;
 
 [GenerateAutoInterface]
-public class RootToSpeckleConverter : IRootToSpeckleConverter
+public class RootToSpeckleConverter(IConverterManager<IToSpeckleTopLevelConverter> toSpeckle) : IRootToSpeckleConverter
 {
-  private readonly IConverterManager<IToSpeckleTopLevelConverter> _toSpeckle;
-
-  public RootToSpeckleConverter(IConverterManager<IToSpeckleTopLevelConverter> toSpeckle)
-  {
-    _toSpeckle = toSpeckle;
-  }
-
-  public Base Convert(object target)
+  public BaseResult Convert(object target)
   {
     Type type = target.GetType();
 
-    var objectConverter = _toSpeckle.ResolveConverter(type);
+    var result = toSpeckle.ResolveConverter(type);
 
-    var convertedObject = objectConverter.Convert(target);
-
-    return convertedObject;
+    if (result.IsSuccess)
+    {
+      var convertedObject = result.Converter.NotNull().Convert(target);
+      return convertedObject;
+    }
+    return BaseResult.NoConverter(result.Message);
   }
 }

--- a/Sdk/Speckle.Converters.Common/ToHost/ConverterWithFallback.cs
+++ b/Sdk/Speckle.Converters.Common/ToHost/ConverterWithFallback.cs
@@ -1,55 +1,27 @@
 using System.Collections;
 using Microsoft.Extensions.Logging;
+using Speckle.Converters.Common.Registration;
 using Speckle.Sdk.Common.Exceptions;
 using Speckle.Sdk.Models;
 using Speckle.Sdk.Models.Extensions;
 
 namespace Speckle.Converters.Common.ToHost;
 
-// POC: CNX-9394 Find a better home for this outside `DependencyInjection` project
-/// <summary>
-/// <inheritdoc cref="ConverterWithoutFallback"/>
-/// <br/>
-/// If no suitable converter conversion is found, and the target <see cref="Base"/> object has a displayValue property
-/// a converter with strong name of <see cref="ConverterWithoutFallback"/> is resolved for.
-/// </summary>
-/// <seealso cref="DisplayableObject"/>
-public sealed class ConverterWithFallback : IRootToHostConverter
+
+public sealed class ConverterWithFallback(ConverterWithoutFallback baseConverter, ILogger<ConverterWithFallback> logger)
+  : IRootToHostConverter
 {
-  private readonly ILogger<ConverterWithFallback> _logger;
-  private readonly ConverterWithoutFallback _baseConverter;
-
-  public ConverterWithFallback(ConverterWithoutFallback baseConverter, ILogger<ConverterWithFallback> logger)
-  {
-    _logger = logger;
-    _baseConverter = baseConverter;
-  }
-
-  /// <summary>
-  /// Converts a <see cref="Base"/> instance to a host object.
-  /// </summary>
-  /// <param name="target">The <see cref="Base"/> instance to convert.</param>
-  /// <returns>The converted host object.
-  /// Fallbacks to display value if a direct conversion is not possible.</returns>
-  /// <remarks>
-  /// The conversion is done in the following order of preference:
-  /// 1. Direct conversion using the <see cref="ConverterWithoutFallback"/>.
-  /// 2. Fallback to display value using the <see cref="Speckle.Sdk.Models.Extensions.BaseExtensions.TryGetDisplayValue{T}"/> method, if a direct conversion is not possible.
-  ///
-  /// If the direct conversion is not available and there is no displayValue, a <see cref="System.NotSupportedException"/> is thrown.
-  /// </remarks>
-  /// <exception cref="System.NotSupportedException">Thrown when no conversion is found for <paramref name="target"/>.</exception>
-  public object Convert(Base target)
+  public HostResult Convert(Base target)
   {
     Type type = target.GetType();
 
     try
     {
-      return _baseConverter.Convert(target);
+      return baseConverter.Convert(target);
     }
     catch (ConversionNotSupportedException e)
     {
-      _logger.LogInformation(e, "Attempt to find conversion for type {type} failed", type);
+      logger.LogInformation(e, "Attempt to find conversion for type {type} failed", type);
     }
 
     // Fallback to display value if it exists.
@@ -57,8 +29,7 @@ public sealed class ConverterWithFallback : IRootToHostConverter
 
     if (displayValue == null || (displayValue is IList && !displayValue.Any()))
     {
-      // TODO: I'm not sure if this should be a ConversionNotSupported instead, but it kinda mixes support + validation so I went for normal conversion exception
-      throw new ConversionException(
+      return HostResult.NoConversion(
         $"No direct conversion found for type {type} and it's fallback display value was null/empty"
       );
     }
@@ -66,15 +37,15 @@ public sealed class ConverterWithFallback : IRootToHostConverter
     return FallbackToDisplayValue(displayValue); // 1 - many mapping
   }
 
-  private object FallbackToDisplayValue(IReadOnlyList<Base> displayValue)
+  private HostResult FallbackToDisplayValue(IReadOnlyList<Base> displayValue)
   {
     var tempDisplayableObject = new DisplayableObject(displayValue);
-    var conversionResult = _baseConverter.Convert(tempDisplayableObject);
+    var conversionResult = baseConverter.Convert(tempDisplayableObject);
 
     // if the host app returns a list of objects as the result of the fallback conversion, we zip them together with the original base display value objects that generated them.
-    if (conversionResult is IEnumerable<object> result)
+    if (conversionResult.Host is IEnumerable<object> result)
     {
-      return result.Zip(displayValue, (a, b) => (a, b));
+      return HostResult.Success(result.Zip(displayValue, (a, b) => (a, b)));
     }
 
     // if not, and the host app "merges" together somehow multiple display values into one entity, we return that.

--- a/Sdk/Speckle.Converters.Common/ToHost/ConverterWithFallback.cs
+++ b/Sdk/Speckle.Converters.Common/ToHost/ConverterWithFallback.cs
@@ -7,7 +7,6 @@ using Speckle.Sdk.Models.Extensions;
 
 namespace Speckle.Converters.Common.ToHost;
 
-
 public sealed class ConverterWithFallback(ConverterWithoutFallback baseConverter, ILogger<ConverterWithFallback> logger)
   : IRootToHostConverter
 {

--- a/Sdk/Speckle.Converters.Common/ToHost/ConverterWithFallback.cs
+++ b/Sdk/Speckle.Converters.Common/ToHost/ConverterWithFallback.cs
@@ -1,6 +1,5 @@
 using System.Collections;
 using Microsoft.Extensions.Logging;
-using Speckle.Converters.Common.Registration;
 using Speckle.Sdk.Common.Exceptions;
 using Speckle.Sdk.Models;
 using Speckle.Sdk.Models.Extensions;

--- a/Sdk/Speckle.Converters.Common/ToHost/ConverterWithoutFallback.cs
+++ b/Sdk/Speckle.Converters.Common/ToHost/ConverterWithoutFallback.cs
@@ -6,30 +6,17 @@ using Speckle.Sdk.Models;
 
 namespace Speckle.Converters.Common.ToHost;
 
-// POC: CNX-9394 Find a better home for this outside `DependencyInjection` project
-/// <summary>
-/// Provides an implementation for <see cref="IRootToHostConverter"/>
-/// that resolves a <see cref="IToHostTopLevelConverter"/> via the injected <see cref="IConverterManager{TConverter}"/>
-/// </summary>
-/// <seealso cref="ConverterWithFallback"/>
-public sealed class ConverterWithoutFallback : IRootToHostConverter
+public sealed class ConverterWithoutFallback(
+  IConverterManager<IToHostTopLevelConverter> converterResolver,
+  ILogger<ConverterWithoutFallback> logger)
+  : IRootToHostConverter
 {
-  private readonly IConverterManager<IToHostTopLevelConverter> _toHost;
-  private readonly ILogger _logger;
+  private readonly ILogger _logger = logger;
 
-  public ConverterWithoutFallback(
-    IConverterManager<IToHostTopLevelConverter> converterResolver,
-    ILogger<ConverterWithoutFallback> logger
-  )
+  public HostResult Convert(Base target)
   {
-    _toHost = converterResolver;
-    _logger = logger;
-  }
-
-  public object Convert(Base target)
-  {
-    var converter = _toHost.ResolveConverter(target.GetType());
-    object result = converter.ConvertAndLog(target, _logger);
+    var converter = converterResolver.ResolveConverter(target.GetType());
+    var result = converter.ConvertAndLog(target, _logger);
     return result;
   }
 }

--- a/Sdk/Speckle.Converters.Common/ToHost/ConverterWithoutFallback.cs
+++ b/Sdk/Speckle.Converters.Common/ToHost/ConverterWithoutFallback.cs
@@ -8,8 +8,8 @@ namespace Speckle.Converters.Common.ToHost;
 
 public sealed class ConverterWithoutFallback(
   IConverterManager<IToHostTopLevelConverter> converterResolver,
-  ILogger<ConverterWithoutFallback> logger)
-  : IRootToHostConverter
+  ILogger<ConverterWithoutFallback> logger
+) : IRootToHostConverter
 {
   private readonly ILogger _logger = logger;
 


### PR DESCRIPTION
Add some result objects for when exceptions should be thrown.  This results in a huge speed increase

Messages no longer have a stacktrace though:
![image](https://github.com/user-attachments/assets/23399bfd-3377-47ca-a9db-f20371d96c75)
