### PR TITLE
CNX-971 - Update AppUtils.cs to include support for additional versions of Navisworks.

### DIFF
--- a/Connectors/Navisworks/Speckle.Connectors.NavisworksShared/Plugin/AppUtils.cs
+++ b/Connectors/Navisworks/Speckle.Connectors.NavisworksShared/Plugin/AppUtils.cs
@@ -4,17 +4,22 @@ namespace Speckle.Connector.Navisworks.NavisPlugin;
 
 public static class AppUtils
 {
-  public static HostApplication App =>
-#if NAVIS
-    HostApplications.Navisworks;
-#else
-    throw new NotSupportedException();
-#endif
-
   public static HostAppVersion Version =>
-#if NAVIS2024
+#if NAVIS2020
+    HostAppVersion.v2020;
+#elif NAVIS2021
+    HostAppVersion.v2021;
+#elif NAVIS2022
+    HostAppVersion.v2022;
+#elif NAVIS2023
+    HostAppVersion.v2023;
+#elif NAVIS2024
     HostAppVersion.v2024;
+#elif NAVIS2025
+    HostAppVersion.v2025;
+#elif NAVIS2026
+    HostAppVersion.v2026;
 #else
-    throw new NotSupportedException();
+    throw new NotSupportedException("This version is not supported");
 #endif
 }

--- a/Connectors/Navisworks/Speckle.Connectors.NavisworksShared/Plugin/AppUtils.cs
+++ b/Connectors/Navisworks/Speckle.Connectors.NavisworksShared/Plugin/AppUtils.cs
@@ -4,6 +4,12 @@ namespace Speckle.Connector.Navisworks.NavisPlugin;
 
 public static class AppUtils
 {
+  public static HostApplication App =>
+#if NAVIS
+    HostApplications.Navisworks;
+#else
+    throw new NotSupportedException();
+#endif
   public static HostAppVersion Version =>
 #if NAVIS2020
     HostAppVersion.v2020;


### PR DESCRIPTION
- Add support for Navisworks 2020, 2021, 2022, 2023, 2025, and 2026.
- Throw a NotSupportedException for unsupported versions.
