### PR TITLE
Bjorn/cnx 1359 have a setting in UI whether include or not

### DIFF
--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Bindings/RevitReceiveBinding.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Bindings/RevitReceiveBinding.cs
@@ -74,6 +74,7 @@ internal sealed class RevitReceiveBinding : IReceiveBinding
           _revitConversionSettingsFactory.Create(
             DetailLevelType.Coarse, //TODO figure out
             null,
+            false,
             false
           )
         );

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Bindings/RevitSendBinding.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Bindings/RevitSendBinding.cs
@@ -104,7 +104,8 @@ internal sealed class RevitSendBinding : RevitBaseBinding, ISendBinding
     [
       new DetailLevelSetting(DetailLevelType.Medium),
       new ReferencePointSetting(ReferencePointType.InternalOrigin),
-      new SendParameterNullOrEmptyStringsSetting(false)
+      new SendParameterNullOrEmptyStringsSetting(false),
+      new LinkedModelsSetting(false)
     ];
 
   public void CancelSend(string modelCardId) => _cancellationManager.CancelOperation(modelCardId);
@@ -131,7 +132,8 @@ internal sealed class RevitSendBinding : RevitBaseBinding, ISendBinding
           _revitConversionSettingsFactory.Create(
             _toSpeckleSettingsManager.GetDetailLevelSetting(modelCard),
             _toSpeckleSettingsManager.GetReferencePointSetting(modelCard),
-            _toSpeckleSettingsManager.GetSendParameterNullOrEmptyStringsSetting(modelCard)
+            _toSpeckleSettingsManager.GetSendParameterNullOrEmptyStringsSetting(modelCard),
+            _toSpeckleSettingsManager.GetLinkedModelsSetting(modelCard)
           )
         );
 

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/Settings/LinkedModelsSetting.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/Settings/LinkedModelsSetting.cs
@@ -1,0 +1,12 @@
+using Speckle.Connectors.DUI.Settings;
+
+namespace Speckle.Connectors.Revit.Operations.Send.Settings;
+
+public class LinkedModelsSetting(bool value) : ICardSetting
+{
+  public string? Id { get; set; } = "includeLinkedModels";
+  public string? Title { get; set; } = "Include Linked Models";
+  public string? Type { get; set; } = "boolean";
+  public object? Value { get; set; } = value;
+  public List<string>? Enum { get; set; }
+}

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/Settings/ToSpeckleSettingsManager.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/Settings/ToSpeckleSettingsManager.cs
@@ -21,6 +21,7 @@ public class ToSpeckleSettingsManager : IToSpeckleSettingsManager
   private readonly Dictionary<string, DetailLevelType> _detailLevelCache = new();
   private readonly Dictionary<string, Transform?> _referencePointCache = new();
   private readonly Dictionary<string, bool?> _sendNullParamsCache = new();
+  private readonly Dictionary<string, bool?> _sendLinkedModelsCache = new();
 
   public ToSpeckleSettingsManager(
     RevitContext revitContext,
@@ -99,6 +100,22 @@ public class ToSpeckleSettingsManager : IToSpeckleSettingsManager
     }
 
     _sendNullParamsCache[modelCard.ModelCardId] = returnValue;
+    return returnValue;
+  }
+
+  public bool GetLinkedModelsSetting(SenderModelCard modelCard)
+  {
+    var value = modelCard.Settings?.First(s => s.Id == "includeLinkedModels").Value as bool?;
+    var returnValue = value != null && value.NotNull();
+
+    if (_sendLinkedModelsCache.TryGetValue(modelCard.ModelCardId.NotNull(), out bool? previousValue))
+    {
+      if (previousValue != returnValue)
+      {
+        EvictCacheForModelCard(modelCard);
+      }
+    }
+    _sendLinkedModelsCache[modelCard.ModelCardId] = returnValue;
     return returnValue;
   }
 

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/Settings/ToSpeckleSettingsManager.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/Settings/ToSpeckleSettingsManager.cs
@@ -103,6 +103,8 @@ public class ToSpeckleSettingsManager : IToSpeckleSettingsManager
     return returnValue;
   }
 
