### PR TITLE
fix(civil): adds top level cogopoint converter

### DIFF
--- a/Converters/Civil3d/Speckle.Converters.Civil3dShared/Civil3dRootToSpeckleConverter.cs
+++ b/Converters/Civil3d/Speckle.Converters.Civil3dShared/Civil3dRootToSpeckleConverter.cs
@@ -34,6 +34,8 @@ public class Civil3dRootToSpeckleConverter : IRootToSpeckleConverter
     object objectToConvert = dbObject;
 
     // check first for civil type objects
+    // POC: some classes (eg Civil.DatabaseServices.CogoPoint) actually inherit from Autocad.DatabaseServices.Entity instead of Civil!!
+    // These need top level converters in Civil for now, but in the future we should implement a EntityToSpeckleTopLevelConverter for Autocad as well.
     if (target is CDB.Entity civilEntity)
     {
       type = civilEntity.GetType();

--- a/Converters/Civil3d/Speckle.Converters.Civil3dShared/Speckle.Converters.Civil3dShared.projitems
+++ b/Converters/Civil3d/Speckle.Converters.Civil3dShared/Speckle.Converters.Civil3dShared.projitems
@@ -23,6 +23,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Helpers\DisplayValueExtractor.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ServiceRegistration.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ToSpeckle\Properties\PropertiesExtractor.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)ToSpeckle\TopLevel\CogoPointToSpeckleTopLevelConverter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ToSpeckle\TopLevel\CivilEntityToSpeckleTopLevelConverter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ToSpeckle\Properties\ClassPropertiesExtractor.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ToSpeckle\Properties\GeneralPropertiesExtractor.cs" />

