### PR TITLE
Nuget publish only on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,8 +71,9 @@ jobs:
         with:
           name: output-*
 
-  build-linux:
+  deploy-nugets:
     runs-on: ubuntu-latest
+    if: ${{ github.ref_type == 'tag' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -93,17 +94,8 @@ jobs:
       - name: ⚒️ Run GitVersion on Linux
         run: ./build.sh build-server-version
 
-      - name: ⚒️ Run tests on Linux
-        run: ./build.sh test-only
-
       - name: ⚒️ Run Build and Pack on Linux
         run: ./build.sh build-linux
-
-      - name: Upload coverage reports to Codecov with GitHub Action
-        uses: codecov/codecov-action@v5
-        with:
-          files: Converters/**/coverage.xml
-          token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Push to nuget.org
         run: dotnet nuget push output/*.nupkg --source "https://api.nuget.org/v3/index.json" --api-key ${{secrets.CONNECTORS_NUGET_TOKEN }} --skip-duplicate


### PR DESCRIPTION
Currently, we publish nugets on every commit to release branch,
but gitversion only increments the version if a tag is made
if a tag isn't made, then only the first run of the CI will publish a nuget, otherwise each commit will try and publish a nuget with a semver that already exists.

---

This isn't an ideal situation, since right now, there's no nice way for me to trigger nugets without also triggering a connectors release.
This will cause major issues for managing the nugets on this repo (IFC importer)
We'll need to come up with a better worfklow,
but in the meantime, this PR will remove the unintended behaviour from the current system.