### PR TITLE
feat(revit): commit structure

### DIFF
--- a/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/SendCollectionManager.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/SendCollectionManager.cs
@@ -99,7 +99,8 @@ public class SendCollectionManager
           levelProperties.Add("units", _converterSettings.Current.SpeckleUnits);
           _levelCache.Add(element.LevelId, (levelName, levelProperties));
         }
-        catch (Exception e) when (!e.IsFatal()) { } // TODO: CNX-1376
+        // the exception is swallowed since if an exception occurs, we fall back to "No Level" for the element
+        catch (Exception e) when (!e.IsFatal()) { }
       }
     }
 

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/SendCollectionManager.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/SendCollectionManager.cs
@@ -63,7 +63,7 @@ public class SendCollectionManager
       else
       {
         // get or create a collection for this linked model
-        if (!_linkedModelCollections.TryGetValue(modelName, out Collection linkedModelCollection))
+        if (!_linkedModelCollections.TryGetValue(modelName, out Collection? linkedModelCollection))
         {
           linkedModelCollection = new Collection(modelName);
           rootObject.elements.Add(linkedModelCollection);

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/RevitRootObjectBuilder.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/RevitRootObjectBuilder.cs
@@ -60,10 +60,22 @@ public class RevitRootObjectBuilder(
     rootObject["units"] = converterSettings.Current.SpeckleUnits;
 
     var filteredDocumentsToConvert = new List<DocumentToConvert>();
+    bool sendWithLinkedModels = false;
     List<SendConversionResult> results = new();
 
     foreach (var documentElementContext in documentElementContexts)
     {
+      if (documentElementContext.Doc.IsLinked)
+      {
+        if (converterSettings.Current.SendLinkedModels)
+        {
+          sendWithLinkedModels = true;
+        }
+        else
+        {
+          continue;
+        }
+      }
       var elementsInTransform = new List<Element>();
       foreach (var el in documentElementContext.Elements)
       {
@@ -171,7 +183,11 @@ public class RevitRootObjectBuilder(
               converted.applicationId = applicationId;
             }
 
-            var collection = sendCollectionManager.GetAndCreateObjectHostCollection(revitElement, rootObject);
+            var collection = sendCollectionManager.GetAndCreateObjectHostCollection(
+              revitElement,
+              rootObject,
+              sendWithLinkedModels
+            );
 
             collection.elements.Add(converted);
             results.Add(new(Status.SUCCESS, applicationId, sourceType, converted));


### PR DESCRIPTION
## Description

Commit structure responds to the presence / absence of linked models (together with the UI setting of course).

## User Value

If no linked models - flat as normal
If linked models - nested under the root.


## Changes:

- `SendCollectionManager` reacts accordingly
- `RevitRootObjectBuilder` sends a `bool` of `sendLinkedModels` which NOT ONLY checks if the setting is enabled, but if there actually are linked models present in the selection / active session

## Screenshots:

### Collection with linked models

<img width="372" alt="image" src="https://github.com/user-attachments/assets/c9aecd01-b873-4462-8df9-237856c600c6" />

### Collection without linked models

<img width="418" alt="image" src="https://github.com/user-attachments/assets/5dc5d4f3-9b9f-4e9b-9e73-a1595c897e3c" />


## Checklist:

- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] I have added appropriate tests.
- [x] I have updated or added relevant documentation.