--- a/Converters/Civil3d/Speckle.Converters.Civil3dShared/ToSpeckle/Raw/Point3dCollectionToSpeckleRawConverter.cs
+++ b/Converters/Civil3d/Speckle.Converters.Civil3dShared/ToSpeckle/Raw/Point3dCollectionToSpeckleRawConverter.cs
@@ -5,15 +5,10 @@ namespace Speckle.Converters.Civil3dShared.ToSpeckle.Raw;
 
 public class Point3dCollectionToSpeckleRawConverter : ITypedConverter<AG.Point3dCollection, SOG.Polyline>
 {
-  private readonly ITypedConverter<AG.Point3d, SOG.Point> _pointConverter;
   private readonly IConverterSettingsStore<Civil3dConversionSettings> _settingsStore;
 
-  public Point3dCollectionToSpeckleRawConverter(
-    ITypedConverter<AG.Point3d, SOG.Point> pointConverter,
-    IConverterSettingsStore<Civil3dConversionSettings> settingsStore
-  )
+  public Point3dCollectionToSpeckleRawConverter(IConverterSettingsStore<Civil3dConversionSettings> settingsStore)
   {
-    _pointConverter = pointConverter;
     _settingsStore = settingsStore;
   }
 

--- a/Converters/Civil3d/Speckle.Converters.Civil3dShared/ToSpeckle/TopLevel/CivilEntityToSpeckleTopLevelConverter.cs
+++ b/Converters/Civil3d/Speckle.Converters.Civil3dShared/ToSpeckle/TopLevel/CivilEntityToSpeckleTopLevelConverter.cs
@@ -7,7 +7,7 @@ using Speckle.Objects.Data;
 using Speckle.Sdk;
 using Speckle.Sdk.Models;
 
-namespace Speckle.Converters.Civil3dShared.ToSpeckle.BuiltElements;
+namespace Speckle.Converters.Civil3dShared.ToSpeckle.TopLevel;
 
 [NameAndRankValue(nameof(CDB.Entity), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
 public class CivilEntityToSpeckleTopLevelConverter : IToSpeckleTopLevelConverter

--- a/Converters/Civil3d/Speckle.Converters.Civil3dShared/ToSpeckle/TopLevel/CogoPointToSpeckleTopLevelConverter.cs
+++ b/Converters/Civil3d/Speckle.Converters.Civil3dShared/ToSpeckle/TopLevel/CogoPointToSpeckleTopLevelConverter.cs
@@ -12,7 +12,7 @@ namespace Speckle.Converters.Civil3dShared.ToSpeckle.TopLevel;
 /// This means cogo points will *not* be picked up by the top level civil entity converter.
 /// POC: implementing a top level autocad entity converter can probably replace this converter.
 /// </summary>
-[NameAndRankValue(nameof(CDB.CogoPoint), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
+[NameAndRankValue(typeof(CDB.CogoPoint), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
 public class CogoPointToSpeckleTopLevelConverter : IToSpeckleTopLevelConverter
 {
   private readonly IConverterSettingsStore<Civil3dConversionSettings> _settingsStore;

--- a/Converters/Civil3d/Speckle.Converters.Civil3dShared/ToSpeckle/TopLevel/CogoPointToSpeckleTopLevelConverter.cs
+++ b/Converters/Civil3d/Speckle.Converters.Civil3dShared/ToSpeckle/TopLevel/CogoPointToSpeckleTopLevelConverter.cs
@@ -1,0 +1,65 @@
+using Speckle.Converters.Civil3dShared.Extensions;
+using Speckle.Converters.Common;
+using Speckle.Converters.Common.Objects;
+using Speckle.Objects.Data;
+using Speckle.Sdk;
+using Speckle.Sdk.Models;
+
+namespace Speckle.Converters.Civil3dShared.ToSpeckle.TopLevel;
+
+/// <summary>
+/// This top level converter is needed because the namespace of CogoPoint is Autodesk.Civil.DatabaseServices, but the inheritance of CogoPoint is Autodesk.Autocad.Entity
+/// This means cogo points will *not* be picked up by the top level civil entity converter.
+/// POC: implementing a top level autocad entity converter can probably replace this converter.
+/// </summary>
+[NameAndRankValue(nameof(CDB.CogoPoint), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
+public class CogoPointToSpeckleTopLevelConverter : IToSpeckleTopLevelConverter
+{
+  private readonly IConverterSettingsStore<Civil3dConversionSettings> _settingsStore;
+  private readonly ITypedConverter<AG.Point3d, SOG.Point> _pointConverter;
+
+  public CogoPointToSpeckleTopLevelConverter(
+    IConverterSettingsStore<Civil3dConversionSettings> settingsStore,
+    ITypedConverter<AG.Point3d, SOG.Point> pointConverter
+  )
+  {
+    _settingsStore = settingsStore;
+    _pointConverter = pointConverter;
+  }
+
+  public Base Convert(object target) => Convert((CDB.CogoPoint)target);
+
+  public Civil3dObject Convert(CDB.CogoPoint target)
+  {
+    string name = "";
+    try
+    {
+      name = target.PointName;
+    }
+    catch (Autodesk.Civil.CivilException e) when (!e.IsFatal()) { } // throws if name doesn't exist
+
+    // extract display value as point
+    SOG.Point displayPoint = _pointConverter.Convert(target.Location);
+
+    Civil3dObject civilObject =
+      new()
+      {
+        name = name,
+        type = target.GetType().ToString().Split('.').Last(),
+        baseCurves = null,
+        elements = new(),
+        displayValue = new() { displayPoint },
+        properties = new(),
+        units = _settingsStore.Current.SpeckleUnits,
+        applicationId = target.Id.GetSpeckleApplicationId()
+      };
+
+    // add additional class properties
+    civilObject["pointNumber"] = target.PointNumber;
+    civilObject["northing"] = target.Northing;
+    //civilObject["latitude"] = target.Latitude; // might not be necessary, and also sometimes throws if transforms are not enabled
+    //civilObject["longitude"] = target.Longitude; // might not be necessary, and also sometimes throws if transforms are not enabled
+
+    return civilObject;
+  }
+}


### PR DESCRIPTION
Cogopoints were not properly supported because the full type name of the class is `Autodesk.**Civil**.DatabaseServices.CogoPoint`, but the inheritance is ` Autodesk.**Autocad**.DatabaseServices.Entity`. 
This means that the top level civil converter is not registering a converter correctly, since cogopoints inherit from autocad entities *not* civil entities and we have no top level entity converter in autocad.

This pr fixes the issue by introducing a top level  `CogoPoint` converter in civil and converting it as a `DataObject` just like all other civil objects. Includes the point name, number, and northing props.

sample model:  https://latest.speckle.systems/projects/2295cb26a0/models/46f44d5e4e

**note** @adamhathcock is making a fix for this on the sdk side to register converters based on the full type name. This was previously resulting in wrong exceptions, eg in this case the Civil Entity converter was successfully registered even though it shouldn't have been, because the inherited base type name (`Entity`) exists in both civil and autocad namespaces