### PR TITLE
fix(Navisworks): CNX-895 - Add `ColorProxy` Support for 2D Linework

### DIFF
--- a/Connectors/Navisworks/Speckle.Connectors.NavisworksShared/DependencyInjection/NavisworksConnectorServiceRegistration.cs
+++ b/Connectors/Navisworks/Speckle.Connectors.NavisworksShared/DependencyInjection/NavisworksConnectorServiceRegistration.cs
@@ -51,6 +51,7 @@ public static class NavisworksConnectorServiceRegistration
     >();
 
     serviceCollection.AddScoped<NavisworksMaterialUnpacker>();
+    serviceCollection.AddScoped<NavisworksColorUnpacker>();
 
     // Sending operations
     serviceCollection.AddScoped<IRootObjectBuilder<NAV.ModelItem>, NavisworksRootObjectBuilder>();

--- a/Connectors/Navisworks/Speckle.Connectors.NavisworksShared/HostApp/NavisworksColorUnpacker.cs
+++ b/Connectors/Navisworks/Speckle.Connectors.NavisworksShared/HostApp/NavisworksColorUnpacker.cs
@@ -1,0 +1,3 @@
+﻿namespace Speckle.Connector.Navisworks.HostApp;
+
+public class NavisworksColorUnpacker { }

--- a/Connectors/Navisworks/Speckle.Connectors.NavisworksShared/HostApp/NavisworksColorUnpacker.cs
+++ b/Connectors/Navisworks/Speckle.Connectors.NavisworksShared/HostApp/NavisworksColorUnpacker.cs
@@ -1,3 +1,170 @@
-﻿namespace Speckle.Connector.Navisworks.HostApp;
+﻿using Microsoft.Extensions.Logging;
+using Speckle.Connector.Navisworks.Services;
+using Speckle.Converter.Navisworks.Helpers;
+using Speckle.Converter.Navisworks.Settings;
+using Speckle.Converters.Common;
+using Speckle.Sdk;
+using Speckle.Sdk.Models.Proxies;
+using ComApi = Autodesk.Navisworks.Api.Interop.ComApi;
+using ComBridge = Autodesk.Navisworks.Api.ComApi.ComApiBridge;
 
