### PR TITLE
Feat(revit): linked models POC

### DIFF
--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Bindings/RevitSendBinding.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Bindings/RevitSendBinding.cs
@@ -91,8 +91,6 @@ internal sealed class RevitSendBinding : RevitBaseBinding, ISendBinding
     _store.DocumentChanged += (_, _) => topLevelExceptionHandler.FireAndForget(async () => await OnDocumentChanged());
   }
 
-  private async Task OnDocumentStoreChangedEvent(object _) => await Commands.NotifyDocumentChanged();
-
   public List<ISendFilter> GetSendFilters() =>
     [
       new RevitSelectionFilter() { IsDefault = true },
@@ -137,8 +135,7 @@ internal sealed class RevitSendBinding : RevitBaseBinding, ISendBinding
           )
         );
 
-      List<Element> elements = await RefreshElementsOnSender(modelCard.NotNull());
-      List<ElementId> elementIds = elements.Select(el => el.Id).ToList();
+      List<ElementId> elementIds = await RefreshElementsIdsOnSender(modelCard.NotNull());
 
       if (elementIds.Count == 0)
       {
@@ -179,7 +176,7 @@ internal sealed class RevitSendBinding : RevitBaseBinding, ISendBinding
     }
   }
 
-  private async Task<List<Element>> RefreshElementsOnSender(SenderModelCard modelCard)
+  private async Task<List<ElementId>> RefreshElementsIdsOnSender(SenderModelCard modelCard)
   {
     var activeUIDoc =
       _revitContext.UIApplication.NotNull().ActiveUIDocument
@@ -214,7 +211,7 @@ internal sealed class RevitSendBinding : RevitBaseBinding, ISendBinding
       );
     }
 
-    return elements;
+    return elements.Select(el => el.Id).ToList();
   }
 
   /// <summary>
@@ -320,7 +317,7 @@ internal sealed class RevitSendBinding : RevitBaseBinding, ISendBinding
   {
     foreach (var sender in _store.GetSenders().ToList())
     {
-      await RefreshElementsOnSender(sender);
+      await RefreshElementsIdsOnSender(sender);
     }
   }
 

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Bindings/RevitSendBinding.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Bindings/RevitSendBinding.cs
@@ -194,6 +194,7 @@ internal sealed class RevitSendBinding : RevitBaseBinding, ISendBinding
       .Where(el => el is not null)
       .ToList();
 
+    // TODO: currently below part suits only for selection, need more work to see how align with other filters
     List<DocumentToConvert> elementsByTransform = [new(null, activeUIDoc.Document, elementsOnMainModel)];
 
     var linkedModels = elementsOnMainModel.Where(el => el is RevitLinkInstance).Cast<RevitLinkInstance>().ToList();

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/DependencyInjection/RevitConnectorModule.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/DependencyInjection/RevitConnectorModule.cs
@@ -48,10 +48,10 @@ public static class ServiceRegistration
     serviceCollection.AddSingleton<IAppIdleManager, RevitIdleManager>();
 
     // send operation and dependencies
-    serviceCollection.AddScoped<SendOperation<ElementId>>();
+    serviceCollection.AddScoped<SendOperation<DocumentToConvert>>();
     serviceCollection.AddScoped<ElementUnpacker>();
     serviceCollection.AddScoped<SendCollectionManager>();
-    serviceCollection.AddScoped<IRootObjectBuilder<ElementId>, RevitRootObjectBuilder>();
+    serviceCollection.AddScoped<IRootObjectBuilder<DocumentToConvert>, RevitRootObjectBuilder>();
     serviceCollection.AddSingleton<ISendConversionCache, SendConversionCache>();
     serviceCollection.AddSingleton<ToSpeckleSettingsManager>();
 

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/DocumentToConvert.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/DocumentToConvert.cs
@@ -1,0 +1,5 @@
+using Autodesk.Revit.DB;
+
+namespace Speckle.Connectors.Revit.HostApp;
+
+public record DocumentToConvert(Transform? Transform, Document Doc, List<Element> Elements);

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/SendCollectionManager.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/SendCollectionManager.cs
@@ -1,6 +1,7 @@
 using Autodesk.Revit.DB;
 using Speckle.Converters.Common;
 using Speckle.Converters.RevitShared.Settings;
