### PR TITLE
bjorn/cnx-1118-model-cards-and-opening-multiple-files-from-the-same-folder

### DIFF
--- a/Connectors/CSi/Speckle.Connectors.CSiShared/HostApp/CsiDocumentModelStore.cs
+++ b/Connectors/CSi/Speckle.Connectors.CSiShared/HostApp/CsiDocumentModelStore.cs
@@ -137,6 +137,7 @@ public class CsiDocumentModelStore : DocumentModelStore, IDisposable
 
     if (disposing)
     {
+      _modelCheckTimer.Stop();
       _modelCheckTimer.Dispose();
     }
 

--- a/Connectors/CSi/Speckle.Connectors.CSiShared/Plugin/SpeckleFormBase.cs
+++ b/Connectors/CSi/Speckle.Connectors.CSiShared/Plugin/SpeckleFormBase.cs
@@ -16,6 +16,7 @@ public abstract class SpeckleFormBase : Form, ICsiApplicationService
 {
   private ElementHost Host { get; set; }
   private cPluginCallback _pluginCallback;
+  private bool _disposed;
 #pragma warning disable CA2213
   private ServiceProvider _container;
 #pragma warning restore CA2213
@@ -82,4 +83,18 @@ public abstract class SpeckleFormBase : Form, ICsiApplicationService
   }
 
   private void Form1Closing(object? sender, FormClosingEventArgs e) => _pluginCallback.Finish(0);
+
+  protected override void Dispose(bool disposing)
+  {
+    if (!_disposed)
+    {
+      if (disposing)
+      {
+        _container.Dispose();
+        Host.Dispose();
+        base.Dispose(disposing);
+      }
+      _disposed = true;
+    }
+  }
 }


### PR DESCRIPTION
## Description & motivation

- Related to [CNX-1111](https://linear.app/speckle/issue/CNX-1111/switching-documents-does-not-invalidate-active-connector-session)
- Gremlin crept in:
  - Open a model in Etabs and load the plugin
  - Close the plugin
  - Open a different model in Etabs
  - **Etabs freezes and closes**
- Problem: `SpeckleFormBase.cs` not being disposed properly (?)

## Changes:

- `override void Dispose` in `SpeckleFormBase.cs`
- `_modelCheckTimer.Stop()` in `CsiDocumentModelStore` before `_modelCheckTimer.Dispose();`

## To-do before merge:

- Thumbs up from @JR-Morgan or @adamhathcock 


## Validation of changes:

- Testing switching between various models (both myself and @bimgeek). 

## Checklist:

- [x] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [x] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] My code follows a similar style to existing code.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.
