### PR TITLE
Fix: revert revit task back for highlight view

### DIFF
--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Bindings/BasicConnectorBindingRevit.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Bindings/BasicConnectorBindingRevit.cs
@@ -103,7 +103,12 @@ internal sealed class BasicConnectorBindingRevit : IBasicConnectorBinding
         var view = revitViewsFilter.GetView();
         if (view is not null)
         {
-          _revitContext.UIApplication.ActiveUIDocument.ActiveView = view;
+          await RevitTask
+            .RunAsync(() =>
+            {
+              _revitContext.UIApplication.ActiveUIDocument.ActiveView = view;
+            })
+            .ConfigureAwait(false);
         }
         return;
       }


### PR DESCRIPTION
It was throwing error as below. I believe I forgot to bring it back while reverting back thread logic

![image](https://github.com/user-attachments/assets/f14119d6-bd9d-4a83-8add-cf9c2642c9ea)

We got our old logic back

![Revit_pTndQgUt7N](https://github.com/user-attachments/assets/08d8a9bb-419f-443c-a259-658d58b025e4)
