### PR TITLE
Chore(navisworks): Add navisworks installer assets

### DIFF
--- a/Build/Consts.cs
+++ b/Build/Consts.cs
@@ -42,6 +42,16 @@ public static class Consts
       ]
     ),
     new(
+      "navisworks",
+      [
+        new("Connectors/Autocad/Speckle.Connectors.Navisworks2020", "net48"),
+        new("Connectors/Autocad/Speckle.Connectors.Navisworks2021", "net48"),
+        new("Connectors/Autocad/Speckle.Connectors.Navisworks2022", "net48"),
+        new("Connectors/Autocad/Speckle.Connectors.Navisworks2023", "net48"),
+        new("Connectors/Autocad/Speckle.Connectors.Navisworks2024", "net48")
+      ]
+    ),
+    new(
       "tekla-structures",
       [
         new("Connectors/Tekla/Speckle.Connector.Tekla2023", "net48"),


### PR DESCRIPTION
@adamhathcock not sure we should add `win-x64` to installer assets, can we get rid of from this file?

![image](https://github.com/user-attachments/assets/b5cbf02a-c034-4cd7-93ae-32031d4134f1)