### PR TITLE
NameAndRankValue now uses a type to get FullName to avoid conflicts

### DIFF
--- a/Converters/ArcGIS/Speckle.Converters.ArcGIS3/ToHost/TopLevel/ArcToHostConverter.cs
+++ b/Converters/ArcGIS/Speckle.Converters.ArcGIS3/ToHost/TopLevel/ArcToHostConverter.cs
@@ -4,7 +4,7 @@ using Speckle.Sdk.Models;
 
 namespace Speckle.Converters.ArcGIS3.ToHost.TopLevel;
 
-[NameAndRankValue(nameof(SOG.Arc), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
+[NameAndRankValue(typeof(SOG.Arc), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
 public class ArcToHostConverter : IToHostTopLevelConverter, ITypedConverter<SOG.Arc, ACG.Polyline>
 {
   private readonly ITypedConverter<SOG.Point, ACG.MapPoint> _pointConverter;

--- a/Converters/ArcGIS/Speckle.Converters.ArcGIS3/ToHost/TopLevel/CircleToHostConverter.cs
+++ b/Converters/ArcGIS/Speckle.Converters.ArcGIS3/ToHost/TopLevel/CircleToHostConverter.cs
@@ -5,7 +5,7 @@ using Speckle.Sdk.Models;
 
 namespace Speckle.Converters.ArcGIS3.ToHost.TopLevel;
 
-[NameAndRankValue(nameof(SOG.Circle), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
+[NameAndRankValue(typeof(SOG.Circle), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
 public class CircleToHostConverter : IToHostTopLevelConverter, ITypedConverter<SOG.Circle, ACG.Polyline>
 {
   private readonly ITypedConverter<SOG.Point, ACG.MapPoint> _pointConverter;

--- a/Converters/ArcGIS/Speckle.Converters.ArcGIS3/ToHost/TopLevel/EllipseToHostConverter.cs
+++ b/Converters/ArcGIS/Speckle.Converters.ArcGIS3/ToHost/TopLevel/EllipseToHostConverter.cs
@@ -5,7 +5,7 @@ using Speckle.Sdk.Models;
 
 namespace Speckle.Converters.ArcGIS3.ToHost.TopLevel;
 
-[NameAndRankValue(nameof(SOG.Ellipse), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
+[NameAndRankValue(typeof(SOG.Ellipse), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
 public class EllipseToHostConverter : IToHostTopLevelConverter, ITypedConverter<SOG.Ellipse, ACG.Polyline>
 {
   private readonly ITypedConverter<SOG.Point, ACG.MapPoint> _pointConverter;

--- a/Converters/ArcGIS/Speckle.Converters.ArcGIS3/ToHost/TopLevel/FallbackToHostConverter.cs
+++ b/Converters/ArcGIS/Speckle.Converters.ArcGIS3/ToHost/TopLevel/FallbackToHostConverter.cs
@@ -6,7 +6,7 @@ using Speckle.Sdk.Models;
 
 namespace Speckle.Converters.ArcGIS3.ToHost.TopLevel;
 
-[NameAndRankValue(nameof(DisplayableObject), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
+[NameAndRankValue(typeof(DisplayableObject), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
 public class FallbackToHostConverter : IToHostTopLevelConverter, ITypedConverter<DisplayableObject, ACG.Geometry>
 {
   private readonly ITypedConverter<List<SOG.Mesh>, ACG.Multipatch> _meshListConverter;

--- a/Converters/ArcGIS/Speckle.Converters.ArcGIS3/ToHost/TopLevel/LineToHostConverter.cs
+++ b/Converters/ArcGIS/Speckle.Converters.ArcGIS3/ToHost/TopLevel/LineToHostConverter.cs
@@ -4,7 +4,7 @@ using Speckle.Sdk.Models;
 
 namespace Speckle.Converters.ArcGIS3.ToHost.TopLevel;
 
-[NameAndRankValue(nameof(SOG.Line), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
+[NameAndRankValue(typeof(SOG.Line), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
 public class LineSingleToHostConverter : IToHostTopLevelConverter, ITypedConverter<SOG.Line, ACG.Polyline>
 {
   private readonly ITypedConverter<SOG.Point, ACG.MapPoint> _pointConverter;

--- a/Converters/ArcGIS/Speckle.Converters.ArcGIS3/ToHost/TopLevel/MeshToHostConverter.cs
+++ b/Converters/ArcGIS/Speckle.Converters.ArcGIS3/ToHost/TopLevel/MeshToHostConverter.cs
@@ -4,7 +4,7 @@ using Speckle.Sdk.Models;
 
 namespace Speckle.Converters.ArcGIS3.ToHost.TopLevel;
 
-[NameAndRankValue(nameof(SOG.Mesh), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
+[NameAndRankValue(typeof(SOG.Mesh), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
 public class MeshToHostConverter : IToHostTopLevelConverter, ITypedConverter<SOG.Mesh, ACG.Multipatch>
 {
   private readonly ITypedConverter<List<SOG.Mesh>, ACG.Multipatch> _meshConverter;

--- a/Converters/ArcGIS/Speckle.Converters.ArcGIS3/ToHost/TopLevel/PointToHostConverter.cs
+++ b/Converters/ArcGIS/Speckle.Converters.ArcGIS3/ToHost/TopLevel/PointToHostConverter.cs
@@ -4,7 +4,7 @@ using Speckle.Sdk.Models;
 
 namespace Speckle.Converters.ArcGIS3.ToHost.TopLevel;
 
-[NameAndRankValue(nameof(SOG.Point), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
+[NameAndRankValue(typeof(SOG.Point), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
 public class PointToHostConverter : IToHostTopLevelConverter
 {
   private readonly ITypedConverter<List<SOG.Point>, ACG.Multipoint> _pointConverter;

--- a/Converters/ArcGIS/Speckle.Converters.ArcGIS3/ToHost/TopLevel/PolycurveToHostConverter.cs
+++ b/Converters/ArcGIS/Speckle.Converters.ArcGIS3/ToHost/TopLevel/PolycurveToHostConverter.cs
@@ -5,7 +5,7 @@ using Speckle.Sdk.Models;
 
 namespace Speckle.Converters.ArcGIS3.ToHost.TopLevel;
 
-[NameAndRankValue(nameof(SOG.Polycurve), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
+[NameAndRankValue(typeof(SOG.Polycurve), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
 public class PolycurveToHostConverter : IToHostTopLevelConverter, ITypedConverter<SOG.Polycurve, ACG.Polyline>
 {
   private readonly IRootToHostConverter _converter;

--- a/Converters/ArcGIS/Speckle.Converters.ArcGIS3/ToHost/TopLevel/PolylineToHostConverter.cs
+++ b/Converters/ArcGIS/Speckle.Converters.ArcGIS3/ToHost/TopLevel/PolylineToHostConverter.cs
@@ -4,7 +4,7 @@ using Speckle.Sdk.Models;
 
 namespace Speckle.Converters.ArcGIS3.ToHost.TopLevel;
 
-[NameAndRankValue(nameof(SOG.Polyline), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
+[NameAndRankValue(typeof(SOG.Polyline), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
 public class PolylineToHostConverter : IToHostTopLevelConverter, ITypedConverter<SOG.Polyline, ACG.Polyline>
 {
   private readonly ITypedConverter<SOG.Point, ACG.MapPoint> _pointConverter;

--- a/Converters/ArcGIS/Speckle.Converters.ArcGIS3/ToSpeckle/TopLevel/CoreObjectsBaseToSpeckleTopLevelConverter.cs
+++ b/Converters/ArcGIS/Speckle.Converters.ArcGIS3/ToSpeckle/TopLevel/CoreObjectsBaseToSpeckleTopLevelConverter.cs
@@ -6,7 +6,7 @@ using Speckle.Sdk.Models;
 
 namespace Speckle.Converters.ArcGIS3.ToSpeckle.TopLevel;
 
-[NameAndRankValue(nameof(AC.CoreObjectsBase), 0)]
+[NameAndRankValue(typeof(AC.CoreObjectsBase), 0)]
 public class CoreObjectsBaseToSpeckleTopLevelConverter : IToSpeckleTopLevelConverter
 {
   private readonly DisplayValueExtractor _displayValueExtractor;

--- a/Converters/Autocad/Speckle.Converters.AutocadShared/ToHost/Geometry/ArcToHostConverter.cs
+++ b/Converters/Autocad/Speckle.Converters.AutocadShared/ToHost/Geometry/ArcToHostConverter.cs
@@ -4,7 +4,7 @@ using Speckle.Sdk.Models;
 
 namespace Speckle.Converters.Autocad.ToHost.Geometry;
 
-[NameAndRankValue(nameof(SOG.Arc), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
+[NameAndRankValue(typeof(SOG.Arc), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
 public class ArcToHostConverter : IToHostTopLevelConverter, ITypedConverter<SOG.Arc, ADB.Arc>
 {
   private readonly ITypedConverter<SOG.Arc, AG.CircularArc3d> _arcConverter;

--- a/Converters/Autocad/Speckle.Converters.AutocadShared/ToHost/Geometry/AutocadPolycurveToHostConverter.cs
+++ b/Converters/Autocad/Speckle.Converters.AutocadShared/ToHost/Geometry/AutocadPolycurveToHostConverter.cs
@@ -5,7 +5,7 @@ using Speckle.Sdk.Models;
 
 namespace Speckle.Converters.Autocad2023.ToHost.Geometry;
 
-[NameAndRankValue(nameof(SOG.Autocad.AutocadPolycurve), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
+[NameAndRankValue(typeof(SOG.Autocad.AutocadPolycurve), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
 public class AutocadPolycurveToHostConverter : IToHostTopLevelConverter
 {
   private readonly ITypedConverter<SOG.Autocad.AutocadPolycurve, ADB.Polyline> _polylineConverter;

--- a/Converters/Autocad/Speckle.Converters.AutocadShared/ToHost/Geometry/CircleToHostConverter.cs
+++ b/Converters/Autocad/Speckle.Converters.AutocadShared/ToHost/Geometry/CircleToHostConverter.cs
@@ -5,7 +5,7 @@ using Speckle.Sdk.Models;
 
 namespace Speckle.Converters.Autocad.ToHost.Geometry;
 
-[NameAndRankValue(nameof(SOG.Circle), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
+[NameAndRankValue(typeof(SOG.Circle), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
 public class CircleToHostConverter : IToHostTopLevelConverter, ITypedConverter<SOG.Circle, ADB.Circle>
 {
   private readonly ITypedConverter<SOG.Point, AG.Point3d> _pointConverter;

--- a/Converters/Autocad/Speckle.Converters.AutocadShared/ToHost/Geometry/CurveToHostConverter.cs
+++ b/Converters/Autocad/Speckle.Converters.AutocadShared/ToHost/Geometry/CurveToHostConverter.cs
@@ -4,7 +4,7 @@ using Speckle.Sdk.Models;
 
 namespace Speckle.Converters.AutocadShared.ToHost.Geometry;
 
-[NameAndRankValue(nameof(SOG.Curve), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
+[NameAndRankValue(typeof(SOG.Curve), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
 public class CurveToHostConverter : IToHostTopLevelConverter, ITypedConverter<SOG.Curve, ADB.Curve>
 {
   private readonly ITypedConverter<SOG.Curve, AG.NurbCurve3d> _curveConverter;

--- a/Converters/Autocad/Speckle.Converters.AutocadShared/ToHost/Geometry/DataObjectConverter.cs
+++ b/Converters/Autocad/Speckle.Converters.AutocadShared/ToHost/Geometry/DataObjectConverter.cs
@@ -6,7 +6,7 @@ using Speckle.Sdk.Models;
 
 namespace Speckle.Converters.Rhino7.ToHost.TopLevel;
 
-[NameAndRankValue(nameof(DataObject), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
+[NameAndRankValue(typeof(DataObject), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
 public class DataObjectConverter : IToHostTopLevelConverter, ITypedConverter<DataObject, List<(ADB.Entity a, Base b)>>
 {
   private readonly ITypedConverter<SOG.Line, ADB.Line> _lineConverter;

--- a/Converters/Autocad/Speckle.Converters.AutocadShared/ToHost/Geometry/EllipseToHostConverter.cs
+++ b/Converters/Autocad/Speckle.Converters.AutocadShared/ToHost/Geometry/EllipseToHostConverter.cs
@@ -5,7 +5,7 @@ using Speckle.Sdk.Models;
 
 namespace Speckle.Converters.Autocad.ToHost.Geometry;
 
-[NameAndRankValue(nameof(SOG.Ellipse), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
+[NameAndRankValue(typeof(SOG.Ellipse), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
 public class EllipseToHostConverter : IToHostTopLevelConverter, ITypedConverter<SOG.Ellipse, ADB.Ellipse>
 {
   private readonly ITypedConverter<SOG.Point, AG.Point3d> _pointConverter;

--- a/Converters/Autocad/Speckle.Converters.AutocadShared/ToHost/Geometry/LineToHostConverter.cs
+++ b/Converters/Autocad/Speckle.Converters.AutocadShared/ToHost/Geometry/LineToHostConverter.cs
@@ -4,7 +4,7 @@ using Speckle.Sdk.Models;
 
 namespace Speckle.Converters.Autocad.ToHost.Geometry;
 
-[NameAndRankValue(nameof(SOG.Line), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
+[NameAndRankValue(typeof(SOG.Line), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
 public class LineToHostConverter : IToHostTopLevelConverter, ITypedConverter<SOG.Line, ADB.Line>
 {
   private readonly ITypedConverter<SOG.Point, AG.Point3d> _pointConverter;

--- a/Converters/Autocad/Speckle.Converters.AutocadShared/ToHost/Geometry/MeshToHostConverter.cs
+++ b/Converters/Autocad/Speckle.Converters.AutocadShared/ToHost/Geometry/MeshToHostConverter.cs
@@ -6,7 +6,7 @@ using Speckle.Sdk.Models;
 
 namespace Speckle.Converters.Autocad.Geometry;
 
-[NameAndRankValue(nameof(SOG.Mesh), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
+[NameAndRankValue(typeof(SOG.Mesh), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
 public class MeshToHostConverter : IToHostTopLevelConverter, ITypedConverter<SOG.Mesh, ADB.PolyFaceMesh>
 {
   private readonly ITypedConverter<SOG.Point, AG.Point3d> _pointConverter;

--- a/Converters/Autocad/Speckle.Converters.AutocadShared/ToHost/Geometry/PointToHostConverter.cs
+++ b/Converters/Autocad/Speckle.Converters.AutocadShared/ToHost/Geometry/PointToHostConverter.cs
@@ -4,7 +4,7 @@ using Speckle.Sdk.Models;
 
 namespace Speckle.Converters.Autocad.ToHost.Geometry;
 
-[NameAndRankValue(nameof(SOG.Point), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
+[NameAndRankValue(typeof(SOG.Point), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
 public class PointToHostConverter : IToHostTopLevelConverter, ITypedConverter<SOG.Point, ADB.DBPoint>
 {
   private readonly ITypedConverter<SOG.Point, AG.Point3d> _pointConverter;

--- a/Converters/Autocad/Speckle.Converters.AutocadShared/ToHost/Geometry/PolycurveToHostConverter.cs
+++ b/Converters/Autocad/Speckle.Converters.AutocadShared/ToHost/Geometry/PolycurveToHostConverter.cs
@@ -9,7 +9,7 @@ namespace Speckle.Converters.AutocadShared.ToHost.Geometry;
 /// If polycurve segments are planar and only of type <see cref="SOG.Line"/> and <see cref="SOG.Arc"/>, it can be represented as Polyline in Autocad.
 /// Otherwise we convert it as spline (list of ADB.Entity) that switch cases according to each segment type.
 /// </summary>
-[NameAndRankValue(nameof(SOG.Polycurve), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
+[NameAndRankValue(typeof(SOG.Polycurve), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
 public class PolycurveToHostConverter : IToHostTopLevelConverter
 {
   private readonly ITypedConverter<SOG.Polycurve, ADB.Polyline> _polylineConverter;

--- a/Converters/Autocad/Speckle.Converters.AutocadShared/ToHost/Geometry/PolylineToHostConverter.cs
+++ b/Converters/Autocad/Speckle.Converters.AutocadShared/ToHost/Geometry/PolylineToHostConverter.cs
@@ -4,7 +4,7 @@ using Speckle.Sdk.Models;
 
 namespace Speckle.Converters.Autocad.ToHost.Geometry;
 
-[NameAndRankValue(nameof(SOG.Polyline), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
+[NameAndRankValue(typeof(SOG.Polyline), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
 public class PolylineToHostConverter : IToHostTopLevelConverter, ITypedConverter<SOG.Polyline, ADB.Polyline3d>
 {
   private readonly ITypedConverter<SOG.Point, AG.Point3d> _pointConverter;

--- a/Converters/Autocad/Speckle.Converters.AutocadShared/ToHost/Raw/ArcToHostRawConverter.cs
+++ b/Converters/Autocad/Speckle.Converters.AutocadShared/ToHost/Raw/ArcToHostRawConverter.cs
@@ -4,7 +4,7 @@ using Speckle.Sdk.Models;
 
 namespace Speckle.Converters.Autocad.ToHost.Raw;
 
-[NameAndRankValue(nameof(SOG.Arc), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
+[NameAndRankValue(typeof(SOG.Arc), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
 public class ArcToHostRowConverter : ITypedConverter<SOG.Arc, AG.CircularArc3d>
 {
   private readonly ITypedConverter<SOG.Point, AG.Point3d> _pointConverter;

--- a/Converters/Autocad/Speckle.Converters.AutocadShared/ToSpeckle/Geometry/ArcToSpeckleConverter.cs
+++ b/Converters/Autocad/Speckle.Converters.AutocadShared/ToSpeckle/Geometry/ArcToSpeckleConverter.cs
@@ -4,7 +4,7 @@ using Speckle.Sdk.Models;
 
 namespace Speckle.Converters.Autocad.ToSpeckle.Geometry;
 
-[NameAndRankValue(nameof(ADB.Arc), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
+[NameAndRankValue(typeof(ADB.Arc), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
 public class DBArcToSpeckleConverter : IToSpeckleTopLevelConverter
 {
   private readonly ITypedConverter<ADB.Arc, SOG.Arc> _arcConverter;

--- a/Converters/Autocad/Speckle.Converters.AutocadShared/ToSpeckle/Geometry/CircleToSpeckleConverter.cs
+++ b/Converters/Autocad/Speckle.Converters.AutocadShared/ToSpeckle/Geometry/CircleToSpeckleConverter.cs
@@ -4,7 +4,7 @@ using Speckle.Sdk.Models;
 
 namespace Speckle.Converters.Autocad.ToSpeckle.Geometry;
 
-[NameAndRankValue(nameof(ADB.Circle), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
+[NameAndRankValue(typeof(ADB.Circle), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
 public class DBCircleToSpeckleConverter : IToSpeckleTopLevelConverter
 {
   private readonly ITypedConverter<ADB.Circle, SOG.Circle> _circleConverter;

--- a/Converters/Autocad/Speckle.Converters.AutocadShared/ToSpeckle/Geometry/EllipseToSpeckleConverter.cs
+++ b/Converters/Autocad/Speckle.Converters.AutocadShared/ToSpeckle/Geometry/EllipseToSpeckleConverter.cs
@@ -4,7 +4,7 @@ using Speckle.Sdk.Models;
 
 namespace Speckle.Converters.Autocad.ToSpeckle.Geometry;
 
-[NameAndRankValue(nameof(ADB.Ellipse), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
+[NameAndRankValue(typeof(ADB.Ellipse), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
 public class DBEllipseToSpeckleConverter : IToSpeckleTopLevelConverter
 {
   private readonly ITypedConverter<ADB.Ellipse, SOG.Ellipse> _ellipseConverter;

--- a/Converters/Autocad/Speckle.Converters.AutocadShared/ToSpeckle/Geometry/LineToSpeckleConverter.cs
+++ b/Converters/Autocad/Speckle.Converters.AutocadShared/ToSpeckle/Geometry/LineToSpeckleConverter.cs
@@ -4,7 +4,7 @@ using Speckle.Sdk.Models;
 
 namespace Speckle.Converters.Autocad.ToSpeckle.Geometry;
 
-[NameAndRankValue(nameof(ADB.Line), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
+[NameAndRankValue(typeof(ADB.Line), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
 public class LineToSpeckleConverter : IToSpeckleTopLevelConverter
 {
   private readonly ITypedConverter<ADB.Line, SOG.Line> _lineConverter;

--- a/Converters/Autocad/Speckle.Converters.AutocadShared/ToSpeckle/Geometry/PointToSpeckleConverter.cs
+++ b/Converters/Autocad/Speckle.Converters.AutocadShared/ToSpeckle/Geometry/PointToSpeckleConverter.cs
@@ -4,7 +4,7 @@ using Speckle.Sdk.Models;
 
 namespace Speckle.Converters.Autocad.ToSpeckle.Geometry;
 
-[NameAndRankValue(nameof(ADB.DBPoint), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
+[NameAndRankValue(typeof(ADB.DBPoint), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
 public class PointToSpeckleConverter : IToSpeckleTopLevelConverter
 {
   private readonly ITypedConverter<AG.Point3d, SOG.Point> _pointConverter;

--- a/Converters/Autocad/Speckle.Converters.AutocadShared/ToSpeckle/Geometry/PolyfaceMeshToSpeckleConverter.cs
+++ b/Converters/Autocad/Speckle.Converters.AutocadShared/ToSpeckle/Geometry/PolyfaceMeshToSpeckleConverter.cs
@@ -11,7 +11,7 @@ namespace Speckle.Converters.Autocad.Geometry;
 /// <remarks>
 /// The IToSpeckleTopLevelConverter inheritance should only expect database-resident <see cref="ADB.PolyFaceMesh"/> objects. IRawConversion inheritance can expect non database-resident objects, when generated from other converters.
 /// </remarks>
-[NameAndRankValue(nameof(ADB.PolyFaceMesh), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
+[NameAndRankValue(typeof(ADB.PolyFaceMesh), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
 public class DBPolyfaceMeshToSpeckleConverter : IToSpeckleTopLevelConverter
 {
   private readonly ITypedConverter<AG.Point3d, SOG.Point> _pointConverter;

--- a/Converters/Autocad/Speckle.Converters.AutocadShared/ToSpeckle/Geometry/Polyline2dToSpeckleConverter.cs
+++ b/Converters/Autocad/Speckle.Converters.AutocadShared/ToSpeckle/Geometry/Polyline2dToSpeckleConverter.cs
@@ -14,7 +14,7 @@ namespace Speckle.Converters.Autocad.Geometry;
 /// <see cref="ADB.Polyline2d"/> of type <see cref="ADB.Poly2dType.CubicSplinePoly"/> and <see cref="ADB.Poly2dType.QuadSplinePoly"/> will have only one <see cref="SOG.Curve"/> in <see cref="SOG.Polycurve.segments"/>.
 /// The IToSpeckleTopLevelConverter inheritance should only expect database-resident <see cref="ADB.Polyline2d"/> objects. IRawConversion inheritance can expect non database-resident objects, when generated from other converters.
 /// </remarks>
-[NameAndRankValue(nameof(ADB.Polyline2d), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
+[NameAndRankValue(typeof(ADB.Polyline2d), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
 public class Polyline2dToSpeckleConverter
   : IToSpeckleTopLevelConverter,
     ITypedConverter<ADB.Polyline2d, SOG.Autocad.AutocadPolycurve>

--- a/Converters/Autocad/Speckle.Converters.AutocadShared/ToSpeckle/Geometry/Polyline3dToSpeckleConverter.cs
+++ b/Converters/Autocad/Speckle.Converters.AutocadShared/ToSpeckle/Geometry/Polyline3dToSpeckleConverter.cs
@@ -13,7 +13,7 @@ namespace Speckle.Converters.Autocad.Geometry;
 /// <see cref="ADB.Polyline3d"/> of type <see cref="ADB.Poly2dType.CubicSplinePoly"/> and <see cref="ADB.Poly2dType.QuadSplinePoly"/> will have only one <see cref="SOG.Curve"/> in <see cref="SOG.Polycurve.segments"/>.
 /// The IToSpeckleTopLevelConverter inheritance should only expect database-resident Polyline2d objects. IRawConversion inheritance can expect non database-resident objects, when generated from other converters.
 /// </remarks>
-[NameAndRankValue(nameof(ADB.Polyline3d), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
+[NameAndRankValue(typeof(ADB.Polyline3d), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
 public class Polyline3dToSpeckleConverter
   : IToSpeckleTopLevelConverter,
     ITypedConverter<ADB.Polyline3d, SOG.Autocad.AutocadPolycurve>

--- a/Converters/Autocad/Speckle.Converters.AutocadShared/ToSpeckle/Geometry/PolylineToSpeckleConverter.cs
+++ b/Converters/Autocad/Speckle.Converters.AutocadShared/ToSpeckle/Geometry/PolylineToSpeckleConverter.cs
@@ -10,7 +10,7 @@ namespace Speckle.Converters.Autocad.Geometry;
 /// <remarks>
 /// <see cref="ADB.Polyline"/> is of type <see cref="SOG.Autocad.AutocadPolyType.Light"/> and will have only <see cref="SOG.Line"/>s and <see cref="SOG.Arc"/>s in <see cref="SOG.Polycurve.segments"/>.
 /// </remarks>
-[NameAndRankValue(nameof(ADB.Polyline), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
+[NameAndRankValue(typeof(ADB.Polyline), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
 public class PolylineToSpeckleConverter
   : IToSpeckleTopLevelConverter,
     ITypedConverter<ADB.Polyline, SOG.Autocad.AutocadPolycurve>

--- a/Converters/Autocad/Speckle.Converters.AutocadShared/ToSpeckle/Geometry/RegionToSpeckleConverter.cs
+++ b/Converters/Autocad/Speckle.Converters.AutocadShared/ToSpeckle/Geometry/RegionToSpeckleConverter.cs
@@ -5,7 +5,7 @@ using Speckle.Sdk.Models;
 
 namespace Speckle.Converters.Autocad.Geometry;
 
-[NameAndRankValue(nameof(ADB.Region), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
+[NameAndRankValue(typeof(ADB.Region), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
 public class RegionToSpeckleConverter : IToSpeckleTopLevelConverter, ITypedConverter<ADB.Region, SOG.Mesh>
 {
   private readonly ITypedConverter<ABR.Brep, SOG.Mesh> _brepConverter;

--- a/Converters/Autocad/Speckle.Converters.AutocadShared/ToSpeckle/Geometry/Solid3dToSpeckleConverter.cs
+++ b/Converters/Autocad/Speckle.Converters.AutocadShared/ToSpeckle/Geometry/Solid3dToSpeckleConverter.cs
@@ -4,7 +4,7 @@ using Speckle.Sdk.Models;
 
 namespace Speckle.Converters.Autocad.Geometry;
 
-[NameAndRankValue(nameof(ADB.Solid3d), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
+[NameAndRankValue(typeof(ADB.Solid3d), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
 public class Solid3dToSpeckleConverter : IToSpeckleTopLevelConverter
 {
   private readonly ITypedConverter<ADB.Solid3d, SOG.Mesh> _solidConverter;

--- a/Converters/Autocad/Speckle.Converters.AutocadShared/ToSpeckle/Geometry/SplineToSpeckleConverter.cs
+++ b/Converters/Autocad/Speckle.Converters.AutocadShared/ToSpeckle/Geometry/SplineToSpeckleConverter.cs
@@ -4,7 +4,7 @@ using Speckle.Sdk.Models;
 
 namespace Speckle.Converters.Autocad.ToSpeckle.Geometry;
 
-[NameAndRankValue(nameof(ADB.Spline), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
+[NameAndRankValue(typeof(ADB.Spline), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
 public class SplineToSpeckleConverter : IToSpeckleTopLevelConverter
 {
   private readonly ITypedConverter<ADB.Spline, SOG.Curve> _splineConverter;

--- a/Converters/Autocad/Speckle.Converters.AutocadShared/ToSpeckle/Geometry/SubDMeshToSpeckleConverter.cs
+++ b/Converters/Autocad/Speckle.Converters.AutocadShared/ToSpeckle/Geometry/SubDMeshToSpeckleConverter.cs
@@ -5,7 +5,7 @@ using Speckle.Sdk.Models;
 
 namespace Speckle.Converters.Autocad.Geometry;
 
-[NameAndRankValue(nameof(ADB.SubDMesh), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
+[NameAndRankValue(typeof(ADB.SubDMesh), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
 public class DBSubDMeshToSpeckleConverter : IToSpeckleTopLevelConverter
 {
   private readonly IConverterSettingsStore<AutocadConversionSettings> _settingsStore;

--- a/Converters/Autocad/Speckle.Converters.AutocadShared/ToSpeckle/Geometry/SurfaceToSpeckleConverter.cs
+++ b/Converters/Autocad/Speckle.Converters.AutocadShared/ToSpeckle/Geometry/SurfaceToSpeckleConverter.cs
@@ -5,7 +5,7 @@ using Speckle.Sdk.Models;
 
 namespace Speckle.Converters.Autocad.Geometry;
 
-[NameAndRankValue(nameof(ADB.Surface), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
+[NameAndRankValue(typeof(ADB.Surface), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
 public class SurfaceToSpeckleConverter : IToSpeckleTopLevelConverter, ITypedConverter<ADB.Surface, SOG.Mesh>
 {
   private readonly ITypedConverter<ABR.Brep, SOG.Mesh> _brepConverter;

--- a/Converters/CSi/Speckle.Converters.ETABSShared/ToSpeckle/TopLevel/EtabsObjectToSpeckleConverter.cs
+++ b/Converters/CSi/Speckle.Converters.ETABSShared/ToSpeckle/TopLevel/EtabsObjectToSpeckleConverter.cs
@@ -22,7 +22,7 @@ namespace Speckle.Converters.ETABSShared.ToSpeckle.TopLevel;
 ///      * IApplicationPropertiesExtractor for ETABS-specific data
 /// 3. CreateTargetObject method ensures type-safe conversion to EtabsObject
 /// </remarks>
-[NameAndRankValue(nameof(CsiWrapperBase), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
+[NameAndRankValue(typeof(CsiWrapperBase), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
 public class EtabsObjectToSpeckleConverter : CsiObjectToSpeckleConverterBase
 {
   public EtabsObjectToSpeckleConverter(

--- a/Converters/Civil3d/Speckle.Converters.Civil3dShared/ToSpeckle/TopLevel/CivilEntityToSpeckleTopLevelConverter.cs
+++ b/Converters/Civil3d/Speckle.Converters.Civil3dShared/ToSpeckle/TopLevel/CivilEntityToSpeckleTopLevelConverter.cs
@@ -9,7 +9,7 @@ using Speckle.Sdk.Models;
 
 namespace Speckle.Converters.Civil3dShared.ToSpeckle.BuiltElements;
 
-[NameAndRankValue(nameof(CDB.Entity), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
+[NameAndRankValue(typeof(CDB.Entity), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
 public class CivilEntityToSpeckleTopLevelConverter : IToSpeckleTopLevelConverter
 {
   private readonly IConverterSettingsStore<Civil3dConversionSettings> _settingsStore;

--- a/Converters/Navisworks/Speckle.Converters.NavisworksShared/ToSpeckle/TopLevel/ModelItemTopLevelConverterToSpeckle.cs
+++ b/Converters/Navisworks/Speckle.Converters.NavisworksShared/ToSpeckle/TopLevel/ModelItemTopLevelConverterToSpeckle.cs
@@ -10,7 +10,7 @@ namespace Speckle.Converter.Navisworks.ToSpeckle;
 /// <summary>
 /// Converts Navisworks ModelItem objects to Speckle Base objects.
 /// </summary>
-[NameAndRankValue(nameof(NAV.ModelItem), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
+[NameAndRankValue(typeof(NAV.ModelItem), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
 public class ModelItemToToSpeckleConverter : IToSpeckleTopLevelConverter
 {
   private readonly StandardPropertyHandler _standardHandler;

--- a/Converters/Revit/Speckle.Converters.RevitShared/ToSpeckle/TopLevel/ModelCurveToSpeckleTopLevelConverter.cs
+++ b/Converters/Revit/Speckle.Converters.RevitShared/ToSpeckle/TopLevel/ModelCurveToSpeckleTopLevelConverter.cs
@@ -6,7 +6,7 @@ using Speckle.Sdk.Models;
 namespace Speckle.Converters.RevitShared.ToSpeckle;
 
 // Converts model curves to regular speckle curves, since we aren't receiving them and the only property used in V2 was the linestyle (not element ids or parameters). Don't see a need to handle these differently from regular geometry.
-[NameAndRankValue(nameof(DB.ModelCurve), 0)]
+[NameAndRankValue(typeof(DB.ModelCurve), 0)]
 public class ModelCurveToSpeckleTopLevelConverter : IToSpeckleTopLevelConverter
 {
   private readonly ITypedConverter<DB.Curve, ICurve> _curveConverter;

--- a/Converters/Revit/Speckle.Converters.RevitShared/ToSpeckle/TopLevel/PointcloudTopLevelConverterToSpeckle.cs
+++ b/Converters/Revit/Speckle.Converters.RevitShared/ToSpeckle/TopLevel/PointcloudTopLevelConverterToSpeckle.cs
@@ -5,7 +5,7 @@ using Speckle.Sdk.Models;
 
 namespace Speckle.Converters.RevitShared.ToSpeckle;
 
-[NameAndRankValue(nameof(DB.PointCloudInstance), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
+[NameAndRankValue(typeof(DB.PointCloudInstance), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
 public sealed class PointcloudTopLevelConverterToSpeckle : IToSpeckleTopLevelConverter
 {
   private readonly IConverterSettingsStore<RevitConversionSettings> _converterSettings;

--- a/Converters/Revit/Speckle.Converters.RevitShared/ToSpeckle/TopLevel/RevitElementTopLevelConverterToSpeckle.cs
+++ b/Converters/Revit/Speckle.Converters.RevitShared/ToSpeckle/TopLevel/RevitElementTopLevelConverterToSpeckle.cs
@@ -10,7 +10,7 @@ using Speckle.Sdk.Models;
 
 namespace Speckle.Converters.RevitShared.ToSpeckle;
 
-[NameAndRankValue(nameof(DB.Element), 0)]
+[NameAndRankValue(typeof(DB.Element), 0)]
 public class ElementTopLevelConverterToSpeckle : IToSpeckleTopLevelConverter
 {
   private readonly DisplayValueExtractor _displayValueExtractor;

--- a/Converters/Rhino/Speckle.Converters.RhinoShared/ToHost/TopLevel/ArcToHostTopLevelConverter.cs
+++ b/Converters/Rhino/Speckle.Converters.RhinoShared/ToHost/TopLevel/ArcToHostTopLevelConverter.cs
@@ -3,7 +3,7 @@ using Speckle.Converters.Common.Objects;
 
 namespace Speckle.Converters.Rhino.ToHost.TopLevel;
 
-[NameAndRankValue(nameof(SOG.Arc), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
+[NameAndRankValue(typeof(SOG.Arc), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
 public class ArcToHostTopLevelConverter : SpeckleToHostGeometryBaseTopLevelConverter<SOG.Arc, RG.ArcCurve>
 {
   public ArcToHostTopLevelConverter(

--- a/Converters/Rhino/Speckle.Converters.RhinoShared/ToHost/TopLevel/BrepToHostTopLevelConverter.cs
+++ b/Converters/Rhino/Speckle.Converters.RhinoShared/ToHost/TopLevel/BrepToHostTopLevelConverter.cs
@@ -3,7 +3,7 @@ using Speckle.Converters.Common.Objects;
 
 namespace Speckle.Converters.Rhino.ToHost.TopLevel;
 
-[NameAndRankValue(nameof(SOG.Brep), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
+[NameAndRankValue(typeof(SOG.Brep), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
 public class BrepToHostTopLevelConverter : SpeckleToHostGeometryBaseTopLevelConverter<SOG.Brep, RG.Brep>
 {
   public BrepToHostTopLevelConverter(

--- a/Converters/Rhino/Speckle.Converters.RhinoShared/ToHost/TopLevel/BrepXToHostTopLevelConverter.cs
+++ b/Converters/Rhino/Speckle.Converters.RhinoShared/ToHost/TopLevel/BrepXToHostTopLevelConverter.cs
@@ -3,7 +3,7 @@ using Speckle.Converters.Common.Objects;
 
 namespace Speckle.Converters.Rhino.ToHost.TopLevel;
 
-[NameAndRankValue(nameof(SOG.BrepX), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
+[NameAndRankValue(typeof(SOG.BrepX), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
 public class BrepXToHostTopLevelConverter : SpeckleToHostGeometryBaseTopLevelConverter<SOG.BrepX, List<RG.GeometryBase>>
 {
   public BrepXToHostTopLevelConverter(
@@ -13,7 +13,7 @@ public class BrepXToHostTopLevelConverter : SpeckleToHostGeometryBaseTopLevelCon
     : base(settingsStore, geometryBaseConverter) { }
 }
 
-[NameAndRankValue(nameof(SOG.SubDX), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
+[NameAndRankValue(typeof(SOG.SubDX), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
 public class SubDXToHostTopLevelConverter : SpeckleToHostGeometryBaseTopLevelConverter<SOG.SubDX, List<RG.GeometryBase>>
 {
   public SubDXToHostTopLevelConverter(
@@ -23,7 +23,7 @@ public class SubDXToHostTopLevelConverter : SpeckleToHostGeometryBaseTopLevelCon
     : base(settingsStore, geometryBaseConverter) { }
 }
 
-[NameAndRankValue(nameof(SOG.ExtrusionX), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
+[NameAndRankValue(typeof(SOG.ExtrusionX), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
 public class ExtrusionXToHostTopLevelConverter
   : SpeckleToHostGeometryBaseTopLevelConverter<SOG.ExtrusionX, List<RG.GeometryBase>>
 {

--- a/Converters/Rhino/Speckle.Converters.RhinoShared/ToHost/TopLevel/CircleToHostTopLevelConverter.cs
+++ b/Converters/Rhino/Speckle.Converters.RhinoShared/ToHost/TopLevel/CircleToHostTopLevelConverter.cs
@@ -3,7 +3,7 @@ using Speckle.Converters.Common.Objects;
 
 namespace Speckle.Converters.Rhino.ToHost.TopLevel;
 
-[NameAndRankValue(nameof(SOG.Circle), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
+[NameAndRankValue(typeof(SOG.Circle), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
 public class CircleToHostTopLevelConverter : SpeckleToHostGeometryBaseTopLevelConverter<SOG.Circle, RG.ArcCurve>
 {
   public CircleToHostTopLevelConverter(

--- a/Converters/Rhino/Speckle.Converters.RhinoShared/ToHost/TopLevel/DataObjectConverter.cs
+++ b/Converters/Rhino/Speckle.Converters.RhinoShared/ToHost/TopLevel/DataObjectConverter.cs
@@ -7,7 +7,7 @@ using Speckle.Sdk.Models;
 
 namespace Speckle.Converters.Rhino.ToHost.TopLevel;
 
-[NameAndRankValue(nameof(DataObject), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
+[NameAndRankValue(typeof(DataObject), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
 public class DataObjectConverter
   : IToHostTopLevelConverter,
     ITypedConverter<DataObject, List<(RG.GeometryBase a, Base b)>>

--- a/Converters/Rhino/Speckle.Converters.RhinoShared/ToHost/TopLevel/DisplayableObjectToHostTopLevelConverter.cs
+++ b/Converters/Rhino/Speckle.Converters.RhinoShared/ToHost/TopLevel/DisplayableObjectToHostTopLevelConverter.cs
@@ -6,7 +6,7 @@ using Speckle.Sdk.Models;
 
 namespace Speckle.Converters.Rhino.ToHost.TopLevel;
 
-[NameAndRankValue(nameof(DisplayableObject), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
+[NameAndRankValue(typeof(DisplayableObject), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
 public class DisplayableObjectConverter
   : IToHostTopLevelConverter,
     ITypedConverter<DisplayableObject, List<(RG.GeometryBase a, Base b)>>

--- a/Converters/Rhino/Speckle.Converters.RhinoShared/ToHost/TopLevel/EllipseToHostTopLevelConverter.cs
+++ b/Converters/Rhino/Speckle.Converters.RhinoShared/ToHost/TopLevel/EllipseToHostTopLevelConverter.cs
@@ -3,7 +3,7 @@ using Speckle.Converters.Common.Objects;
 
 namespace Speckle.Converters.Rhino.ToHost.TopLevel;
 
-[NameAndRankValue(nameof(SOG.Ellipse), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
+[NameAndRankValue(typeof(SOG.Ellipse), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
 public class EllipseToHostTopLevelConverter : SpeckleToHostGeometryBaseTopLevelConverter<SOG.Ellipse, RG.NurbsCurve>
 {
   public EllipseToHostTopLevelConverter(

--- a/Converters/Rhino/Speckle.Converters.RhinoShared/ToHost/TopLevel/LineToHostTopLevelConverter.cs
+++ b/Converters/Rhino/Speckle.Converters.RhinoShared/ToHost/TopLevel/LineToHostTopLevelConverter.cs
@@ -3,7 +3,7 @@ using Speckle.Converters.Common.Objects;
 
 namespace Speckle.Converters.Rhino.ToHost.TopLevel;
 
-[NameAndRankValue(nameof(SOG.Line), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
+[NameAndRankValue(typeof(SOG.Line), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
 public class LineToHostTopLevelConverter : SpeckleToHostGeometryBaseTopLevelConverter<SOG.Line, RG.LineCurve>
 {
   public LineToHostTopLevelConverter(

--- a/Converters/Rhino/Speckle.Converters.RhinoShared/ToHost/TopLevel/MeshToHostTopLevelConverter.cs
+++ b/Converters/Rhino/Speckle.Converters.RhinoShared/ToHost/TopLevel/MeshToHostTopLevelConverter.cs
@@ -3,7 +3,7 @@ using Speckle.Converters.Common.Objects;
 
 namespace Speckle.Converters.Rhino.ToHost.TopLevel;
 
-[NameAndRankValue(nameof(SOG.Mesh), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
+[NameAndRankValue(typeof(SOG.Mesh), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
 public class MeshToHostTopLevelConverter : SpeckleToHostGeometryBaseTopLevelConverter<SOG.Mesh, RG.Mesh>
 {
   public MeshToHostTopLevelConverter(

--- a/Converters/Rhino/Speckle.Converters.RhinoShared/ToHost/TopLevel/NurbsCurveToHostTopLevelConverter.cs
+++ b/Converters/Rhino/Speckle.Converters.RhinoShared/ToHost/TopLevel/NurbsCurveToHostTopLevelConverter.cs
@@ -3,7 +3,7 @@ using Speckle.Converters.Common.Objects;
 
 namespace Speckle.Converters.Rhino.ToHost.TopLevel;
 
-[NameAndRankValue(nameof(SOG.Curve), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
+[NameAndRankValue(typeof(SOG.Curve), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
 public class NurbsCurveToHostTopLevelConverter : SpeckleToHostGeometryBaseTopLevelConverter<SOG.Curve, RG.NurbsCurve>
 {
   public NurbsCurveToHostTopLevelConverter(

--- a/Converters/Rhino/Speckle.Converters.RhinoShared/ToHost/TopLevel/PointCloudToHostTopLevelConverter.cs
+++ b/Converters/Rhino/Speckle.Converters.RhinoShared/ToHost/TopLevel/PointCloudToHostTopLevelConverter.cs
@@ -3,7 +3,7 @@ using Speckle.Converters.Common.Objects;
 
 namespace Speckle.Converters.Rhino.ToHost.TopLevel;
 
-[NameAndRankValue(nameof(SOG.Pointcloud), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
+[NameAndRankValue(typeof(SOG.Pointcloud), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
 public class PointCloudToHostTopLevelConverter
   : SpeckleToHostGeometryBaseTopLevelConverter<SOG.Pointcloud, RG.PointCloud>
 {

--- a/Converters/Rhino/Speckle.Converters.RhinoShared/ToHost/TopLevel/PointToHostTopLevelConverter.cs
+++ b/Converters/Rhino/Speckle.Converters.RhinoShared/ToHost/TopLevel/PointToHostTopLevelConverter.cs
@@ -3,7 +3,7 @@ using Speckle.Converters.Common.Objects;
 
 namespace Speckle.Converters.Rhino.ToHost.TopLevel;
 
-[NameAndRankValue(nameof(SOG.Point), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
+[NameAndRankValue(typeof(SOG.Point), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
 public class PointToHostTopLevelConverter : SpeckleToHostGeometryBaseTopLevelConverter<SOG.Point, RG.Point>
 {
   public PointToHostTopLevelConverter(

--- a/Converters/Rhino/Speckle.Converters.RhinoShared/ToHost/TopLevel/PolycurveToHostTopLevelConverter.cs
+++ b/Converters/Rhino/Speckle.Converters.RhinoShared/ToHost/TopLevel/PolycurveToHostTopLevelConverter.cs
@@ -3,7 +3,7 @@ using Speckle.Converters.Common.Objects;
 
 namespace Speckle.Converters.Rhino.ToHost.TopLevel;
 
-[NameAndRankValue(nameof(SOG.Polycurve), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
+[NameAndRankValue(typeof(SOG.Polycurve), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
 public class PolycurveToHostTopLevelConverter : SpeckleToHostGeometryBaseTopLevelConverter<SOG.Polycurve, RG.PolyCurve>
 {
   public PolycurveToHostTopLevelConverter(

--- a/Converters/Rhino/Speckle.Converters.RhinoShared/ToHost/TopLevel/PolylineToHostTopLevelConverter.cs
+++ b/Converters/Rhino/Speckle.Converters.RhinoShared/ToHost/TopLevel/PolylineToHostTopLevelConverter.cs
@@ -3,7 +3,7 @@ using Speckle.Converters.Common.Objects;
 
 namespace Speckle.Converters.Rhino.ToHost.TopLevel;
 
-[NameAndRankValue(nameof(SOG.Polyline), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
+[NameAndRankValue(typeof(SOG.Polyline), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
 public class PolylineToHostTopLevelConverter
   : SpeckleToHostGeometryBaseTopLevelConverter<SOG.Polyline, RG.PolylineCurve>
 {

--- a/Converters/Rhino/Speckle.Converters.RhinoShared/ToSpeckle/Raw/MeshToSpeckleConverter.cs
+++ b/Converters/Rhino/Speckle.Converters.RhinoShared/ToSpeckle/Raw/MeshToSpeckleConverter.cs
@@ -4,7 +4,7 @@ using Speckle.Sdk.Common.Exceptions;
 
 namespace Speckle.Converters.Rhino.ToSpeckle.Raw;
 
-[NameAndRankValue(nameof(RG.Mesh), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
+[NameAndRankValue(typeof(RG.Mesh), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
 public class MeshToSpeckleConverter : ITypedConverter<RG.Mesh, SOG.Mesh>
 {
   private readonly ITypedConverter<RG.Point3d, SOG.Point> _pointConverter;

--- a/Converters/Rhino/Speckle.Converters.RhinoShared/ToSpeckle/TopLevel/BrepObjectToSpeckleTopLevelConverter.cs
+++ b/Converters/Rhino/Speckle.Converters.RhinoShared/ToSpeckle/TopLevel/BrepObjectToSpeckleTopLevelConverter.cs
@@ -7,7 +7,7 @@ using Speckle.Sdk.Models;
 
 namespace Speckle.Converters.Rhino.ToSpeckle.TopLevel;
 
-[NameAndRankValue(nameof(BrepObject), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
+[NameAndRankValue(typeof(BrepObject), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
 public class BrepObjectToSpeckleTopLevelConverter : IToSpeckleTopLevelConverter
 {
   private readonly ITypedConverter<RG.Mesh, SOG.Mesh> _meshConverter;

--- a/Converters/Rhino/Speckle.Converters.RhinoShared/ToSpeckle/TopLevel/CurveObjectToSpeckleTopLevelConverter.cs
+++ b/Converters/Rhino/Speckle.Converters.RhinoShared/ToSpeckle/TopLevel/CurveObjectToSpeckleTopLevelConverter.cs
@@ -5,7 +5,7 @@ using Speckle.Sdk.Models;
 
 namespace Speckle.Converters.Rhino.ToSpeckle.TopLevel;
 
-[NameAndRankValue(nameof(CurveObject), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
+[NameAndRankValue(typeof(CurveObject), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
 public class CurveObjectToSpeckleTopLevelConverter : RhinoObjectToSpeckleTopLevelConverter<CurveObject, RG.Curve, Base>
 {
   public CurveObjectToSpeckleTopLevelConverter(ITypedConverter<RG.Curve, Base> conversion)

--- a/Converters/Rhino/Speckle.Converters.RhinoShared/ToSpeckle/TopLevel/ExtrusionObjectToSpeckleTopLevelConverter.cs
+++ b/Converters/Rhino/Speckle.Converters.RhinoShared/ToSpeckle/TopLevel/ExtrusionObjectToSpeckleTopLevelConverter.cs
@@ -7,7 +7,7 @@ using Speckle.Sdk.Models;
 
 namespace Speckle.Converters.Rhino.ToSpeckle.TopLevel;
 
-[NameAndRankValue(nameof(ExtrusionObject), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
+[NameAndRankValue(typeof(ExtrusionObject), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
 public class ExtrusionObjectToSpeckleTopLevelConverter : IToSpeckleTopLevelConverter
 {
   private readonly ITypedConverter<RG.Mesh, SOG.Mesh> _meshConverter;

--- a/Converters/Rhino/Speckle.Converters.RhinoShared/ToSpeckle/TopLevel/MeshObjectToSpeckleTopLevelConverter.cs
+++ b/Converters/Rhino/Speckle.Converters.RhinoShared/ToSpeckle/TopLevel/MeshObjectToSpeckleTopLevelConverter.cs
@@ -4,7 +4,7 @@ using Speckle.Converters.Common.Objects;
 
 namespace Speckle.Converters.Rhino.ToSpeckle.TopLevel;
 
-[NameAndRankValue(nameof(MeshObject), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
+[NameAndRankValue(typeof(MeshObject), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
 public class MeshObjectToSpeckleTopLevelConverter : RhinoObjectToSpeckleTopLevelConverter<MeshObject, RG.Mesh, SOG.Mesh>
 {
   public MeshObjectToSpeckleTopLevelConverter(ITypedConverter<RG.Mesh, SOG.Mesh> conversion)

--- a/Converters/Rhino/Speckle.Converters.RhinoShared/ToSpeckle/TopLevel/PointCloudObjectToSpeckleTopLevelConverter.cs
+++ b/Converters/Rhino/Speckle.Converters.RhinoShared/ToSpeckle/TopLevel/PointCloudObjectToSpeckleTopLevelConverter.cs
@@ -4,7 +4,7 @@ using Speckle.Converters.Common.Objects;
 
 namespace Speckle.Converters.Rhino.ToSpeckle.TopLevel;
 
-[NameAndRankValue(nameof(PointCloudObject), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
+[NameAndRankValue(typeof(PointCloudObject), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
 public class PointCloudObjectToSpeckleTopLevelConverter
   : RhinoObjectToSpeckleTopLevelConverter<PointCloudObject, RG.PointCloud, SOG.Pointcloud>
 {

--- a/Converters/Rhino/Speckle.Converters.RhinoShared/ToSpeckle/TopLevel/PointObjectToSpeckleTopLevelConverter.cs
+++ b/Converters/Rhino/Speckle.Converters.RhinoShared/ToSpeckle/TopLevel/PointObjectToSpeckleTopLevelConverter.cs
@@ -4,7 +4,7 @@ using Speckle.Converters.Common.Objects;
 
 namespace Speckle.Converters.Rhino.ToSpeckle.TopLevel;
 
-[NameAndRankValue(nameof(PointObject), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
+[NameAndRankValue(typeof(PointObject), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
 public class PointObjectToSpeckleTopLevelConverter
   : RhinoObjectToSpeckleTopLevelConverter<PointObject, RG.Point, SOG.Point>
 {

--- a/Converters/Rhino/Speckle.Converters.RhinoShared/ToSpeckle/TopLevel/SubDObjectToSpeckleTopLevelConverter.cs
+++ b/Converters/Rhino/Speckle.Converters.RhinoShared/ToSpeckle/TopLevel/SubDObjectToSpeckleTopLevelConverter.cs
@@ -7,7 +7,7 @@ using Speckle.Sdk.Models;
 
 namespace Speckle.Converters.Rhino.ToSpeckle.TopLevel;
 
-[NameAndRankValue(nameof(SubDObject), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
+[NameAndRankValue(typeof(SubDObject), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
 public class SubDObjectToSpeckleTopLevelConverter : IToSpeckleTopLevelConverter
 {
   private readonly ITypedConverter<RG.Mesh, SOG.Mesh> _meshConverter;

--- a/Converters/Tekla/Speckle.Converters.TeklaShared/ToSpeckle/TopLevel/ModelObjectToSpeckleConverter.cs
+++ b/Converters/Tekla/Speckle.Converters.TeklaShared/ToSpeckle/TopLevel/ModelObjectToSpeckleConverter.cs
@@ -7,7 +7,7 @@ using Speckle.Sdk.Models;
 
 namespace Speckle.Converters.TeklaShared.ToSpeckle.TopLevel;
 
-[NameAndRankValue(nameof(TSM.ModelObject), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
+[NameAndRankValue(typeof(TSM.ModelObject), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
 public class ModelObjectToSpeckleConverter : IToSpeckleTopLevelConverter
 {
   private readonly IConverterSettingsStore<TeklaConversionSettings> _settingsStore;

--- a/Sdk/Speckle.Converters.Common.Tests/ConverterManagerTests.cs
+++ b/Sdk/Speckle.Converters.Common.Tests/ConverterManagerTests.cs
@@ -36,7 +36,7 @@ public class ConverterManagerTests
   [Test]
   public void Test_NoFallback()
   {
-    var sut = SetupManager("String", typeof(TestConverter));
+    var sut = SetupManager("System.String", typeof(TestConverter));
     var converter = sut.ResolveConverter(typeof(string), false);
     converter.Should().NotBeNull();
   }
@@ -44,7 +44,7 @@ public class ConverterManagerTests
   [Test]
   public void Test_Fallback()
   {
-    var sut = SetupManager("Object", typeof(TestConverter));
+    var sut = SetupManager("System.Object", typeof(TestConverter));
     var converter = sut.ResolveConverter(typeof(string), true);
     converter.Should().NotBeNull();
   }

--- a/Sdk/Speckle.Converters.Common/NameAndRankValueAttribute.cs
+++ b/Sdk/Speckle.Converters.Common/NameAndRankValueAttribute.cs
@@ -2,17 +2,11 @@
 
 // POC: maybe better to put in utils/reflection
 [AttributeUsage(AttributeTargets.Class)]
-public sealed class NameAndRankValueAttribute : Attribute
+public sealed class NameAndRankValueAttribute(Type type, int rank) : Attribute
 {
   // DO NOT CHANGE! This is the base, lowest rank for a conversion
   public const int SPECKLE_DEFAULT_RANK = 0;
 
-  public string Name { get; private set; }
-  public int Rank { get; private set; }
-
-  public NameAndRankValueAttribute(string name, int rank)
-  {
-    Name = name;
-    Rank = rank;
-  }
+  public Type Type { get; private set; } = type;
+  public int Rank { get; private set; } = rank;
 }

--- a/Sdk/Speckle.Converters.Common/Registration/ConverterManager.cs
+++ b/Sdk/Speckle.Converters.Common/Registration/ConverterManager.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using Microsoft.Extensions.DependencyInjection;
+using Speckle.Sdk.Common;
 using Speckle.Sdk.Common.Exceptions;
 
 namespace Speckle.Converters.Common.Registration;
@@ -14,7 +15,7 @@ public class ConverterManager<T>(ConcurrentDictionary<string, Type> converterTyp
     var currentType = type;
     while (true)
     {
-      var typeName = currentType.Name;
+      var typeName = currentType.FullName.NotNull();
       var converter = GetConverterByType(typeName);
       if (converter is null && recursive)
       {
@@ -37,9 +38,9 @@ public class ConverterManager<T>(ConcurrentDictionary<string, Type> converterTyp
     }
   }
 
-  private T? GetConverterByType(string typeName)
+  private T? GetConverterByType(string fullName)
   {
-    if (converterTypes.TryGetValue(typeName, out var converter))
+    if (converterTypes.TryGetValue(fullName, out var converter))
     {
       return (T)ActivatorUtilities.CreateInstance(serviceProvider, converter);
     }


### PR DESCRIPTION
Loading Autocad 2025 with Civil3d plugin (quesitonable) using a model with a TinSurface resulted in resolving to an Autocad specific converter (ADB.Surface) instead of a converter using the Civil3d Surface or Entity.  

Fully namespaced types are needed to resolve the correct converter

related: https://github.com/specklesystems/speckle-sharp-sdk/pull/476