### PR TITLE
extrude simple holed surfaces in tekla

### DIFF
--- a/Converters/Tekla/Speckle.Converters.TeklaShared/ToSpeckle/Raw/SolidToSpeckleConverter.cs
+++ b/Converters/Tekla/Speckle.Converters.TeklaShared/ToSpeckle/Raw/SolidToSpeckleConverter.cs
@@ -93,7 +93,7 @@ public class SolidToSpeckleConverter : ITypedConverter<TSM.Solid, SOG.Mesh>
     };
   }
 
-  private static SOG.Mesh ExtrudeFromPolygons(List<Poly3> face1, List<Poly3> face2)
+  private SOG.Mesh ExtrudeFromPolygons(List<Poly3> face1, List<Poly3> face2)
   {
     var point = face2[0].Vertices[0];
     var generator = new MeshGenerator(new BaseTransformer(), new TriangleNetTriangulator());
@@ -102,7 +102,7 @@ public class SolidToSpeckleConverter : ITypedConverter<TSM.Solid, SOG.Mesh>
     return Mesh3ToSpeckleMesh(mesh3);
   }
 
-  private static SOG.Mesh Mesh3ToSpeckleMesh(Mesh3 mesh3)
+  private SOG.Mesh Mesh3ToSpeckleMesh(Mesh3 mesh3)
   {
     var vertices = new List<double>();
     var faces = new List<int>();
@@ -126,7 +126,7 @@ public class SolidToSpeckleConverter : ITypedConverter<TSM.Solid, SOG.Mesh>
     {
       vertices = vertices,
       faces = faces,
-      units = "mm"
+      units = _settingsStore.Current.SpeckleUnits
     };
 
     return mesh;

--- a/Converters/Tekla/Speckle.Converters.TeklaShared/ToSpeckle/Raw/SolidToSpeckleConverter.cs
+++ b/Converters/Tekla/Speckle.Converters.TeklaShared/ToSpeckle/Raw/SolidToSpeckleConverter.cs
@@ -1,5 +1,8 @@
+using Speckle.Common.MeshTriangulation;
 using Speckle.Converters.Common;
 using Speckle.Converters.Common.Objects;
+using Speckle.DoubleNumerics;
+using Tekla.Structures.Solid;
 
 namespace Speckle.Converters.TeklaShared.ToSpeckle.Raw;
 
@@ -14,6 +17,21 @@ public class SolidToSpeckleConverter : ITypedConverter<TSM.Solid, SOG.Mesh>
 
   public SOG.Mesh Convert(TSM.Solid target)
   {
+    // early return extruded Mesh
+    // if there are exactly 2 opposite facing contours with holes (inner loops)
+    var facesAsPolygons = GetFacesAsPolygons(target);
+    var facesToExtrude = facesAsPolygons.Where(lst => lst.Count > 1).ToList();
+    if (facesToExtrude.Count == 2)
+    {
+      var n0 = facesToExtrude[0][0].GetNormal();
+      var n1 = facesToExtrude[1][0].GetNormal();
+
+      if ((n0 + n1).Length() < 0.001)
+      {
+        return ExtrudeFromPolygons(facesToExtrude[0], facesToExtrude[1]);
+      }
+    }
+
     List<double> vertices = new List<double>();
     List<int> faces = new List<int>();
     int currentIndex = 0;
@@ -73,5 +91,75 @@ public class SolidToSpeckleConverter : ITypedConverter<TSM.Solid, SOG.Mesh>
       faces = faces,
       units = _settingsStore.Current.SpeckleUnits
     };
+  }
+
+  private static SOG.Mesh ExtrudeFromPolygons(List<Poly3> face1, List<Poly3> face2)
+  {
+    var point = face2[0].Vertices[0];
+    var generator = new MeshGenerator(new BaseTransformer(), new TriangleNetTriangulator());
+    var mesh3 = generator.ExtrudeMesh(face1, point);
+
+    return Mesh3ToSpeckleMesh(mesh3);
+  }
+
+  private static SOG.Mesh Mesh3ToSpeckleMesh(Mesh3 mesh3)
+  {
+    var vertices = new List<double>();
+    var faces = new List<int>();
+
+    foreach (var v in mesh3.Vertices)
+    {
+      vertices.Add(v.X);
+      vertices.Add(v.Y);
+      vertices.Add(v.Z);
+    }
+
+    for (int i = 0; i < mesh3.Triangles.Count; i += 3)
+    {
+      faces.Add(3);
+      faces.Add(mesh3.Triangles[i]);
+      faces.Add(mesh3.Triangles[i + 1]);
+      faces.Add(mesh3.Triangles[i + 2]);
+    }
+
+    var mesh = new SOG.Mesh
+    {
+      vertices = vertices,
+      faces = faces,
+      units = "mm"
+    };
+
+    return mesh;
+  }
+
+  private static List<List<Poly3>> GetFacesAsPolygons(TSM.Solid solid)
+  {
+    var polyFaces = new List<List<Poly3>>();
+
+    FaceEnumerator faceEnum = solid.GetFaceEnumerator();
+    while (faceEnum.MoveNext())
+    {
+      Face face = faceEnum.Current;
+      LoopEnumerator loopEnum = face.GetLoopEnumerator();
+
+      var polyFace = new List<Poly3>();
+      while (loopEnum.MoveNext())
+      {
+        Loop loop = loopEnum.Current;
+        VertexEnumerator vertexEnum = loop.GetVertexEnumerator();
+
+        var vertices = new List<Vector3>();
+        while (vertexEnum.MoveNext())
+        {
+          Tekla.Structures.Geometry3d.Point point = vertexEnum.Current;
+          vertices.Add(new Vector3(point.X, point.Y, point.Z));
+        }
+        polyFace.Add(new Poly3(vertices));
+      }
+
+      polyFaces.Add(polyFace);
+    }
+
+    return polyFaces;
   }
 }

