### PR TITLE
Always run Main stuff on the revit message pump

### DIFF
--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Plugin/RevitThreadContext.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Plugin/RevitThreadContext.cs
@@ -13,4 +13,10 @@ public class RevitThreadContext : ThreadContext
   protected override Task<T> MainToWorker<T>(Func<T> action) => Task.FromResult(action());
 
   protected override Task<T> WorkerToMain<T>(Func<T> action) => RevitTask.RunAsync(action);
+
+  protected override Task RunMainAsync(Func<Task> action) =>  RevitTask.RunAsync(action);
+
+  protected override Task<T> RunMainAsync<T>(Func<T> action) =>  RevitTask.RunAsync(action);
+
+  protected override Task<T> RunMainAsync<T>(Func<Task<T>> action) => RevitTask.RunAsync(action);
 }

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Plugin/RevitThreadContext.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Plugin/RevitThreadContext.cs
@@ -14,9 +14,9 @@ public class RevitThreadContext : ThreadContext
 
   protected override Task<T> WorkerToMain<T>(Func<T> action) => RevitTask.RunAsync(action);
 
-  protected override Task RunMainAsync(Func<Task> action) =>  RevitTask.RunAsync(action);
+  protected override Task RunMainAsync(Func<Task> action) => RevitTask.RunAsync(action);
 
-  protected override Task<T> RunMainAsync<T>(Func<T> action) =>  RevitTask.RunAsync(action);
+  protected override Task<T> RunMainAsync<T>(Func<T> action) => RevitTask.RunAsync(action);
 
   protected override Task<T> RunMainAsync<T>(Func<Task<T>> action) => RevitTask.RunAsync(action);
 }

--- a/Sdk/Speckle.Connectors.Common/Threading/ThreadContext.cs
+++ b/Sdk/Speckle.Connectors.Common/Threading/ThreadContext.cs
@@ -14,7 +14,7 @@ public abstract class ThreadContext : IThreadContext
     {
       if (IsMainThread)
       {
-        action();
+        RunMain(action);
       }
       else
       {
@@ -37,7 +37,7 @@ public abstract class ThreadContext : IThreadContext
       }
       else
       {
-        action();
+        RunMain(action);
       }
     }
   }
@@ -48,7 +48,7 @@ public abstract class ThreadContext : IThreadContext
     {
       if (IsMainThread)
       {
-        return Task.FromResult(action());
+        return RunMainAsync(action);
       }
 
       return WorkerToMain(action);
@@ -58,7 +58,7 @@ public abstract class ThreadContext : IThreadContext
       return MainToWorker(action);
     }
 
-    return Task.FromResult(action());
+    return RunMainAsync(action);
   }
 
   public async Task RunOnThreadAsync(Func<Task> action, bool useMain)
@@ -67,7 +67,7 @@ public abstract class ThreadContext : IThreadContext
     {
       if (IsMainThread)
       {
-        await action();
+        await RunMainAsync(action);
       }
       else
       {
@@ -90,7 +90,7 @@ public abstract class ThreadContext : IThreadContext
       }
       else
       {
-        await action();
+        await RunMainAsync(action);
       }
     }
   }
@@ -101,7 +101,7 @@ public abstract class ThreadContext : IThreadContext
     {
       if (IsMainThread)
       {
-        return action();
+        return RunMainAsync(action);
       }
 
       return WorkerToMainAsync(action);
@@ -110,7 +110,7 @@ public abstract class ThreadContext : IThreadContext
     {
       return MainToWorkerAsync(action);
     }
-    return action();
+    return RunMainAsync(action);
   }
 
   protected abstract Task<T> WorkerToMainAsync<T>(Func<Task<T>> action);
@@ -119,4 +119,13 @@ public abstract class ThreadContext : IThreadContext
   protected abstract Task<T> WorkerToMain<T>(Func<T> action);
 
   protected abstract Task<T> MainToWorker<T>(Func<T> action);
+  
+  protected virtual void RunMain(Action action) => 
+    action();
+  protected virtual Task<T> RunMainAsync<T>(Func<T> action) => 
+    Task.FromResult(action());
+  protected virtual Task RunMainAsync(Func<Task> action) => 
+    Task.FromResult(action());
+  protected virtual Task<T> RunMainAsync<T>(Func<Task<T>> action) => 
+    action();
 }

--- a/Sdk/Speckle.Connectors.Common/Threading/ThreadContext.cs
+++ b/Sdk/Speckle.Connectors.Common/Threading/ThreadContext.cs
@@ -119,13 +119,12 @@ public abstract class ThreadContext : IThreadContext
   protected abstract Task<T> WorkerToMain<T>(Func<T> action);
 
   protected abstract Task<T> MainToWorker<T>(Func<T> action);
-  
-  protected virtual void RunMain(Action action) => 
-    action();
-  protected virtual Task<T> RunMainAsync<T>(Func<T> action) => 
-    Task.FromResult(action());
-  protected virtual Task RunMainAsync(Func<Task> action) => 
-    Task.FromResult(action());
-  protected virtual Task<T> RunMainAsync<T>(Func<Task<T>> action) => 
-    action();
+
+  protected virtual void RunMain(Action action) => action();
+
+  protected virtual Task<T> RunMainAsync<T>(Func<T> action) => Task.FromResult(action());
+
+  protected virtual Task RunMainAsync(Func<Task> action) => Task.FromResult(action());
+
+  protected virtual Task<T> RunMainAsync<T>(Func<Task<T>> action) => action();
 }


### PR DESCRIPTION
This fixes receive.   It also makes sense to ensure UI/Main thread access is always on the revit message pump