### PR TITLE
This is a workaround for Revit's order of operations when initializing

### DIFF
--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Plugin/RevitCefPlugin.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Plugin/RevitCefPlugin.cs
@@ -11,6 +11,7 @@ using Revit.Async;
 using Speckle.Connectors.Common;
 using Speckle.Connectors.DUI.Bindings;
 using Speckle.Connectors.DUI.Bridge;
+using Speckle.Connectors.DUI.Models;
 using Speckle.Converters.RevitShared.Helpers;
 using Speckle.Sdk;
 
@@ -99,13 +100,17 @@ internal sealed class RevitCefPlugin : IRevitPlugin
     dui3Button.SetContextualHelp(new ContextualHelp(ContextualHelpType.Url, "https://speckle.systems"));
   }
 
-  private void OnApplicationInitialized(object? sender, Autodesk.Revit.DB.Events.ApplicationInitializedEventArgs e)
+  private async void OnApplicationInitialized(
+    object? sender,
+    Autodesk.Revit.DB.Events.ApplicationInitializedEventArgs e
+  )
   {
     var uiApplication = new UIApplication(sender as Application);
     _revitContext.UIApplication = uiApplication;
 
     // POC: might be worth to interface this out, we shall see...
     RevitTask.Initialize(uiApplication);
+    await _serviceProvider.GetRequiredService<DocumentModelStore>().OnDocumentStoreInitialized();
 
     PostApplicationInit(); // for double-click file open
   }

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Plugin/RevitExternalApplication.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Plugin/RevitExternalApplication.cs
@@ -48,7 +48,7 @@ internal sealed class RevitExternalApplication : IExternalApplication
       services.AddRevitConverters();
       services.AddSingleton(application);
       _container = services.BuildServiceProvider();
-      _container.UseDUI();
+      _container.UseDUI(true);
 
       // resolve root object
       _revitPlugin = _container.GetRequiredService<IRevitPlugin>();

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/Bindings/RhinoSendBinding.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/Bindings/RhinoSendBinding.cs
@@ -120,7 +120,7 @@ public sealed class RhinoSendBinding : ISendBinding
 
     // NOTE: BE CAREFUL handling things in this event handler since it is triggered whenever we save something into file!
     eventAggregator
-      .GetEvent<ActiveDocumentChanged>()
+      .GetEvent<DocumentPropertiesChanged>()
       .Subscribe(async e =>
       {
         var newUnit = e.Document.ModelUnitSystem;

--- a/DUI3/Speckle.Connectors.DUI/ContainerRegistration.cs
+++ b/DUI3/Speckle.Connectors.DUI/ContainerRegistration.cs
@@ -51,7 +51,7 @@ public static class ContainerRegistration
     return serviceCollection;
   }
 
-  public static IServiceProvider UseDUI(this IServiceProvider serviceProvider)
+  public static IServiceProvider UseDUI(this IServiceProvider serviceProvider, bool isRevit = false)
   {
     //observe the unobserved!
     TaskScheduler.UnobservedTaskException += async (_, args) =>
@@ -64,7 +64,11 @@ public static class ContainerRegistration
       args.SetObserved();
     };
 
-    serviceProvider.GetRequiredService<DocumentModelStore>().OnDocumentStoreInitialized().Wait();
+    if (!isRevit)
+    {
+      serviceProvider.GetRequiredService<DocumentModelStore>().OnDocumentStoreInitialized().Wait();
+    }
+
     return serviceProvider;
   }
 }


### PR DESCRIPTION
This will be redone in a fast follow PR focusing on Revit properly using the Event Aggregator