### PR TITLE
feat: Perf testing helpers for Jetbrains

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,6 +10,7 @@
     <PackageVersion Include="FluentAssertions" Version="6.12.1" />
     <PackageVersion Include="Glob" Version="1.1.9" />
     <PackageVersion Include="ILRepack.FullAuto" Version="1.6.0" />
+    <PackageVersion Include="JetBrains.Profiler.SelfApi" Version="2.5.12" />
     <PackageVersion Include="LibTessDotNet" Version="1.1.15" />
     <PackageVersion Include="Moq" Version="4.20.70" />
     <PackageVersion Include="Microsoft.Build" Version="17.11.4" />

--- a/Local.sln
+++ b/Local.sln
@@ -270,9 +270,12 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Speckle.Importers.Ifc.Tester", "Importers\Ifc\Speckle.Importers.Ifc.Tester\Speckle.Importers.Ifc.Tester.csproj", "{B3B126CA-A419-48D1-B117-6DEE1DE1AFAD}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Speckle.Importers.Ifc.Tester2", "Importers\Ifc\Speckle.Importers.Ifc.Tester2\Speckle.Importers.Ifc.Tester2.csproj", "{867DC1A5-A886-4F49-8665-793EB9832F9E}"
+EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Speckle.Connectors.Common.Tests", "Sdk\Speckle.Connectors.Common.Tests\Speckle.Connectors.Common.Tests.csproj", "{C19C3EDF-D95D-4D22-9949-D99F91447AE7}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Speckle.Common.MeshTriangulation", "Sdk\Speckle.Common.MeshTriangulation\Speckle.Common.MeshTriangulation.csproj", "{20BB9687-2C92-44E9-9E2F-9D2F45641354}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Speckle.Performance", "Sdk\Speckle.Performance\Speckle.Performance.csproj", "{54C21396-EFCA-446B-BFBA-2139B0D29ED8}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -713,6 +716,12 @@ Global
 		{20BB9687-2C92-44E9-9E2F-9D2F45641354}.Local|Any CPU.Build.0 = Debug|Any CPU
 		{20BB9687-2C92-44E9-9E2F-9D2F45641354}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{20BB9687-2C92-44E9-9E2F-9D2F45641354}.Release|Any CPU.Build.0 = Release|Any CPU
