### PR TITLE
fix(revit): handle multiple linked model instances with transform hashing

### DIFF
--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/RevitRootObjectBuilder.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/RevitRootObjectBuilder.cs
@@ -168,7 +168,8 @@ public class RevitRootObjectBuilder(
             bool hasTransform = atomicObjectByDocumentAndTransform.Transform != null;
 
             // non-transformed elements can safely rely on cache
-            // TODO: Potential here to transform cached objects and NOT reconvert
+            // TODO: Potential here to transform cached objects and NOT reconvert,
+            // TODO: we wont do !hasTransform here, and re-set application id before this
             if (
               !hasTransform
               && sendConversionCache.TryGetValue(sendInfo.ProjectId, applicationId, out ObjectReference? value)


### PR DESCRIPTION
## Description

Add transform-specific hashing to properly handle multiple instances of the same linked model. Uses transform properties to create a unique suffix for the applicationId, preventing cached objects from being incorrectly reused across different transform contexts. This also fixes problems observed when trying to recieve back into Revit.

Fixes:
- [CNX-1385](https://linear.app/speckle/issue/CNX-1385/linked-models-instancing)
- [CNX-1434](https://linear.app/speckle/issue/CNX-1434/loading-linked-models-back-in-revit).

## User Value

Lots.

## Changes:

- Added a `GetTransformHash` method to create unique hashes for transforms (based on `IdGenerator.cs` from `Base`)
- Modified caching logic in `RevitRootObjectBuilder` to consider element transformations
- Added unique transform-specific suffixes to `applicationId` for elements with transforms
- If `revitElement` doesn't have a transform, then its `applicationId` just stays as is

## Screenshots:

You can see the Speckle model here: [cnx-1385](https://latest.speckle.systems/projects/99d30f721c/models/314fb22e94)

### Same wall instances suffixed with transform hash

![image](https://github.com/user-attachments/assets/fd66e2ee-57de-42d5-8adb-e5394fe35f04)

![image](https://github.com/user-attachments/assets/2f92b09c-1e0f-46fe-a13c-10a7bc022b75)

### Main model elements remain unchanged

<img width="1280" alt="image" src="https://github.com/user-attachments/assets/6e717e41-c469-4776-960f-a3a04df9d840" />

## Validation of changes:
- We send a model with **mutiple instances of the same linked model**
- A wall from the main model is shown with a normal looking `applicationId`
- A wall from an instance of a linked model has an `applicationId` with `_t` suffix and the `transformHash`
- This model can then be received back in Revit with no issues, fixing [CNX-1434](https://linear.app/speckle/issue/CNX-1434/loading-linked-models-back-in-revit).

https://github.com/user-attachments/assets/b976b99b-ac6a-4b2c-b2f2-8fd3e5c67680

## Checklist:

- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [ ] I have added appropriate tests.
- [x] I have updated or added relevant documentation.