--- a/Sdk/Speckle.Common.MeshTriangulation/MeshGenerator.cs
+++ b/Sdk/Speckle.Common.MeshTriangulation/MeshGenerator.cs
@@ -15,7 +15,7 @@ public sealed class MeshGenerator
 
   // creates a triangulated surface mesh from the given polygons
   // each polygon has to contain at least 3 points
-  // the frist polygon is the contour of the mesh, it has to be clockwise
+  // the first polygon is the contour of the mesh, it has to be clockwise
   // the rest of the polygons define the holes, these have to be counterclockwise
   public Mesh3 TriangulateSurface(IReadOnlyList<Poly3> polygons)
   {
@@ -32,7 +32,7 @@ public sealed class MeshGenerator
 
   // creates an extruded triangle mesh from the given polygons
   // each polygon has to contain at least 3 points
-  // the frist polygon is the contour of the mesh, it has to be clockwise
+  // the first polygon is the contour of the mesh, it has to be clockwise
   // the rest of the polygons define the holes, these have to be counterclockwise
   // the mesh will be extruded in the normal direction by the given height
   public Mesh3 ExtrudeMesh(IReadOnlyList<Poly3> polygons, double extrusionHeight)

--- a/Sdk/Speckle.Common.MeshTriangulation/MeshGenerator.cs
+++ b/Sdk/Speckle.Common.MeshTriangulation/MeshGenerator.cs
@@ -37,7 +37,7 @@ public sealed class MeshGenerator
   // the mesh will be extruded in the normal direction by the given height
   public Mesh3 ExtrudeMesh(IReadOnlyList<Poly3> polygons, double extrusionHeight)
   {
-    if (polygons.Count < 3)
+    if (polygons.Count < 1)
     {
       throw new ArgumentException("No polygon was provided for extrusion");
     }
@@ -117,5 +117,27 @@ public sealed class MeshGenerator
     }
 
     return new Mesh3(vertices, triangles);
+  }
+
+  public Mesh3 ExtrudeMesh(IReadOnlyList<Poly3> polygons, Vector3 point)
+  {
+    var distance = GetDistanceToPlane(polygons[0], point);
+    return ExtrudeMesh(polygons, distance);
+  }
+
+  public static double GetDistanceToPlane(Poly3 plane, Vector3 point)
+  {
+    var p1 = plane.Vertices[0];
+    var p2 = plane.Vertices[1];
+    var p3 = plane.Vertices[2];
+
+    Vector3 v1 = p2 - p1;
+    Vector3 v2 = p3 - p1;
+    Vector3 normal = Vector3.Normalize(Vector3.Cross(v1, v2));
+
+    var dot = -Vector3.Dot(normal, p1);
+    var distance = Math.Abs(Vector3.Dot(normal, point) + dot);
+
+    return distance;
   }
 }

--- a/Sdk/Speckle.Common.MeshTriangulation/TriangleNetTriangulator.cs
+++ b/Sdk/Speckle.Common.MeshTriangulation/TriangleNetTriangulator.cs
@@ -47,7 +47,7 @@ public class TriangleNetTriangulator : ITriangulator
       verts.Add(new Vertex(v.X, v.Y, 1));
     }
 
-    p.Add(new Contour(verts, 1));
+    p.Add(new TriangleNet.Geometry.Contour(verts, 1));
   }
 
   private void AddHole(Polygon p, Poly2 poly2)
@@ -60,7 +60,7 @@ public class TriangleNetTriangulator : ITriangulator
 
     // we need a point inside the hole to add it
     var pointInHole = GetRightPointOfEdge(poly2.Vertices[0], poly2.Vertices[1]);
-    p.Add(new Contour(verts, 2), new Point(pointInHole.X, pointInHole.Y));
+    p.Add(new TriangleNet.Geometry.Contour(verts, 2), new Point(pointInHole.X, pointInHole.Y));
   }
 
   // picks a point on the right side of the given edge


### PR DESCRIPTION
- extrude simple holed surfaces in Tekla
- we only extrude if there are exactly 2 surfaces with holes and they face in opposite directions
- in other cases the conversion will fall back to the original logic and will send the 3D Mesh without holes