### PR TITLE
First pass sending IFC Projects, Sites, Buildings, and Storeys as Collections 

### DIFF
--- a/Importers/Ifc/Speckle.Importers.Ifc.Tester2/Program.cs
+++ b/Importers/Ifc/Speckle.Importers.Ifc.Tester2/Program.cs
@@ -10,7 +10,7 @@ using Speckle.Sdk.Host;
 using Speckle.Sdk.Models;
 
 // Settings
-var filePath = new FilePath(@"C:\Users\Jedd\Desktop\231110AC11-Institute-Var-2-IFC.ifc");
+var filePath = new FilePath(@"C:\Users\Jedd\Desktop\GRAPHISOFT_Archicad_Sample_Project-S-Office_v1.0_AC25.ifc");
 const string PROJECT_ID = "f3a42bdf24";
 
 // Setup

--- a/Importers/Ifc/Speckle.Importers.Ifc/Ara3D.IfcParser/IfcEntity.cs
+++ b/Importers/Ifc/Speckle.Importers.Ifc/Ara3D.IfcParser/IfcEntity.cs
@@ -1,4 +1,5 @@
-﻿using Speckle.Importers.Ifc.Ara3D.StepParser;
+﻿using System.Diagnostics.CodeAnalysis;
+using Speckle.Importers.Ifc.Ara3D.StepParser;
 
 namespace Speckle.Importers.Ifc.Ara3D.IfcParser;
 
@@ -32,13 +33,14 @@ public class IfcEntity
 
   public override string ToString() => $"{Type}#{Id}";
 
+  [MemberNotNullWhen(true, nameof(Guid))]
   public bool IsIfcRoot => Count >= 4 && this[0] is StepString && (this[1] is StepId) || (this[1] is StepUnassigned);
 
   // Modern IFC files conform to this, but older ones have been observed to have different length IDs.
   // Leaving as a comment for now.
   //&& str.Value.Length == 22;
 
-  public string? Guid => IsIfcRoot ? (this[0] as StepString)?.Value.ToString() : null;
+  public string? Guid => IsIfcRoot ? ((StepString)this[0]).Value.ToString() : null;
 
   public uint OwnerId => IsIfcRoot ? (this[1] as StepId)?.Id ?? 0 : 0;
 

