### PR TITLE
Use 3 instead of 0 for cardinality indicator of triangle faces

### DIFF
--- a/Converters/Navisworks/Speckle.Converters.NavisworksShared/ToSpeckle/Raw/GeometryToSpeckleConverter.cs
+++ b/Converters/Navisworks/Speckle.Converters.NavisworksShared/ToSpeckle/Raw/GeometryToSpeckleConverter.cs
@@ -192,7 +192,7 @@ public class GeometryToSpeckleConverter
           (triangle.Vertex3.Z + _transformVector.Z) * SCALE
         ]
       );
-      faces.AddRange([0, t * 3, t * 3 + 1, t * 3 + 2]);
+      faces.AddRange([3, t * 3, t * 3 + 1, t * 3 + 2]);
     }
 
     return new Mesh


### PR DESCRIPTION
@kekesidavid reported an issue consuming Navisworks meshes inside Archiacd.

Navisworks is currently sending Meshes using the very old encoding for triangles (using `0` cardinality indicator to mean "triangle" instead using `3`)

I was not expecting any connector to still be sending using the old format. I assume navisworks v2 slipped through, and this has been copied over to v3.