-public class NavisworksColorUnpacker { }
+namespace Speckle.Connector.Navisworks.HostApp;
+
+public class NavisworksColorUnpacker(
+  ILogger<NavisworksColorUnpacker> logger,
+  IConverterSettingsStore<NavisworksConversionSettings> converterSettings,
+  IElementSelectionService selectionService
+)
+{
+  private static T Select<T>(RepresentationMode mode, T active, T permanent, T original, T defaultValue) =>
+    mode switch
+    {
+      RepresentationMode.Active => active,
+      RepresentationMode.Permanent => permanent,
+      RepresentationMode.Original => original,
+      _ => defaultValue,
+    };
+
+  internal List<ColorProxy> UnpackColor(
+    IReadOnlyList<NAV.ModelItem> navisworksObjects,
+    Dictionary<string, List<NAV.ModelItem>> groupedNodes
+  )
+  {
+    if (navisworksObjects == null)
+    {
+      throw new ArgumentNullException(nameof(navisworksObjects));
+    }
+
+    if (groupedNodes == null)
+    {
+      throw new ArgumentNullException(nameof(groupedNodes));
+    }
+
+    Dictionary<string, ColorProxy> colorProxies = [];
+    Dictionary<string, string> mergedIds = [];
+
+    // Build mergedIds map once
+    foreach (var group in groupedNodes)
+    {
+      foreach (var node in group.Value)
+      {
+        mergedIds[selectionService.GetModelItemPath(node)] = group.Key;
+      }
+    }
+
+    foreach (NAV.ModelItem navisworksObject in navisworksObjects)
+    {
+      try
+      {
+        // Skip non-2D elements
+        if (!Is2DElement(navisworksObject))
+        {
+          continue;
+        }
+
+        var navisworksObjectId = selectionService.GetModelItemPath(navisworksObject);
+        var finalId = mergedIds.TryGetValue(navisworksObjectId, out var mergedId) ? mergedId : navisworksObjectId;
+
+        var geometry = navisworksObject.Geometry;
+        var mode = converterSettings.Current.User.VisualRepresentationMode;
+
+        using var defaultColor = new NAV.Color(1.0, 1.0, 1.0);
+
+        var representationColor = Select(
+          mode,
+          geometry.ActiveColor,
+          geometry.PermanentColor,
+          geometry.OriginalColor,
+          defaultColor
+        );
+
+        var colorId = Select(
+          mode,
+          $"{geometry.ActiveColor.GetHashCode()}_{geometry.ActiveTransparency}".GetHashCode(),
+          $"{geometry.PermanentColor.GetHashCode()}_{geometry.PermanentTransparency}".GetHashCode(),
+          $"{geometry.OriginalColor.GetHashCode()}_{geometry.OriginalTransparency}".GetHashCode(),
+          0
+        );
+
+        var colorName = ColorConverter.NavisworksColorToColor(representationColor).Name;
+
+        if (colorProxies.TryGetValue(colorId.ToString(), out ColorProxy? colorProxy))
+        {
+          colorProxy.objects.Add(finalId);
+        }
+        else
+        {
+          colorProxies[colorId.ToString()] = new ColorProxy
+          {
+            value = ColorConverter.NavisworksColorToColor(representationColor).ToArgb(),
+            name = colorName,
+            applicationId = colorId.ToString(),
+            objects = [finalId]
+          };
+        }
+      }
+      catch (Exception ex) when (!ex.IsFatal())
+      {
+        logger.LogError(ex, "Failed to unpack color for Navisworks object");
+      }
+    }
+
+    return colorProxies.Values.ToList();
+  }
+
+  private static bool Is2DElement(NAV.ModelItem modelItem)
+  {
+    if (!modelItem.HasGeometry)
+    {
+      return false;
+    }
+
+    var primitiveChecker = new PrimitiveChecker();
+
+    var comSelection = ComBridge.ToInwOpSelection([modelItem]);
+    try
+    {
+      foreach (ComApi.InwOaPath path in comSelection.Paths())
+      {
+        GC.KeepAlive(path);
+
+        foreach (ComApi.InwOaFragment3 fragment in path.Fragments())
+        {
+          GC.KeepAlive(fragment);
+
+          fragment.GenerateSimplePrimitives(ComApi.nwEVertexProperty.eNORMAL, primitiveChecker);
+
+          // Exit early if triangles are found
+          if (primitiveChecker.HasTriangles)
+          {
+            return false;
+          }
+        }
+      }
+
+      // Return true if any 2D primitives are found
+      return primitiveChecker.HasLines || primitiveChecker.HasPoints || primitiveChecker.HasSnapPoints;
+    }
+    finally
+    {
+      System.Runtime.InteropServices.Marshal.ReleaseComObject(comSelection);
+    }
+  }
+}
+
+public class PrimitiveChecker : ComApi.InwSimplePrimitivesCB
+{
+  public bool HasTriangles { get; private set; }
+  public bool HasLines { get; private set; }
+  public bool HasPoints { get; private set; }
+  public bool HasSnapPoints { get; private set; }
+
+  public void Line(ComApi.InwSimpleVertex v1, ComApi.InwSimpleVertex v2) => HasLines = true;
+
+  public void Point(ComApi.InwSimpleVertex v1) => HasPoints = true;
+
+  public void SnapPoint(ComApi.InwSimpleVertex v1) => HasSnapPoints = true;
+
+  public void Triangle(ComApi.InwSimpleVertex v1, ComApi.InwSimpleVertex v2, ComApi.InwSimpleVertex v3) =>
+    HasTriangles = true;
+}

