### PR TITLE
fix(tekla): moves class properties to top level of properties dictionary

### DIFF
--- a/Converters/Tekla/Speckle.Converters.TeklaShared/ToSpeckle/Helpers/PropertiesExtractor.cs
+++ b/Converters/Tekla/Speckle.Converters.TeklaShared/ToSpeckle/Helpers/PropertiesExtractor.cs
@@ -4,19 +4,23 @@ public class PropertiesExtractor
 {
   private readonly ReportPropertyExtractor _reportPropertyExtractor;
   private readonly UserDefinedAttributesExtractor _userDefinedAttributesExtractor;
+  private readonly ClassPropertyExtractor _classPropertyExtractor;
 
   public PropertiesExtractor(
     ReportPropertyExtractor reportPropertyExtractor,
-    UserDefinedAttributesExtractor userDefinedAttributesExtractor
+    UserDefinedAttributesExtractor userDefinedAttributesExtractor,
+    ClassPropertyExtractor classPropertyExtractor
   )
   {
     _reportPropertyExtractor = reportPropertyExtractor;
     _userDefinedAttributesExtractor = userDefinedAttributesExtractor;
+    _classPropertyExtractor = classPropertyExtractor;
   }
 
   public Dictionary<string, object?> GetProperties(TSM.ModelObject modelObject)
   {
-    Dictionary<string, object?> properties = new();
+    // get the top level class properties first
+    Dictionary<string, object?> properties = _classPropertyExtractor.GetProperties(modelObject);
 
     Dictionary<string, object?> report = _reportPropertyExtractor.GetReportProperties(modelObject);
     if (report.Count > 0)

--- a/Converters/Tekla/Speckle.Converters.TeklaShared/ToSpeckle/TopLevel/ModelObjectToSpeckleConverter.cs
+++ b/Converters/Tekla/Speckle.Converters.TeklaShared/ToSpeckle/TopLevel/ModelObjectToSpeckleConverter.cs
@@ -72,13 +72,6 @@ public class ModelObjectToSpeckleConverter : IToSpeckleTopLevelConverter
       units = _settingsStore.Current.SpeckleUnits
     };
 
-    // add dynamic class properties
-    var classProperties = _classPropertyExtractor.GetProperties(target);
-    foreach (var prop in classProperties)
-    {
-      result[prop.Key] = prop.Value;
-    }
-
     return result;
   }
 }


### PR DESCRIPTION
## Description
 Some tekla object properties are being dynamically attached to the `teklaobject`. Moves these properties to the top level of the `properties` dictionary instead.

## User Value

Standardizes all object properties


## Changes:

- tekla converter
