### PR TITLE
Dimitrie/cnx 1238 rhino 8 restarting during an operation throws with key not

### DIFF
--- a/Connectors/ArcGIS/Speckle.Connectors.ArcGIS3/Bindings/ArcGISReceiveBinding.cs
+++ b/Connectors/ArcGIS/Speckle.Connectors.ArcGIS3/Bindings/ArcGISReceiveBinding.cs
@@ -60,7 +60,7 @@ public sealed class ArcGISReceiveBinding : IReceiveBinding
         throw new InvalidOperationException("No download model card was found.");
       }
 
-      using var cancellationItem = _cancellationManager.GetCancellationItem(modelCardId);
+      var cancellationItem = _cancellationManager.GetCancellationItem(modelCardId);
       using var scope = _serviceProvider.CreateScope();
       scope
         .ServiceProvider.GetRequiredService<IConverterSettingsStore<ArcGISConversionSettings>>()

--- a/Connectors/ArcGIS/Speckle.Connectors.ArcGIS3/Bindings/ArcGISSendBinding.cs
+++ b/Connectors/ArcGIS/Speckle.Connectors.ArcGIS3/Bindings/ArcGISSendBinding.cs
@@ -373,7 +373,7 @@ public sealed class ArcGISSendBinding : ISendBinding
         throw new InvalidOperationException("No publish model card was found.");
       }
 
-      using var cancellationItem = _cancellationManager.GetCancellationItem(modelCardId);
+      var cancellationItem = _cancellationManager.GetCancellationItem(modelCardId);
 
       using var scope = _serviceProvider.CreateScope();
       scope

--- a/Connectors/Autocad/Speckle.Connectors.AutocadShared/Bindings/AutocadReceiveBinding.cs
+++ b/Connectors/Autocad/Speckle.Connectors.AutocadShared/Bindings/AutocadReceiveBinding.cs
@@ -74,7 +74,7 @@ public sealed class AutocadReceiveBinding : IReceiveBinding
         throw new InvalidOperationException("No download model card was found.");
       }
 
-      using var cancellationItem = _cancellationManager.GetCancellationItem(modelCardId);
+      var cancellationItem = _cancellationManager.GetCancellationItem(modelCardId);
 
       // Disable document activation (document creation and document switch)
       // Not disabling results in DUI model card being out of sync with the active document

--- a/Connectors/Autocad/Speckle.Connectors.AutocadShared/Bindings/AutocadSendBaseBinding.cs
+++ b/Connectors/Autocad/Speckle.Connectors.AutocadShared/Bindings/AutocadSendBaseBinding.cs
@@ -162,7 +162,7 @@ public abstract class AutocadSendBaseBinding : ISendBinding
       using var scope = _serviceProvider.CreateScope();
       InitializeSettings(scope.ServiceProvider);
 
-      using var cancellationItem = _cancellationManager.GetCancellationItem(modelCardId);
+      var cancellationItem = _cancellationManager.GetCancellationItem(modelCardId);
 
       // Disable document activation (document creation and document switch)
       // Not disabling results in DUI model card being out of sync with the active document

--- a/Connectors/CSi/Speckle.Connectors.CSiShared/Bindings/CsiSharedSendBinding.cs
+++ b/Connectors/CSi/Speckle.Connectors.CSiShared/Bindings/CsiSharedSendBinding.cs
@@ -84,7 +84,7 @@ public sealed class CsiSharedSendBinding : ISendBinding
         .ServiceProvider.GetRequiredService<IConverterSettingsStore<CsiConversionSettings>>()
         .Initialize(_csiConversionSettingsFactory.Create(_csiApplicationService.SapModel));
 
-      using var cancellationItem = _cancellationManager.GetCancellationItem(modelCardId);
+      var cancellationItem = _cancellationManager.GetCancellationItem(modelCardId);
 
       List<ICsiWrapper> wrappers = modelCard
         .SendFilter.NotNull()

--- a/Connectors/Navisworks/Speckle.Connectors.NavisworksShared/Bindings/NavisworksSendBinding.cs
+++ b/Connectors/Navisworks/Speckle.Connectors.NavisworksShared/Bindings/NavisworksSendBinding.cs
@@ -100,7 +100,7 @@ public class NavisworksSendBinding : ISendBinding
 
       InitializeConverterSettings(scope, modelCard);
 
