### PR TITLE
public release on tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,8 +33,6 @@ jobs:
         run: ./build.ps1 zip
 
       - name: ⬆️ Upload artifacts
-        #if tag and it's main branch (or installer-test branch)
-        if: (github.ref_type == 'tag' && startsWith(github.ref, 'refs/tags/v3.') && github.ref == 'refs/heads/main') || startsWith(github.ref, 'refs/heads/installer-test/')
         uses: actions/upload-artifact@v4
         with:
           name: output-${{ env.SPECKLE_VERSION }}
@@ -49,11 +47,9 @@ jobs:
   deploy-installers:
     runs-on: ubuntu-latest
     needs: build-windows
-    #if tag and it's main branch (or installer-test branch)
-    if: (github.ref_type == 'tag' && startsWith(github.ref, 'refs/tags/v3.') && github.ref == 'refs/heads/main') || startsWith(github.ref, 'refs/heads/installer-test/')
     env:
-      IS_RELEASE_BRANCH: ${{ github.ref == 'refs/heads/main' }}
-      IS_TEST_INSTALLER: ${{ startsWith(github.ref, 'refs/heads/installer-test/') }}
+      IS_PUBLIC_RELEASE: ${{ github.ref_type == 'tag' }}
+      IS_TEST_INSTALLER: ${{ github.ref_type != 'tag' }}
     steps:
       - name: 🔫 Trigger Build Installers
         uses: ALEEF02/workflow-dispatch@v3.0.0
@@ -61,7 +57,7 @@ jobs:
           workflow: Build Installers
           repo: specklesystems/connector-installers
           token: ${{ secrets.CONNECTORS_GH_TOKEN }}
-          inputs: '{ "run_id": "${{ github.run_id }}", "version": "${{ needs.build-windows.outputs.version }}", "public_release": ${{ env.IS_RELEASE_BRANCH }}, "store_artifacts": ${{ env.IS_TEST_INSTALLER }} }'
+          inputs: '{ "run_id": "${{ github.run_id }}", "version": "${{ needs.build-windows.outputs.version }}", "public_release": ${{ env.IS_PUBLIC_RELEASE }}, "store_artifacts": ${{ env.IS_TEST_INSTALLER }} }'
           ref: main
           wait-for-completion: true
           wait-for-completion-interval: 10s


### PR DESCRIPTION
Previous logic for checking tag & main was flawed,

This PR will trigger public releases on all tag pushes, and test installers on all `main` and `installers-test/**` pushes