+  // NOTE: Cache invalidation currently a placeholder until we have more understanding on the sends
+  // TODO: Evaluate cache invalidation for GetLinkedModelsSetting
   public bool GetLinkedModelsSetting(SenderModelCard modelCard)
   {
     var value = modelCard.Settings?.First(s => s.Id == "includeLinkedModels").Value as bool?;

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Speckle.Connectors.RevitShared.projitems
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Speckle.Connectors.RevitShared.projitems
@@ -40,6 +40,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Operations\Send\Filters\RevitSelectionFilter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Operations\Send\Filters\RevitViewsFilter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Operations\Send\RevitRootObjectBuilder.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Operations\Send\Settings\LinkedModelsSetting.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Operations\Send\Settings\SendParameterNullOrEmptyStringsSetting.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Operations\Send\Settings\ToSpeckleSettingsManager.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Operations\Send\Settings\ReferencePointSetting.cs" />

--- a/Converters/Revit/Speckle.Converters.RevitShared.Tests/ModelCurveArrayToSpeckleConverterTests.cs
+++ b/Converters/Revit/Speckle.Converters.RevitShared.Tests/ModelCurveArrayToSpeckleConverterTests.cs
@@ -54,7 +54,7 @@ public class ModelCurveArrayToSpeckleConverterTests : MoqTest
     var units = "units";
     revitConversionContextStack
       .Setup(x => x.Current)
-      .Returns(new RevitConversionSettings(null!, DetailLevelType.Coarse, null, units, false));
+      .Returns(new RevitConversionSettings(null!, DetailLevelType.Coarse, null, units, false, false));
 
     var scaleLength = 2.2;
     scalingServiceToSpeckle.Setup(x => x.ScaleLength(2 + 3)).Returns(scaleLength);

--- a/Converters/Revit/Speckle.Converters.RevitShared/Settings/RevitConversionSettings.cs
+++ b/Converters/Revit/Speckle.Converters.RevitShared/Settings/RevitConversionSettings.cs
@@ -6,5 +6,6 @@ public record RevitConversionSettings(
   DB.Transform? ReferencePointTransform,
   string SpeckleUnits,
   bool SendParameterNullOrEmptyStrings,
+  bool SendLinkedModels,
   double Tolerance = 0.0164042 // 5mm in ft
 );

--- a/Converters/Revit/Speckle.Converters.RevitShared/Settings/RevitConversionSettingsFactory.cs
+++ b/Converters/Revit/Speckle.Converters.RevitShared/Settings/RevitConversionSettingsFactory.cs
@@ -15,6 +15,7 @@ public class RevitConversionSettingsFactory(
     DetailLevelType detailLevelType,
     DB.Transform? referencePointTransform,
     bool sendEmptyOrNullParams,
+    bool sendLinkedModels,
     double tolerance = 0.0164042 // 5mm in ft
   )
   {
@@ -25,6 +26,7 @@ public class RevitConversionSettingsFactory(
       referencePointTransform,
       unitConverter.ConvertOrThrow(document.GetUnits().GetFormatOptions(DB.SpecTypeId.Length).GetUnitTypeId()),
       sendEmptyOrNullParams,
+      sendLinkedModels,
       tolerance
     );
   }


### PR DESCRIPTION
<!---

Provide a short summary in the Title above. Use the following template:

category(project): summary

Categories:

* feat: (new feature for the user, not a new feature for build script)
* fix: (bug fix for the user, not a fix to a build script)
* docs: (changes to the documentation)
* style: (formatting, missing semi colons, etc; no production code change)
* refactor: (refactoring production code, eg. renaming a variable)
* test: (adding missing tests, refactoring tests; no production code change)
* chore: (updating grunt tasks etc; no production code change)

Example:

feat(revit): added category filter to send

-->

## Description

<!---

Describe your changes, and why you're making them.

Link related github issues here ->
Fixes #85, Fixes #22, Connects #123

-->

## User Value

<!---

Describe in 1 sentence the user value.

This can also be a link to the relevant thread in Speckle community, or a link to the Linear issue.
-->


## Changes:

<!---

- Item 1
- Item 2

-->

## To-do before merge:

<!---

(Optional -- remove this section if not needed)

Include any notes about things that need to happen before this PR is merged, e.g.:

- [ ] Change the base branch

- [ ] Ensure PR #56 is merged

-->

## Screenshots:

<!---

Include a screenshot the before and after.  This can be a screenshot of a plugin, web frontend, or output in a terminal.

-->

## Validation of changes:

<!---

Describe what tests have been added or amended, and why these demonstrate it works and will prevent this feature being accidentally broken by future changes.

-->

## Checklist:

<!---

This checklist is a useful reminder of related tasks to uphold our repo quality. Amend this list as needed for the pr.

-->
- [ ] My commits are related to the pull request and do not amend unrelated code or documentation.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.

