### PR TITLE
fix(revit): use correct unit scaling for material quantities

### DIFF
--- a/Converters/Revit/Speckle.Converters.RevitShared/ToSpeckle/Raw/MaterialQuantitiesToSpeckle.cs
+++ b/Converters/Revit/Speckle.Converters.RevitShared/ToSpeckle/Raw/MaterialQuantitiesToSpeckle.cs
@@ -54,21 +54,22 @@ public class MaterialQuantitiesToSpeckleLite : ITypedConverter<DB.Element, Dicti
         }
 
         var materialQuantity = new Dictionary<string, object>();
-        double factor = _scalingService.ScaleLength(1);
         var unitSettings = _converterSettings.Current.Document.GetUnits();
 
+        var areaUnitType = unitSettings.GetFormatOptions(DB.SpecTypeId.Area).GetUnitTypeId();
         AddMaterialProperty(
           materialQuantity,
           "area",
-          factor * factor * target.GetMaterialArea(matId, false),
-          unitSettings.GetFormatOptions(DB.SpecTypeId.Area).GetUnitTypeId()
+          _scalingService.Scale(target.GetMaterialArea(matId, false), areaUnitType),
+          areaUnitType
         );
 
+        var volumeUnitType = unitSettings.GetFormatOptions(DB.SpecTypeId.Volume).GetUnitTypeId();
         AddMaterialProperty(
           materialQuantity,
           "volume",
-          factor * factor * factor * target.GetMaterialVolume(matId),
-          unitSettings.GetFormatOptions(DB.SpecTypeId.Volume).GetUnitTypeId()
+          _scalingService.Scale(target.GetMaterialVolume(matId), volumeUnitType),
+          volumeUnitType
         );
 
         if (_converterSettings.Current.Document.GetElement(matId) is DB.Material material)


### PR DESCRIPTION
## Description

Fixes inconsistent `area` and `volume` measurements between `ParameterExtractor` and `MaterialQuantitiesToSpeckle` by using proper unit-specific scaling instead of derived length factor squaring and cubing.

When extracting material quantities, volumes (e.g.) were being scaled incorrectly by 10⁶ due to improper unit conversion handling.

Fixes [CNX-1277](https://linear.app/speckle/issue/CNX-1277/revit-material-quantities-scaling-bug).

## User Value

Ensures consistent and accurate material quantity measurements across all Revit elements.

## Changes:

- Replace manual length factor squaring and cubing with unit-specific `Scale()` method in `MaterialQuantitiesToSpeckle`
- Fix incorrect volume unit conversions
- Fix incorrect area unit conversions

## Validation of changes:

- Before: [Commit](https://latest.speckle.systems/projects/99d30f721c/models/23db9dbd5d)
- After: [Commit](https://latest.speckle.systems/projects/99d30f721c/models/bbed9ff3e4)

Left is after changes, right is before changes:

<img width="1279" alt="image" src="https://github.com/user-attachments/assets/86c5f941-bba2-4711-ab4c-c1c0b880cd1b" />

The `area` in `Parameters/Instance Parameters/Dimensions` is different, because the one just reports the in plan footprint, the other (`MaterialQuantitiesToSpeckle.cs`) measures the cumulative surface area for all faces assuming a nominal thickness of "paint".

## Checklist:

- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] I have added appropriate tests.
- [x] I have updated or added relevant documentation.

