### PR TITLE
Event Aggregator Deadlock Fix

### DIFF
--- a/DUI3/Speckle.Connectors.DUI/Eventing/EventBase.cs
+++ b/DUI3/Speckle.Connectors.DUI/Eventing/EventBase.cs
@@ -18,17 +18,19 @@ public abstract class EventBase
 
   protected async Task InternalPublish(params object[] arguments)
   {
-    var executionStrategies = PruneAndReturnStrategies().ToList();
+    var executionStrategies = PruneAndReturnStrategies();
     foreach (var executionStrategy in executionStrategies)
     {
+      //It's important that we can executeStrategy outside of the lock(_subscription)
       await executionStrategy(arguments);
     }
   }
 
-  private IEnumerable<Func<object[], Task>> PruneAndReturnStrategies()
+  private List<Func<object[], Task>> PruneAndReturnStrategies()
   {
     lock (_subscriptions)
     {
+      List<Func<object[], Task>> ret = new();
       for (var i = _subscriptions.Count - 1; i >= 0; i--)
       {
         var listItem = _subscriptions[i].GetExecutionStrategy();
@@ -40,9 +42,11 @@ public abstract class EventBase
         }
         else
         {
-          yield return listItem;
+          ret.Add(listItem);
         }
       }
+
+      return ret;
     }
   }
 

--- a/DUI3/Speckle.Connectors.DUI/Eventing/EventBase.cs
+++ b/DUI3/Speckle.Connectors.DUI/Eventing/EventBase.cs
@@ -18,7 +18,7 @@ public abstract class EventBase
 
   protected async Task InternalPublish(params object[] arguments)
   {
-    var executionStrategies = PruneAndReturnStrategies();
+    var executionStrategies = PruneAndReturnStrategies().ToList();
     foreach (var executionStrategy in executionStrategies)
     {
       await executionStrategy(arguments);

--- a/DUI3/Speckle.Connectors.DUI/Eventing/EventBase.cs
+++ b/DUI3/Speckle.Connectors.DUI/Eventing/EventBase.cs
@@ -21,7 +21,7 @@ public abstract class EventBase
     var executionStrategies = PruneAndReturnStrategies();
     foreach (var executionStrategy in executionStrategies)
     {
-      //It's important that we can executeStrategy outside of the lock(_subscription)
+      //It's important that we call executeStrategy outside of the lock(_subscription)
       await executionStrategy(arguments);
     }
   }


### PR DESCRIPTION
I was seeing a deadlock scenario in Rhino.

One thread was locking `_subscriptions` while publishing events, however in the callback of that event, it was trying to re-subscribe to an event, which was trying to re-enter a lock.

This PR replaces a `yield` enumerable with a list return to ensure that we aren't inside a lock during the executing of publish events.

![image](https://github.com/user-attachments/assets/da4cd043-b9ee-42e3-bc99-54fae1354352)
