### PR TITLE
Rework Revit/CEF threading to not use RevitTask always

### DIFF
--- a/Connectors/ArcGIS/Speckle.Connectors.ArcGIS3/Bindings/ArcGISReceiveBinding.cs
+++ b/Connectors/ArcGIS/Speckle.Connectors.ArcGIS3/Bindings/ArcGISReceiveBinding.cs
@@ -73,7 +73,7 @@ public sealed class ArcGISReceiveBinding : IReceiveBinding
         );
       // Receive host objects
       var receiveOperationResults = await scope
-        .ServiceProvider.GetRequiredService<ReceiveOperation>()
+        .ServiceProvider.GetRequiredService<IReceiveOperation>()
         .Execute(
           modelCard.GetReceiveInfo("ArcGIS"), // POC: get host app name from settings? same for GetSendInfo
           _operationProgressManager.CreateOperationProgressEventHandler(Parent, modelCardId, cancellationItem.Token),

--- a/Connectors/ArcGIS/Speckle.Connectors.ArcGIS3/DependencyInjection/ArcGISConnectorModule.cs
+++ b/Connectors/ArcGIS/Speckle.Connectors.ArcGIS3/DependencyInjection/ArcGISConnectorModule.cs
@@ -26,7 +26,7 @@ public static class ArcGISConnectorModule
 {
   public static void AddArcGIS(this IServiceCollection serviceCollection)
   {
-    serviceCollection.AddConnectorUtils();
+    serviceCollection.AddConnectorUtils<ReceiveOperation>();
     serviceCollection.AddDUI<ArcGISThreadContext, ArcGISDocumentStore>();
     serviceCollection.AddDUIView();
 

--- a/Connectors/ArcGIS/Speckle.Connectors.ArcGIS3/Operations/Receive/ArcGISHostObjectBuilder.cs
+++ b/Connectors/ArcGIS/Speckle.Connectors.ArcGIS3/Operations/Receive/ArcGISHostObjectBuilder.cs
@@ -22,7 +22,7 @@ using Speckle.Sdk.Models.Proxies;
 
 namespace Speckle.Connectors.ArcGIS.Operations.Receive;
 
-public class ArcGISHostObjectBuilder : IHostObjectBuilder
+public class ArcGISHostObjectBuilder : HostObjectBuilderBase
 {
   private readonly IRootToHostConverter _converter;
   private readonly IFeatureClassUtils _featureClassUtils;
@@ -53,7 +53,7 @@ public class ArcGISHostObjectBuilder : IHostObjectBuilder
     _colorManager = colorManager;
   }
 
-  public HostObjectBuilderResult Build(
+  public override HostObjectBuilderResult BuildBase(
     Base rootObject,
     string projectName,
     string modelName,

--- a/Connectors/Autocad/Speckle.Connectors.AutocadShared/Bindings/AutocadReceiveBinding.cs
+++ b/Connectors/Autocad/Speckle.Connectors.AutocadShared/Bindings/AutocadReceiveBinding.cs
@@ -76,7 +76,7 @@ public sealed class AutocadReceiveBinding : IReceiveBinding
 
       // Receive host objects
       var operationResults = await scope
-        .ServiceProvider.GetRequiredService<ReceiveOperation>()
+        .ServiceProvider.GetRequiredService<IReceiveOperation>()
         .Execute(
           modelCard.GetReceiveInfo(_speckleApplication.Slug),
           _operationProgressManager.CreateOperationProgressEventHandler(Parent, modelCardId, cancellationItem.Token),

--- a/Connectors/Autocad/Speckle.Connectors.AutocadShared/DependencyInjection/SharedRegistration.cs
+++ b/Connectors/Autocad/Speckle.Connectors.AutocadShared/DependencyInjection/SharedRegistration.cs
@@ -23,7 +23,7 @@ public static class SharedRegistration
 {
   public static void AddAutocadBase(this IServiceCollection serviceCollection)
   {
-    serviceCollection.AddConnectorUtils();
+    serviceCollection.AddConnectorUtils<ReceiveOperation>();
     serviceCollection.AddDUI<DefaultThreadContext, AutocadDocumentStore>();
     serviceCollection.AddDUIView();
 

--- a/Connectors/Autocad/Speckle.Connectors.AutocadShared/Operations/Receive/AutocadHostObjectBuilder.cs
+++ b/Connectors/Autocad/Speckle.Connectors.AutocadShared/Operations/Receive/AutocadHostObjectBuilder.cs
@@ -29,9 +29,9 @@ public class AutocadHostObjectBuilder(
   IAutocadColorBaker colorBaker,
   AutocadContext autocadContext,
   RootObjectUnpacker rootObjectUnpacker
-) : IHostObjectBuilder
+) : HostObjectBuilderBase
 {
-  public HostObjectBuilderResult Build(
+  public override HostObjectBuilderResult BuildBase(
     Base rootObject,
     string projectName,
     string modelName,

--- a/Connectors/CSi/Speckle.Connectors.CSiShared/ServiceRegistration.cs
+++ b/Connectors/CSi/Speckle.Connectors.CSiShared/ServiceRegistration.cs
@@ -24,7 +24,7 @@ public static class ServiceRegistration
   {
     services.AddSingleton<IBrowserBridge, BrowserBridge>();
 
-    services.AddConnectorUtils();
+    services.AddConnectorUtils<ReceiveOperation>();
     services.AddDUI<DefaultThreadContext, CsiDocumentModelStore>();
     services.AddDUIView();
 

--- a/Connectors/Navisworks/Speckle.Connectors.NavisworksShared/DependencyInjection/NavisworksConnectorServiceRegistration.cs
+++ b/Connectors/Navisworks/Speckle.Connectors.NavisworksShared/DependencyInjection/NavisworksConnectorServiceRegistration.cs
@@ -25,7 +25,7 @@ public static class NavisworksConnectorServiceRegistration
   public static void AddNavisworks(this IServiceCollection serviceCollection)
   {
     // Register Core functionality
-    serviceCollection.AddConnectorUtils();
+    serviceCollection.AddConnectorUtils<ReceiveOperation>();
     serviceCollection.AddDUI<DefaultThreadContext, NavisworksDocumentModelStore>();
     serviceCollection.AddDUIView();
 

--- a/Connectors/Revit/Speckle.Connectors.RevitShared.Cef/CefSharpPanel.xaml.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared.Cef/CefSharpPanel.xaml.cs
@@ -15,7 +15,15 @@ public partial class CefSharpPanel : Page, Autodesk.Revit.UI.IDockablePaneProvid
 
   public void ExecuteScript(string script)
   {
-    Browser.Dispatcher.Invoke(() => Browser.ExecuteScriptAsync(script), DispatcherPriority.Background);
+    Console.WriteLine($"Execute future script: {script}");
+    Browser.Dispatcher.Invoke(
+      () =>
+      {
+        Console.WriteLine($"Executing script: {script}");
+        Browser.ExecuteScriptAsync(script);
+      },
+      DispatcherPriority.Background
+    );
   }
 
   public bool IsBrowserInitialized => Browser.IsBrowserInitialized;

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Bindings/RevitReceiveBinding.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Bindings/RevitReceiveBinding.cs
@@ -78,7 +78,7 @@ internal sealed class RevitReceiveBinding : IReceiveBinding
         );
       // Receive host objects
       HostObjectBuilderResult conversionResults = await scope
-        .ServiceProvider.GetRequiredService<ReceiveOperation>()
+        .ServiceProvider.GetRequiredService<IReceiveOperation>()
         .Execute(
           modelCard.GetReceiveInfo(_speckleApplication.Slug),
           _operationProgressManager.CreateOperationProgressEventHandler(Parent, modelCardId, cancellationItem.Token),

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/DependencyInjection/RevitConnectorModule.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/DependencyInjection/RevitConnectorModule.cs
@@ -5,6 +5,7 @@ using Speckle.Connectors.Common;
 using Speckle.Connectors.Common.Builders;
 using Speckle.Connectors.Common.Caching;
 using Speckle.Connectors.Common.Operations;
+using Speckle.Connectors.Common.Threading;
 using Speckle.Connectors.DUI;
 using Speckle.Connectors.DUI.Bindings;
 using Speckle.Connectors.DUI.Bridge;
@@ -25,8 +26,8 @@ public static class ServiceRegistration
 {
   public static void AddRevit(this IServiceCollection serviceCollection)
   {
-    serviceCollection.AddConnectorUtils();
-    serviceCollection.AddDUI<RevitThreadContext, RevitDocumentStore>();
+    serviceCollection.AddConnectorUtils<RevitReceiveOperation>();
+    serviceCollection.AddDUI<DefaultThreadContext, RevitDocumentStore>();
     RegisterUiDependencies(serviceCollection);
 
     // Storage Schema

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/RevitDocumentStore.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/RevitDocumentStore.cs
@@ -86,25 +86,24 @@ internal sealed class RevitDocumentStore : DocumentModelStore
     }
 
     RevitThreadContext
-      .Run(
-        () =>
-        {
-          using Transaction t = new(doc, "Speckle Write State");
-          t.Start();
-          using DataStorage ds = GetSettingsDataStorage(doc) ?? DataStorage.Create(doc);
+      .Run(() =>
+      {
+        using Transaction t = new(doc, "Speckle Write State");
+        t.Start();
+        using DataStorage ds = GetSettingsDataStorage(doc) ?? DataStorage.Create(doc);
 
-          using Entity stateEntity = new(_documentModelStorageSchema.GetSchema());
-          string serializedModels = Serialize();
-          stateEntity.Set("contents", serializedModels);
+        using Entity stateEntity = new(_documentModelStorageSchema.GetSchema());
+        string serializedModels = Serialize();
+        stateEntity.Set("contents", serializedModels);
 
-          using Entity idEntity = new(_idStorageSchema.GetSchema());
-          idEntity.Set("Id", s_revitDocumentStoreId);
+        using Entity idEntity = new(_idStorageSchema.GetSchema());
+        idEntity.Set("Id", s_revitDocumentStoreId);
 
-          ds.SetEntity(idEntity);
-          ds.SetEntity(stateEntity);
-          t.Commit();
-        }
-      ).FireAndForget();
+        ds.SetEntity(idEntity);
+        ds.SetEntity(stateEntity);
+        t.Commit();
+      })
+      .FireAndForget();
   }
 
   protected override void LoadState()

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Plugin/RevitExternalApplication.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Plugin/RevitExternalApplication.cs
@@ -41,6 +41,7 @@ internal sealed class RevitExternalApplication : IExternalApplication
   {
     try
     {
+      RevitTask.Initialize(application);
       // POC: not sure what this is doing...  could be messing up our Aliasing????
       AppDomain.CurrentDomain.AssemblyResolve += AssemblyResolver.OnAssemblyResolve<RevitExternalApplication>;
       var services = new ServiceCollection();
@@ -52,7 +53,6 @@ internal sealed class RevitExternalApplication : IExternalApplication
       _container = services.BuildServiceProvider();
       _container.UseDUI();
 
-      RevitTask.Initialize(application);
       RevitEvents.Register(_container.GetRequiredService<IEventAggregator>(), application);
       // resolve root object
       _revitPlugin = _container.GetRequiredService<IRevitPlugin>();

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Plugin/RevitThreadContext.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Plugin/RevitThreadContext.cs
@@ -19,4 +19,61 @@ public class RevitThreadContext : ThreadContext
   protected override Task<T> RunMainAsync<T>(Func<T> action) => RevitTask.RunAsync(action);
 
   protected override Task<T> RunMainAsync<T>(Func<Task<T>> action) => RevitTask.RunAsync(action);
+
+  private static readonly AsyncLocal<bool> s_isInContext = new();
+
+  public static Task Run(Func<Task> action)
+  {
+    if (s_isInContext.Value)
+    {
+      return action();
+    }
+    try
+    {
+      s_isInContext.Value = true;
+      return RevitTask.RunAsync(action);
+    }
+    finally
+    {
+      s_isInContext.Value = false;
+    }
+  }
+
+  public static Task Run(Action action)
+  {
+    if (s_isInContext.Value)
+    {
+      action();
+      return Task.CompletedTask;
+    }
+
+    try
+    {
+      s_isInContext.Value = true;
+      return RevitTask.RunAsync(action);
+    }
+    finally
+    {
+      s_isInContext.Value = false;
+    }
+  }
+
+  public static Task<T> Run<T>(Func<T> action)
+  {
+    if (s_isInContext.Value)
+    {
+      var x = action();
+      return Task.FromResult(x);
+    }
+
+    try
+    {
+      s_isInContext.Value = true;
+      return RevitTask.RunAsync(action);
+    }
+    finally
+    {
+      s_isInContext.Value = false;
+    }
+  }
 }

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Speckle.Connectors.RevitShared.projitems
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Speckle.Connectors.RevitShared.projitems
@@ -28,6 +28,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)HostApp\IStorageSchema.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HostApp\RevitDocumentStore.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DependencyInjection\RevitConnectorModule.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)HostApp\RevitReceiveOperation.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HostApp\RevitGroupBaker.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HostApp\RevitUtils.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HostApp\SendCollectionManager.cs" />

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/Bindings/RhinoReceiveBinding.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/Bindings/RhinoReceiveBinding.cs
@@ -75,7 +75,7 @@ public class RhinoReceiveBinding : IReceiveBinding
       undoRecord = RhinoDoc.ActiveDoc.BeginUndoRecord($"Receive Speckle model {modelCard.ModelName}");
       // Receive host objects
       HostObjectBuilderResult conversionResults = await scope
-        .ServiceProvider.GetRequiredService<ReceiveOperation>()
+        .ServiceProvider.GetRequiredService<IReceiveOperation>()
         .Execute(
           modelCard.GetReceiveInfo(_speckleApplication.Slug),
           _operationProgressManager.CreateOperationProgressEventHandler(Parent, modelCardId, cancellationItem.Token),

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/Operations/Receive/RhinoHostObjectBuilder.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/Operations/Receive/RhinoHostObjectBuilder.cs
@@ -22,7 +22,7 @@ namespace Speckle.Connectors.Rhino.Operations.Receive;
 /// <summary>
 /// <para>Expects to be a scoped dependency per receive operation.</para>
 /// </summary>
-public class RhinoHostObjectBuilder : IHostObjectBuilder
+public class RhinoHostObjectBuilder : HostObjectBuilderBase
 {
   private readonly IRootToHostConverter _converter;
   private readonly IConverterSettingsStore<RhinoConversionSettings> _converterSettings;
@@ -61,7 +61,7 @@ public class RhinoHostObjectBuilder : IHostObjectBuilder
   }
 
 #pragma warning disable CA1506
-  public HostObjectBuilderResult Build(
+  public override HostObjectBuilderResult BuildBase(
 #pragma warning restore CA1506
     Base rootObject,
     string projectName,

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/Registration/ServiceRegistration.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/Registration/ServiceRegistration.cs
@@ -30,7 +30,7 @@ public static class ServiceRegistration
     serviceCollection.AddSingleton<PlugIn>(SpeckleConnectorsRhinoPlugin.Instance);
     serviceCollection.AddSingleton<Command>(SpeckleConnectorsRhinoCommand.Instance);
 
-    serviceCollection.AddConnectorUtils();
+    serviceCollection.AddConnectorUtils<ReceiveOperation>();
     serviceCollection.AddDUI<DefaultThreadContext, RhinoDocumentStore>();
     serviceCollection.AddDUIView();
 

--- a/Connectors/Tekla/Speckle.Connector.TeklaShared/ServiceRegistration.cs
+++ b/Connectors/Tekla/Speckle.Connector.TeklaShared/ServiceRegistration.cs
@@ -30,7 +30,7 @@ public static class ServiceRegistration
 
     services.AddSingleton<IBrowserBridge, BrowserBridge>();
 
-    services.AddConnectorUtils();
+    services.AddConnectorUtils<ReceiveOperation>();
     services.AddDUI<DefaultThreadContext, TeklaDocumentModelStore>();
     services.AddDUIView();
 

--- a/DUI3/Speckle.Connectors.DUI/Bindings/OperationProgressManager.cs
+++ b/DUI3/Speckle.Connectors.DUI/Bindings/OperationProgressManager.cs
@@ -31,6 +31,7 @@ public class OperationProgressManager : IOperationProgressManager
   {
     var progress = new NonUIThreadProgress<CardProgress>(args =>
     {
+      Console.WriteLine($"Progress: {args.Status} {args.Progress}");
       SetModelProgress(
         bridge,
         modelCardId,

--- a/Sdk/Speckle.Connectors.Common/Builders/IHostObjectBuilder.cs
+++ b/Sdk/Speckle.Connectors.Common/Builders/IHostObjectBuilder.cs
@@ -28,15 +28,25 @@ public interface IHostObjectBuilder
 
 public abstract class HostObjectBuilderBase : IHostObjectBuilder
 {
-  public  Task<HostObjectBuilderResult> Build(Base rootObject, string projectName, string modelName, IProgress<CardProgress> onOperationProgressed,
-    CancellationToken cancellationToken)  {
-    var result = BuildBase(rootObject, projectName, modelName, onOperationProgressed, cancellationToken );
+  public Task<HostObjectBuilderResult> Build(
+    Base rootObject,
+    string projectName,
+    string modelName,
+    IProgress<CardProgress> onOperationProgressed,
+    CancellationToken cancellationToken
+  )
+  {
+    var result = BuildBase(rootObject, projectName, modelName, onOperationProgressed, cancellationToken);
     return Task.FromResult(result);
   }
 
-  public abstract HostObjectBuilderResult BuildBase(Base rootObject, string projectName, string modelName,
+  public abstract HostObjectBuilderResult BuildBase(
+    Base rootObject,
+    string projectName,
+    string modelName,
     IProgress<CardProgress> onOperationProgressed,
-    CancellationToken cancellationToken);
+    CancellationToken cancellationToken
+  );
 }
 
 public record HostObjectBuilderResult(

--- a/Sdk/Speckle.Connectors.Common/Builders/IHostObjectBuilder.cs
+++ b/Sdk/Speckle.Connectors.Common/Builders/IHostObjectBuilder.cs
@@ -17,13 +17,26 @@ public interface IHostObjectBuilder
   /// <returns> List of application ids.</returns> // POC: Where we will return these ids will matter later when we target to also cache received application ids.
   /// <remarks>Project and model name are needed for now to construct host app objects into related layers or filters.
   /// POC: we might consider later to have HostObjectBuilderContext? that might hold all possible data we will need.</remarks>
-  HostObjectBuilderResult Build(
+  Task<HostObjectBuilderResult> Build(
     Base rootObject,
     string projectName,
     string modelName,
     IProgress<CardProgress> onOperationProgressed,
     CancellationToken cancellationToken
   );
+}
+
+public abstract class HostObjectBuilderBase : IHostObjectBuilder
+{
+  public  Task<HostObjectBuilderResult> Build(Base rootObject, string projectName, string modelName, IProgress<CardProgress> onOperationProgressed,
+    CancellationToken cancellationToken)  {
+    var result = BuildBase(rootObject, projectName, modelName, onOperationProgressed, cancellationToken );
+    return Task.FromResult(result);
+  }
+
+  public abstract HostObjectBuilderResult BuildBase(Base rootObject, string projectName, string modelName,
+    IProgress<CardProgress> onOperationProgressed,
+    CancellationToken cancellationToken);
 }
 
 public record HostObjectBuilderResult(

--- a/Sdk/Speckle.Connectors.Common/ContainerRegistration.cs
+++ b/Sdk/Speckle.Connectors.Common/ContainerRegistration.cs
@@ -11,7 +11,7 @@ namespace Speckle.Connectors.Common;
 public static class ContainerRegistration
 {
   public static void AddConnectorUtils<T>(this IServiceCollection serviceCollection)
-  where T : class, IReceiveOperation
+    where T : class, IReceiveOperation
   {
     // send operation and dependencies
     serviceCollection.AddSingleton<ICancellationManager, CancellationManager>();

--- a/Sdk/Speckle.Connectors.Common/ContainerRegistration.cs
+++ b/Sdk/Speckle.Connectors.Common/ContainerRegistration.cs
@@ -10,12 +10,13 @@ namespace Speckle.Connectors.Common;
 
 public static class ContainerRegistration
 {
-  public static void AddConnectorUtils(this IServiceCollection serviceCollection)
+  public static void AddConnectorUtils<T>(this IServiceCollection serviceCollection)
+  where T : class, IReceiveOperation
   {
     // send operation and dependencies
     serviceCollection.AddSingleton<ICancellationManager, CancellationManager>();
     serviceCollection.AddScoped<RootObjectUnpacker>();
-    serviceCollection.AddScoped<ReceiveOperation>();
+    serviceCollection.AddScoped<IReceiveOperation, T>();
     serviceCollection.AddSingleton<AccountService>();
     serviceCollection.AddMatchingInterfacesAsTransient(Assembly.GetExecutingAssembly());
 


### PR DESCRIPTION
With the new ThreadContext and Send2, thread interaction with RevitTask and progress has changed.  The problem before this PR was that RevitTask was being used too often and caused CEF not to process UI messages right away.  They got queued up for all SDK related operations.  As a temporary, brute-force, fix, CEF/Revit operations (send/receive) are being localised and made obvious for future refactor.

This PR should allow for UI responsive and cancellation during these phases of operations:
 
- [x] SDK Downloading
- [ ]  SDK Deserialization
- [x] SDK Caching/checking cache
- [x] Host App Conversion to Revit objects

Also tested send

- [x] Host App Conversion to Speckle objects
- [x] SDK Uploading
- [x]  SDK Serialization
- [x] SDK Caching/checking cache

Deserialization currently does not allow for the CEF UI to be redrawn despite messages being sent correctly.  Messages catch up then the conversion phase begins