### PR TITLE
feat(rhino): wraps receive in an undo operation

### DIFF
--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/Bindings/RhinoReceiveBinding.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/Bindings/RhinoReceiveBinding.cs
@@ -59,7 +59,7 @@ public class RhinoReceiveBinding : IReceiveBinding
     scope
       .ServiceProvider.GetRequiredService<IConverterSettingsStore<RhinoConversionSettings>>()
       .Initialize(_rhinoConversionSettingsFactory.Create(RhinoDoc.ActiveDoc));
-    
+
     uint undoRecord = 0;
     try
     {
@@ -96,8 +96,7 @@ public class RhinoReceiveBinding : IReceiveBinding
       // So have 3 state on UI -> Cancellation clicked -> Cancelling -> Cancelled
       return;
     }
-    catch (Exception ex) when
-      (!ex.IsFatal()) // UX reasons - we will report operation exceptions as model card error. We may change this later when we have more exception documentation
+    catch (Exception ex) when (!ex.IsFatal()) // UX reasons - we will report operation exceptions as model card error. We may change this later when we have more exception documentation
     {
       _logger.LogModelCardHandledError(ex);
       await Commands.SetModelError(modelCardId, ex);


### PR DESCRIPTION
Tested with 
- full receive
- incomplete (cancelled) receive

Properly registers in rhino: 

![image](https://github.com/user-attachments/assets/3f110012-1bf7-4571-a850-c04b07115239)

Tested with 7 & 8
