### PR TITLE
feat(revit): linked models send by category

### DIFF
--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Bindings/RevitSendBinding.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Bindings/RevitSendBinding.cs
@@ -188,6 +188,8 @@ internal sealed class RevitSendBinding : RevitBaseBinding, ISendBinding
       viewFilter.SetContext(_revitContext);
     }
 
+    // decomposing into elementsOnMainModel and linkedElements happens after this method call
+    // therefore, RefreshObjectIds was modified to not filter RevitLinkInstances out!
     var selectedObjects = modelCard.SendFilter.NotNull().RefreshObjectIds();
 
     // all elements is a mix of regular elements and linked models
@@ -203,6 +205,7 @@ internal sealed class RevitSendBinding : RevitBaseBinding, ISendBinding
     var linkedModels = allElements.OfType<RevitLinkInstance>().ToList();
     List<DocumentToConvert> documentElementContexts = [new(null, activeUIDoc.Document, elementsOnMainModel)];
 
+    // TODO: wrap RevitLinkInstance stuff in some helper classes. This is getting long
     foreach (var linkedModel in linkedModels)
     {
       var linkedDoc = linkedModel.GetLinkDocument();
@@ -211,7 +214,7 @@ internal sealed class RevitSendBinding : RevitBaseBinding, ISendBinding
       {
         List<Element> linkedElements;
 
-        // sending via 1 of 2 (or 3) modes (selection / categories) for linked models is very rough atm - poc
+        // sending via 1 of 2 modes (selection / categories) for linked models is very rough atm - poc
         // send option 1 - categories
         if (modelCard.SendFilter is RevitCategoriesFilter categoryFilter && categoryFilter.SelectedCategories != null)
         {

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Bindings/RevitSendBinding.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Bindings/RevitSendBinding.cs
@@ -195,8 +195,7 @@ internal sealed class RevitSendBinding : RevitBaseBinding, ISendBinding
       .Where(el => el is not null)
       .ToList();
 
-    // elementsOnMainModel shouldn't include linked instances
-    // we need to remove from elementsOnMainModel, otherwise when processing, we're still trying to convert the link
+    // elementsOnMainModel shouldn't include linked instances otherwise when processing, we're still trying to convert link
     var elementsOnMainModel = allElements.Where(el => el is not RevitLinkInstance).ToList();
 
     // treat linked instances on their own. Collector focuses on decomposing the linked instances


### PR DESCRIPTION
## Description

Enabling sending of linked models by category.

## User Value

Choose what categories of a linked model to send.

## Changes:

- Modified `RevitCategoriesFilter` implementation of `RefreshObjectIds` to not filter out `RevitLinkInstance`
- In the for loop for the `linkedModels` added a conditional for `RevitCategoriesFIlter` and filtered as per main model elements
- Overview and comments in [Figma Jam](https://www.figma.com/board/wVIjAWbnOju2yEbtZaLZur/Connectors-v3?node-id=1256-3248&t=HAc9graNFACGHzNJ-4)

## Screenshots:

https://github.com/user-attachments/assets/f3cd8986-a9bb-4af5-8edd-6f5ce0b13953

## Checklist:

- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] I have added appropriate tests.
- [x] I have updated or added relevant documentation.

