### PR TITLE
chore(navisworks): IRootObjectBuilder requires Build method

### DIFF
--- a/Connectors/Navisworks/Speckle.Connectors.NavisworksShared/Operations/Send/NavisworksRootObjectBuilder.cs
+++ b/Connectors/Navisworks/Speckle.Connectors.NavisworksShared/Operations/Send/NavisworksRootObjectBuilder.cs
@@ -189,4 +189,11 @@ public class NavisworksRootObjectBuilder(
       return new SendConversionResult(Status.ERROR, applicationId, "ModelItem", null, ex);
     }
   }
+
+  public RootObjectBuilderResult Build(
+    IReadOnlyList<NAV.ModelItem> objects,
+    SendInfo sendInfo,
+    IProgress<CardProgress> onOperationProgressed,
+    CancellationToken cancellationToken
+  ) => throw new NotImplementedException();
 }

--- a/Converters/Navisworks/Speckle.Converters.NavisworksShared/ToSpeckle/TopLevel/ModelItemTopLevelConverterToSpeckle.cs
+++ b/Converters/Navisworks/Speckle.Converters.NavisworksShared/ToSpeckle/TopLevel/ModelItemTopLevelConverterToSpeckle.cs
@@ -10,7 +10,7 @@ namespace Speckle.Converter.Navisworks.ToSpeckle;
 /// <summary>
 /// Converts Navisworks ModelItem objects to Speckle Base objects.
 /// </summary>
-[NameAndRankValue(typeof(NAV.ModelItem), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
+[NameAndRankValue(nameof(NAV.ModelItem), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
 public class ModelItemToToSpeckleConverter : IToSpeckleTopLevelConverter
 {
   private readonly StandardPropertyHandler _standardHandler;


### PR DESCRIPTION
prior to fix, `NavisworksRootObjectBuilder` only implemented `BuildAsync`

- Added a new method Build() to `NavisworksRootObjectBuilder` class

`[NameAndRankValue]` expects `string` prior to fix was using `typeof(Type)` which returned a type.
- Modified the attribute value in `ModelItemTopLevelConverterToSpeckle` class
