### PR TITLE
Dimitrie/cnx 916 revit all conversions pass nothing fails 

### DIFF
--- a/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/SupportedCategoriesUtils.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/SupportedCategoriesUtils.cs
@@ -1,0 +1,21 @@
+using Autodesk.Revit.DB;
+
+namespace Speckle.Connectors.Revit.HostApp;
+
+public static class SupportedCategoriesUtils
+{
+  /// <summary>
+  /// Filters out all categories besides Model categories. This utility should be used
+  /// to clean any elements we might want to send pre-conversion as well as in what categories
+  /// to display in our category filter.
+  /// </summary>
+  /// <param name="category"></param>
+  /// <returns></returns>
+  public static bool IsSupportedCategory(Category category)
+  {
+    return (
+        category.CategoryType == CategoryType.Model
+      // || category.CategoryType == CategoryType.AnalyticalModel
+      ) && category.IsVisibleInUI;
+  }
+}

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/Filters/RevitCategoriesFilter.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/Filters/RevitCategoriesFilter.cs
@@ -2,6 +2,7 @@
 using Speckle.Connectors.DUI.Exceptions;
 using Speckle.Connectors.DUI.Models.Card.SendFilter;
 using Speckle.Connectors.DUI.Utils;
+using Speckle.Connectors.Revit.HostApp;
 using Speckle.Converters.RevitShared.Helpers;
 
 namespace Speckle.Connectors.RevitShared.Operations.Send.Filters;
@@ -69,7 +70,10 @@ public class RevitCategoriesFilter : DiscriminatedObject, ISendFilter, IRevitSen
 
     foreach (Category category in _doc.Settings.Categories)
     {
-      categories.Add(new CategoryData(category.Name, category.Id.ToString()));
+      if (SupportedCategoriesUtils.IsSupportedCategory(category))
+      {
+        categories.Add(new CategoryData(category.Name, category.Id.ToString()));
+      }
     }
 
     AvailableCategories = categories;

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/Filters/RevitViewsFilter.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/Filters/RevitViewsFilter.cs
@@ -88,6 +88,18 @@ public class RevitViewsFilter : DiscriminatedObject, ISendFilter, IRevitSendFilt
       .OfClass(typeof(View))
       .Cast<View>()
       .Where(v => !v.IsTemplate)
+      .Where(v => !v.IsModifiable || !v.IsAssemblyView)
+      .Where(v =>
+        v.ViewType
+          is ViewType.FloorPlan
+            or ViewType.Elevation
+            or ViewType.Rendering
+            or ViewType.Section
+            or ViewType.ThreeD
+            or ViewType.Detail
+            or ViewType.CeilingPlan
+            or ViewType.AreaPlan
+      )
       .Select(v => v.ViewType.ToString() + " - " + v.Name.ToString())
       .ToList();
     AvailableViews = views;

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/Filters/RevitViewsFilter.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/Filters/RevitViewsFilter.cs
@@ -88,7 +88,7 @@ public class RevitViewsFilter : DiscriminatedObject, ISendFilter, IRevitSendFilt
       .OfClass(typeof(View))
       .Cast<View>()
       .Where(v => !v.IsTemplate)
-      .Where(v => !v.IsModifiable || !v.IsAssemblyView)
+      .Where(v => !v.IsAssemblyView)
       .Where(v =>
         v.ViewType
           is ViewType.FloorPlan

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/RevitRootObjectBuilder.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/RevitRootObjectBuilder.cs
@@ -48,7 +48,7 @@ public class RevitRootObjectBuilder(
     rootObject["units"] = converterSettings.Current.SpeckleUnits;
 
     var revitElements = new List<Element>();
-
+    List<SendConversionResult> results = new(revitElements.Count);
     // Convert ids to actual revit elements
     foreach (var id in objects)
     {
@@ -65,6 +65,15 @@ public class RevitRootObjectBuilder(
 
       if (!SupportedCategoriesUtils.IsSupportedCategory(el.Category))
       {
+        results.Add(
+          new(
+            Status.WARNING,
+            el.UniqueId,
+            el.Category.Name,
+            null,
+            new SpeckleException($"Category {el.Category.Name} is not supported.")
+          )
+        );
         continue;
       }
 
@@ -75,8 +84,6 @@ public class RevitRootObjectBuilder(
     {
       throw new SpeckleSendFilterException("No objects were found. Please update your publish filter!");
     }
-
-    List<SendConversionResult> results = new(revitElements.Count);
 
     // Unpack groups (& other complex data structures)
     var atomicObjects = elementUnpacker.UnpackSelectionForConversion(revitElements).ToList();

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/RevitRootObjectBuilder.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/RevitRootObjectBuilder.cs
@@ -53,15 +53,27 @@ public class RevitRootObjectBuilder(
     foreach (var id in objects)
     {
       var el = converterSettings.Current.Document.GetElement(id);
-      if (el != null)
+      if (el == null)
       {
-        revitElements.Add(el);
+        continue;
       }
+
+      if (el.Category == null)
+      {
+        continue;
+      }
+
+      if (!SupportedCategoriesUtils.IsSupportedCategory(el.Category))
+      {
+        continue;
+      }
+
+      revitElements.Add(el);
     }
 
     if (revitElements.Count == 0)
     {
-      throw new SpeckleSendFilterException("No objects were found. Please update your send filter!");
+      throw new SpeckleSendFilterException("No objects were found. Please update your publish filter!");
     }
 
     List<SendConversionResult> results = new(revitElements.Count);

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Speckle.Connectors.RevitShared.projitems
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Speckle.Connectors.RevitShared.projitems
@@ -22,6 +22,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)HostApp\DocumentModelStorageSchema.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HostApp\Elements.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HostApp\RevitMaterialBaker.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)HostApp\SupportedCategoriesUtils.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Operations\Receive\HideWarningsFailuresPreprocessor.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HostApp\IdStorageSchema.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HostApp\IStorageSchema.cs" />

--- a/Converters/Revit/Speckle.Converters.RevitShared/ToSpeckle/TopLevel/RevitElementTopLevelConverterToSpeckle.cs
+++ b/Converters/Revit/Speckle.Converters.RevitShared/ToSpeckle/TopLevel/RevitElementTopLevelConverterToSpeckle.cs
@@ -73,7 +73,7 @@ public class ElementTopLevelConverterToSpeckle : IToSpeckleTopLevelConverter
 
     // get location if any
     Base? convertedLocation = null;
-    if (target.Location is DB.Location location) // location can be null
+    if (target.Location is DB.Location location and (DB.LocationCurve or DB.LocationPoint)) // location can be null
     {
       try
       {


### PR DESCRIPTION
A bundled set of fixes, related issues. 

1) Categories in the category filter are now down from ~300 to a more legitimate set of approx 120 that we have high confidence are meaningful - specifically model categories. 

2) We pre-filter elements out that do not make sense to convert anyway, based on the same rules of (1). This means **sending empty views does not succeed anymore**, which is legit. 

3) Pruned views to the ones that actually make sense, ignoring schedules and other view types. 

4) Fixed a performance regression introduced with the data object, whereby we'd be endlessly throwing for all elements with an unsupported location property - which can be numerous, eg. floors