### PR TITLE
Fix(revit): Null check before attempt to override view options

### DIFF
--- a/Converters/Revit/Speckle.Converters.RevitShared/Helpers/DisplayValueExtractor.cs
+++ b/Converters/Revit/Speckle.Converters.RevitShared/Helpers/DisplayValueExtractor.cs
@@ -240,20 +240,23 @@ public sealed class DisplayValueExtractor
   /// <returns></returns>
   private DB.Options OverrideViewOptions(DB.Element element, DB.Options currentOptions)
   {
+    // there is no point to progress if element category already null
+    if (element.Category is null)
+    {
+      return currentOptions;
+    }
+
     var elementBuiltInCategory = element.Category.GetBuiltInCategory();
 
     // Note: some elements do not get display values (you get invalid solids) unless we force the view detail level to be fine. This is annoying, but it's bad ux: people think the
     // elements are not there (they are, just invisible).
     if (
-      element.Category is not null
-      && (
-        elementBuiltInCategory == DB.BuiltInCategory.OST_PipeFitting
-        || elementBuiltInCategory == DB.BuiltInCategory.OST_PipeAccessory
-        || elementBuiltInCategory == DB.BuiltInCategory.OST_PlumbingFixtures
+      elementBuiltInCategory == DB.BuiltInCategory.OST_PipeFitting
+      || elementBuiltInCategory == DB.BuiltInCategory.OST_PipeAccessory
+      || elementBuiltInCategory == DB.BuiltInCategory.OST_PlumbingFixtures
 #if REVIT2024_OR_GREATER
-        || element is DB.Toposolid // note, brought back from 2.x.x.
+      || element is DB.Toposolid // note, brought back from 2.x.x.
 #endif
-      )
     )
     {
       currentOptions.DetailLevel = DB.ViewDetailLevel.Fine; // Force detail level to be fine


### PR DESCRIPTION
I remember @didimitrie you were fixing an issue on forum while implementing `OverrideViewOptions` function, i believe what i did shouldn't effect what you have done before, but would be nice if you can test that behavior.

BEFORE
![image](https://github.com/user-attachments/assets/4fba291f-5fbb-45a4-aef3-e5c3e57e704d)

AFTER
![image](https://github.com/user-attachments/assets/9a1aec39-7f82-4efa-ba09-c13feb79c86c)