+		{54C21396-EFCA-446B-BFBA-2139B0D29ED8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{54C21396-EFCA-446B-BFBA-2139B0D29ED8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{54C21396-EFCA-446B-BFBA-2139B0D29ED8}.Local|Any CPU.ActiveCfg = Debug|Any CPU
+		{54C21396-EFCA-446B-BFBA-2139B0D29ED8}.Local|Any CPU.Build.0 = Debug|Any CPU
+		{54C21396-EFCA-446B-BFBA-2139B0D29ED8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{54C21396-EFCA-446B-BFBA-2139B0D29ED8}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -839,6 +848,7 @@ Global
 		{867DC1A5-A886-4F49-8665-793EB9832F9E} = {0EF6C4D6-AC76-408F-8D32-2F9DA8006077}
 		{C19C3EDF-D95D-4D22-9949-D99F91447AE7} = {2E00592E-558D-492D-88F9-3ECEE4C0C7DA}
 		{20BB9687-2C92-44E9-9E2F-9D2F45641354} = {2E00592E-558D-492D-88F9-3ECEE4C0C7DA}
+		{54C21396-EFCA-446B-BFBA-2139B0D29ED8} = {2E00592E-558D-492D-88F9-3ECEE4C0C7DA}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {EE253116-7070-4E9A-BCE8-2911C251B8C8}

--- a/Sdk/Speckle.Performance/JetbrainsProfiler.cs
+++ b/Sdk/Speckle.Performance/JetbrainsProfiler.cs
@@ -2,7 +2,6 @@
 
 namespace Speckle.Performance;
 
-
 public static class JetbrainsProfiler
 {
   private sealed class CpuClass : IDisposable

--- a/Sdk/Speckle.Performance/JetbrainsProfiler.cs
+++ b/Sdk/Speckle.Performance/JetbrainsProfiler.cs
@@ -1,0 +1,49 @@
+﻿using JetBrains.Profiler.SelfApi;
+
+namespace Speckle.Performance;
+
+
+public static class JetbrainsProfiler
+{
+  private sealed class CpuClass : IDisposable
+  {
+    public CpuClass(string snapshotPath)
+    {
+      DotTrace.Init();
+      var config2 = new DotTrace.Config();
+      config2.SaveToDir(snapshotPath);
+      DotTrace.Attach(config2);
+      DotTrace.StartCollectingData();
+    }
+
+    public void Dispose()
+    {
+      DotTrace.StopCollectingData();
+      DotTrace.SaveData();
+      DotTrace.Detach();
+    }
+  }
+
+  private sealed class MemoryClass : IDisposable
+  {
+    public MemoryClass(string snapshotPath)
+    {
+      DotMemory.Init();
+      var config = new DotMemory.Config();
+      config.OpenDotMemory();
+      config.SaveToDir(snapshotPath);
+      DotMemory.Attach(config);
+      DotMemory.GetSnapshot("Before");
+    }
+
+    public void Dispose()
+    {
+      DotMemory.GetSnapshot("After");
+      DotMemory.Detach();
+    }
+  }
+
+  public static IDisposable Cpu(string snapshotPath) => new CpuClass(snapshotPath);
+
+  public static IDisposable Memory(string snapshotPath) => new MemoryClass(snapshotPath);
+}

--- a/Sdk/Speckle.Performance/Speckle.Performance.csproj
+++ b/Sdk/Speckle.Performance/Speckle.Performance.csproj
@@ -1,0 +1,10 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+      <TargetFrameworks>net48;net6.0;net8.0</TargetFrameworks>
+    </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="JetBrains.Profiler.SelfApi" />
+  </ItemGroup>
+</Project>

--- a/Sdk/Speckle.Performance/packages.lock.json
+++ b/Sdk/Speckle.Performance/packages.lock.json
@@ -1,0 +1,242 @@
+{
+  "version": 2,
+  "dependencies": {
+    ".NETFramework,Version=v4.8": {
+      "JetBrains.Profiler.SelfApi": {
+        "type": "Direct",
+        "requested": "[2.5.12, )",
+        "resolved": "2.5.12",
+        "contentHash": "m0MGIX6Eut9Z5hzqF4gNVn8oK2jeYDe7kihZTtD2/Iy9P7zE+zemO9VisiMD/1I1V8Es7lHOI49HNq9VGut96A==",
+        "dependencies": {
+          "JetBrains.HabitatDetector": "1.4.3",
+          "JetBrains.Profiler.Api": "1.4.8"
+        }
+      },
+      "Microsoft.NETFramework.ReferenceAssemblies": {
+        "type": "Direct",
+        "requested": "[1.0.3, )",
+        "resolved": "1.0.3",
+        "contentHash": "vUc9Npcs14QsyOD01tnv/m8sQUnGTGOw1BCmKcv77LBJY7OxhJ+zJF7UD/sCL3lYNFuqmQEVlkfS4Quif6FyYg==",
+        "dependencies": {
+          "Microsoft.NETFramework.ReferenceAssemblies.net48": "1.0.3"
+        }
+      },
+      "Microsoft.SourceLink.GitHub": {
+        "type": "Direct",
+        "requested": "[8.0.0, )",
+        "resolved": "8.0.0",
+        "contentHash": "G5q7OqtwIyGTkeIOAc3u2ZuV/kicQaec5EaRnc0pIeSnh9LUjj+PYQrJYBURvDt7twGl2PKA7nSN0kz1Zw5bnQ==",
+        "dependencies": {
+          "Microsoft.Build.Tasks.Git": "8.0.0",
+          "Microsoft.SourceLink.Common": "8.0.0"
+        }
+      },
+      "PolySharp": {
+        "type": "Direct",
+        "requested": "[1.14.1, )",
+        "resolved": "1.14.1",
+        "contentHash": "mOOmFYwad3MIOL14VCjj02LljyF1GNw1wP0YVlxtcPvqdxjGGMNdNJJxHptlry3MOd8b40Flm8RPOM8JOlN2sQ=="
+      },
+      "Speckle.InterfaceGenerator": {
+        "type": "Direct",
+        "requested": "[0.9.6, )",
+        "resolved": "0.9.6",
+        "contentHash": "HKH7tYrYYlCK1ct483hgxERAdVdMtl7gUKW9ijWXxA1UsYR4Z+TrRHYmzZ9qmpu1NnTycSrp005NYM78GDKV1w=="
+      },
+      "JetBrains.FormatRipper": {
+        "type": "Transitive",
+        "resolved": "2.2.2",
+        "contentHash": "UvbPJM1ryALWSrnMX428ZxLujOrSAxdCgSwr1/7A0mFFxM8Rxku0OjN+zZENmZQ6Hirm7StkC176qy0m30UgjQ=="
+      },
+      "JetBrains.HabitatDetector": {
+        "type": "Transitive",
+        "resolved": "1.4.3",
+        "contentHash": "4VC4sP/T+16MwsfUjwbKVYwKEOEu9cdQxLvN9uUiIm17m2y1SlV4Aj29HKsFbFyCbTePOGQMw3ccoPuym6d+EQ==",
+        "dependencies": {
+          "JetBrains.FormatRipper": "2.2.2"
+        }
+      },
+      "JetBrains.Profiler.Api": {
+        "type": "Transitive",
+        "resolved": "1.4.8",
+        "contentHash": "hH0Hej/hjwTn14yhhzEcGaB3HJ40C/CwW2E8RrhsqCcBg5bs50LQFOx2a5dFXjWDMzspAso5xADtQmBI6lXKTw==",
+        "dependencies": {
+          "JetBrains.HabitatDetector": "1.4.3"
+        }
+      },
+      "Microsoft.Build.Tasks.Git": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "bZKfSIKJRXLTuSzLudMFte/8CempWjVamNUR5eHJizsy+iuOuO/k2gnh7W0dHJmYY0tBf+gUErfluCv5mySAOQ=="
+      },
+      "Microsoft.NETFramework.ReferenceAssemblies.net48": {
+        "type": "Transitive",
+        "resolved": "1.0.3",
+        "contentHash": "zMk4D+9zyiEWByyQ7oPImPN/Jhpj166Ky0Nlla4eXlNL8hI/BtSJsgR8Inldd4NNpIAH3oh8yym0W2DrhXdSLQ=="
+      },
+      "Microsoft.SourceLink.Common": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "dk9JPxTCIevS75HyEQ0E4OVAFhB2N+V9ShCXf8Q6FkUQZDkgLI12y679Nym1YqsiSysuQskT7Z+6nUf3yab6Vw=="
+      }
+    },
+    "net6.0": {
+      "JetBrains.Profiler.SelfApi": {
+        "type": "Direct",
+        "requested": "[2.5.12, )",
+        "resolved": "2.5.12",
+        "contentHash": "m0MGIX6Eut9Z5hzqF4gNVn8oK2jeYDe7kihZTtD2/Iy9P7zE+zemO9VisiMD/1I1V8Es7lHOI49HNq9VGut96A==",
+        "dependencies": {
+          "JetBrains.HabitatDetector": "1.4.3",
+          "JetBrains.Profiler.Api": "1.4.8"
+        }
+      },
+      "Microsoft.NETFramework.ReferenceAssemblies": {
+        "type": "Direct",
+        "requested": "[1.0.3, )",
+        "resolved": "1.0.3",
+        "contentHash": "vUc9Npcs14QsyOD01tnv/m8sQUnGTGOw1BCmKcv77LBJY7OxhJ+zJF7UD/sCL3lYNFuqmQEVlkfS4Quif6FyYg==",
+        "dependencies": {
+          "Microsoft.NETFramework.ReferenceAssemblies.net461": "1.0.3"
+        }
+      },
+      "Microsoft.SourceLink.GitHub": {
+        "type": "Direct",
+        "requested": "[8.0.0, )",
+        "resolved": "8.0.0",
+        "contentHash": "G5q7OqtwIyGTkeIOAc3u2ZuV/kicQaec5EaRnc0pIeSnh9LUjj+PYQrJYBURvDt7twGl2PKA7nSN0kz1Zw5bnQ==",
+        "dependencies": {
+          "Microsoft.Build.Tasks.Git": "8.0.0",
+          "Microsoft.SourceLink.Common": "8.0.0"
+        }
+      },
+      "PolySharp": {
+        "type": "Direct",
+        "requested": "[1.14.1, )",
+        "resolved": "1.14.1",
+        "contentHash": "mOOmFYwad3MIOL14VCjj02LljyF1GNw1wP0YVlxtcPvqdxjGGMNdNJJxHptlry3MOd8b40Flm8RPOM8JOlN2sQ=="
+      },
+      "Speckle.InterfaceGenerator": {
+        "type": "Direct",
+        "requested": "[0.9.6, )",
+        "resolved": "0.9.6",
+        "contentHash": "HKH7tYrYYlCK1ct483hgxERAdVdMtl7gUKW9ijWXxA1UsYR4Z+TrRHYmzZ9qmpu1NnTycSrp005NYM78GDKV1w=="
+      },
+      "JetBrains.FormatRipper": {
+        "type": "Transitive",
+        "resolved": "2.2.2",
+        "contentHash": "UvbPJM1ryALWSrnMX428ZxLujOrSAxdCgSwr1/7A0mFFxM8Rxku0OjN+zZENmZQ6Hirm7StkC176qy0m30UgjQ=="
+      },
+      "JetBrains.HabitatDetector": {
+        "type": "Transitive",
+        "resolved": "1.4.3",
+        "contentHash": "4VC4sP/T+16MwsfUjwbKVYwKEOEu9cdQxLvN9uUiIm17m2y1SlV4Aj29HKsFbFyCbTePOGQMw3ccoPuym6d+EQ==",
+        "dependencies": {
+          "JetBrains.FormatRipper": "2.2.2"
+        }
+      },
+      "JetBrains.Profiler.Api": {
+        "type": "Transitive",
+        "resolved": "1.4.8",
+        "contentHash": "hH0Hej/hjwTn14yhhzEcGaB3HJ40C/CwW2E8RrhsqCcBg5bs50LQFOx2a5dFXjWDMzspAso5xADtQmBI6lXKTw==",
+        "dependencies": {
+          "JetBrains.HabitatDetector": "1.4.3"
+        }
+      },
+      "Microsoft.Build.Tasks.Git": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "bZKfSIKJRXLTuSzLudMFte/8CempWjVamNUR5eHJizsy+iuOuO/k2gnh7W0dHJmYY0tBf+gUErfluCv5mySAOQ=="
+      },
+      "Microsoft.NETFramework.ReferenceAssemblies.net461": {
+        "type": "Transitive",
+        "resolved": "1.0.3",
+        "contentHash": "AmOJZwCqnOCNp6PPcf9joyogScWLtwy0M1WkqfEQ0M9nYwyDD7EX9ZjscKS5iYnyvteX7kzSKFCKt9I9dXA6mA=="
+      },
+      "Microsoft.SourceLink.Common": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "dk9JPxTCIevS75HyEQ0E4OVAFhB2N+V9ShCXf8Q6FkUQZDkgLI12y679Nym1YqsiSysuQskT7Z+6nUf3yab6Vw=="
+      }
+    },
+    "net8.0": {
+      "JetBrains.Profiler.SelfApi": {
+        "type": "Direct",
+        "requested": "[2.5.12, )",
+        "resolved": "2.5.12",
+        "contentHash": "m0MGIX6Eut9Z5hzqF4gNVn8oK2jeYDe7kihZTtD2/Iy9P7zE+zemO9VisiMD/1I1V8Es7lHOI49HNq9VGut96A==",
+        "dependencies": {
+          "JetBrains.HabitatDetector": "1.4.3",
+          "JetBrains.Profiler.Api": "1.4.8"
+        }
+      },
+      "Microsoft.NETFramework.ReferenceAssemblies": {
+        "type": "Direct",
+        "requested": "[1.0.3, )",
+        "resolved": "1.0.3",
+        "contentHash": "vUc9Npcs14QsyOD01tnv/m8sQUnGTGOw1BCmKcv77LBJY7OxhJ+zJF7UD/sCL3lYNFuqmQEVlkfS4Quif6FyYg==",
+        "dependencies": {
+          "Microsoft.NETFramework.ReferenceAssemblies.net461": "1.0.3"
+        }
+      },
+      "Microsoft.SourceLink.GitHub": {
+        "type": "Direct",
+        "requested": "[8.0.0, )",
+        "resolved": "8.0.0",
+        "contentHash": "G5q7OqtwIyGTkeIOAc3u2ZuV/kicQaec5EaRnc0pIeSnh9LUjj+PYQrJYBURvDt7twGl2PKA7nSN0kz1Zw5bnQ==",
+        "dependencies": {
+          "Microsoft.Build.Tasks.Git": "8.0.0",
+          "Microsoft.SourceLink.Common": "8.0.0"
+        }
+      },
+      "PolySharp": {
+        "type": "Direct",
+        "requested": "[1.14.1, )",
+        "resolved": "1.14.1",
+        "contentHash": "mOOmFYwad3MIOL14VCjj02LljyF1GNw1wP0YVlxtcPvqdxjGGMNdNJJxHptlry3MOd8b40Flm8RPOM8JOlN2sQ=="
+      },
+      "Speckle.InterfaceGenerator": {
+        "type": "Direct",
+        "requested": "[0.9.6, )",
+        "resolved": "0.9.6",
+        "contentHash": "HKH7tYrYYlCK1ct483hgxERAdVdMtl7gUKW9ijWXxA1UsYR4Z+TrRHYmzZ9qmpu1NnTycSrp005NYM78GDKV1w=="
+      },
+      "JetBrains.FormatRipper": {
+        "type": "Transitive",
+        "resolved": "2.2.2",
+        "contentHash": "UvbPJM1ryALWSrnMX428ZxLujOrSAxdCgSwr1/7A0mFFxM8Rxku0OjN+zZENmZQ6Hirm7StkC176qy0m30UgjQ=="
+      },
+      "JetBrains.HabitatDetector": {
+        "type": "Transitive",
+        "resolved": "1.4.3",
+        "contentHash": "4VC4sP/T+16MwsfUjwbKVYwKEOEu9cdQxLvN9uUiIm17m2y1SlV4Aj29HKsFbFyCbTePOGQMw3ccoPuym6d+EQ==",
+        "dependencies": {
+          "JetBrains.FormatRipper": "2.2.2"
+        }
+      },
+      "JetBrains.Profiler.Api": {
+        "type": "Transitive",
+        "resolved": "1.4.8",
+        "contentHash": "hH0Hej/hjwTn14yhhzEcGaB3HJ40C/CwW2E8RrhsqCcBg5bs50LQFOx2a5dFXjWDMzspAso5xADtQmBI6lXKTw==",
+        "dependencies": {
+          "JetBrains.HabitatDetector": "1.4.3"
+        }
+      },
+      "Microsoft.Build.Tasks.Git": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "bZKfSIKJRXLTuSzLudMFte/8CempWjVamNUR5eHJizsy+iuOuO/k2gnh7W0dHJmYY0tBf+gUErfluCv5mySAOQ=="
+      },
+      "Microsoft.NETFramework.ReferenceAssemblies.net461": {
+        "type": "Transitive",
+        "resolved": "1.0.3",
+        "contentHash": "AmOJZwCqnOCNp6PPcf9joyogScWLtwy0M1WkqfEQ0M9nYwyDD7EX9ZjscKS5iYnyvteX7kzSKFCKt9I9dXA6mA=="
+      },
+      "Microsoft.SourceLink.Common": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "dk9JPxTCIevS75HyEQ0E4OVAFhB2N+V9ShCXf8Q6FkUQZDkgLI12y679Nym1YqsiSysuQskT7Z+6nUf3yab6Vw=="
+      }
+    }
+  }
+}

