### PR TITLE
bjorn/cnx-1133-user-facing-attributes-not-consistent-for-joints

### DIFF
--- a/Connectors/CSi/Speckle.Connectors.ETABSShared/HostApp/EtabsSendCollectionManager.cs
+++ b/Connectors/CSi/Speckle.Connectors.ETABSShared/HostApp/EtabsSendCollectionManager.cs
@@ -48,9 +48,14 @@ public class EtabsSendCollectionManager : CsiSendCollectionManager
       return DEFAULT_LEVEL;
     }
 
-    if (properties.TryGetValue("Object ID", out var objectId) && objectId is Dictionary<string, object> parameters)
+    if (
+      properties.TryGetValue(ObjectPropertyCategory.OBJECT_ID, out var objectId)
+      && objectId is Dictionary<string, object> parameters
+    )
     {
-      return parameters.TryGetValue("level", out var level) ? level?.ToString() ?? DEFAULT_LEVEL : DEFAULT_LEVEL;
+      return parameters.TryGetValue(CommonObjectProperty.LEVEL, out var level)
+        ? level?.ToString() ?? DEFAULT_LEVEL
+        : DEFAULT_LEVEL;
     }
 
     return DEFAULT_LEVEL;
@@ -72,9 +77,12 @@ public class EtabsSendCollectionManager : CsiSendCollectionManager
       && obj["properties"] is Dictionary<string, object> properties
     )
     {
-      if (properties.TryGetValue("Object ID", out var objectId) && objectId is Dictionary<string, object> parameters)
+      if (
+        properties.TryGetValue(ObjectPropertyCategory.OBJECT_ID, out var objectId)
+        && objectId is Dictionary<string, object> parameters
+      )
       {
-        if (parameters.TryGetValue("designOrientation", out var orientation))
+        if (parameters.TryGetValue(CommonObjectProperty.DESIGN_ORIENTATION, out var orientation))
         {
           return GetCategoryFromDesignOrientation(orientation?.ToString(), type);
         }

--- a/Converters/CSi/Speckle.Converters.CSiShared/ToSpeckle/Helpers/CsiFramePropertiesExtractor.cs
+++ b/Converters/CSi/Speckle.Converters.CSiShared/ToSpeckle/Helpers/CsiFramePropertiesExtractor.cs
@@ -51,10 +51,10 @@ public sealed class CsiFramePropertiesExtractor
     (geometry["I-End Joint"], geometry["J-End Joint"]) = GetEndPointNames(frame);
 
     var assignments = frameData.Properties.EnsureNested(ObjectPropertyCategory.ASSIGNMENTS);
-    assignments["Groups"] = GetGroupAssigns(frame);
-    assignments["Material Overwrite"] = GetMaterialOverwrite(frame);
-    assignments["Local Axis 2 Angle"] = GetLocalAxes(frame);
-    assignments["Property Modifiers"] = GetModifiers(frame);
+    assignments[CommonObjectProperty.GROUPS] = GetGroupAssigns(frame);
+    assignments[CommonObjectProperty.MATERIAL_OVERWRITE] = GetMaterialOverwrite(frame);
+    assignments[CommonObjectProperty.LOCAL_AXIS_2_ANGLE] = GetLocalAxes(frame);
+    assignments[CommonObjectProperty.PROPERTY_MODIFIERS] = GetModifiers(frame);
     assignments["End Releases"] = GetReleases(frame);
 
     // NOTE: sectionId and materialId a "quick-fix" to enable filtering in the viewer etc.
@@ -110,8 +110,8 @@ public sealed class CsiFramePropertiesExtractor
     _ = _settingsStore.Current.SapModel.FrameObj.GetLocalAxes(frame.Name, ref angle, ref advanced);
 
     Dictionary<string, object?> resultsDictionary = [];
-    resultsDictionary.AddWithUnits("Angle", angle, "Degrees");
-    resultsDictionary["Advanced"] = advanced.ToString();
+    resultsDictionary.AddWithUnits(CommonObjectProperty.ANGLE, angle, "Degrees");
+    resultsDictionary[CommonObjectProperty.ADVANCED] = advanced.ToString();
 
     return resultsDictionary;
   }

--- a/Converters/CSi/Speckle.Converters.CSiShared/ToSpeckle/Helpers/CsiJointPropertiesExtractor.cs
+++ b/Converters/CSi/Speckle.Converters.CSiShared/ToSpeckle/Helpers/CsiJointPropertiesExtractor.cs
@@ -35,8 +35,8 @@ public sealed class CsiJointPropertiesExtractor
     jointData.ApplicationId = joint.GetSpeckleApplicationId(_settingsStore.Current.SapModel);
 
     var assignments = jointData.Properties.EnsureNested(ObjectPropertyCategory.ASSIGNMENTS);
-    assignments["groups"] = new List<string>(GetGroupAssigns(joint));
-    assignments["restraints"] = GetRestraints(joint);
+    assignments[CommonObjectProperty.GROUPS] = new List<string>(GetGroupAssigns(joint));
+    assignments["Restraints"] = GetRestraints(joint);
   }
 
   private string[] GetGroupAssigns(CsiJointWrapper joint)