-      using var cancellationItem = _cancellationManager.GetCancellationItem(modelCardId);
+      var cancellationItem = _cancellationManager.GetCancellationItem(modelCardId);
 
       var navisworksModelItems = GetNavisworksModelItems(modelCard);
 

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Bindings/RevitReceiveBinding.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Bindings/RevitReceiveBinding.cs
@@ -64,7 +64,7 @@ internal sealed class RevitReceiveBinding : IReceiveBinding
         throw new InvalidOperationException("No download model card was found.");
       }
 
-      using var cancellationItem = _cancellationManager.GetCancellationItem(modelCardId);
+      var cancellationItem = _cancellationManager.GetCancellationItem(modelCardId);
 
       using var scope = _serviceProvider.CreateScope();
       scope

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Bindings/RevitSendBinding.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Bindings/RevitSendBinding.cs
@@ -121,7 +121,7 @@ internal sealed class RevitSendBinding : RevitBaseBinding, ISendBinding
         throw new InvalidOperationException("No publish model card was found.");
       }
 
-      using var cancellationItem = _cancellationManager.GetCancellationItem(modelCardId);
+      var cancellationItem = _cancellationManager.GetCancellationItem(modelCardId);
 
       using var scope = _serviceProvider.CreateScope();
       scope

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/Bindings/RhinoReceiveBinding.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/Bindings/RhinoReceiveBinding.cs
@@ -70,7 +70,7 @@ public class RhinoReceiveBinding : IReceiveBinding
         throw new InvalidOperationException("No download model card was found.");
       }
 
-      using var cancellationItem = _cancellationManager.GetCancellationItem(modelCardId);
+      var cancellationItem = _cancellationManager.GetCancellationItem(modelCardId);
 
       undoRecord = RhinoDoc.ActiveDoc.BeginUndoRecord($"Receive Speckle model {modelCard.ModelName}");
       // Receive host objects

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/Bindings/RhinoSendBinding.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/Bindings/RhinoSendBinding.cs
@@ -297,7 +297,7 @@ public sealed class RhinoSendBinding : ISendBinding
         throw new InvalidOperationException("No publish model card was found.");
       }
 
-      using var cancellationItem = _cancellationManager.GetCancellationItem(modelCardId);
+      var cancellationItem = _cancellationManager.GetCancellationItem(modelCardId);
 
       List<RhinoObject> rhinoObjects = modelCard
         .SendFilter.NotNull()

--- a/Connectors/Tekla/Speckle.Connector.TeklaShared/Bindings/TeklaSendBinding.cs
+++ b/Connectors/Tekla/Speckle.Connector.TeklaShared/Bindings/TeklaSendBinding.cs
@@ -126,7 +126,7 @@ public sealed class TeklaSendBinding : ISendBinding
           _teklaConversionSettingsFactory.Create(_model, _toSpeckleSettingsManager.GetSendRebarsAsSolid(modelCard))
         );
 
-      using var cancellationItem = _cancellationManager.GetCancellationItem(modelCardId);
+      var cancellationItem = _cancellationManager.GetCancellationItem(modelCardId);
 
       List<ModelObject> teklaObjects = modelCard
         .SendFilter.NotNull()

