### PR TITLE
fix(etabs): ensure csi operations run on main thread to prevent etabs exceptions

### DIFF
--- a/Connectors/CSi/Speckle.Connectors.CSiShared/Bindings/CsiSharedBasicConnectorBinding.cs
+++ b/Connectors/CSi/Speckle.Connectors.CSiShared/Bindings/CsiSharedBasicConnectorBinding.cs
@@ -53,11 +53,17 @@ public class CsiSharedBasicConnectorBinding : IBasicConnectorBinding
 
   public DocumentModelStore GetDocumentState() => _store;
 
-  public void AddModel(ModelCard model) => _threadContext.RunOnMain(() => _store.AddModel(model));
+  /// <remarks>Operations must run on the main thread for ETABS and SAP 2000</remarks>
+  public void AddModel(ModelCard model) =>
+    _topLevelExceptionHandler.CatchUnhandled(() => _threadContext.RunOnThread(() => _store.AddModel(model), true));
 
-  public void UpdateModel(ModelCard model) => _threadContext.RunOnMain(() => _store.UpdateModel(model));
+  /// <remarks>Operations must run on the main thread for ETABS and SAP 2000</remarks>
+  public void UpdateModel(ModelCard model) =>
+    _topLevelExceptionHandler.CatchUnhandled(() => _threadContext.RunOnThread(() => _store.UpdateModel(model), true));
 
-  public void RemoveModel(ModelCard model) => _threadContext.RunOnMain(() => _store.RemoveModel(model));
+  /// <remarks>Operations must run on the main thread for ETABS and SAP 2000</remarks>
+  public void RemoveModel(ModelCard model) =>
+    _topLevelExceptionHandler.CatchUnhandled(() => _threadContext.RunOnThread(() => _store.RemoveModel(model), true));
 
   public Task HighlightModel(string modelCardId) => Task.CompletedTask;
 

--- a/Connectors/CSi/Speckle.Connectors.CSiShared/Bindings/CsiSharedSelectionBinding.cs
+++ b/Connectors/CSi/Speckle.Connectors.CSiShared/Bindings/CsiSharedSelectionBinding.cs
@@ -38,12 +38,14 @@ public class CsiSharedSelectionBinding : ISelectionBinding, IDisposable
 
   private void CheckSelectionChanged()
   {
+    // timer callbacks are on a background thread, but CSI API calls must be on main thread
     var currentSelection = GetSelection();
     var currentIds = new HashSet<string>(currentSelection.SelectedObjectIds);
 
     if (!_lastSelection.SetEquals(currentIds))
     {
       _lastSelection = currentIds;
+      // ensure UI updates also run on main thread
       _threadContext.RunOnMain(() => Parent.Send(SelectionBindingEvents.SET_SELECTION, currentSelection));
     }
   }

--- a/Connectors/CSi/Speckle.Connectors.CSiShared/HostApp/CsiDocumentModelStore.cs
+++ b/Connectors/CSi/Speckle.Connectors.CSiShared/HostApp/CsiDocumentModelStore.cs
@@ -43,6 +43,8 @@ public class CsiDocumentModelStore : DocumentModelStore, IDisposable
 
     // initialize timer to check for model changes
     _modelCheckTimer = new Timer(1000);
+
+    // timer runs on background thread but model checks must be on main thread
     _modelCheckTimer.Elapsed += (_, _) =>
       _topLevelExceptionHandler.CatchUnhandled(() => _threadContext.RunOnMain(CheckModelChanges));
     _modelCheckTimer.Start();

--- a/Connectors/CSi/Speckle.Connectors.CSiShared/HostApp/CsiDocumentModelStore.cs
+++ b/Connectors/CSi/Speckle.Connectors.CSiShared/HostApp/CsiDocumentModelStore.cs
@@ -1,5 +1,6 @@
 ﻿using System.IO;
 using Microsoft.Extensions.Logging;
+using Speckle.Connectors.Common.Threading;
 using Speckle.Connectors.DUI.Bridge;
 using Speckle.Connectors.DUI.Models;
 using Speckle.Connectors.DUI.Utils;
@@ -16,6 +17,7 @@ public class CsiDocumentModelStore : DocumentModelStore, IDisposable
   private readonly ILogger<CsiDocumentModelStore> _logger;
   private readonly ICsiApplicationService _csiApplicationService;
   private readonly ITopLevelExceptionHandler _topLevelExceptionHandler;
+  private readonly IThreadContext _threadContext;
   private readonly Timer _modelCheckTimer;
   private string _lastModelFilename = string.Empty;
   private bool _disposed;
@@ -28,10 +30,12 @@ public class CsiDocumentModelStore : DocumentModelStore, IDisposable
     ISpeckleApplication speckleApplication,
     ILogger<CsiDocumentModelStore> logger,
     ICsiApplicationService csiApplicationService,
-    ITopLevelExceptionHandler topLevelExceptionHandler
+    ITopLevelExceptionHandler topLevelExceptionHandler,
+    IThreadContext threadContext
   )
     : base(jsonSerializer)
   {
+    _threadContext = threadContext;
     _speckleApplication = speckleApplication;
     _logger = logger;
     _csiApplicationService = csiApplicationService;
@@ -39,7 +43,8 @@ public class CsiDocumentModelStore : DocumentModelStore, IDisposable
 
     // initialize timer to check for model changes
     _modelCheckTimer = new Timer(1000);
-    _modelCheckTimer.Elapsed += (_, _) => _topLevelExceptionHandler.CatchUnhandled(CheckModelChanges);
+    _modelCheckTimer.Elapsed += (_, _) =>
+      _topLevelExceptionHandler.CatchUnhandled(() => _threadContext.RunOnMain(CheckModelChanges));
     _modelCheckTimer.Start();
   }
 


### PR DESCRIPTION
## Description

Etabs Warnings appearing since the #574 fix:

1. `IndexOutOfRangeException` in toolbar dropdown operations 
2. `InvalidOperationException` with cross-thread access to Windows Forms controls
3. "Error in initializing next undo arrays" when performing certain operations

## User Value

Horrible user experience. NOTE: these dialogs / warnings don't pop up but remain in the background and dont affect send. For the screenshot, the pop-ups were activated:

<img width="960" alt="Screenshot 2025-02-14 144918" src="https://github.com/user-attachments/assets/5b71266e-b15f-4ae3-9cf5-8b550b420d86" />

## Changes:

Rather than changing DUI threading behavior, contained the fix within the CSI:

1. Added `IThreadContext` injection to CSI bindings and store
2. Wrapped CSI API calls in `RunOnMain` to ensure they execute on the main thread
3. Ensured UI updates from timers and event handlers maintain proper thread affinity

## Screenshots:

### Before

<img width="452" alt="Screenshot 2025-02-14 150709" src="https://github.com/user-attachments/assets/07da2a9f-c09a-4ddc-8873-852856789687" />

### After

<img width="263" alt="image" src="https://github.com/user-attachments/assets/1e4589bc-a73a-4a6d-95a5-131fcfd4b307" />

## Validation of changes:

Tested both in ETABS 21 and ETABS 22, leaving the plugin open for 10 mins.

## Checklist:

- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] I have added appropriate tests.
- [x] I have updated or added relevant documentation.