@@ -53,12 +53,12 @@ public sealed class CsiJointPropertiesExtractor
     _ = _settingsStore.Current.SapModel.PointObj.GetRestraint(joint.Name, ref restraints);
     return new Dictionary<string, bool?>
     {
-      ["U1"] = restraints[0],
-      ["U2"] = restraints[1],
-      ["U3"] = restraints[2],
-      ["R1"] = restraints[3],
-      ["R2"] = restraints[4],
-      ["R3"] = restraints[5],
+      ["UX Restrained"] = restraints[0],
+      ["UY Restrained"] = restraints[1],
+      ["UZ Restrained"] = restraints[2],
+      ["RX Restrained"] = restraints[3],
+      ["RY Restrained"] = restraints[4],
+      ["RZ Restrained"] = restraints[5],
     };
   }
 }

--- a/Converters/CSi/Speckle.Converters.CSiShared/ToSpeckle/Helpers/CsiShellPropertiesExtractor.cs
+++ b/Converters/CSi/Speckle.Converters.CSiShared/ToSpeckle/Helpers/CsiShellPropertiesExtractor.cs
@@ -35,10 +35,10 @@ public sealed class CsiShellPropertiesExtractor
     geometry["Joints"] = GetPointNames(shell); // TODO: 🪲 Viewer shows 4 but only displays 3
 
     var assignments = shellData.Properties.EnsureNested(ObjectPropertyCategory.ASSIGNMENTS);
-    assignments["Groups"] = GetGroupAssigns(shell);
-    assignments["Local Axis 2 Angle"] = GetLocalAxes(shell);
-    assignments["Material Overwrite"] = GetMaterialOverwrite(shell);
-    assignments["Property Modifiers"] = GetModifiers(shell);
+    assignments[CommonObjectProperty.GROUPS] = GetGroupAssigns(shell);
+    assignments[CommonObjectProperty.LOCAL_AXIS_2_ANGLE] = GetLocalAxes(shell);
+    assignments[CommonObjectProperty.MATERIAL_OVERWRITE] = GetMaterialOverwrite(shell);
+    assignments[CommonObjectProperty.PROPERTY_MODIFIERS] = GetModifiers(shell);
   }
 
   private string[] GetGroupAssigns(CsiShellWrapper shell)
@@ -56,8 +56,8 @@ public sealed class CsiShellPropertiesExtractor
     _ = _settingsStore.Current.SapModel.AreaObj.GetLocalAxes(shell.Name, ref angle, ref advanced);
 
     Dictionary<string, object?> resultsDictionary = [];
-    resultsDictionary.AddWithUnits("Angle", angle, "Degrees");
-    resultsDictionary["Advanced"] = advanced.ToString();
+    resultsDictionary.AddWithUnits(CommonObjectProperty.ANGLE, angle, "Degrees");
+    resultsDictionary[CommonObjectProperty.ADVANCED] = advanced.ToString();
 
     return resultsDictionary;
   }

--- a/Converters/CSi/Speckle.Converters.CSiShared/Utils/Constants.cs
+++ b/Converters/CSi/Speckle.Converters.CSiShared/Utils/Constants.cs
@@ -25,10 +25,29 @@ public static class ObjectPropertyKey
   public const string SECTION_ID = "Section Property";
 }
 
+/// <summary>
+/// These strings are repeatedly used group properties (mimics the host app UI)
+/// </summary>
 public static class SectionPropertyCategory
 {
   public const string GENERAL_DATA = "General Data";
   public const string SECTION_PROPERTIES = "Section Properties";
   public const string SECTION_DIMENSIONS = "Section Dimensions";
   public const string PROPERTY_DATA = "Property Data";
+}
+
+/// <summary>
+/// These strings are properties repeated and common to various object types (joint, frame, shell etc.)
+/// </summary>
+public static class CommonObjectProperty
+{
+  public const string LABEL = "Label";
+  public const string LEVEL = "Level";
+  public const string GROUPS = "Groups";
+  public const string SPRING_ASSIGNMENT = "Spring Assignment";
+  public const string LOCAL_AXIS_2_ANGLE = "Local Axis 2 Angle";
+  public const string MATERIAL_OVERWRITE = "Material Overwrite";
+  public const string PROPERTY_MODIFIERS = "Property Modifiers";
+  public const string ANGLE = "Angle";
+  public const string ADVANCED = "Advanced";
 }

