### PR TITLE
refactor: linked model helper class and refactor

### DIFF
--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Bindings/RevitSendBinding.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Bindings/RevitSendBinding.cs
@@ -232,6 +232,8 @@ internal sealed class RevitSendBinding : RevitBaseBinding, ISendBinding
           linkedDocumentContexts.Add(new(transform, linkedDoc, linkedElements));
         }
         // ⚠️ when disabled, still adds empty contexts to maintain warning generation in RevitRootObjectBuilder
+        // this approach (to signal that warnings are needed) relies on empty element lists which smells and is a bit of an implicit mechanism
+        // buuuuut, it works (for now 👀).
         else
         {
           linkedDocumentContexts.Add(new(transform, linkedDoc, new List<Element>()));

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Bindings/RevitSendBinding.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Bindings/RevitSendBinding.cs
@@ -224,15 +224,16 @@ internal sealed class RevitSendBinding : RevitBaseBinding, ISendBinding
         var transform = linkedModel.GetTotalTransform().Inverse;
 
         // decision about whether to process elements is made here, not in the handler
+        // only collects elements from linked models when the setting is enabled
         if (includeLinkedModels)
         {
           // handler is only responsible for element collection mechanics
           var linkedElements = _linkedModelHandler.GetLinkedModelElements(modelCard.SendFilter, linkedDoc);
           linkedDocumentContexts.Add(new(transform, linkedDoc, linkedElements));
         }
+        // ⚠️ when disabled, still adds empty contexts to maintain warning generation in RevitRootObjectBuilder
         else
         {
-          // ⚠️ HACK ALERT: empty element list when user has disabled linked model processing (in order to add warning in results of RevitRootObjectBuilder)
           linkedDocumentContexts.Add(new(transform, linkedDoc, new List<Element>()));
         }
       }

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/DependencyInjection/RevitConnectorModule.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/DependencyInjection/RevitConnectorModule.cs
@@ -54,6 +54,7 @@ public static class ServiceRegistration
     serviceCollection.AddScoped<IRootObjectBuilder<DocumentToConvert>, RevitRootObjectBuilder>();
     serviceCollection.AddSingleton<ISendConversionCache, SendConversionCache>();
     serviceCollection.AddSingleton<ToSpeckleSettingsManager>();
+    serviceCollection.AddSingleton<LinkedModelHandler>();
 
     // receive operation and dependencies
     serviceCollection.AddScoped<IHostObjectBuilder, RevitHostObjectBuilder>();

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/DocumentToConvert.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/DocumentToConvert.cs
@@ -2,9 +2,4 @@ using Autodesk.Revit.DB;
 
 namespace Speckle.Connectors.Revit.HostApp;
 
-public record DocumentToConvert(
-  Transform? Transform,
-  Document Doc,
-  List<Element> Elements,
-  bool IsLinkedDocument = false
-);
+public record DocumentToConvert(Transform? Transform, Document Doc, List<Element> Elements);

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/DocumentToConvert.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/DocumentToConvert.cs
@@ -2,4 +2,9 @@ using Autodesk.Revit.DB;
 
 namespace Speckle.Connectors.Revit.HostApp;
 
