### PR TITLE
Runs BrowserBridge incoming always on worker, fixes confusion on threadcontext

### DIFF
--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Plugin/RevitThreadContext.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Plugin/RevitThreadContext.cs
@@ -15,8 +15,8 @@ public class RevitThreadContext : ThreadContext
   protected override Task<T> WorkerToMain<T>(Func<T> action) => RevitTask.RunAsync(action);
 
   protected override Task<T> RunMainInline<T>(Func<T> action) => RevitTask.RunAsync(action);
-  
-  protected override  Task RunMainInline(Func<Task> action) => RevitTask.RunAsync(action);
+
+  protected override Task RunMainInline(Func<Task> action) => RevitTask.RunAsync(action);
 
   protected override void RunMainInline(Action action) => RevitTask.RunAsync(action);
 

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Plugin/RevitThreadContext.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Plugin/RevitThreadContext.cs
@@ -14,9 +14,11 @@ public class RevitThreadContext : ThreadContext
 
   protected override Task<T> WorkerToMain<T>(Func<T> action) => RevitTask.RunAsync(action);
 
-  protected override Task RunMainAsync(Func<Task> action) => RevitTask.RunAsync(action);
+  protected override Task<T> RunMainInline<T>(Func<T> action) => RevitTask.RunAsync(action);
+  
+  protected override  Task RunMainInline(Func<Task> action) => RevitTask.RunAsync(action);
 
-  protected override Task<T> RunMainAsync<T>(Func<T> action) => RevitTask.RunAsync(action);
+  protected override void RunMainInline(Action action) => RevitTask.RunAsync(action);
 
-  protected override Task<T> RunMainAsync<T>(Func<Task<T>> action) => RevitTask.RunAsync(action);
+  protected override Task<T> RunMainInline<T>(Func<Task<T>> action) => RevitTask.RunAsync(action);
 }

--- a/DUI3/Speckle.Connectors.DUI/Bridge/BrowserBridge.cs
+++ b/DUI3/Speckle.Connectors.DUI/Bridge/BrowserBridge.cs
@@ -124,7 +124,7 @@ public sealed class BrowserBridge : IBrowserBridge
   //don't wait for browser runs on purpose
   public void RunMethod(string methodName, string requestId, string methodArgs) =>
     _threadContext
-      .RunOnThreadAsync(
+      .RunOnWorkerAsync(
         async () =>
         {
           var task = await _topLevelExceptionHandler
@@ -140,8 +140,7 @@ public sealed class BrowserBridge : IBrowserBridge
             string resultJson = SerializeFormattedException(task.Exception);
             NotifyUIMethodCallResultReady(requestId, resultJson);
           }
-        },
-        _threadOptions.RunCommandsOnMainThread
+        }
       )
       .FireAndForget();
 

--- a/DUI3/Speckle.Connectors.DUI/Bridge/BrowserBridge.cs
+++ b/DUI3/Speckle.Connectors.DUI/Bridge/BrowserBridge.cs
@@ -124,24 +124,22 @@ public sealed class BrowserBridge : IBrowserBridge
   //don't wait for browser runs on purpose
   public void RunMethod(string methodName, string requestId, string methodArgs) =>
     _threadContext
-      .RunOnWorkerAsync(
-        async () =>
-        {
-          var task = await _topLevelExceptionHandler
-            .CatchUnhandledAsync(async () =>
-            {
-              var result = await ExecuteMethod(methodName, methodArgs).ConfigureAwait(false);
-              string resultJson = _jsonSerializer.Serialize(result);
-              NotifyUIMethodCallResultReady(requestId, resultJson);
-            })
-            .ConfigureAwait(false);
-          if (task.Exception is not null)
+      .RunOnWorkerAsync(async () =>
+      {
+        var task = await _topLevelExceptionHandler
+          .CatchUnhandledAsync(async () =>
           {
-            string resultJson = SerializeFormattedException(task.Exception);
+            var result = await ExecuteMethod(methodName, methodArgs).ConfigureAwait(false);
+            string resultJson = _jsonSerializer.Serialize(result);
             NotifyUIMethodCallResultReady(requestId, resultJson);
-          }
+          })
+          .ConfigureAwait(false);
+        if (task.Exception is not null)
+        {
+          string resultJson = SerializeFormattedException(task.Exception);
+          NotifyUIMethodCallResultReady(requestId, resultJson);
         }
-      )
+      })
       .FireAndForget();
 
   /// <summary>

--- a/Sdk/Speckle.Connectors.Common/Threading/ThreadContext.cs
+++ b/Sdk/Speckle.Connectors.Common/Threading/ThreadContext.cs
@@ -119,6 +119,7 @@ public abstract class ThreadContext : IThreadContext
   protected abstract Task<T> WorkerToMain<T>(Func<T> action);
 
   protected abstract Task<T> MainToWorker<T>(Func<T> action);
+
   protected virtual void RunWorkerInline(Action action) => action();
 
   protected virtual Task<T> RunWorkerInline<T>(Func<T> action) => Task.FromResult(action());

