### PR TITLE
fix(Navisworks): CNX-973 Fix: Material ID Logic and Render Proxy Cache

### DIFF
--- a/Connectors/Navisworks/Speckle.Connectors.NavisworksShared/HostApp/NavisworksMaterialUnpacker.cs
+++ b/Connectors/Navisworks/Speckle.Connectors.NavisworksShared/HostApp/NavisworksMaterialUnpacker.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging;
 using Speckle.Connector.Navisworks.Services;
 using Speckle.Converter.Navisworks.Settings;
 using Speckle.Converters.Common;
@@ -70,15 +70,15 @@ public class NavisworksMaterialUnpacker(
 
         var renderMaterialId = Select(
           mode,
-          geometry.ActiveColor.GetHashCode(),
-          geometry.PermanentColor.GetHashCode(),
-          geometry.OriginalColor.GetHashCode(),
+          $"{geometry.ActiveColor.GetHashCode()}_{geometry.ActiveTransparency}".GetHashCode(),
+          $"{geometry.PermanentColor.GetHashCode()}_{geometry.PermanentTransparency}".GetHashCode(),
+          $"{geometry.OriginalColor.GetHashCode()}_{geometry.OriginalTransparency}".GetHashCode(),
           0
         );
 
         var materialName = $"NavisworksMaterial_{Math.Abs(NavisworksColorToColor(renderColor).ToArgb())}";
 
-        // Alternatively the material could be stored on the Item property
+        // Check Item category for material name
         var itemCategory = navisworksObject.PropertyCategories.FindCategoryByDisplayName("Item");
         if (itemCategory != null)
         {
@@ -90,7 +90,7 @@ public class NavisworksMaterialUnpacker(
           }
         }
 
-        // Or in a Material property
+        // Check Material category for material name
         var materialPropertyCategory = navisworksObject.PropertyCategories.FindCategoryByDisplayName("Material");
         if (materialPropertyCategory != null)
         {
@@ -104,7 +104,7 @@ public class NavisworksMaterialUnpacker(
 
         if (renderMaterialProxies.TryGetValue(renderMaterialId.ToString(), out RenderMaterialProxy? value))
         {
-          value.objects.Add(navisworksObjectId);
+          value.objects.Add(finalId);
         }
         else
         {
@@ -119,7 +119,7 @@ public class NavisworksMaterialUnpacker(
               renderColor,
               renderMaterialId
             ),
-            objects = [navisworksObjectId]
+            objects = [finalId]
           };
         }
       }

--- a/Connectors/Navisworks/Speckle.Connectors.NavisworksShared/HostApp/NavisworksMaterialUnpacker.cs
+++ b/Connectors/Navisworks/Speckle.Connectors.NavisworksShared/HostApp/NavisworksMaterialUnpacker.cs
@@ -157,8 +157,9 @@ public class NavisworksMaterialUnpacker(
 
   private static System.Drawing.Color NavisworksColorToColor(NAV.Color color) =>
     System.Drawing.Color.FromArgb(
-      Convert.ToInt32(color.R * 255),
-      Convert.ToInt32(color.G * 255),
-      Convert.ToInt32(color.B * 255)
+      alpha: 255,
+      red: Convert.ToInt32(color.R * 255),
+      green: Convert.ToInt32(color.G * 255),
+      blue: Convert.ToInt32(color.B * 255)
     );
 }

--- a/Connectors/Navisworks/Speckle.Connectors.NavisworksShared/HostApp/NavisworksMaterialUnpacker.cs
+++ b/Connectors/Navisworks/Speckle.Connectors.NavisworksShared/HostApp/NavisworksMaterialUnpacker.cs
@@ -126,9 +126,6 @@ public class NavisworksMaterialUnpacker(
         {
           renderMaterialProxies[renderMaterialId.ToString()] = new RenderMaterialProxy()
           {
-            // For now, we will just use the color and transparency to create a new material
-            // There is more information that is in the Material object that could be used to create a more accurate material
-            // But is constant regardless of the user settings
             value = ConvertRenderColorAndTransparencyToSpeckle(
               materialName,
               renderTransparency,

--- a/Connectors/Navisworks/Speckle.Connectors.NavisworksShared/Operations/Send/NavisworksRootObjectBuilder.cs
+++ b/Connectors/Navisworks/Speckle.Connectors.NavisworksShared/Operations/Send/NavisworksRootObjectBuilder.cs
@@ -1,4 +1,4 @@
-using Microsoft.Extensions.Logging;
+﻿using Microsoft.Extensions.Logging;
 using Speckle.Connector.Navisworks.HostApp;
 using Speckle.Connector.Navisworks.Services;
 using Speckle.Connectors.Common.Builders;

--- a/Connectors/Navisworks/Speckle.Connectors.NavisworksShared/Operations/Send/NavisworksRootObjectBuilder.cs
+++ b/Connectors/Navisworks/Speckle.Connectors.NavisworksShared/Operations/Send/NavisworksRootObjectBuilder.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging;
 using Speckle.Connector.Navisworks.HostApp;
 using Speckle.Connector.Navisworks.Services;
 using Speckle.Connectors.Common.Builders;
@@ -26,6 +26,8 @@ public class NavisworksRootObjectBuilder(
   IElementSelectionService elementSelectionService
 ) : IRootObjectBuilder<NAV.ModelItem>
 {
+  private bool SkipNodeMerging { get; set; }
+
   internal NavisworksConversionSettings GetCurrentSettings() => converterSettings.Current;
 
   public RootObjectBuilderResult Build(
@@ -35,6 +37,10 @@ public class NavisworksRootObjectBuilder(
     CancellationToken cancellationToken
   )
   {
+#if DEBUG
+    // This is a temporary workaround to disable node merging for debugging purposes - false is default, true is for debugging
+    SkipNodeMerging = false;
+#endif
     using var activity = activityFactory.Start("Build");
 
     // 1. Validate input
@@ -82,7 +88,7 @@ public class NavisworksRootObjectBuilder(
 
     // 4. Initialize final elements list and group nodes
     var finalElements = new List<Base>();
-    var groupedNodes = GroupSiblingGeometryNodes(navisworksModelItems);
+    var groupedNodes = SkipNodeMerging ? [] : GroupSiblingGeometryNodes(navisworksModelItems);
     var processedPaths = new HashSet<string>();
 
     // 5. Process and merge grouped nodes
@@ -146,7 +152,10 @@ public class NavisworksRootObjectBuilder(
     using (var _ = activityFactory.Start("UnpackRenderMaterials"))
     {
       // 7.  - Unpack the render material proxies
-      rootObjectCollection[ProxyKeys.RENDER_MATERIAL] = materialUnpacker.UnpackRenderMaterial(navisworksModelItems);
+      rootObjectCollection[ProxyKeys.RENDER_MATERIAL] = materialUnpacker.UnpackRenderMaterial(
+        navisworksModelItems,
+        groupedNodes
+      );
     }
 
     // 8. Finalize and return


### PR DESCRIPTION
This update addresses an issue in the `materialID` logic, where the `renderProxies` material cache was based solely on colour. This caused transparent elements sharing the same colour to incorrectly reuse the same material, leading to rendering errors.

Additionally, the material unpacking routine has been improved to cross-check grouped geometry nodes. Previously, unnamed sibling nodes with no unique properties could result in incorrect overrides or omissions of render proxies for child geometries. The update introduces a new parameter for grouped nodes, ensuring the parent group does not improperly affect the `displayValue` render proxies of its children.

also fixes: CNX-893