--- a/Sdk/Speckle.Connectors.Common.Tests/CancellationManagerTests.cs
+++ b/Sdk/Speckle.Connectors.Common.Tests/CancellationManagerTests.cs
@@ -7,6 +7,9 @@ namespace Speckle.Connectors.Common.Tests;
 public class CancellationManagerTests
 {
   [Test]
+  [Ignore(
+    "Changed cancellation manager to no longer dispose stuff. See [CNX-1238: Rhino 8: Restarting during an operation throws with \"key not present in the dictionary\" in the cancellation manager](https://linear.app/speckle/issue/CNX-1238/rhino-8-restarting-during-an-operation-throws-with-key-not-present-in)"
+  )]
   public void CancelOne()
   {
     var manager = new CancellationManager();
@@ -21,7 +24,7 @@ public class CancellationManagerTests
     item.Token.IsCancellationRequested.Should().BeTrue();
     manager.IsCancellationRequested(id).Should().BeTrue();
     manager.IsExist(id).Should().BeTrue();
-    item.Dispose();
+    // item.Dispose();
 
     manager.IsExist(id).Should().BeFalse();
     Assert.Throws<KeyNotFoundException>(() => item.Token.IsCancellationRequested.Should().BeTrue());
@@ -30,6 +33,9 @@ public class CancellationManagerTests
   }
 
   [Test]
+  [Ignore(
+    "Changed cancellation manager to no longer dispose stuff. See [CNX-1238: Rhino 8: Restarting during an operation throws with \"key not present in the dictionary\" in the cancellation manager](https://linear.app/speckle/issue/CNX-1238/rhino-8-restarting-during-an-operation-throws-with-key-not-present-in)"
+  )]
   public void CancelTwo()
   {
     var manager = new CancellationManager();
@@ -46,7 +52,7 @@ public class CancellationManagerTests
     item1.Token.IsCancellationRequested.Should().BeTrue();
     manager.IsCancellationRequested(id1).Should().BeTrue();
     manager.IsExist(id1).Should().BeTrue();
-    item1.Dispose();
+    // item1.Dispose();
 
     manager.IsExist(id1).Should().BeFalse();
     Assert.Throws<KeyNotFoundException>(() => item1.Token.IsCancellationRequested.Should().BeTrue());
@@ -59,7 +65,7 @@ public class CancellationManagerTests
     item2.Token.IsCancellationRequested.Should().BeTrue();
     manager.IsCancellationRequested(id2).Should().BeTrue();
     manager.IsExist(id2).Should().BeTrue();
-    item2.Dispose();
+    // item2.Dispose();
 
     manager.IsExist(id2).Should().BeFalse();
     Assert.Throws<KeyNotFoundException>(() => item2.Token.IsCancellationRequested.Should().BeTrue());
@@ -68,6 +74,9 @@ public class CancellationManagerTests
   }
 
   [Test]
+  [Ignore(
+    "Changed cancellation manager to no longer dispose stuff. See [CNX-1238: Rhino 8: Restarting during an operation throws with \"key not present in the dictionary\" in the cancellation manager](https://linear.app/speckle/issue/CNX-1238/rhino-8-restarting-during-an-operation-throws-with-key-not-present-in)"
+  )]
   public void CancelAll()
   {
     var manager = new CancellationManager();
@@ -87,8 +96,8 @@ public class CancellationManagerTests
     manager.IsCancellationRequested(id2).Should().BeTrue();
     manager.IsExist(id1).Should().BeTrue();
     manager.IsExist(id2).Should().BeTrue();
-    item1.Dispose();
-    item2.Dispose();
+    // item1.Dispose();
+    // item2.Dispose();
 
     manager.IsExist(id1).Should().BeFalse();
     manager.IsExist(id2).Should().BeFalse();

--- a/Sdk/Speckle.Connectors.Common/Cancellation/CancellationManager.cs
+++ b/Sdk/Speckle.Connectors.Common/Cancellation/CancellationManager.cs
@@ -2,7 +2,7 @@ using Speckle.InterfaceGenerator;
 
 namespace Speckle.Connectors.Common.Cancellation;
 
-public interface ICancellationItem : IDisposable
+public interface ICancellationItem
 {
   CancellationToken Token { get; }
 }
@@ -15,8 +15,6 @@ public class CancellationManager : ICancellationManager
 {
   private sealed class CancellationItem(CancellationManager manager, string id) : ICancellationItem
   {
-    public void Dispose() => manager.DisposeOperation(id);
-
     public CancellationToken Token => manager.GetToken(id);
   }
 
@@ -57,8 +55,6 @@ public class CancellationManager : ICancellationManager
   /// <returns> Initialized cancellation token source.</returns>
   public ICancellationItem GetCancellationItem(string id)
   {
-    DisposeOperation(id);
-
     var cts = new CancellationTokenSource();
     _operationsInProgress[id] = cts;
     return new CancellationItem(this, id);
@@ -73,16 +69,6 @@ public class CancellationManager : ICancellationManager
     if (_operationsInProgress.TryGetValue(id, out CancellationTokenSource? cts))
     {
       cts.Cancel();
-    }
-  }
-
-  private void DisposeOperation(string id)
-  {
-    if (_operationsInProgress.TryGetValue(id, out CancellationTokenSource? cts))
-    {
-      cts.Cancel();
-      cts.Dispose();
-      _operationsInProgress.Remove(id);
     }
   }
 


### PR DESCRIPTION
Fixes a rhino issue that was introduced by https://github.com/specklesystems/speckle-sharp-connectors/pull/557

@adamhathcock this fix is probably not cool, but happy if you take over with a more proper one if it's really needed to have disposal on `ICancellationItem`s 