### PR TITLE
fix(navisworks): Update Navisworks connector plugin bundle target and version content target paths.

### DIFF
--- a/Connectors/Navisworks/Speckle.Connectors.Navisworks2020/Speckle.Connectors.Navisworks2020.csproj
+++ b/Connectors/Navisworks/Speckle.Connectors.Navisworks2020/Speckle.Connectors.Navisworks2020.csproj
@@ -15,8 +15,8 @@
     <Authors>$(Authors) jonathon@speckle.systems</Authors>
     <PackageTags>$(PackageTags) connector nwd nwc nwf navisworks manage</PackageTags>
 
-    <PluginBundleTarget>$(AppData)\Autodesk\ApplicationPlugins\Speckle.Connectors.Navisworksv3.bundle</PluginBundleTarget>
-    <PluginVersionContentTarget>$(AppData)\Autodesk\ApplicationPlugins\Speckle.Connectors.Navisworksv3.bundle\Contents\$(NavisworksVersion)</PluginVersionContentTarget>
+    <PluginBundleTarget>$(AppData)\Autodesk\ApplicationPlugins\Speckle.Connectors.Navisworks.bundle</PluginBundleTarget>
+    <PluginVersionContentTarget>$(AppData)\Autodesk\ApplicationPlugins\Speckle.Connectors.Navisworks.bundle\Contents\$(NavisworksVersion)</PluginVersionContentTarget>
 
   </PropertyGroup>
 

--- a/Connectors/Navisworks/Speckle.Connectors.Navisworks2021/Speckle.Connectors.Navisworks2021.csproj
+++ b/Connectors/Navisworks/Speckle.Connectors.Navisworks2021/Speckle.Connectors.Navisworks2021.csproj
@@ -15,8 +15,8 @@
     <Authors>$(Authors) jonathon@speckle.systems</Authors>
     <PackageTags>$(PackageTags) connector nwd nwc nwf navisworks manage</PackageTags>
 
-    <PluginBundleTarget>$(AppData)\Autodesk\ApplicationPlugins\Speckle.Connectors.Navisworksv3.bundle</PluginBundleTarget>
-    <PluginVersionContentTarget>$(AppData)\Autodesk\ApplicationPlugins\Speckle.Connectors.Navisworksv3.bundle\Contents\$(NavisworksVersion)</PluginVersionContentTarget>
+    <PluginBundleTarget>$(AppData)\Autodesk\ApplicationPlugins\Speckle.Connectors.Navisworks.bundle</PluginBundleTarget>
+    <PluginVersionContentTarget>$(AppData)\Autodesk\ApplicationPlugins\Speckle.Connectors.Navisworks.bundle\Contents\$(NavisworksVersion)</PluginVersionContentTarget>
 
   </PropertyGroup>
 

--- a/Connectors/Navisworks/Speckle.Connectors.Navisworks2022/Speckle.Connectors.Navisworks2022.csproj
+++ b/Connectors/Navisworks/Speckle.Connectors.Navisworks2022/Speckle.Connectors.Navisworks2022.csproj
@@ -16,8 +16,8 @@
     <Authors>$(Authors) jonathon@speckle.systems</Authors>
     <PackageTags>$(PackageTags) connector nwd nwc nwf navisworks manage</PackageTags>
 
-    <PluginBundleTarget>$(AppData)\Autodesk\ApplicationPlugins\Speckle.Connectors.Navisworksv3.bundle</PluginBundleTarget>
-    <PluginVersionContentTarget>$(AppData)\Autodesk\ApplicationPlugins\Speckle.Connectors.Navisworksv3.bundle\Contents\$(NavisworksVersion)</PluginVersionContentTarget>
+    <PluginBundleTarget>$(AppData)\Autodesk\ApplicationPlugins\Speckle.Connectors.Navisworks.bundle</PluginBundleTarget>
+    <PluginVersionContentTarget>$(AppData)\Autodesk\ApplicationPlugins\Speckle.Connectors.Navisworks.bundle\Contents\$(NavisworksVersion)</PluginVersionContentTarget>
 
   </PropertyGroup>
 