+using Speckle.Sdk;
 using Speckle.Sdk.Models.Collections;
 
 namespace Speckle.Connectors.Revit.HostApp;
@@ -43,11 +44,15 @@ public class SendCollectionManager
       }
       else
       {
-        var level = (Level)doc.GetElement(element.LevelId);
-        levelName = level.Name;
-        levelProperties.Add("elevation", level.Elevation);
-        levelProperties.Add("units", _converterSettings.Current.SpeckleUnits);
-        _levelCache.Add(element.LevelId, (levelName, levelProperties));
+        try
+        {
+          var level = (Level)doc.GetElement(element.LevelId);
+          levelName = level.Name;
+          levelProperties.Add("elevation", level.Elevation);
+          levelProperties.Add("units", _converterSettings.Current.SpeckleUnits);
+          _levelCache.Add(element.LevelId, (levelName, levelProperties));
+        }
+        catch (Exception e) when (!e.IsFatal()) { }
       }
     }
 

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/SendCollectionManager.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/SendCollectionManager.cs
@@ -1,3 +1,4 @@
+using System.IO;
 using Autodesk.Revit.DB;
 using Speckle.Converters.Common;
 using Speckle.Converters.RevitShared.Settings;
@@ -31,6 +32,8 @@ public class SendCollectionManager
   {
     var doc = _converterSettings.Current.Document;
     var path = new List<string>();
+    string fileName = Path.GetFileNameWithoutExtension(doc.PathName);
+    path.Add(fileName);
 
     // Step 0: get the level and its properties
     string levelName = "No Level";

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/RevitRootObjectBuilder.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/RevitRootObjectBuilder.cs
@@ -105,7 +105,7 @@ public class RevitRootObjectBuilder(
 
     foreach (var atomicObjectByDocumentAndTransform in atomicObjectsByDocumentAndTransform)
     {
-      // here we do magic for changing the transform according to model. first one is always the main model.
+      // here we do magic for changing the transform and the related document according to model. first one is always the main model.
       using (
         converterSettings.Push(currentSettings =>
           currentSettings with

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Speckle.Connectors.RevitShared.projitems
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Speckle.Connectors.RevitShared.projitems
@@ -20,6 +20,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bindings\RevitSendBinding.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ElementIdHelper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HostApp\DocumentModelStorageSchema.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)HostApp\DocumentToConvert.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HostApp\Elements.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HostApp\RevitMaterialBaker.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HostApp\SupportedCategoriesUtils.cs" />

--- a/Converters/Revit/Speckle.Converters.RevitShared/ToSpeckle/Raw/Geometry/MeshByMaterialDictionaryToSpeckle.cs
+++ b/Converters/Revit/Speckle.Converters.RevitShared/ToSpeckle/Raw/Geometry/MeshByMaterialDictionaryToSpeckle.cs
@@ -62,14 +62,17 @@ public class MeshByMaterialDictionaryToSpeckle
     var objectRenderMaterialProxiesMap = _revitToSpeckleCacheSingleton.ObjectRenderMaterialProxiesMap;
     var materialProxyMap = new Dictionary<string, RenderMaterialProxy>();
     var key = args.parentElementId.ToString();
-    // ids are same in copy pasted linked models, otherwise we reset the materialProxyMap in cache and only one of the linked model is having the render materials
-    if (objectRenderMaterialProxiesMap.TryGetValue(key, out var cachedMaterialProxy))
+    if (!string.IsNullOrEmpty(key)) // ci being strict on null checks. this shouldn't be necessary
     {
-      materialProxyMap = cachedMaterialProxy;
-    }
-    else
-    {
-      objectRenderMaterialProxiesMap[key] = materialProxyMap;
+      // ids are same in copy pasted linked models, otherwise we reset the materialProxyMap in cache and only one of the linked model is having the render materials
+      if (objectRenderMaterialProxiesMap.TryGetValue(key, out var cachedMaterialProxy))
+      {
+        materialProxyMap = cachedMaterialProxy;
+      }
+      else
+      {
+        objectRenderMaterialProxiesMap[key] = materialProxyMap;
+      }
     }
 
     if (args.target.Count == 0)

--- a/Converters/Revit/Speckle.Converters.RevitShared/ToSpeckle/Raw/Geometry/MeshByMaterialDictionaryToSpeckle.cs
+++ b/Converters/Revit/Speckle.Converters.RevitShared/ToSpeckle/Raw/Geometry/MeshByMaterialDictionaryToSpeckle.cs
@@ -62,6 +62,7 @@ public class MeshByMaterialDictionaryToSpeckle
     var objectRenderMaterialProxiesMap = _revitToSpeckleCacheSingleton.ObjectRenderMaterialProxiesMap;
     var materialProxyMap = new Dictionary<string, RenderMaterialProxy>();
     var key = args.parentElementId.ToString();
+    // ids are same in copy pasted linked models, otherwise we reset the materialProxyMap in cache and only one of the linked model is having the render materials
     if (objectRenderMaterialProxiesMap.TryGetValue(key, out var cachedMaterialProxy))
     {
       materialProxyMap = cachedMaterialProxy;

--- a/Converters/Revit/Speckle.Converters.RevitShared/ToSpeckle/Raw/Geometry/MeshByMaterialDictionaryToSpeckle.cs
+++ b/Converters/Revit/Speckle.Converters.RevitShared/ToSpeckle/Raw/Geometry/MeshByMaterialDictionaryToSpeckle.cs
@@ -61,7 +61,15 @@ public class MeshByMaterialDictionaryToSpeckle
     List<SOG.Mesh> result = new(args.target.Keys.Count);
     var objectRenderMaterialProxiesMap = _revitToSpeckleCacheSingleton.ObjectRenderMaterialProxiesMap;
     var materialProxyMap = new Dictionary<string, RenderMaterialProxy>();
-    objectRenderMaterialProxiesMap[args.parentElementId.ToString().NotNull()] = materialProxyMap;
+    var key = args.parentElementId.ToString();
+    if (objectRenderMaterialProxiesMap.TryGetValue(key, out var cachedMaterialProxy))
+    {
+      materialProxyMap = cachedMaterialProxy;
+    }
+    else
+    {
+      objectRenderMaterialProxiesMap[key] = materialProxyMap;
+    }
 
     if (args.target.Count == 0)
     {

--- a/Converters/Revit/Speckle.Converters.RevitShared/ToSpeckle/Raw/Geometry/MeshByMaterialDictionaryToSpeckle.cs
+++ b/Converters/Revit/Speckle.Converters.RevitShared/ToSpeckle/Raw/Geometry/MeshByMaterialDictionaryToSpeckle.cs
@@ -61,18 +61,15 @@ public class MeshByMaterialDictionaryToSpeckle
     List<SOG.Mesh> result = new(args.target.Keys.Count);
     var objectRenderMaterialProxiesMap = _revitToSpeckleCacheSingleton.ObjectRenderMaterialProxiesMap;
     var materialProxyMap = new Dictionary<string, RenderMaterialProxy>();
-    var key = args.parentElementId.ToString();
-    if (!string.IsNullOrEmpty(key)) // ci being strict on null checks. this shouldn't be necessary
+    var key = args.parentElementId.ToString().NotNull();
+    // ids are same in copy pasted linked models, otherwise we reset the materialProxyMap in cache and only one of the linked model is having the render materials
+    if (objectRenderMaterialProxiesMap.TryGetValue(key, out var cachedMaterialProxy))
     {
-      // ids are same in copy pasted linked models, otherwise we reset the materialProxyMap in cache and only one of the linked model is having the render materials
-      if (objectRenderMaterialProxiesMap.TryGetValue(key, out var cachedMaterialProxy))
-      {
-        materialProxyMap = cachedMaterialProxy;
-      }
-      else
-      {
-        objectRenderMaterialProxiesMap[key] = materialProxyMap;
-      }
+      materialProxyMap = cachedMaterialProxy;
+    }
+    else
+    {
+      objectRenderMaterialProxiesMap[key] = materialProxyMap;
     }
 
     if (args.target.Count == 0)


### PR DESCRIPTION
RevitRootObjectBuilder is refactored to align linked models support. We pass `DocumentToConvert` object to send operation which was `ElementId` before.