--- a/Converters/CSi/Speckle.Converters.CSiShared/Utils/Constants.cs
+++ b/Converters/CSi/Speckle.Converters.CSiShared/Utils/Constants.cs
@@ -50,4 +50,5 @@ public static class CommonObjectProperty
   public const string PROPERTY_MODIFIERS = "Property Modifiers";
   public const string ANGLE = "Angle";
   public const string ADVANCED = "Advanced";
+  public const string DESIGN_ORIENTATION = "Design Orientation";
 }

--- a/Converters/CSi/Speckle.Converters.ETABSShared/ToSpeckle/Helpers/EtabsFramePropertiesExtractor.cs
+++ b/Converters/CSi/Speckle.Converters.ETABSShared/ToSpeckle/Helpers/EtabsFramePropertiesExtractor.cs
@@ -35,10 +35,10 @@ public sealed class EtabsFramePropertiesExtractor
   {
     var objectId = properties.EnsureNested(ObjectPropertyCategory.OBJECT_ID);
     objectId["Design Orientation"] = GetDesignOrientation(frame);
-    (objectId["Label"], objectId["Level"]) = GetLabelAndLevel(frame);
+    (objectId[CommonObjectProperty.LABEL], objectId[CommonObjectProperty.LEVEL]) = GetLabelAndLevel(frame);
 
     var assignments = properties.EnsureNested(ObjectPropertyCategory.ASSIGNMENTS);
-    assignments["Spring Assignment"] = GetSpringAssignmentName(frame);
+    assignments[CommonObjectProperty.SPRING_ASSIGNMENT] = GetSpringAssignmentName(frame);
 
     var design = properties.EnsureNested(ObjectPropertyCategory.DESIGN);
     design["Design Procedure"] = GetDesignProcedure(frame);

--- a/Converters/CSi/Speckle.Converters.ETABSShared/ToSpeckle/Helpers/EtabsFramePropertiesExtractor.cs
+++ b/Converters/CSi/Speckle.Converters.ETABSShared/ToSpeckle/Helpers/EtabsFramePropertiesExtractor.cs
@@ -34,7 +34,7 @@ public sealed class EtabsFramePropertiesExtractor
   public void ExtractProperties(CsiFrameWrapper frame, Dictionary<string, object?> properties)
   {
     var objectId = properties.EnsureNested(ObjectPropertyCategory.OBJECT_ID);
-    objectId["Design Orientation"] = GetDesignOrientation(frame);
+    objectId[CommonObjectProperty.DESIGN_ORIENTATION] = GetDesignOrientation(frame);
     (objectId[CommonObjectProperty.LABEL], objectId[CommonObjectProperty.LEVEL]) = GetLabelAndLevel(frame);
 
     var assignments = properties.EnsureNested(ObjectPropertyCategory.ASSIGNMENTS);

--- a/Converters/CSi/Speckle.Converters.ETABSShared/ToSpeckle/Helpers/EtabsJointPropertiesExtractor.cs
+++ b/Converters/CSi/Speckle.Converters.ETABSShared/ToSpeckle/Helpers/EtabsJointPropertiesExtractor.cs
@@ -34,17 +34,17 @@ public sealed class EtabsJointPropertiesExtractor
   public void ExtractProperties(CsiJointWrapper joint, Dictionary<string, object?> properties)
   {
     var objectId = properties.EnsureNested(ObjectPropertyCategory.OBJECT_ID);
-    (objectId["label"], objectId["level"]) = GetLabelAndLevel(joint);
+    (objectId[CommonObjectProperty.LABEL], objectId[CommonObjectProperty.LEVEL]) = GetLabelAndLevel(joint);
 
     var assignments = properties.EnsureNested(ObjectPropertyCategory.ASSIGNMENTS);
-    (assignments["diaphragmOption"], assignments["diaphragmName"]) = GetAssignedDiaphragm(joint);
-    assignments["springAssignment"] = GetSpringAssignmentName(joint);
+    (assignments["Diaphragm Option"], assignments["Diaphragm Name"]) = GetAssignedDiaphragm(joint);
+    assignments[CommonObjectProperty.SPRING_ASSIGNMENT] = GetSpringAssignmentName(joint);
   }
 
   private (string diaphramOption, string diaphragmName) GetAssignedDiaphragm(CsiJointWrapper joint)
   {
     eDiaphragmOption diaphragmOption = eDiaphragmOption.Disconnect;
-    string diaphragmName = "None"; // Is there a better way to handle null?
+    string diaphragmName = string.Empty;
     _ = _settingsStore.Current.SapModel.PointObj.GetDiaphragm(joint.Name, ref diaphragmOption, ref diaphragmName);
     return (diaphragmOption.ToString(), diaphragmName);
   }
@@ -59,7 +59,7 @@ public sealed class EtabsJointPropertiesExtractor
 
   private string GetSpringAssignmentName(CsiJointWrapper joint)
   {
-    string springPropertyName = "None"; // Is there a better way to handle null?
+    string springPropertyName = string.Empty;
     _ = _settingsStore.Current.SapModel.PointObj.GetSpringAssignment(joint.Name, ref springPropertyName);
     return springPropertyName;
   }

--- a/Converters/CSi/Speckle.Converters.ETABSShared/ToSpeckle/Helpers/EtabsShellPropertiesExtractor.cs
+++ b/Converters/CSi/Speckle.Converters.ETABSShared/ToSpeckle/Helpers/EtabsShellPropertiesExtractor.cs
@@ -43,7 +43,7 @@ public sealed class EtabsShellPropertiesExtractor
   public void ExtractProperties(CsiShellWrapper shell, Dictionary<string, object?> properties)
   {
     var objectId = properties.EnsureNested(ObjectPropertyCategory.OBJECT_ID);
-    objectId["Design Orientation"] = GetDesignOrientation(shell);
+    objectId[CommonObjectProperty.DESIGN_ORIENTATION] = GetDesignOrientation(shell);
     (objectId[CommonObjectProperty.LABEL], objectId[CommonObjectProperty.LEVEL]) = GetLabelAndLevel(shell);
 
     var assignments = properties.EnsureNested(ObjectPropertyCategory.ASSIGNMENTS);

--- a/Converters/CSi/Speckle.Converters.ETABSShared/ToSpeckle/Helpers/EtabsShellPropertiesExtractor.cs
+++ b/Converters/CSi/Speckle.Converters.ETABSShared/ToSpeckle/Helpers/EtabsShellPropertiesExtractor.cs
@@ -44,14 +44,14 @@ public sealed class EtabsShellPropertiesExtractor
   {
     var objectId = properties.EnsureNested(ObjectPropertyCategory.OBJECT_ID);
     objectId["Design Orientation"] = GetDesignOrientation(shell);
-    (objectId["Label"], objectId["Level"]) = GetLabelAndLevel(shell);
+    (objectId[CommonObjectProperty.LABEL], objectId[CommonObjectProperty.LEVEL]) = GetLabelAndLevel(shell);
 
     var assignments = properties.EnsureNested(ObjectPropertyCategory.ASSIGNMENTS);
     assignments["Diaphragm"] = GetAssignedDiaphragmName(shell);
     assignments["Opening"] = IsOpening(shell);
     assignments["Pier"] = GetPierAssignmentName(shell);
     assignments["Spandrel"] = GetSpandrelAssignmentName(shell);
-    assignments["Spring Assignment"] = GetSpringAssignmentName(shell);
+    assignments[CommonObjectProperty.SPRING_ASSIGNMENT] = GetSpringAssignmentName(shell);
 
     // NOTE: Section Property and Material are a "quick-fix" to enable filtering in the viewer etc.
     // Assign Section Property to variable as this will be an argument for the GetMaterialName method


### PR DESCRIPTION
## Description & Motivation

- Related to [CNX-1133](https://linear.app/speckle/issue/CNX-1133/user-facing-attributes-not-consistent-for-joints)
- This was missed in [CNX-1112](https://linear.app/speckle/issue/CNX-1112/get-user-facing-names-of-properties)

## Changes:

- `JOINT` to have user-facing attributes like `SHELL` and `FRAME`
- All properties occuring more than once moved to `Constants.cs` to avoid this in the future
- Caught some old strings in the `EtabsSendCollectionManager`!

## Screenshots:

### Before Changes
Two occurences of, what should be the same property:

![image](https://github.com/user-attachments/assets/fa7140fc-fdd2-415e-bb19-ef949455ffeb)


Evident that the "old" camelCase was being used:

<img width="329" alt="image" src="https://github.com/user-attachments/assets/708da6ac-b90a-4ae3-8d01-e614f1e64106" />


### After Changes
Filtering by common properties as expected:

![image](https://github.com/user-attachments/assets/5f112469-b1f7-40ab-8b34-a7e2e57a9c68)

Conforming with the other objects:

![image](https://github.com/user-attachments/assets/25e3cfaf-ea47-4365-8b30-89410b5cd88a)

## Checklist:

- [x] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [x] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] My code follows a similar style to existing code.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.
