### PR TITLE
enhancement(Navisworks): CNX-972 - less aggressive object merging

### DIFF
--- a/Connectors/Navisworks/Speckle.Connectors.NavisworksShared/Bindings/NavisworksSendBinding.cs
+++ b/Connectors/Navisworks/Speckle.Connectors.NavisworksShared/Bindings/NavisworksSendBinding.cs
@@ -31,7 +31,6 @@ public class NavisworksSendBinding : ISendBinding
 
   private readonly DocumentModelStore _store;
   private readonly IServiceProvider _serviceProvider;
-  private readonly List<ISendFilter> _sendFilters;
   private readonly ICancellationManager _cancellationManager;
   private readonly IOperationProgressManager _operationProgressManager;
   private readonly ILogger<NavisworksSendBinding> _logger;
@@ -45,7 +44,6 @@ public class NavisworksSendBinding : ISendBinding
   public NavisworksSendBinding(
     DocumentModelStore store,
     IBrowserBridge parent,
-    IEnumerable<ISendFilter> sendFilters,
     IServiceProvider serviceProvider,
     ICancellationManager cancellationManager,
     IOperationProgressManager operationProgressManager,
@@ -62,7 +60,6 @@ public class NavisworksSendBinding : ISendBinding
     Commands = new SendBindingUICommands(parent);
     _store = store;
     _serviceProvider = serviceProvider;
-    _sendFilters = sendFilters.ToList();
     _cancellationManager = cancellationManager;
     _operationProgressManager = operationProgressManager;
     _logger = logger;
@@ -77,7 +74,7 @@ public class NavisworksSendBinding : ISendBinding
 
   private static void SubscribeToNavisworksEvents() { }
 
-  // Do not change the behavior/scope of this class on send binding unless make sure the behavior is same. Otherwise we might not be able to update list of saved sets.
+  // Do not change the behavior/scope of this class on send binding unless make sure the behavior is same. Otherwise, we might not be able to update list of saved sets.
   public List<ISendFilter> GetSendFilters() =>
     [
       new NavisworksSelectionFilter() { IsDefault = true },

--- a/Connectors/Navisworks/Speckle.Connectors.NavisworksShared/HostApp/NavisworksColorUnpacker.cs
+++ b/Connectors/Navisworks/Speckle.Connectors.NavisworksShared/HostApp/NavisworksColorUnpacker.cs
@@ -43,12 +43,13 @@ public class NavisworksColorUnpacker(
     Dictionary<string, ColorProxy> colorProxies = [];
     Dictionary<string, string> mergedIds = [];
 
-    // Build mergedIds map once
     foreach (var group in groupedNodes)
     {
-      foreach (var node in group.Value)
+      string groupKey = group.Key;
+
+      foreach (var nodePath in group.Value.Select(selectionService.GetModelItemPath))
       {
-        mergedIds[selectionService.GetModelItemPath(node)] = group.Key;
+        mergedIds[nodePath] = groupKey;
       }
     }
 
@@ -56,13 +57,13 @@ public class NavisworksColorUnpacker(
     {
       try
       {
-        // Skip non-2D elements
         if (!Is2DElement(navisworksObject))
         {
           continue;
         }
 
         var navisworksObjectId = selectionService.GetModelItemPath(navisworksObject);
+
         var finalId = mergedIds.TryGetValue(navisworksObjectId, out var mergedId) ? mergedId : navisworksObjectId;
 
         var geometry = navisworksObject.Geometry;
@@ -77,7 +78,6 @@ public class NavisworksColorUnpacker(
           geometry.OriginalColor,
           defaultColor
         );
-
         var colorId = Select(
           mode,
           $"{geometry.ActiveColor.GetHashCode()}_{geometry.ActiveTransparency}".GetHashCode(),

--- a/Connectors/Navisworks/Speckle.Connectors.NavisworksShared/HostApp/NavisworksMaterialUnpacker.cs
+++ b/Connectors/Navisworks/Speckle.Connectors.NavisworksShared/HostApp/NavisworksMaterialUnpacker.cs
@@ -43,12 +43,13 @@ public class NavisworksMaterialUnpacker(
     Dictionary<string, RenderMaterialProxy> renderMaterialProxies = [];
     Dictionary<string, string> mergedIds = [];
 
-    // Build mergedIds map once
     foreach (var group in groupedNodes)
     {
-      foreach (var node in group.Value)
+      string groupKey = group.Key;
+
+      foreach (var nodePath in group.Value.Select(selectionService.GetModelItemPath))
       {
-        mergedIds[selectionService.GetModelItemPath(node)] = group.Key;
+        mergedIds[nodePath] = groupKey;
       }
     }
 
@@ -63,7 +64,6 @@ public class NavisworksMaterialUnpacker(
 
         var navisworksObjectId = selectionService.GetModelItemPath(navisworksObject);
         var finalId = mergedIds.TryGetValue(navisworksObjectId, out var mergedId) ? mergedId : navisworksObjectId;
-
         var geometry = navisworksObject.Geometry;
         var mode = converterSettings.Current.User.VisualRepresentationMode;
 
@@ -76,7 +76,6 @@ public class NavisworksMaterialUnpacker(
           geometry.OriginalColor,
           defaultColor
         );
-
         var renderTransparency = Select(
           mode,
           geometry.ActiveTransparency,
@@ -84,7 +83,6 @@ public class NavisworksMaterialUnpacker(
           geometry.OriginalTransparency,
           0.0
         );
-
         var renderMaterialId = Select(
           mode,
           $"{geometry.ActiveColor.GetHashCode()}_{geometry.ActiveTransparency}".GetHashCode(),

--- a/Connectors/Navisworks/Speckle.Connectors.NavisworksShared/Operations/Send/GeometryNodeMerger.cs
+++ b/Connectors/Navisworks/Speckle.Connectors.NavisworksShared/Operations/Send/GeometryNodeMerger.cs
@@ -1,4 +1,5 @@
 ﻿using Speckle.Connector.Navisworks.Services;
+using Speckle.Converter.Navisworks.Constants;
 
 namespace Speckle.Connector.Navisworks.Operations.Send;
 
@@ -7,16 +8,61 @@ namespace Speckle.Connector.Navisworks.Operations.Send;
 /// </summary>
 public static class GeometryNodeMerger
 {
-  public static Dictionary<string, List<NAV.ModelItem>> GroupSiblingGeometryNodes(IReadOnlyList<NAV.ModelItem> nodes) =>
-    nodes
+  /// <summary>
+  /// Groups sibling geometry nodes based on material properties for merging.
+  /// Only merges nodes that share the same parent and have identical material properties.
+  /// </summary>
+  /// <param name="nodes">The collection of ModelItems to process</param>
+  /// <returns>Dictionary mapping parent paths (with material signature suffix) to their mergeable child nodes</returns>
+  public static Dictionary<string, List<NAV.ModelItem>> GroupSiblingGeometryNodes(IReadOnlyList<NAV.ModelItem> nodes)
+  {
+    // Group nameless geometry nodes by parent path and material signature
+    var mergeableGroups = nodes
       .Where(node => node.HasGeometry && string.IsNullOrEmpty(node.DisplayName)) // Only anonymous geometry nodes
       .GroupBy(node =>
       {
+        // Get parent path
         var service = new ElementSelectionService();
         var path = service.GetModelItemPath(node);
         var lastSeparatorIndex = path.LastIndexOf(PathConstants.SEPARATOR);
-        return lastSeparatorIndex == -1 ? path : path[..lastSeparatorIndex];
+        var parentPath = lastSeparatorIndex == -1 ? path : path[..lastSeparatorIndex];
+
+        // Combine parent path with material signature
+        string materialSignature = GetMaterialSignature(node);
+        return $"{parentPath}{PathConstants.MATERIAL_SEPARATOR}{materialSignature}";
       })
-      .Where(group => group.Count() > 1) // Only group multiples
+      .Where(group => group.Count() > 1) // Only include groups with multiple children
       .ToDictionary(group => group.Key, group => group.ToList());
+
+    return mergeableGroups;
+  }
+
+  /// <summary>
+  /// Creates a signature string that represents the material properties of a node.
+  /// </summary>
+  /// <param name="node">The ModelItem to create a material signature for</param>
+  /// <returns>A signature string representing the node's material properties</returns>
+  private static string GetMaterialSignature(NAV.ModelItem node)
+  {
+    if (!node.HasGeometry || node.Geometry == null)
+    {
+      return "nogeometry";
+    }
+
+    var geometry = node.Geometry;
+
+    // Create a material signature based on active, permanent, and original colors and transparency
+    return $"{geometry.ActiveColor?.GetHashCode() ?? 0}_{geometry.ActiveTransparency}_{geometry.PermanentColor?.GetHashCode() ?? 0}_{geometry.PermanentTransparency}_{geometry.OriginalColor?.GetHashCode() ?? 0}_{geometry.OriginalTransparency}";
+  }
+
+  /// <summary>
+  /// Extracts just the parent path from a composite key that may include a material signature.
+  /// </summary>
+  /// <param name="compositeKey">The composite key which may include both path and material signature</param>
+  /// <returns>The parent path portion of the key</returns>
+  public static string GetParentPathFromKey(string compositeKey)
+  {
+    var separatorIndex = compositeKey.IndexOf(PathConstants.MATERIAL_SEPARATOR, StringComparison.Ordinal);
+    return separatorIndex > 0 ? compositeKey[..separatorIndex] : compositeKey;
+  }
 }

--- a/Connectors/Navisworks/Speckle.Connectors.NavisworksShared/Operations/Send/GeometryNodeMerger.cs
+++ b/Connectors/Navisworks/Speckle.Connectors.NavisworksShared/Operations/Send/GeometryNodeMerger.cs
@@ -1,4 +1,4 @@
-using Speckle.Connector.Navisworks.Services;
+﻿using Speckle.Connector.Navisworks.Services;
 using Speckle.Converter.Navisworks.Constants;
 
 namespace Speckle.Connector.Navisworks.Operations.Send;

--- a/Connectors/Navisworks/Speckle.Connectors.NavisworksShared/Operations/Send/GeometryNodeMerger.cs
+++ b/Connectors/Navisworks/Speckle.Connectors.NavisworksShared/Operations/Send/GeometryNodeMerger.cs
@@ -1,4 +1,4 @@
-﻿using Speckle.Connector.Navisworks.Services;
+using Speckle.Connector.Navisworks.Services;
 using Speckle.Converter.Navisworks.Constants;
 
 namespace Speckle.Connector.Navisworks.Operations.Send;
@@ -16,20 +16,23 @@ public static class GeometryNodeMerger
   /// <returns>Dictionary mapping parent paths (with material signature suffix) to their mergeable child nodes</returns>
   public static Dictionary<string, List<NAV.ModelItem>> GroupSiblingGeometryNodes(IReadOnlyList<NAV.ModelItem> nodes)
   {
+    var selectionService = new ElementSelectionService();
+
     // Group nameless geometry nodes by parent path and material signature
     var mergeableGroups = nodes
       .Where(node => node.HasGeometry && string.IsNullOrEmpty(node.DisplayName)) // Only anonymous geometry nodes
       .GroupBy(node =>
       {
         // Get parent path
-        var service = new ElementSelectionService();
-        var path = service.GetModelItemPath(node);
+        var path = selectionService.GetModelItemPath(node);
         var lastSeparatorIndex = path.LastIndexOf(PathConstants.SEPARATOR);
         var parentPath = lastSeparatorIndex == -1 ? path : path[..lastSeparatorIndex];
 
-        // Combine parent path with material signature
-        string materialSignature = GetMaterialSignature(node);
-        return $"{parentPath}{PathConstants.MATERIAL_SEPARATOR}{materialSignature}";
+        // Generate material signature
+        string signature = GenerateSignature(node);
+
+        // Combine parent path with signature
+        return $"{parentPath}{PathConstants.MATERIAL_SEPARATOR}{signature}";
       })
       .Where(group => group.Count() > 1) // Only include groups with multiple children
       .ToDictionary(group => group.Key, group => group.ToList());
@@ -38,31 +41,123 @@ public static class GeometryNodeMerger
   }
 
   /// <summary>
-  /// Creates a signature string that represents the material properties of a node.
+  /// Generates a signature for a node based on material properties
   /// </summary>
-  /// <param name="node">The ModelItem to create a material signature for</param>
-  /// <returns>A signature string representing the node's material properties</returns>
-  private static string GetMaterialSignature(NAV.ModelItem node)
+  private static string GenerateSignature(NAV.ModelItem node)
   {
-    if (!node.HasGeometry || node.Geometry == null)
-    {
-      return "nogeometry";
-    }
+    var signatureProperties = new Dictionary<string, object>();
 
-    var geometry = node.Geometry;
+    // We can as many signature defining methods as we want here
+    AddMaterialProperties(node, signatureProperties);
 
-    // Create a material signature based on active, permanent, and original colors and transparency
-    return $"{geometry.ActiveColor?.GetHashCode() ?? 0}_{geometry.ActiveTransparency}_{geometry.PermanentColor?.GetHashCode() ?? 0}_{geometry.PermanentTransparency}_{geometry.OriginalColor?.GetHashCode() ?? 0}_{geometry.OriginalTransparency}";
+    // When we are done adding properties, we can generate the signature
+    return GetSignature(signatureProperties);
   }
 
   /// <summary>
-  /// Extracts just the parent path from a composite key that may include a material signature.
+  /// Adds material-related properties to the properties dictionary
   /// </summary>
-  /// <param name="compositeKey">The composite key which may include both path and material signature</param>
-  /// <returns>The parent path portion of the key</returns>
-  public static string GetParentPathFromKey(string compositeKey)
+  private static void AddMaterialProperties(NAV.ModelItem node, Dictionary<string, object> properties)
   {
-    var separatorIndex = compositeKey.IndexOf(PathConstants.MATERIAL_SEPARATOR, StringComparison.Ordinal);
-    return separatorIndex > 0 ? compositeKey[..separatorIndex] : compositeKey;
+    if (!node.HasGeometry || node.Geometry == null)
+    {
+      return;
+    }
+
+    var geometry = node.Geometry;
+    if (geometry.ActiveColor != null)
+    {
+      properties["ActiveColor"] = (geometry.ActiveColor.R, geometry.ActiveColor.G, geometry.ActiveColor.B);
+      properties["ActiveTransparency"] = geometry.ActiveTransparency;
+    }
+
+    // Add material name if available
+    var materialName = GetMaterialName(node);
+    if (!string.IsNullOrEmpty(materialName))
+    {
+      properties["MaterialName"] = materialName;
+    }
+  }
+
+  /// <summary>
+  /// Creates a hash-based signature from a dictionary of properties.
+  /// </summary>
+  /// <param name="properties">Dictionary containing property name/value pairs to include in the signature</param>
+  /// <param name="hashLength">Length of the returned hash string (default: 8 characters)</param>
+  /// <returns>A hash string representing the combined properties</returns>
+  private static string GetSignature(Dictionary<string, object> properties, int hashLength = 8)
+  {
+    if (properties.Count == 0)
+    {
+      return "empty";
+    }
+
+    // Build a consistent string representation of all properties
+    var hashInput = new System.Text.StringBuilder();
+
+    // Sort keys to ensure consistent order
+    var sortedKeys = properties.Keys.OrderBy(k => k).ToList();
+
+    foreach (var key in sortedKeys)
+    {
+      var value = properties[key];
+      switch (value)
+      {
+        case null:
+          continue;
+        // Format numbers with fixed precision to avoid floating point inconsistencies
+        case double doubleValue:
+          hashInput.Append($"{key}:{Math.Round(doubleValue, 6)}_");
+          break;
+        case float floatValue:
+          hashInput.Append($"{key}:{Math.Round(floatValue, 6)}_");
+          break;
+        default:
+          hashInput.Append($"{key}:{value.GetHashCode()}_");
+          break;
+      }
+    }
+
+    return hashInput.Length == 0 ? "empty" : GetHash(hashInput.ToString(), hashLength);
+  }
+
+  /// <summary>
+  /// Generates a non-cryptographic hash from the input string. Mostly to avoid MD5.Create() warnings.
+  /// </summary>
+  /// <param name="input">The input string to hash.</param>
+  /// <param name="length">The length of the returned hash string (default: 8 characters).</param>
+  /// <returns>A non-cryptographic hash string of the specified length.</returns>
+  private static string GetHash(string input, int length = 8) =>
+    Math.Abs(input.Aggregate(0, (ct, c) => ct * 31 + c)).ToString("X").PadLeft(length, '0')[
+      ..Math.Min(length, Math.Abs(input.Aggregate(0, (ct, c) => ct * 31 + c)).ToString("X").Length)
+    ];
+
+  /// <summary>
+  /// Extracts material name from a node if available.
+  /// </summary>
+  private static string GetMaterialName(NAV.ModelItem node)
+  {
+    // Check Item category for material name
+    var itemCategory = node.PropertyCategories.FindCategoryByDisplayName("Item");
+    if (itemCategory != null)
+    {
+      var itemProperties = itemCategory.Properties;
+      var itemMaterial = itemProperties.FindPropertyByDisplayName("Material");
+      if (itemMaterial != null && !string.IsNullOrEmpty(itemMaterial.DisplayName))
+      {
+        return itemMaterial.Value.ToDisplayString();
+      }
+    }
+
+    // Check Material category for material name
+    var materialPropertyCategory = node.PropertyCategories.FindCategoryByDisplayName("Material");
+    if (materialPropertyCategory == null)
+    {
+      return string.Empty;
+    }
+
+    var material = materialPropertyCategory.Properties;
+    var name = material.FindPropertyByDisplayName("Name");
+    return name != null && !string.IsNullOrEmpty(name.DisplayName) ? name.Value.ToDisplayString() : string.Empty;
   }
 }

--- a/Connectors/Navisworks/Speckle.Connectors.NavisworksShared/Operations/Send/NavisworksHierarchyBuilder.cs
+++ b/Connectors/Navisworks/Speckle.Connectors.NavisworksShared/Operations/Send/NavisworksHierarchyBuilder.cs
@@ -1,4 +1,5 @@
 ﻿using Speckle.Connector.Navisworks.Services;
+using Speckle.Converter.Navisworks.Constants;
 using Speckle.Converters.Common;
 using Speckle.Sdk.Models;
 using Speckle.Sdk.Models.Collections;

--- a/Connectors/Navisworks/Speckle.Connectors.NavisworksShared/Operations/Send/NavisworksRootObjectBuilder.cs
+++ b/Connectors/Navisworks/Speckle.Connectors.NavisworksShared/Operations/Send/NavisworksRootObjectBuilder.cs
@@ -221,6 +221,9 @@ public class NavisworksRootObjectBuilder(
   /// </remarks>
   private NavisworksObject CreateNavisworksObject(string groupKey, List<Base> siblingBases)
   {
+    // Extract the parent path from the potentially composite key
+    string parentPath = GetParentPathFromKey(groupKey);
+
     (string name, string path) = GetContext(groupKey);
 
     return new NavisworksObject
@@ -229,7 +232,7 @@ public class NavisworksRootObjectBuilder(
       displayValue = siblingBases.SelectMany(b => b["displayValue"] as List<Base> ?? []).ToList(),
       properties = siblingBases.First()["properties"] as Dictionary<string, object?> ?? [],
       units = converterSettings.Current.Derived.SpeckleUnits,
-      applicationId = groupKey,
+      applicationId = parentPath, // Use the parent path as the applicationId
       ["path"] = path
     };
   }

--- a/Connectors/Navisworks/Speckle.Connectors.NavisworksShared/Operations/Send/NavisworksRootObjectBuilder.cs
+++ b/Connectors/Navisworks/Speckle.Connectors.NavisworksShared/Operations/Send/NavisworksRootObjectBuilder.cs
@@ -221,10 +221,8 @@ public class NavisworksRootObjectBuilder(
   /// </remarks>
   private NavisworksObject CreateNavisworksObject(string groupKey, List<Base> siblingBases)
   {
-    // Extract the parent path from the potentially composite key
-    string parentPath = GetParentPathFromKey(groupKey);
-
-    (string name, string path) = GetContext(groupKey);
+    string cleanParentPath = ElementSelectionHelper.GetCleanPath(groupKey);
+    (string name, string path) = GetContext(cleanParentPath);
 
     return new NavisworksObject
     {
@@ -232,7 +230,7 @@ public class NavisworksRootObjectBuilder(
       displayValue = siblingBases.SelectMany(b => b["displayValue"] as List<Base> ?? []).ToList(),
       properties = siblingBases.First()["properties"] as Dictionary<string, object?> ?? [],
       units = converterSettings.Current.Derived.SpeckleUnits,
-      applicationId = parentPath, // Use the parent path as the applicationId
+      applicationId = groupKey, // Use the full composite key as applicationId to preserve uniqueness
       ["path"] = path
     };
   }

--- a/Connectors/Navisworks/Speckle.Connectors.NavisworksShared/PathConstants.cs
+++ b/Connectors/Navisworks/Speckle.Connectors.NavisworksShared/PathConstants.cs
@@ -1,6 +1,0 @@
-﻿namespace Speckle.Connector.Navisworks;
-
-public static class PathConstants
-{
-  public const char SEPARATOR = '/';
-}

--- a/Connectors/Navisworks/Speckle.Connectors.NavisworksShared/Speckle.Connectors.NavisworksShared.projitems
+++ b/Connectors/Navisworks/Speckle.Connectors.NavisworksShared/Speckle.Connectors.NavisworksShared.projitems
@@ -29,7 +29,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)Operations\Send\Settings\VisualRepresentationSetting.cs"/>
     <Compile Include="$(MSBuildThisFileDirectory)Operations\Send\Filters\NavisworksSelectionFilter.cs"/>
     <Compile Include="$(MSBuildThisFileDirectory)Operations\Send\Filters\NavisworksSavedSetsFilter.cs"/>
-    <Compile Include="$(MSBuildThisFileDirectory)PathConstants.cs"/>
     <Compile Include="$(MSBuildThisFileDirectory)Plugin\BrowserPane.xaml.cs"/>
     <Compile Include="$(MSBuildThisFileDirectory)Plugin\DockableConnectorPane.cs"/>
     <Compile Include="$(MSBuildThisFileDirectory)Plugin\NavisworksRibbon.xaml.cs"/>

--- a/Converters/Navisworks/Speckle.Converters.NavisworksShared/Helpers/ElementSelectionHelper.cs
+++ b/Converters/Navisworks/Speckle.Converters.NavisworksShared/Helpers/ElementSelectionHelper.cs
@@ -1,4 +1,6 @@
-﻿namespace Speckle.Converter.Navisworks.Helpers;
+﻿using Speckle.Converter.Navisworks.Constants;
+
+namespace Speckle.Converter.Navisworks.Helpers;
 
 /// <summary>
 /// Provides extension methods for working with Navisworks ModelItem selections.
@@ -32,6 +34,22 @@ public static class ElementSelectionHelper
     return pathIndex;
   }
 
+  /// <summary>
+  /// Extracts just the path part if the indexPath contains a material signature.
+  /// </summary>
+  /// <param name="indexPath">The potentially composite path that might include a material signature</param>
+  /// <returns>The clean path without any material signature</returns>
+  public static string GetCleanPath(string indexPath)
+  {
+    if (indexPath == null)
+    {
+      throw new ArgumentNullException(nameof(indexPath));
+    }
+
+    int separatorIndex = indexPath.IndexOf(PathConstants.MATERIAL_SEPARATOR, StringComparison.Ordinal);
+    return separatorIndex > 0 ? indexPath[..separatorIndex] : indexPath;
+  }
+
   public static NAV.ModelItem ResolveIndexPathToModelItem(string indexPath)
   {
     if (indexPath == null)
@@ -39,7 +57,10 @@ public static class ElementSelectionHelper
       throw new ArgumentNullException(nameof(indexPath));
     }
 
-    var indexPathParts = indexPath.Split(PathConstants.SEPARATOR);
+    // Extract just the path part if the indexPath contains a material signature
+    string pathToResolve = GetCleanPath(indexPath);
+
+    var indexPathParts = pathToResolve.Split(PathConstants.SEPARATOR);
 
     var modelIndex = int.Parse(indexPathParts[0]);
     var pathId = string.Join(PathConstants.SEPARATOR.ToString(), indexPathParts.Skip(1));
@@ -68,13 +89,6 @@ public static class ElementSelectionHelper
     return modelItem.AncestorsAndSelf.All(item => !item.IsHidden);
   }
 
-  public static IReadOnlyCollection<NAV.ModelItem> ResolveGeometryLeafNodes(NAV.ModelItem modelItem)
-  {
-    if (modelItem == null)
-    {
-      throw new ArgumentNullException(nameof(modelItem));
-    }
-
-    return modelItem.DescendantsAndSelf.Where(x => x.HasGeometry).ToList();
-  }
+  public static List<NAV.ModelItem> ResolveGeometryLeafNodes(NAV.ModelItem modelItem) =>
+    modelItem.DescendantsAndSelf.Where(x => x.HasGeometry).ToList();
 }

--- a/Converters/Navisworks/Speckle.Converters.NavisworksShared/PathConstants.cs
+++ b/Converters/Navisworks/Speckle.Converters.NavisworksShared/PathConstants.cs
@@ -3,5 +3,5 @@
 public static class PathConstants
 {
   public const char SEPARATOR = '/';
-  public const string MATERIAL_SEPARATOR = "::MATERIAL::";
+  public const string MATERIAL_SEPARATOR = "::";
 }

--- a/Converters/Navisworks/Speckle.Converters.NavisworksShared/PathConstants.cs
+++ b/Converters/Navisworks/Speckle.Converters.NavisworksShared/PathConstants.cs
@@ -1,6 +1,7 @@
-﻿namespace Speckle.Converter.Navisworks;
+﻿namespace Speckle.Converter.Navisworks.Constants;
 
 public static class PathConstants
 {
   public const char SEPARATOR = '/';
+  public const string MATERIAL_SEPARATOR = "::MATERIAL::";
 }


### PR DESCRIPTION
## Description

Previously, our GeometryNodeMerger grouped only anonymous geometry nodes with the same parent path. This PR refactors that logic to consider material properties and generate a unique signature for merging. This future-proofs the connector by adding additional properties to the signature generation process without reworking the entire grouping logic.

### Key updates include:

1. Enhanced Grouping Logic
   - `GroupSiblingGeometryNodes` now appends a material-based signature to that path instead of grouping nodes solely by the parent path.
   - Nodes with the same parent path and identical material signatures will be merged, reducing redundant geometry.

2. Signature Generation

   - New private methods:
      - `GenerateSignature(NAV.ModelItem node)`: aggregates relevant material properties (colour, transparency, etc.).
      - `AddMaterialProperties(...)`: a flexible entry point to include more properties in the future (e.g., textures or custom user data).
      - `GetSignature(...)`: constructs a stable string from sorted property key-value pairs, then hashes it.
      - `GetHash(...)`: produces a short, non-cryptographic hash for minimal collisions.

3. Material Name Extraction

   - `GetMaterialName(NAV.ModelItem node)` checks the “`Item`” and “`Material`” property categories to retrieve a name if available.
 
This refactor increases maintainability by centralizing property-based merging, making expanding or modifying what defines “identical” geometry easier.

## User Value

- Optimized Model Sends: Merging geometry nodes with identical material properties reduces data duplication and sending time. However the prior implementation lost material definitions between sibling geometries.
- Easier Maintenance: The refactor includes a straightforward, extensible signature generation approach, ideal for future additions (e.g., extra metadata or layering info).
- Reduced Code Duplication: A single entry point to gather and process properties for grouping.


## Changes:

1. `GeometryNodeMerger.cs`

- Replaced the old single-line `GroupSiblingGeometryNodes` method with a more robust approach that:
- Collects each node’s parent path.
- Appends a hashed signature of relevant material properties to form a composite key.
- Groups nodes accordingly in a dictionary, ensuring we only merge sets with identical signatures.
- Added helper methods (`GenerateSignature`, `AddMaterialProperties`, `GetSignature`, `GetHash`, and `GetMaterialName`).

## Screenshots:

### Source
![image](https://github.com/user-attachments/assets/d733612a-129a-4a4c-aaef-33545b018487)

This shows that all the geometry nodes are sibling nodes.

### Before
![image](https://github.com/user-attachments/assets/9fd40513-a1e2-41be-bcf7-10e1265abd85)

Arbitrarily the nodes were merged into two grouped node of sibling objects (lines and meshes)

### After
![Screenshot 2025-02-25 215558](https://github.com/user-attachments/assets/ed15fc41-73cc-472f-8d88-54d170c01238)

The current implementation differentiates siblings by material appearance.

![image](https://github.com/user-attachments/assets/e045d8f9-afeb-46e7-8c8e-060998c366ad)
Diff shows the impact and additional unique objects for the same source.

![image](https://github.com/user-attachments/assets/a0ebd542-e759-4190-8786-00112a934f01)
`applicationId` modified from the basic path description pattern 0/1/23.... to suffix `::signature_hash` where merged nodes exist.

## Validation of changes:

Manual testing across multiple formats and model hierarchies.

## Checklist:


- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.