--- a/Connectors/Navisworks/Speckle.Connectors.NavisworksShared/HostApp/NavisworksMaterialUnpacker.cs
+++ b/Connectors/Navisworks/Speckle.Connectors.NavisworksShared/HostApp/NavisworksMaterialUnpacker.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.Logging;
 using Speckle.Connector.Navisworks.Services;
+using Speckle.Converter.Navisworks.Helpers;
 using Speckle.Converter.Navisworks.Settings;
 using Speckle.Converters.Common;
 using Speckle.Objects.Other;
@@ -92,7 +93,8 @@ public class NavisworksMaterialUnpacker(
           0
         );
 
-        var materialName = $"NavisworksMaterial_{Math.Abs(NavisworksColorToColor(renderColor).ToArgb())}";
+        var materialName =
+          $"NavisworksMaterial_{Math.Abs(ColorConverter.NavisworksColorToColor(renderColor).ToArgb())}";
 
         // Check Item category for material name
         var itemCategory = navisworksObject.PropertyCategories.FindCategoryByDisplayName("Item");
@@ -152,7 +154,7 @@ public class NavisworksMaterialUnpacker(
     int applicationId
   )
   {
-    var color = NavisworksColorToColor(navisworksColor);
+    var color = ColorConverter.NavisworksColorToColor(navisworksColor);
 
     var speckleRenderMaterial = new RenderMaterial()
     {
@@ -167,12 +169,4 @@ public class NavisworksMaterialUnpacker(
 
     return speckleRenderMaterial;
   }
-
-  private static System.Drawing.Color NavisworksColorToColor(NAV.Color color) =>
-    System.Drawing.Color.FromArgb(
-      alpha: 255,
-      red: Convert.ToInt32(color.R * 255),
-      green: Convert.ToInt32(color.G * 255),
-      blue: Convert.ToInt32(color.B * 255)
-    );
 }

--- a/Connectors/Navisworks/Speckle.Connectors.NavisworksShared/Operations/Send/NavisworksRootObjectBuilder.cs
+++ b/Connectors/Navisworks/Speckle.Connectors.NavisworksShared/Operations/Send/NavisworksRootObjectBuilder.cs
@@ -1,4 +1,4 @@
-using Microsoft.Extensions.Logging;
+﻿using Microsoft.Extensions.Logging;
 using Speckle.Connector.Navisworks.HostApp;
 using Speckle.Connector.Navisworks.Services;
 using Speckle.Connectors.Common.Builders;
@@ -31,6 +31,15 @@ public class NavisworksRootObjectBuilder(
 
   internal NavisworksConversionSettings GetCurrentSettings() => converterSettings.Current;
 
+  /// <summary>
+  /// Asynchronously builds a Speckle object hierarchy from Navisworks model items.
+  /// </summary>
+  /// <param name="navisworksModelItems">The list of Navisworks items to convert.</param>
+  /// <param name="sendInfo">Information about the send operation.</param>
+  /// <param name="onOperationProgressed">Progress reporting callback.</param>
+  /// <param name="cancellationToken">Token to cancel the operation.</param>
+  /// <returns>A result containing the root collection and conversion results.</returns>
+  /// <exception cref="SpeckleException">Thrown when no objects can be converted.</exception>
   public async Task<RootObjectBuilderResult> BuildAsync(
     IReadOnlyList<NAV.ModelItem> navisworksModelItems,
     SendInfo sendInfo,
@@ -44,34 +53,70 @@ public class NavisworksRootObjectBuilder(
 #endif
     using var activity = activityFactory.Start("Build");
 
-    // 1. Validate input
+    ValidateInputs(navisworksModelItems, sendInfo, onOperationProgressed);
+
+    // 2. Initialize root collection
+    var rootCollection = InitializeRootCollection();
+
+    // 3. Convert all model items and store results
+    var (convertedElements, conversionResults) = await ConvertModelItemsAsync(
+      navisworksModelItems,
+      sendInfo,
+      onOperationProgressed,
+      cancellationToken
+    );
+
+    ValidateConversionResults(conversionResults);
+
+    var groupedNodes = SkipNodeMerging ? [] : GroupSiblingGeometryNodes(navisworksModelItems);
+    var finalElements = BuildFinalElements(convertedElements, groupedNodes);
+
+    await AddProxiesToCollection(rootCollection, navisworksModelItems, groupedNodes);
+
+    rootCollection.elements = finalElements;
+    return new RootObjectBuilderResult(rootCollection, conversionResults);
+  }
+
+  private static void ValidateInputs(
+    IReadOnlyList<NAV.ModelItem> navisworksModelItems,
+    SendInfo sendInfo,
+    IProgress<CardProgress> onOperationProgressed
+  )
+  {
     if (!navisworksModelItems.Any())
     {
       throw new SpeckleException("No objects to convert");
     }
 
-    // 2. Initialize root collection
-    var rootObjectCollection = new Collection
-    {
-      name = NavisworksApp.ActiveDocument.Title ?? "Unnamed model",
-      ["units"] = converterSettings.Current.Derived.SpeckleUnits
-    };
-
-    // 3. Convert all model items and store results
     if (navisworksModelItems == null)
     {
       throw new ArgumentNullException(nameof(navisworksModelItems));
     }
 
-    List<SendConversionResult> results = new(navisworksModelItems.Count);
+    if (onOperationProgressed == null || sendInfo == null)
+    {
+      throw new ArgumentNullException(onOperationProgressed == null ? nameof(onOperationProgressed) : nameof(sendInfo));
+    }
+  }
+
+  private Collection InitializeRootCollection() =>
+    new()
+    {
+      name = NavisworksApp.ActiveDocument.Title ?? "Unnamed model",
+      ["units"] = converterSettings.Current.Derived.SpeckleUnits
+    };
+
+  private Task<(Dictionary<string, Base?> converted, List<SendConversionResult> results)> ConvertModelItemsAsync(
+    IReadOnlyList<NAV.ModelItem> navisworksModelItems,
+    SendInfo sendInfo,
+    IProgress<CardProgress> onOperationProgressed,
+    CancellationToken cancellationToken
+  )
+  {
+    var results = new List<SendConversionResult>(navisworksModelItems.Count);
     var convertedBases = new Dictionary<string, Base?>();
     int processedCount = 0;
     int totalCount = navisworksModelItems.Count;
-
-    if (onOperationProgressed == null || sendInfo == null)
-    {
-      throw new ArgumentNullException(nameof(onOperationProgressed));
-    }
 
     foreach (var item in navisworksModelItems)
     {
@@ -80,91 +125,145 @@ public class NavisworksRootObjectBuilder(
       results.Add(converted);
       processedCount++;
       onOperationProgressed.Report(new CardProgress("Converting", (double)processedCount / totalCount));
-      await Task.Yield();
     }
 
+    return Task.FromResult((convertedBases, results));
+  }
+
+  private static void ValidateConversionResults(List<SendConversionResult> results)
+  {
     if (results.All(x => x.Status == Status.ERROR))
     {
-      throw new SpeckleException("Failed to convert all objects."); // fail fast instead creating empty commit! It will appear as model card error with red color.
+      throw new SpeckleException("Failed to convert all objects.");
     }
+  }
 
-    // 4. Initialize final elements list and group nodes
+  private List<Base> BuildFinalElements(
+    Dictionary<string, Base?> convertedBases,
+    Dictionary<string, List<NAV.ModelItem>> groupedNodes
+  )
+  {
     var finalElements = new List<Base>();
-    var groupedNodes = SkipNodeMerging ? [] : GroupSiblingGeometryNodes(navisworksModelItems);
     var processedPaths = new HashSet<string>();
 
-    // 5. Process and merge grouped nodes
+    AddGroupedElements(finalElements, convertedBases, groupedNodes, processedPaths);
+    AddRemainingElements(finalElements, convertedBases, processedPaths);
+
+    return finalElements;
+  }
+
+  private void AddGroupedElements(
+    List<Base> finalElements,
+    Dictionary<string, Base?> convertedBases,
+    Dictionary<string, List<NAV.ModelItem>> groupedNodes,
+    HashSet<string> processedPaths
+  )
+  {
     foreach (var group in groupedNodes)
     {
       var siblingBases = new List<Base>();
       foreach (var itemPath in group.Value.Select(elementSelectionService.GetModelItemPath))
       {
         processedPaths.Add(itemPath);
-
         if (convertedBases.TryGetValue(itemPath, out var convertedBase) && convertedBase != null)
         {
           siblingBases.Add(convertedBase);
         }
       }
 
-      if (siblingBases.Count == 0)
+      if (siblingBases.Count > 0)
       {
-        continue;
-      }
-
-      var navisworksObject = new NavisworksObject
-      {
-        name = elementSelectionService.GetModelItemFromPath(group.Key).DisplayName ?? string.Empty,
-        displayValue = siblingBases.SelectMany(b => b["displayValue"] as List<Base> ?? []).ToList(),
-        properties = siblingBases.First()["properties"] as Dictionary<string, object?> ?? [],
-        units = converterSettings.Current.Derived.SpeckleUnits,
-        applicationId = group.Key
-      };
-
-      finalElements.Add(navisworksObject);
-    }
-
-    // 6. Add remaining non-grouped nodes
-    foreach (var result in results.Where(result => !processedPaths.Contains(result.SourceId)))
-    {
-      if (!convertedBases.TryGetValue(result.SourceId, out var convertedBase) || convertedBase == null)
-      {
-        continue;
-      }
-      // TODO: check if converted base is a collection when full tree sending is implemented
-
-      if (convertedBase is Collection convertedCollection)
-      {
-        finalElements.Add(convertedCollection);
-      }
-      else
-      {
-        var navisworksObject = new NavisworksObject
-        {
-          name = convertedBase["name"] as string ?? string.Empty,
-          displayValue = convertedBase["displayValue"] as List<Base> ?? [],
-          properties = convertedBase["properties"] as Dictionary<string, object?> ?? [],
-          units = converterSettings.Current.Derived.SpeckleUnits,
-          applicationId = convertedBase.applicationId
-        };
-        finalElements.Add(navisworksObject);
+        finalElements.Add(CreateNavisworksObject(group.Key, siblingBases));
       }
     }
-
-    using (var _ = activityFactory.Start("UnpackRenderMaterials"))
-    {
-      // 7.  - Unpack the render material proxies
-      rootObjectCollection[ProxyKeys.RENDER_MATERIAL] = materialUnpacker.UnpackRenderMaterial(
-        navisworksModelItems,
-        groupedNodes
-      );
-    }
-
-    // 8. Finalize and return
-    rootObjectCollection.elements = finalElements;
-    return new RootObjectBuilderResult(rootObjectCollection, results);
   }
 
+  private void AddRemainingElements(
+    List<Base> finalElements,
+    Dictionary<string, Base?> convertedBases,
+    HashSet<string> processedPaths
+  )
+  {
+    foreach (var kvp in convertedBases.Where(kvp => !processedPaths.Contains(kvp.Key)))
+    {
+      switch (kvp.Value)
+      {
+        case null:
+          continue;
+        case Collection collection:
+          finalElements.Add(collection);
+          break;
+        default:
+          finalElements.Add(CreateNavisworksObject(kvp.Value));
+          break;
+      }
+    }
+  }
+
+  /// <summary>
+  /// Processes and adds any remaining non-grouped elements.
+  /// </summary>
+  /// <remarks>
+  /// Handles both Collection and Base type elements differently.
+  /// Only processes elements that weren't handled in grouped processing.
+  /// </remarks>
+  private NavisworksObject CreateNavisworksObject(string groupKey, List<Base> siblingBases) =>
+    new()
+    {
+      name = elementSelectionService.GetModelItemFromPath(groupKey).DisplayName ?? string.Empty,
+      displayValue = siblingBases.SelectMany(b => b["displayValue"] as List<Base> ?? []).ToList(),
+      properties = siblingBases.First()["properties"] as Dictionary<string, object?> ?? [],
+      units = converterSettings.Current.Derived.SpeckleUnits,
+      applicationId = groupKey
+    };
+
+  /// <summary>
+  /// Creates a NavisworksObject from a single converted base.
+  /// </summary>
+  /// <param name="convertedBase">The converted Speckle Base object.</param>
+  /// <returns>A new NavisworksObject containing the converted data.</returns>
+  private NavisworksObject CreateNavisworksObject(Base convertedBase) =>
+    new()
+    {
+      name = convertedBase["name"] as string ?? string.Empty,
+      displayValue = convertedBase["displayValue"] as List<Base> ?? [],
+      properties = convertedBase["properties"] as Dictionary<string, object?> ?? [],
+      units = converterSettings.Current.Derived.SpeckleUnits,
+      applicationId = convertedBase.applicationId
+    };
+
+  private Task AddProxiesToCollection(
+    Collection rootCollection,
+    IReadOnlyList<NAV.ModelItem> navisworksModelItems,
+    Dictionary<string, List<NAV.ModelItem>> groupedNodes
+  )
+  {
+    using var _ = activityFactory.Start("UnpackProxies");
+
+    var renderMaterials = materialUnpacker.UnpackRenderMaterial(navisworksModelItems, groupedNodes);
+    if (renderMaterials.Count > 0)
+    {
+      rootCollection[ProxyKeys.RENDER_MATERIAL] = renderMaterials;
+    }
+
+    var colors = colorUnpacker.UnpackColor(navisworksModelItems, groupedNodes);
+    if (colors.Count > 0)
+    {
+      rootCollection[ProxyKeys.COLOR] = colors;
+    }
+
+    return Task.CompletedTask;
+  }
+
+  /// <summary>
+  /// Converts a single Navisworks item to a Speckle object.
+  /// </summary>
+  /// <remarks>
+  /// Attempts to retrieve from cache first.
+  /// Falls back to fresh conversion if not cached.
+  /// Logs errors but doesn't throw exceptions.
+  /// </remarks>
+  /// <returns>A SendConversionResult indicating success or failure.</returns>
   private SendConversionResult ConvertNavisworksItem(
     NAV.ModelItem navisworksItem,
     Dictionary<string, Base?> convertedBases,

--- a/Connectors/Navisworks/Speckle.Connectors.NavisworksShared/Operations/Send/NavisworksRootObjectBuilder.cs
+++ b/Connectors/Navisworks/Speckle.Connectors.NavisworksShared/Operations/Send/NavisworksRootObjectBuilder.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging;
 using Speckle.Connector.Navisworks.HostApp;
 using Speckle.Connector.Navisworks.Services;
 using Speckle.Connectors.Common.Builders;
@@ -23,6 +23,7 @@ public class NavisworksRootObjectBuilder(
   ILogger<NavisworksRootObjectBuilder> logger,
   ISdkActivityFactory activityFactory,
   NavisworksMaterialUnpacker materialUnpacker,
+  NavisworksColorUnpacker colorUnpacker,
   IElementSelectionService elementSelectionService
 ) : IRootObjectBuilder<NAV.ModelItem>
 {

--- a/Connectors/Navisworks/Speckle.Connectors.NavisworksShared/Speckle.Connectors.NavisworksShared.projitems
+++ b/Connectors/Navisworks/Speckle.Connectors.NavisworksShared/Speckle.Connectors.NavisworksShared.projitems
@@ -15,6 +15,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)DependencyInjection\NavisworksConnectorServiceRegistration.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\ElementSelectionService.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)GlobalUsing.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)HostApp\NavisworksColorUnpacker.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HostApp\NavisworksDocumentEvents.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HostApp\NavisworksDocumentModelStore.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HostApp\NavisworksIdleManager.cs" />

--- a/Converters/Navisworks/Speckle.Converters.NavisworksShared/Helpers/ColorConverter.cs
+++ b/Converters/Navisworks/Speckle.Converters.NavisworksShared/Helpers/ColorConverter.cs
@@ -1,0 +1,56 @@
+﻿using Convert = System.Convert;
+using Sys = System.Drawing;
+
+namespace Speckle.Converter.Navisworks.Helpers;
+
+public static class ColorConverter
+{
+  /// <summary>
+  /// Converts a Navisworks color to a System.Drawing.Color.
+  /// </summary>
+  /// <param name="color">The Navisworks color to convert</param>
+  /// <param name="transparency">Optional transparency value (0.0 to 1.0)</param>
+  /// <returns>A System.Drawing.Color with the converted values</returns>
+  public static Sys.Color NavisworksColorToColor(NAV.Color color, double? transparency = null)
+  {
+    var alpha = transparency.HasValue ? Convert.ToInt32((1.0 - transparency.Value) * 255) : 255;
+
+    return Sys.Color.FromArgb(
+      alpha: alpha,
+      red: Convert.ToInt32(color.R * 255),
+      green: Convert.ToInt32(color.G * 255),
+      blue: Convert.ToInt32(color.B * 255)
+    );
+  }
+
+  /// <summary>
+  /// Converts RGB values to a color hash string.
+  /// </summary>
+  /// <param name="color">The Navisworks color</param>
+  /// <param name="transparency">Optional transparency value</param>
+  /// <returns>A unique hash string for the color</returns>
+  public static string GetColorHash(NAV.Color color, double? transparency = null)
+  {
+    var rgbValues =
+      Convert.ToInt32(color.R * 255) << 16 | Convert.ToInt32(color.G * 255) << 8 | Convert.ToInt32(color.B * 255);
+
+    if (!transparency.HasValue)
+    {
+      return rgbValues.ToString();
+    }
+
+    var alpha = Convert.ToInt32((1.0 - transparency.Value) * 255);
+    return $"{rgbValues}_{alpha}";
+  }
+
+  /// <summary>
+  /// Gets a human-readable color name.
+  /// </summary>
+  /// <param name="color">The Navisworks color to name</param>
+  /// <returns>A descriptive name for the color</returns>
+  public static string GetColorName(NAV.Color color)
+  {
+    var converted = NavisworksColorToColor(color);
+    return converted.IsKnownColor ? converted.Name : $"Custom_{converted.ToArgb():X8}";
+  }
+}

--- a/Converters/Navisworks/Speckle.Converters.NavisworksShared/Speckle.Converters.NavisworksShared.projitems
+++ b/Converters/Navisworks/Speckle.Converters.NavisworksShared/Speckle.Converters.NavisworksShared.projitems
@@ -21,6 +21,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\ArrayExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Geometries\Primitives.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Geometries\TransformMatrix.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Helpers\ColorConverter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Helpers\ElementSelectionHelper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Helpers\PrimitiveProcessor.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Helpers\PropertyHelpers.cs" />


### PR DESCRIPTION
Currently, all geometry in the Navisworks connector uses RenderMaterialProxies for colour representation. This causes 2D linework to appear uncoloured as it requires ColorProxies instead. This PR adds proper ColorProxy support for 2D elements while maintaining RenderMaterialProxy handling for 3D geometry.

### Changes
- Add new `ColorProxy` handling for 2D linework
- New simplistic `ComApI.InwSimplePrimitivesCB` callback for primitive type detection
- Implement proxy type detection based on geometry type
- Update root object builder to support both proxy types

- Additionally, refactors `BuildAsync` to reduce complexity and clear method steps

## Source

![image](https://github.com/user-attachments/assets/c5b4f701-3a91-4d3c-a0dc-aa30fcea560d)

## Before

![Screenshot 2025-01-13 233327](https://github.com/user-attachments/assets/2ed2f611-410a-4e36-a6b7-47549c18339f)


## After

![Screenshot 2025-01-13 233144](https://github.com/user-attachments/assets/f081bce9-f961-4700-9ea9-e700bcc09006)

