### PR TITLE
Better handle UnobservedTaskExceptions without the Event Aggregator. …

### DIFF
--- a/DUI3/Speckle.Connectors.DUI/ContainerRegistration.cs
+++ b/DUI3/Speckle.Connectors.DUI/ContainerRegistration.cs
@@ -58,7 +58,9 @@ public static class ContainerRegistration
     {
       try
       {
-        serviceProvider.GetRequiredService<ILoggerFactory>().CreateLogger("UnobservedTaskException")
+        serviceProvider
+          .GetRequiredService<ILoggerFactory>()
+          .CreateLogger("UnobservedTaskException")
           .LogError(args.Exception, "Unobserved task exception");
       }
 #pragma warning disable CA1031

--- a/DUI3/Speckle.Connectors.DUI/ContainerRegistration.cs
+++ b/DUI3/Speckle.Connectors.DUI/ContainerRegistration.cs
@@ -54,14 +54,25 @@ public static class ContainerRegistration
   public static IServiceProvider UseDUI(this IServiceProvider serviceProvider, bool initializeDocumentStore = true)
   {
     //observe the unobserved!
-    TaskScheduler.UnobservedTaskException += async (_, args) =>
+    TaskScheduler.UnobservedTaskException += (_, args) =>
     {
-      await serviceProvider
-        .GetRequiredService<IEventAggregator>()
-        .GetEvent<ExceptionEvent>()
-        .PublishAsync(args.Exception);
-      serviceProvider.GetRequiredService<ILogger>().LogError(args.Exception, "Unobserved task exception");
-      args.SetObserved();
+      try
+      {
+        serviceProvider.GetRequiredService<ILoggerFactory>().CreateLogger("UnobservedTaskException")
+          .LogError(args.Exception, "Unobserved task exception");
+      }
+#pragma warning disable CA1031
+      catch (Exception e)
+#pragma warning restore CA1031
+      {
+        Console.WriteLine("Error logging unobserved task exception");
+        Console.WriteLine(args.Exception);
+        Console.WriteLine(e);
+      }
+      finally
+      {
+        args.SetObserved();
+      }
     };
 
     if (initializeDocumentStore)


### PR DESCRIPTION
… Logs will have them.

UnobservedTaskExceptions can easily flood the EA so don't process them with the EA.

Cancelling a send or receives (since SDK upgrades aren't merged) can reproduce the issue.  

Related:
https://github.com/specklesystems/speckle-sharp-sdk/pull/216
https://github.com/specklesystems/speckle-sharp-sdk/pull/218
https://github.com/specklesystems/speckle-sharp-connectors/pull/527