### PR TITLE
Add support for vertex normals in rhino

### DIFF
--- a/Converters/Rhino/Speckle.Converters.RhinoShared/ToSpeckle/Raw/MeshToSpeckleConverter.cs
+++ b/Converters/Rhino/Speckle.Converters.RhinoShared/ToSpeckle/Raw/MeshToSpeckleConverter.cs
@@ -65,6 +65,14 @@ public class MeshToSpeckleConverter : ITypedConverter<RG.Mesh, SOG.Mesh>
       colors.Add(c.ToArgb());
     }
 
+    List<double> vertexNormals = new(target.Normals.Count * 3);
+    foreach (var n in target.Normals)
+    {
+      vertexNormals.Add(n.X);
+      vertexNormals.Add(n.Y);
+      vertexNormals.Add(n.Z);
+    }
+
     double volume = target.IsClosed ? target.Volume() : 0;
     SOG.Box bbox = _boxConverter.Convert(new RG.Box(target.GetBoundingBox(false)));
 
@@ -74,6 +82,7 @@ public class MeshToSpeckleConverter : ITypedConverter<RG.Mesh, SOG.Mesh>
       faces = faces,
       colors = colors,
       textureCoordinates = textureCoordinates,
+      vertexNormals = vertexNormals,
       units = _settingsStore.Current.SpeckleUnits,
       volume = volume,
       bbox = bbox


### PR DESCRIPTION
Extracted only the rhino changes from my branch adding vertex normals, since I cannot say for certain if its worth us implementing vertex normal support in Autocad and Revit (my findings suggest that they look the same whether we extract normals or not)