### PR TITLE
fix(civil3d): handles property exceptions for corridor elements

### DIFF
--- a/Converters/Civil3d/Speckle.Converters.Civil3dShared/Helpers/CorridorDisplayValueExtractor.cs
+++ b/Converters/Civil3d/Speckle.Converters.Civil3dShared/Helpers/CorridorDisplayValueExtractor.cs
@@ -94,6 +94,11 @@ public sealed class CorridorDisplayValueExtractor
     {
       foreach (ADB.ObjectId solidId in corridor.ExportSolids(param, corridor.Database))
       {
+        if (solidId.IsNull) // unclear why this happens
+        {
+          continue;
+        }
+
         SOG.Mesh? mesh = null;
         var solid = tr.GetObject(solidId, ADB.OpenMode.ForRead);
         if (solid is ADB.Solid3d solid3d)

--- a/Converters/Civil3d/Speckle.Converters.Civil3dShared/ToSpeckle/Properties/GeneralPropertiesExtractor.cs
+++ b/Converters/Civil3d/Speckle.Converters.Civil3dShared/ToSpeckle/Properties/GeneralPropertiesExtractor.cs
@@ -316,8 +316,10 @@ public class GeneralPropertiesExtractor
     {
       try
       {
+        // accessing "OffsetAlignmentInfo" on offset alignments will sometimes throw /shrug.
+        // this happens when an offset alignment is unlinked from the parent and the CreateMode is still set to "ManuallyCreation"
+        // https://help.autodesk.com/view/CIV3D/2024/ENU/?guid=2ecbe421-4c08-cbde-d078-56a9f03b93f9
         var offsetInfo = alignment.OffsetAlignmentInfo;
-
         generalPropertiesDict["Offset Parameters"] = new Dictionary<string, object?>
         {
           ["side"] = offsetInfo.Side.ToString(),
@@ -325,7 +327,7 @@ public class GeneralPropertiesExtractor
           ["nominalOffset"] = offsetInfo.NominalOffset
         };
       }
-      catch (InvalidOperationException) { } // accessing "OffsetAlignmentInfo" will sometimes throw even for offset alignments /shrug. do nothing
+      catch (InvalidOperationException) { } // do nothing
     }
 
     return generalPropertiesDict;


### PR DESCRIPTION
## Description & motivation

Fixes a community-submitted bug for baseline points on corridors that throw due to accessing an offset from baseline property. This pr will omit the `offset` property from any point which throws when accessing it.

Also fixes a similar bug in offset alignments, that will throw when accessing `offset` properties, and now skips null corridor solid ids when extracting displayvalues.

Fixes https://github.com/specklesystems/speckle-sharp-connectors/issues/506
Fixes https://github.com/specklesystems/speckle-sharp-connectors/issues/507

## Changes:

- Civil3d converter

## Screenshots:

before: 
![image](https://github.com/user-attachments/assets/7b31af57-9b92-4b06-85b1-574b2f422888)

after:
![{D0C2E1C4-78E7-4438-9531-7366926EA7BB}](https://github.com/user-attachments/assets/6d93a0c7-0995-485f-b21b-dbb2edfbd998)

full model with offset alignment:
https://latest.speckle.systems/projects/3f895e614f/models/1737754fb4

corridor with the baseline in the viewer: https://latest.speckle.systems/projects/3f895e614f/models/8c1d9068c3fffc232512c87086dcb369

## Validation of changes:

Confirmed with the provided test file