--- a/Connectors/Navisworks/Speckle.Connectors.Navisworks2023/Speckle.Connectors.Navisworks2023.csproj
+++ b/Connectors/Navisworks/Speckle.Connectors.Navisworks2023/Speckle.Connectors.Navisworks2023.csproj
@@ -16,8 +16,8 @@
     <Authors>$(Authors) jonathon@speckle.systems</Authors>
     <PackageTags>$(PackageTags) connector nwd nwc nwf navisworks manage</PackageTags>
 
-    <PluginBundleTarget>$(AppData)\Autodesk\ApplicationPlugins\Speckle.Connectors.Navisworksv3.bundle</PluginBundleTarget>
-    <PluginVersionContentTarget>$(AppData)\Autodesk\ApplicationPlugins\Speckle.Connectors.Navisworksv3.bundle\Contents\$(NavisworksVersion)</PluginVersionContentTarget>
+    <PluginBundleTarget>$(AppData)\Autodesk\ApplicationPlugins\Speckle.Connectors.Navisworks.bundle</PluginBundleTarget>
+    <PluginVersionContentTarget>$(AppData)\Autodesk\ApplicationPlugins\Speckle.Connectors.Navisworks.bundle\Contents\$(NavisworksVersion)</PluginVersionContentTarget>
     <RootNamespace>Speckle.Connector.Navisworks</RootNamespace>
 
   </PropertyGroup>

--- a/Connectors/Navisworks/Speckle.Connectors.Navisworks2024/Speckle.Connectors.Navisworks2024.csproj
+++ b/Connectors/Navisworks/Speckle.Connectors.Navisworks2024/Speckle.Connectors.Navisworks2024.csproj
@@ -16,8 +16,8 @@
     <Authors>$(Authors) jonathon@speckle.systems</Authors>
     <PackageTags>$(PackageTags) connector nwd nwc nwf navisworks manage</PackageTags>
 
-    <PluginBundleTarget>$(AppData)\Autodesk\ApplicationPlugins\Speckle.Connectors.Navisworksv3.bundle</PluginBundleTarget>
-    <PluginVersionContentTarget>$(AppData)\Autodesk\ApplicationPlugins\Speckle.Connectors.Navisworksv3.bundle\Contents\$(NavisworksVersion)</PluginVersionContentTarget>
+    <PluginBundleTarget>$(AppData)\Autodesk\ApplicationPlugins\Speckle.Connectors.Navisworks.bundle</PluginBundleTarget>
+    <PluginVersionContentTarget>$(AppData)\Autodesk\ApplicationPlugins\Speckle.Connectors.Navisworks.bundle\Contents\$(NavisworksVersion)</PluginVersionContentTarget>
     <RootNamespace>Speckle.Connector.Navisworks</RootNamespace>
 
   </PropertyGroup>

--- a/Connectors/Navisworks/Speckle.Connectors.Navisworks2025/Speckle.Connectors.Navisworks2025.csproj
+++ b/Connectors/Navisworks/Speckle.Connectors.Navisworks2025/Speckle.Connectors.Navisworks2025.csproj
@@ -15,8 +15,8 @@
     <Authors>$(Authors) jonathon@speckle.systems</Authors>
     <PackageTags>$(PackageTags) connector nwd nwc nwf navisworks manage</PackageTags>
 
-    <PluginBundleTarget>$(AppData)\Autodesk\ApplicationPlugins\Speckle.Connectors.Navisworksv3.bundle</PluginBundleTarget>
-    <PluginVersionContentTarget>$(AppData)\Autodesk\ApplicationPlugins\Speckle.Connectors.Navisworksv3.bundle\Contents\$(NavisworksVersion)</PluginVersionContentTarget>
+    <PluginBundleTarget>$(AppData)\Autodesk\ApplicationPlugins\Speckle.Connectors.Navisworks.bundle</PluginBundleTarget>
+    <PluginVersionContentTarget>$(AppData)\Autodesk\ApplicationPlugins\Speckle.Connectors.Navisworks.bundle\Contents\$(NavisworksVersion)</PluginVersionContentTarget>
 
   </PropertyGroup>
 


### PR DESCRIPTION
- Update the plugin bundle target path to "$(AppData)\Autodesk\ApplicationPlugins\Speckle.Connectors.Navisworks.bundle".
- Update the plugin version content target path to "$(AppData)\Autodesk\ApplicationPlugins\Speckle.Connectors.Navisworks.bundle\Contents\$(NavisworksVersion)".

These changes ensure that the correct paths are used for the Navisworks connector plugin bundle and its version content.
