### PR TITLE
chore(civil3d): add comment for featureline display values

### DIFF
--- a/Converters/Civil3d/Speckle.Converters.Civil3dShared/Helpers/DisplayValueExtractor.cs
+++ b/Converters/Civil3d/Speckle.Converters.Civil3dShared/Helpers/DisplayValueExtractor.cs
@@ -36,6 +36,11 @@ public sealed class DisplayValueExtractor
   {
     switch (entity)
     {
+      // POC: we are sending featurelines as approximated polylines because they are 2.5d curves:
+      // they can have line or arc segments, and each vertex can have different elevations.
+      // there is no native type that can capture the full 3d representation of these curves.
+      // if this becomes essential, can explore a hack where each point is converted to 2d, and separate line/arc segments are calculated, and then their points readjusted with 3d z values
+      // SurveyFigures inherit from featureline
       case CDB.FeatureLine featureline:
         SOG.Polyline featurelinePolyline = _pointCollectionConverter.Convert(
           featureline.GetPoints(Autodesk.Civil.FeatureLinePointType.PIPoint)


### PR DESCRIPTION
Just adds a simple POC comment to featureline display value conversion.

Featurelines are 2.5d curves: they can have line or arc segments, and different elevations at each vertex.
There is no native way to retrieve the full 3d accurate representation of a featureline, so currently we are sending them as 3d polylines with line segments only.

Adding comment for context in case future bug reports happen due to polyline representation of polycurve featurelines.