--- a/Speckle.Connectors.sln
+++ b/Speckle.Connectors.sln
@@ -278,9 +278,12 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Speckle.Importers.Ifc.Tester", "Importers\Ifc\Speckle.Importers.Ifc.Tester\Speckle.Importers.Ifc.Tester.csproj", "{FCD6CB79-6B41-4448-99E1-787408AD24B0}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Speckle.Importers.Ifc.Tester2", "Importers\Ifc\Speckle.Importers.Ifc.Tester2\Speckle.Importers.Ifc.Tester2.csproj", "{17FB6920-DF63-4D94-86A4-F1619D501C6D}"
+EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Speckle.Connectors.Common.Tests", "Sdk\Speckle.Connectors.Common.Tests\Speckle.Connectors.Common.Tests.csproj", "{F86DFA8A-E2E0-4EBE-9BAF-72AE2698EDC6}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Speckle.Common.MeshTriangulation", "Sdk\Speckle.Common.MeshTriangulation\Speckle.Common.MeshTriangulation.csproj", "{B740A025-1035-4A75-865B-7825857D610C}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Speckle.Performance", "Sdk\Speckle.Performance\Speckle.Performance.csproj", "{65230E97-8EBA-4594-8A17-2847C5E2B459}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -703,6 +706,12 @@ Global
 		{B740A025-1035-4A75-865B-7825857D610C}.Local|Any CPU.Build.0 = Debug|Any CPU
 		{B740A025-1035-4A75-865B-7825857D610C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B740A025-1035-4A75-865B-7825857D610C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{65230E97-8EBA-4594-8A17-2847C5E2B459}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{65230E97-8EBA-4594-8A17-2847C5E2B459}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{65230E97-8EBA-4594-8A17-2847C5E2B459}.Local|Any CPU.ActiveCfg = Debug|Any CPU
+		{65230E97-8EBA-4594-8A17-2847C5E2B459}.Local|Any CPU.Build.0 = Debug|Any CPU
+		{65230E97-8EBA-4594-8A17-2847C5E2B459}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{65230E97-8EBA-4594-8A17-2847C5E2B459}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -829,6 +838,7 @@ Global
 		{17FB6920-DF63-4D94-86A4-F1619D501C6D} = {F93052A6-6937-443F-8F1F-4A967A8A2BEF}
 		{F86DFA8A-E2E0-4EBE-9BAF-72AE2698EDC6} = {2E00592E-558D-492D-88F9-3ECEE4C0C7DA}
 		{B740A025-1035-4A75-865B-7825857D610C} = {2E00592E-558D-492D-88F9-3ECEE4C0C7DA}
+		{65230E97-8EBA-4594-8A17-2847C5E2B459} = {2E00592E-558D-492D-88F9-3ECEE4C0C7DA}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {EE253116-7070-4E9A-BCE8-2911C251B8C8}


### PR DESCRIPTION
These create snapshots for dotTrace and dotMemory that can be diff'ed together.

dotTrace or dotMemory should be installed to make sense.

1 - add the reference (this isn't there by default to avoid dependencies in the artifact output)
![image](https://github.com/user-attachments/assets/88d5c307-7e74-47e1-853a-d7db4d997afc)
2 - wrap the relevant code.  In this case, conversion on a receive for all applications:
![image](https://github.com/user-attachments/assets/4ff32ffb-e514-44ef-8ee0-ee8ca3a74d27)

this creates a trace or snapshot to be loaded and analyzed.

There is usually a pause while an executable is ran to initialize the trace/snapshot

Memory is autoopened and you can view the diff
![image](https://github.com/user-attachments/assets/0ebf13fa-8cab-4187-873e-a81fd94bdcec)
