### PR TITLE
fix(Civil3D): Catch error with SpiralDirection due to Civil 3D 2022 Bug

### DIFF
--- a/Converters/Civil3d/Speckle.Converters.Civil3dShared/ToSpeckle/Raw/AlignmentSubentitySpiralToSpeckleRawConverter.cs
+++ b/Converters/Civil3d/Speckle.Converters.Civil3dShared/ToSpeckle/Raw/AlignmentSubentitySpiralToSpeckleRawConverter.cs
@@ -46,6 +46,19 @@ public class AlignmentSubentitySpiralToSpeckleRawConverter
     polylineValue.Add(spiral.EndPoint.Y);
     polylineValue.Add(0);
 
+    // Civil 3D 2022 has a bug with the spiral definition sometimes throwing an InvalidOperation exception
+    // Catch the error here and set direction to null if this occurs
+    string? spiralDirection;
+    try
+    {
+      spiralDirection = spiral.Direction.ToString();
+    }
+    catch (InvalidOperationException)
+    {
+      // Set the spiralDirection as null
+      spiralDirection = null;
+    }
+
     SOG.Polyline polyline =
       new()
       {
@@ -55,7 +68,7 @@ public class AlignmentSubentitySpiralToSpeckleRawConverter
         // add alignment spiral props
         length = spiral.Length,
         ["delta"] = spiral.Delta,
-        ["direction"] = spiral.Direction.ToString(),
+        ["direction"] = spiralDirection,
         ["spiralDefinition"] = spiral.SpiralDefinition.ToString(),
         ["totalX"] = spiral.TotalX,
         ["totalY"] = spiral.TotalY,


### PR DESCRIPTION
## Description

Caught error with Spiral Direction

## User Value

Allows alignments with the issue to still upload to Speckle

## Changes:

AlignmentSubentitySpiralToSpeckleRawConverter.cs:
Put accessing the spiral.Direction property in a try/catch block in case it throws an InvalidOperation exception

## To-do before merge:

None

## Screenshots:

See https://github.com/specklesystems/speckle-sharp-connectors/issues/691 

## Validation of changes:

Test carried out on the drawing attached in https://github.com/specklesystems/speckle-sharp-connectors/issues/691 
Alignment succecsfully uploads

## Checklist:

- [X] My commits are related to the pull request and do not amend unrelated code or documentation.
- [X] I have added appropriate tests.
- [X] I have updated or added relevant documentation.