--- a/Importers/Ifc/Speckle.Importers.Ifc/Converters/GeometryConverter.cs
+++ b/Importers/Ifc/Speckle.Importers.Ifc/Converters/GeometryConverter.cs
@@ -7,7 +7,7 @@ namespace Speckle.Importers.Ifc.Converters;
 [GenerateAutoInterface]
 public class GeometryConverter(IMeshConverter meshConverter) : IGeometryConverter
 {
-  public IList<Base> Convert(IfcGeometry geometry)
+  public List<Base> Convert(IfcGeometry geometry)
   {
     List<Base> ret = new();
     foreach (var mesh in geometry.GetMeshes())

--- a/Importers/Ifc/Speckle.Importers.Ifc/Converters/GraphConverter.cs
+++ b/Importers/Ifc/Speckle.Importers.Ifc/Converters/GraphConverter.cs
@@ -3,7 +3,6 @@ using Speckle.Importers.Ifc.Services;
 using Speckle.Importers.Ifc.Types;
 using Speckle.InterfaceGenerator;
 using Speckle.Sdk.Models;
-using Speckle.Sdk.Models.Collections;
 
 namespace Speckle.Importers.Ifc.Converters;
 
@@ -12,14 +11,11 @@ public class GraphConverter(INodeConverter nodeConverter, IRenderMaterialProxyMa
 {
   public Base Convert(IfcModel model, IfcGraph graph)
   {
-    var collection = new Collection();
-
-    var children = graph.GetSources().Select(x => nodeConverter.Convert(model, x)).ToList();
-    collection.elements = children;
+    Base rootCollection = nodeConverter.Convert(model, graph.GetIfcProject());
 
     //Grabing materials from ProxyManager
-    collection["renderMaterialProxies"] = proxyManager.RenderMaterialProxies.Values.ToList();
+    rootCollection["renderMaterialProxies"] = proxyManager.RenderMaterialProxies.Values.ToList();
 
-    return collection;
+    return rootCollection;
   }
 }

--- a/Importers/Ifc/Speckle.Importers.Ifc/Converters/NodeConverter.cs
+++ b/Importers/Ifc/Speckle.Importers.Ifc/Converters/NodeConverter.cs
@@ -1,66 +1,96 @@
-using System.Reflection;
 using Speckle.Importers.Ifc.Ara3D.IfcParser;
 using Speckle.Importers.Ifc.Types;
 using Speckle.InterfaceGenerator;
+using Speckle.Objects.Data;
 using Speckle.Sdk.Models;
+using Speckle.Sdk.Models.Collections;
 
 namespace Speckle.Importers.Ifc.Converters;
 
 [GenerateAutoInterface]
 public class NodeConverter(IGeometryConverter geometryConverter) : INodeConverter
 {
+  /// <summary>
+  /// Converts objects that inherit IfcRoot class
+  /// </summary>
+  /// <param name="node"></param>
+  /// <returns></returns>
+  private Collection ConvertCollection(IfcModel model, IfcNode node)
+  {
+    if (!node.IsIfcRoot)
+      throw new ArgumentException("Expected to be an IfcRoot", paramName: nameof(node));
+
+    return new Collection()
+    {
+      name = node.Name ?? node.Guid,
+      applicationId = node.Guid,
+      elements = ConvertChildren(model, node),
+      ["ifc_type"] = node.Type,
+      ["expressID"] = node.Id,
+      ["properties"] = ConvertPropertySets(node),
+    };
+  }
+
   public Base Convert(IfcModel model, IfcNode node)
   {
-    var b = new Base();
-    if (node is IfcPropSet ps)
+    if (!node.IsIfcRoot)
+      throw new ArgumentException("Expected to be an IfcRoot", paramName: nameof(node));
+
+    if (node is IfcPropSet)
     {
-      b["Name"] = ps.Name;
-      b["GlobalId"] = ps.Guid;
+      return new Base();
     }
 
-    // https://github.com/specklesystems/speckle-server/issues/1180
-    b["ifc_type"] = node.Type;
+    return node.Type switch
+    {
+      "IFCPROJECT" or "IFCSITE" or "IFCBUILDING" or "IFCBUILDINGSTOREY" => ConvertCollection(model, node),
+      _ => ConvertDataObject(model, node)
+    };
+  }
 
-    // This is required because "speckle_type" has no setter, but is backed by a private field.
-    var baseType = typeof(Base);
-    var typeField = baseType.GetField("_type", BindingFlags.Instance | BindingFlags.NonPublic);
-    typeField?.SetValue(b, node.Type);
+  private List<Base> ConvertChildren(IfcModel model, IfcNode node)
+  {
+    return node.GetChildren().Where(x => x.IsIfcRoot).Select(x => Convert(model, x)).ToList();
+  }
 
-    // Guid is null for property values, and other Ifc entities not derived from IfcRoot
-    b.applicationId = node.Guid;
-
-    // This is the express ID used to identify an entity wihtin a file.
-    b["expressID"] = node.Id;
+  public DataObject ConvertDataObject(IfcModel model, IfcNode node)
+  {
+    if (!node.IsIfcRoot)
+      throw new ArgumentException("Expected to be an IfcRoot", paramName: nameof(node));
 
     // Even if there is no geometry, this will return an empty collection.
     var geo = model.GetGeometry(node.Id);
-    if (geo != null)
-    {
-      var c = geometryConverter.Convert(geo);
-      if (c.Count > 0)
-        b["@displayValue"] = c;
-    }
-
-    // Create the children
-    var children = node.GetChildren().Select(x => Convert(model, x)).ToList();
-    b["@elements"] = children;
-
-    // Add the properties
-    foreach (var p in node.GetPropSets())
-    {
-      // Only when there are actually some properties.
-      if (p.NumProperties > 0)
-      {
-        var name = p.Name;
-        if (string.IsNullOrWhiteSpace(name))
-          name = $"#{p.Id}";
-        b[name] = ToSpeckleDictionary(p);
-      }
-    }
+    List<Base> displayValue = geo != null ? geometryConverter.Convert(geo) : new();
 
     // TODO: add the "type" properties
 
-    return b;
+    return new DataObject()
+    {
+      applicationId = node.Guid, // Guid is null for property values, and other Ifc entities not derived from IfcRoot
+      properties = ConvertPropertySets(node),
+      name = node.Name ?? node.Guid,
+      displayValue = displayValue,
+      ["@elements"] = ConvertChildren(model, node),
+      ["ifc_type"] = node.Type,
+      ["expressID"] = node.Id,
+    };
+  }
+
+  private static Dictionary<string, object?> ConvertPropertySets(IfcNode node)
+  {
+    var result = new Dictionary<string, object?>();
+    foreach (var p in node.GetPropSets())
+    {
+      if (p.NumProperties <= 0)
+        continue;
+
+      var name = p.Name;
+      if (string.IsNullOrWhiteSpace(name))
+        name = $"#{p.Id}";
+      result[name] = ToSpeckleDictionary(p);
+    }
+
+    return result;
   }
 
   public static Dictionary<string, object?> ToSpeckleDictionary(IfcPropSet ps)


### PR DESCRIPTION
Before, we had a one-size fits all conversion function that converted everything that wasn't geometry.

I've separated collection and data object paths to implement sending objects with the correct type, and having clarity of the structure of ifc conversion