--- a/Sdk/Speckle.Connectors.Common/Threading/ThreadContext.cs
+++ b/Sdk/Speckle.Connectors.Common/Threading/ThreadContext.cs
@@ -14,7 +14,7 @@ public abstract class ThreadContext : IThreadContext
     {
       if (IsMainThread)
       {
-        RunMain(action);
+        RunMainInline(action);
       }
       else
       {
@@ -37,7 +37,7 @@ public abstract class ThreadContext : IThreadContext
       }
       else
       {
-        RunMain(action);
+        RunWorkerInline(action);
       }
     }
   }
@@ -48,7 +48,7 @@ public abstract class ThreadContext : IThreadContext
     {
       if (IsMainThread)
       {
-        return RunMainAsync(action);
+        return RunMainInline(action);
       }
 
       return WorkerToMain(action);
@@ -58,7 +58,7 @@ public abstract class ThreadContext : IThreadContext
       return MainToWorker(action);
     }
 
-    return RunMainAsync(action);
+    return RunWorkerInline(action);
   }
 
   public async Task RunOnThreadAsync(Func<Task> action, bool useMain)
@@ -67,7 +67,7 @@ public abstract class ThreadContext : IThreadContext
     {
       if (IsMainThread)
       {
-        await RunMainAsync(action);
+        await RunMainInline(action);
       }
       else
       {
@@ -90,7 +90,7 @@ public abstract class ThreadContext : IThreadContext
       }
       else
       {
-        await RunMainAsync(action);
+        await RunWorkerInline(action);
       }
     }
   }
@@ -101,7 +101,7 @@ public abstract class ThreadContext : IThreadContext
     {
       if (IsMainThread)
       {
-        return RunMainAsync(action);
+        return RunMainInline(action);
       }
 
       return WorkerToMainAsync(action);
@@ -110,7 +110,7 @@ public abstract class ThreadContext : IThreadContext
     {
       return MainToWorkerAsync(action);
     }
-    return RunMainAsync(action);
+    return RunWorkerInline(action);
   }
 
   protected abstract Task<T> WorkerToMainAsync<T>(Func<Task<T>> action);
@@ -119,12 +119,19 @@ public abstract class ThreadContext : IThreadContext
   protected abstract Task<T> WorkerToMain<T>(Func<T> action);
 
   protected abstract Task<T> MainToWorker<T>(Func<T> action);
+  protected virtual void RunWorkerInline(Action action) => action();
 
-  protected virtual void RunMain(Action action) => action();
+  protected virtual Task<T> RunWorkerInline<T>(Func<T> action) => Task.FromResult(action());
 
-  protected virtual Task<T> RunMainAsync<T>(Func<T> action) => Task.FromResult(action());
+  protected virtual Task RunWorkerInline(Func<Task> action) => Task.FromResult(action());
 
-  protected virtual Task RunMainAsync(Func<Task> action) => Task.FromResult(action());
+  protected virtual Task<T> RunWorkerInline<T>(Func<Task<T>> action) => action();
 
-  protected virtual Task<T> RunMainAsync<T>(Func<Task<T>> action) => action();
+  protected virtual void RunMainInline(Action action) => action();
+
+  protected virtual Task<T> RunMainInline<T>(Func<T> action) => Task.FromResult(action());
+
+  protected virtual Task RunMainInline(Func<Task> action) => Task.FromResult(action());
+
+  protected virtual Task<T> RunMainInline<T>(Func<Task<T>> action) => action();
 }

--- a/Sdk/Speckle.Connectors.Common/Threading/ThreadOptions.cs
+++ b/Sdk/Speckle.Connectors.Common/Threading/ThreadOptions.cs
@@ -8,5 +8,5 @@ namespace Speckle.Connectors.Common.Threading;
 public class ThreadOptions(ISpeckleApplication speckleApplication) : IThreadOptions
 {
   public bool RunReceiveBuildOnMainThread => speckleApplication.HostApplication != HostApplications.Rhino.Name;
-  public bool RunCommandsOnMainThread => speckleApplication.HostApplication != HostApplications.ArcGIS.Name;
+  public bool RunCommandsOnMainThread => speckleApplication.HostApplication == HostApplications.ArcGIS.Name;
 }

--- a/Sdk/Speckle.Connectors.Common/Threading/ThreadOptions.cs
+++ b/Sdk/Speckle.Connectors.Common/Threading/ThreadOptions.cs
@@ -8,5 +8,4 @@ namespace Speckle.Connectors.Common.Threading;
 public class ThreadOptions(ISpeckleApplication speckleApplication) : IThreadOptions
 {
   public bool RunReceiveBuildOnMainThread => speckleApplication.HostApplication != HostApplications.Rhino.Name;
-  public bool RunCommandsOnMainThread => speckleApplication.HostApplication == HostApplications.ArcGIS.Name;
 }


### PR DESCRIPTION
Tested send/receive:
- [x] Autocad
- [ ] Rhino
- [ ] Revit