### PR TITLE
fix(etabs): catch tendon and link objects as warning

### DIFF
--- a/Converters/CSi/Speckle.Converters.CSiShared/Extensions/SpeckleApplicationIdExtensions.cs
+++ b/Converters/CSi/Speckle.Converters.CSiShared/Extensions/SpeckleApplicationIdExtensions.cs
@@ -3,16 +3,6 @@ namespace Speckle.Converters.CSiShared.Extensions;
 public static class SpeckleApplicationIdExtensions
 {
   /// <summary>
-  /// Retrieves the Speckle object application id for a frame object
-  /// </summary>
-  public static string GetSpeckleApplicationId(this CsiFrameWrapper wrapper, cSapModel sapModel)
-  {
-    string applicationId = string.Empty;
-    _ = sapModel.FrameObj.GetGUID(wrapper.Name, ref applicationId);
-    return applicationId;
-  }
-
-  /// <summary>
   /// Retrieves the Speckle object application id for a joint object
   /// </summary>
   public static string GetSpeckleApplicationId(this CsiJointWrapper wrapper, cSapModel sapModel)
@@ -23,12 +13,52 @@ public static class SpeckleApplicationIdExtensions
   }
 
   /// <summary>
+  /// Retrieves the Speckle object application id for a frame object
+  /// </summary>
+  public static string GetSpeckleApplicationId(this CsiFrameWrapper wrapper, cSapModel sapModel)
+  {
+    string applicationId = string.Empty;
+    _ = sapModel.FrameObj.GetGUID(wrapper.Name, ref applicationId);
+    return applicationId;
+  }
+
+  /// <summary>
+  /// Retrieves the Speckle object application id for a cable object
+  /// </summary>
+  public static string GetSpeckleApplicationId(this CsiCableWrapper wrapper, cSapModel sapModel)
+  {
+    string applicationId = string.Empty;
+    _ = sapModel.CableObj.GetGUID(wrapper.Name, ref applicationId);
+    return applicationId;
+  }
+
+  /// <summary>
   /// Retrieves the Speckle object application id for a shell object
   /// </summary>
   public static string GetSpeckleApplicationId(this CsiShellWrapper wrapper, cSapModel sapModel)
   {
     string applicationId = string.Empty;
     _ = sapModel.AreaObj.GetGUID(wrapper.Name, ref applicationId);
+    return applicationId;
+  }
+
+  /// <summary>
+  /// Retrieves the Speckle object application id for a solid object
+  /// </summary>
+  public static string GetSpeckleApplicationId(this CsiSolidWrapper wrapper, cSapModel sapModel)
+  {
+    string applicationId = string.Empty;
+    _ = sapModel.SolidObj.GetGUID(wrapper.Name, ref applicationId);
+    return applicationId;
+  }
+
+  /// <summary>
+  /// Retrieves the Speckle object application id for a link object
+  /// </summary>
+  public static string GetSpeckleApplicationId(this CsiLinkWrapper wrapper, cSapModel sapModel)
+  {
+    string applicationId = string.Empty;
+    _ = sapModel.LinkObj.GetGUID(wrapper.Name, ref applicationId);
     return applicationId;
   }
 }

--- a/Converters/CSi/Speckle.Converters.CSiShared/ToSpeckle/Helpers/SharedPropertiesExtractor.cs
+++ b/Converters/CSi/Speckle.Converters.CSiShared/ToSpeckle/Helpers/SharedPropertiesExtractor.cs
@@ -57,15 +57,22 @@ public class SharedPropertiesExtractor
 
     switch (wrapper)
     {
-      case CsiFrameWrapper frame:
-        _csiFramePropertiesExtractor.ExtractProperties(frame, objectData);
-        break;
       case CsiJointWrapper joint:
         _csiJointPropertiesExtractor.ExtractProperties(joint, objectData);
+        break;
+      case CsiFrameWrapper frame:
+        _csiFramePropertiesExtractor.ExtractProperties(frame, objectData);
         break;
       case CsiShellWrapper shell:
         _csiShellPropertiesExtractor.ExtractProperties(shell, objectData);
         break;
+      case CsiTendonWrapper:
+      case CsiLinkWrapper:
+      case CsiCableWrapper:
+      case CsiSolidWrapper:
+        throw new NotImplementedException($"Data extraction for {wrapper.ObjectName} not yet supported.");
+      default:
+        throw new ArgumentException($"Unsupported wrapper type: {nameof(wrapper)}");
     }
 
     return objectData;


### PR DESCRIPTION
## Description

- Link to [CNX-1138](https://linear.app/speckle/issue/CNX-1138/unexpected-object-selection)
- `ETABS` as a building module should not have `REBAR`, `LINK` or `TENDON` objects modelled (i.e. we won't support this workflow). However, for the event that these objects are present in the model, we note the proper conversion success and don't throw a conversion error in the UI.

## User Value
User is informed of which objects aren't converted and why. Not that the whole conversion fails.

## Changes:

- `GetSpeckleApplicationId` for all possible types
- `NotImplementedException` for `LINK` and `TENDON`
- Marked as `WARNING` in the conversion result

## Screenshots:

### Before

<img width="289" alt="image" src="https://github.com/user-attachments/assets/9276deea-4597-41dc-80a8-218f53a904a6" />

### After

<img width="289" alt="image" src="https://github.com/user-attachments/assets/a7c71180-2ae5-479a-a10e-8dfc72293f4b" />


## Checklist:

- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] I have added appropriate tests.
- [x] I have updated or added relevant documentation.