-public record DocumentToConvert(Transform? Transform, Document Doc, List<Element> Elements);
+public record DocumentToConvert(
+  Transform? Transform,
+  Document Doc,
+  List<Element> Elements,
+  bool IsLinkedDocument = false
+);

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/LinkedModelHandler.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/LinkedModelHandler.cs
@@ -1,0 +1,65 @@
+using Autodesk.Revit.DB;
+using Speckle.Connectors.DUI.Models.Card.SendFilter;
+using Speckle.Connectors.RevitShared;
+using Speckle.Connectors.RevitShared.Operations.Send.Filters;
+
+namespace Speckle.Connectors.Revit.HostApp;
+
+/// <summary>
+/// Handles unpacking elements inside linked models.
+/// This class is responsible for the mechanics of retrieving elements from linked documents
+/// based on different filter types, but not for making decisions about whether linked models
+/// should be processed (which is the responsibility of the calling code)!
+/// </summary>
+public class LinkedModelHandler
+{
+  /// <summary>
+  /// Gets elements from a linked document based on the provided send filter.
+  /// This method handles the specifics of element collection but doesn't make decisions
+  /// about whether the linked model should be processed - that's the caller's responsibility.
+  /// </summary>
+  public List<Element> GetLinkedModelElements(ISendFilter sendFilter, Document linkedDocument)
+  {
+    // send mode → Categories
+    if (sendFilter is RevitCategoriesFilter categoryFilter && categoryFilter.SelectedCategories is not null)
+    {
+      var categoryIds = categoryFilter
+        .SelectedCategories.Select(c => ElementIdHelper.GetElementId(c))
+        .OfType<ElementId>()
+        .ToList();
+
+      if (categoryIds.Count > 0)
+      {
+        return GetElementsByCategory(linkedDocument, categoryIds);
+      }
+      return new List<Element>();
+    }
+    // send mode → Selection
+    return GetAllElementsForLinkedModelSelection(linkedDocument);
+  }
+
+  /// <summary>
+  /// Gets elements from a document that belong to the specified categories.
+  /// </summary>
+  private List<Element> GetElementsByCategory(Document linkedDoc, List<ElementId> categoryIds)
+  {
+    using var multicategoryFilter = new ElementMulticategoryFilter(categoryIds);
+    using var collector = new FilteredElementCollector(linkedDoc);
+    return collector
+      .WhereElementIsNotElementType()
+      .WhereElementIsViewIndependent()
+      .WherePasses(multicategoryFilter)
+      .ToList();
+  }
+
+  /// <summary>
+  /// Retrieves all elements from the linked document when using selection filters.
+  /// When a linked model is selected in the main document, we include all elements
+  /// from that linked model since the selection is of the entire linked instance.
+  /// </summary>
+  private List<Element> GetAllElementsForLinkedModelSelection(Document linkedDoc)
+  {
+    using var collector = new FilteredElementCollector(linkedDoc);
+    return collector.WhereElementIsNotElementType().WhereElementIsViewIndependent().ToList();
+  }
+}

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/RevitRootObjectBuilder.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/RevitRootObjectBuilder.cs
@@ -66,7 +66,7 @@ public class RevitRootObjectBuilder(
     foreach (var documentElementContext in documentElementContexts)
     {
       // add appropriate warnings for linked documents
-      if (documentElementContext.IsLinkedDocument && !sendWithLinkedModels)
+      if (documentElementContext.Doc.IsLinked && !sendWithLinkedModels)
       {
         results.Add(
           new(

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/RevitRootObjectBuilder.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/RevitRootObjectBuilder.cs
@@ -81,6 +81,7 @@ public class RevitRootObjectBuilder(
       }
 
       // filter for valid elements
+      // if send linked models setting is disabled List<Elements> will be empty, and we won't enter foreach loop
       var elementsInTransform = new List<Element>();
       foreach (var el in documentElementContext.Elements)
       {
@@ -125,21 +126,6 @@ public class RevitRootObjectBuilder(
 
     foreach (var atomicObjectByDocumentAndTransform in atomicObjectsByDocumentAndTransform)
     {
-      // if user doesn't have send linked models enabled, don't convert ...
-      if (atomicObjectByDocumentAndTransform.Doc.IsLinked && !converterSettings.Current.SendLinkedModels)
-      {
-        results.Add(
-          new(
-            Status.WARNING,
-            atomicObjectByDocumentAndTransform.Doc.PathName, // TODO: User won't be able to highlight linked model from report.
-            typeof(RevitLinkInstance).ToString(),
-            null,
-            new SpeckleException("Enable linked model support from the settings to send this object")
-          )
-        );
-        continue;
-      }
-
       // here we do magic for changing the transform and the related document according to model. first one is always the main model.
       using (
         converterSettings.Push(currentSettings =>

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Speckle.Connectors.RevitShared.projitems
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Speckle.Connectors.RevitShared.projitems
@@ -22,6 +22,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)HostApp\DocumentModelStorageSchema.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HostApp\DocumentToConvert.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HostApp\Elements.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)HostApp\LinkedModelHandler.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HostApp\RevitMaterialBaker.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HostApp\SupportedCategoriesUtils.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Operations\Receive\HideWarningsFailuresPreprocessor.cs" />


### PR DESCRIPTION
## Description

Refactor how linked models are handled. The major changes focus on processing linked models more efficiently (no unnecessary unpacking and processing of elements) and creating a clearer separation of responsibilities between components (got blurry between `RevitSendBinding` and `RevitRootObjectBuilder`).

## User Value

Would significantly improves performance when sending models with disabled linked model setting, especially for large projects with many linked models.

## Changes:

###  Premature Processing of Linked Models ✅ FIXED
Addressed in `RevitSendBinding.cs`.
- Early check of linked model setting
- See comments for better explanation
- Only collects linked model elements IF setting is enabled

### Mixing of Concerns ✅ FIXED
Getting some clearer separation of responsibilites between the three classes:
- `LinkedModelHandler` - this is a new class. Dedicated to element collection mechanics from linked models and handling different filter types (categories vs. selection) ONLY. Won't respond to UI setting for linked models.
- `RevitSendBinding` - controls flow and handles decision-making based on UI setting.
- `RevitRootObjectBuilder` - processes contexts and delegates to conversions. We have maintained the warning users get if a linked model is present but no setting enabled => this approach (to signal that warnings are needed) relies on empty element lists sent from `RevitSendBinding` which smells and is a bit of an implicit mechanism (but temp. fix and works for now).

## Screenshots:

### Selection including linked models but setting not enabled:

<img width="1280" alt="image" src="https://github.com/user-attachments/assets/846966b9-ea3b-489d-b5b1-47d5326e00a2" />

### Collection structure maintained

#### Main model + linked models

<img width="1280" alt="image" src="https://github.com/user-attachments/assets/4f0b86f8-26fe-421e-9105-42f369bd1b7a" />

#### Main model only

<img width="1280" alt="image" src="https://github.com/user-attachments/assets/1cf90107-5666-4414-91ed-9e9b16678fea" />

## Checklist:
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [ ] I have added appropriate tests.
- [x] I have updated or added relevant documentation.

