### PR TITLE
fix(civil3d): alignment spiral points set to 0 elevation

### DIFF
--- a/Converters/Civil3d/Speckle.Converters.Civil3dShared/ToSpeckle/Raw/AlignmentSubentitySpiralToSpeckleRawConverter.cs
+++ b/Converters/Civil3d/Speckle.Converters.Civil3dShared/ToSpeckle/Raw/AlignmentSubentitySpiralToSpeckleRawConverter.cs
@@ -37,11 +37,10 @@ public class AlignmentSubentitySpiralToSpeckleRawConverter
     {
       double x = 0;
       double y = 0;
-      double z = 0;
-      alignment.PointLocation(spiral.StartStation + i * spiralSegmentLength, 0, 0.001, ref x, ref y, ref z);
+      alignment.PointLocation(spiral.StartStation + i * spiralSegmentLength, 0, ref x, ref y);
       polylineValue.Add(x);
       polylineValue.Add(y);
-      polylineValue.Add(z);
+      polylineValue.Add(0);
     }
     polylineValue.Add(spiral.EndPoint.X);
     polylineValue.Add(spiral.EndPoint.Y);


### PR DESCRIPTION
## Description

Fixes bug where alignment spiral subentity curve points z-value was being assigned to the point's bearing instead of 0.
Fixes #553

## User Value

no more incorrect alignment spiral curves

## Changes:

- civil converter
