### PR TITLE
Exclude library assets for all host applications for connectors/converters

### DIFF
--- a/Connectors/Autocad/Speckle.Connectors.Autocad2022/Speckle.Connectors.Autocad2022.csproj
+++ b/Connectors/Autocad/Speckle.Connectors.Autocad2022/Speckle.Connectors.Autocad2022.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Speckle.AutoCAD.API" VersionOverride="2022.0.2" />
+    <PackageReference Include="Speckle.AutoCAD.API" VersionOverride="2022.0.2" ExcludeAssets="runtime"/>
   </ItemGroup>  
   
   <ItemGroup>

--- a/Connectors/Autocad/Speckle.Connectors.Autocad2023/Speckle.Connectors.Autocad2023.csproj
+++ b/Connectors/Autocad/Speckle.Connectors.Autocad2023/Speckle.Connectors.Autocad2023.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Speckle.AutoCAD.API" VersionOverride="2023.0.0" />
+    <PackageReference Include="Speckle.AutoCAD.API" VersionOverride="2023.0.0" ExcludeAssets="runtime"/>
   </ItemGroup>  
   
   <ItemGroup>

--- a/Connectors/Autocad/Speckle.Connectors.Autocad2024/Speckle.Connectors.Autocad2024.csproj
+++ b/Connectors/Autocad/Speckle.Connectors.Autocad2024/Speckle.Connectors.Autocad2024.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Speckle.AutoCAD.API" VersionOverride="2024.0.0" />
+    <PackageReference Include="Speckle.AutoCAD.API" VersionOverride="2024.0.0" ExcludeAssets="runtime"/>
   </ItemGroup>  
   
   <ItemGroup>   

--- a/Connectors/Autocad/Speckle.Connectors.Autocad2025/Speckle.Connectors.Autocad2025.csproj
+++ b/Connectors/Autocad/Speckle.Connectors.Autocad2025/Speckle.Connectors.Autocad2025.csproj
@@ -13,8 +13,7 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Speckle.AutoCAD.API" VersionOverride="2025.0.0" />
-    <FrameworkReference Include="Microsoft.WindowsDesktop.App"/>
+    <PackageReference Include="Speckle.AutoCAD.API" VersionOverride="2025.0.0" ExcludeAssets="runtime"/>
   </ItemGroup>  
   
   <ItemGroup>   

--- a/Connectors/Autocad/Speckle.Connectors.Civil3d2022/Speckle.Connectors.Civil3d2022.csproj
+++ b/Connectors/Autocad/Speckle.Connectors.Civil3d2022/Speckle.Connectors.Civil3d2022.csproj
@@ -10,8 +10,8 @@
     <StartProgram>$(ProgramW6432)\Autodesk\AutoCAD $(Civil3DVersion)\acad.exe</StartProgram>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Speckle.AutoCAD.API" />
-    <PackageReference Include="Speckle.Civil3D.API" />
+    <PackageReference Include="Speckle.AutoCAD.API"  VersionOverride="2022.0.2" ExcludeAssets="runtime"/>
+    <PackageReference Include="Speckle.Civil3D.API"  VersionOverride="2022.0.2" ExcludeAssets="runtime"/>
   </ItemGroup>
   
   <ItemGroup>

--- a/Connectors/Autocad/Speckle.Connectors.Civil3d2023/Speckle.Connectors.Civil3d2023.csproj
+++ b/Connectors/Autocad/Speckle.Connectors.Civil3d2023/Speckle.Connectors.Civil3d2023.csproj
@@ -11,8 +11,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Speckle.AutoCAD.API" VersionOverride="2023.0.0" />
-    <PackageReference Include="Speckle.Civil3D.API" VersionOverride="2023.0.0" />
+    <PackageReference Include="Speckle.AutoCAD.API" VersionOverride="2023.0.0" ExcludeAssets="runtime"/>
+    <PackageReference Include="Speckle.Civil3D.API" VersionOverride="2023.0.0" ExcludeAssets="runtime"/>
   </ItemGroup>
   
   <ItemGroup>

--- a/Connectors/Autocad/Speckle.Connectors.Civil3d2024/Speckle.Connectors.Civil3d2024.csproj
+++ b/Connectors/Autocad/Speckle.Connectors.Civil3d2024/Speckle.Connectors.Civil3d2024.csproj
@@ -11,8 +11,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Speckle.AutoCAD.API" VersionOverride="2024.0.0" />
-    <PackageReference Include="Speckle.Civil3D.API" VersionOverride="2024.0.0" />
+    <PackageReference Include="Speckle.AutoCAD.API" VersionOverride="2024.0.0" ExcludeAssets="runtime"/>
+    <PackageReference Include="Speckle.Civil3D.API" VersionOverride="2024.0.0" ExcludeAssets="runtime"/>
   </ItemGroup>
   
   <ItemGroup>

--- a/Connectors/Autocad/Speckle.Connectors.Civil3d2025/Speckle.Connectors.Civil3d2025.csproj
+++ b/Connectors/Autocad/Speckle.Connectors.Civil3d2025/Speckle.Connectors.Civil3d2025.csproj
@@ -13,9 +13,8 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Speckle.AutoCAD.API" VersionOverride="2025.0.0" />
-    <PackageReference Include="Speckle.Civil3d.API" VersionOverride="2025.0.0" />
-    <FrameworkReference Include="Microsoft.WindowsDesktop.App" />
+    <PackageReference Include="Speckle.AutoCAD.API" VersionOverride="2025.0.0" ExcludeAssets="runtime"/>
+    <PackageReference Include="Speckle.Civil3d.API" VersionOverride="2025.0.0" ExcludeAssets="runtime"/>
   </ItemGroup>  
   
   <ItemGroup>   

--- a/Connectors/Navisworks/Speckle.Connectors.Navisworks2020/Speckle.Connectors.Navisworks2020.csproj
+++ b/Connectors/Navisworks/Speckle.Connectors.Navisworks2020/Speckle.Connectors.Navisworks2020.csproj
@@ -16,7 +16,7 @@
 
   <ItemGroup>
     <Reference Include="WindowsFormsIntegration"/>
-    <PackageReference Include="Speckle.Navisworks.API" VersionOverride="2020.0.0"/>
+    <PackageReference Include="Speckle.Navisworks.API" VersionOverride="2020.0.0" ExcludeAssets="runtime"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/Connectors/Navisworks/Speckle.Connectors.Navisworks2021/Speckle.Connectors.Navisworks2021.csproj
+++ b/Connectors/Navisworks/Speckle.Connectors.Navisworks2021/Speckle.Connectors.Navisworks2021.csproj
@@ -16,7 +16,7 @@
 
   <ItemGroup>
     <Reference Include="WindowsFormsIntegration"/>
-    <PackageReference Include="Speckle.Navisworks.API" VersionOverride="2021.0.0"/>
+    <PackageReference Include="Speckle.Navisworks.API" VersionOverride="2021.0.0" ExcludeAssets="runtime"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/Connectors/Navisworks/Speckle.Connectors.Navisworks2022/Speckle.Connectors.Navisworks2022.csproj
+++ b/Connectors/Navisworks/Speckle.Connectors.Navisworks2022/Speckle.Connectors.Navisworks2022.csproj
@@ -16,7 +16,7 @@
 
   <ItemGroup>
     <Reference Include="WindowsFormsIntegration"/>
-    <PackageReference Include="Speckle.Navisworks.API" VersionOverride="2022.0.0"/>
+    <PackageReference Include="Speckle.Navisworks.API" VersionOverride="2022.0.0" ExcludeAssets="runtime"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/Connectors/Navisworks/Speckle.Connectors.Navisworks2023/Speckle.Connectors.Navisworks2023.csproj
+++ b/Connectors/Navisworks/Speckle.Connectors.Navisworks2023/Speckle.Connectors.Navisworks2023.csproj
@@ -16,7 +16,7 @@
 
   <ItemGroup>
     <Reference Include="WindowsFormsIntegration"/>
-    <PackageReference Include="Speckle.Navisworks.API" VersionOverride="2023.0.0"/>
+    <PackageReference Include="Speckle.Navisworks.API" VersionOverride="2023.0.0" ExcludeAssets="runtime"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/Connectors/Navisworks/Speckle.Connectors.Navisworks2024/Speckle.Connectors.Navisworks2024.csproj
+++ b/Connectors/Navisworks/Speckle.Connectors.Navisworks2024/Speckle.Connectors.Navisworks2024.csproj
@@ -16,7 +16,7 @@
 
   <ItemGroup>
     <Reference Include="WindowsFormsIntegration"/>
-    <PackageReference Include="Speckle.Navisworks.API" VersionOverride="2024.0.0"/>
+    <PackageReference Include="Speckle.Navisworks.API" VersionOverride="2024.0.0" ExcludeAssets="runtime"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/Connectors/Navisworks/Speckle.Connectors.Navisworks2025/Speckle.Connectors.Navisworks2025.csproj
+++ b/Connectors/Navisworks/Speckle.Connectors.Navisworks2025/Speckle.Connectors.Navisworks2025.csproj
@@ -16,7 +16,7 @@
 
   <ItemGroup>
     <Reference Include="WindowsFormsIntegration"/>
-    <PackageReference Include="Speckle.Navisworks.API" VersionOverride="2025.0.0"/>
+    <PackageReference Include="Speckle.Navisworks.API" VersionOverride="2025.0.0" ExcludeAssets="runtime"/>
     <PackageReference Include="Microsoft.Web.WebView2" VersionOverride="1.0.2045.28" />
   </ItemGroup>
 

--- a/Converters/Autocad/Speckle.Converters.Autocad2022/Speckle.Converters.Autocad2022.csproj
+++ b/Converters/Autocad/Speckle.Converters.Autocad2022/Speckle.Converters.Autocad2022.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Speckle.AutoCAD.API" VersionOverride="2022.0.2" />
+    <PackageReference Include="Speckle.AutoCAD.API" VersionOverride="2022.0.2" ExcludeAssets="runtime"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/Converters/Autocad/Speckle.Converters.Autocad2023/Speckle.Converters.Autocad2023.csproj
+++ b/Converters/Autocad/Speckle.Converters.Autocad2023/Speckle.Converters.Autocad2023.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Speckle.AutoCAD.API" VersionOverride="2023.0.0" />
+    <PackageReference Include="Speckle.AutoCAD.API" VersionOverride="2023.0.0" ExcludeAssets="runtime"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/Converters/Autocad/Speckle.Converters.Autocad2024/Speckle.Converters.Autocad2024.csproj
+++ b/Converters/Autocad/Speckle.Converters.Autocad2024/Speckle.Converters.Autocad2024.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Speckle.AutoCAD.API" VersionOverride="2024.0.0" />
+    <PackageReference Include="Speckle.AutoCAD.API" VersionOverride="2024.0.0" ExcludeAssets="runtime"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/Converters/Civil3d/Speckle.Converters.Civil3d2022/Speckle.Converters.Civil3d2022.csproj
+++ b/Converters/Civil3d/Speckle.Converters.Civil3d2022/Speckle.Converters.Civil3d2022.csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Speckle.AutoCAD.API" />
-    <PackageReference Include="Speckle.Civil3D.API" />
+    <PackageReference Include="Speckle.AutoCAD.API" VersionOverride="2022.0.2" ExcludeAssets="runtime"/>
+    <PackageReference Include="Speckle.Civil3D.API" VersionOverride="2022.0.2" ExcludeAssets="runtime"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/Converters/Civil3d/Speckle.Converters.Civil3d2023/Speckle.Converters.Civil3d2023.csproj
+++ b/Converters/Civil3d/Speckle.Converters.Civil3d2023/Speckle.Converters.Civil3d2023.csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Speckle.AutoCAD.API" VersionOverride="2023.0.0" />
-    <PackageReference Include="Speckle.Civil3D.API" VersionOverride="2023.0.0" />
+    <PackageReference Include="Speckle.AutoCAD.API" VersionOverride="2023.0.0" ExcludeAssets="runtime"/>
+    <PackageReference Include="Speckle.Civil3D.API" VersionOverride="2023.0.0" ExcludeAssets="runtime"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/Converters/Civil3d/Speckle.Converters.Civil3d2024/Speckle.Converters.Civil3d2024.csproj
+++ b/Converters/Civil3d/Speckle.Converters.Civil3d2024/Speckle.Converters.Civil3d2024.csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Speckle.AutoCAD.API" VersionOverride="2024.0.0" />
-    <PackageReference Include="Speckle.Civil3D.API" VersionOverride="2024.0.0" />
+    <PackageReference Include="Speckle.AutoCAD.API" VersionOverride="2024.0.0" ExcludeAssets="runtime"/>
+    <PackageReference Include="Speckle.Civil3D.API" VersionOverride="2024.0.0" ExcludeAssets="runtime"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/Converters/Civil3d/Speckle.Converters.Civil3d2025/Speckle.Converters.Civil3d2025.csproj
+++ b/Converters/Civil3d/Speckle.Converters.Civil3d2025/Speckle.Converters.Civil3d2025.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Speckle.AutoCAD.API" VersionOverride="2025.0.0"/>
-    <PackageReference Include="Speckle.Civil3d.API" VersionOverride="2025.0.0" />
+    <PackageReference Include="Speckle.AutoCAD.API" VersionOverride="2025.0.0" ExcludeAssets="runtime"/>
+    <PackageReference Include="Speckle.Civil3d.API" VersionOverride="2025.0.0" ExcludeAssets="runtime"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/Converters/Navisworks/Speckle.Converters.Navisworks2020/Speckle.Converters.Navisworks2020.csproj
+++ b/Converters/Navisworks/Speckle.Converters.Navisworks2020/Speckle.Converters.Navisworks2020.csproj
@@ -6,7 +6,7 @@
     <Configurations>Debug;Release;Local</Configurations>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Speckle.Navisworks.API" VersionOverride="2020.0.0" />
+    <PackageReference Include="Speckle.Navisworks.API" VersionOverride="2020.0.0" ExcludeAssets="runtime"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/Converters/Navisworks/Speckle.Converters.Navisworks2021/Speckle.Converters.Navisworks2021.csproj
+++ b/Converters/Navisworks/Speckle.Converters.Navisworks2021/Speckle.Converters.Navisworks2021.csproj
@@ -6,7 +6,7 @@
     <Configurations>Debug;Release;Local</Configurations>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Speckle.Navisworks.API" VersionOverride="2021.0.0" />
+    <PackageReference Include="Speckle.Navisworks.API" VersionOverride="2021.0.0" ExcludeAssets="runtime"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/Converters/Navisworks/Speckle.Converters.Navisworks2022/Speckle.Converters.Navisworks2022.csproj
+++ b/Converters/Navisworks/Speckle.Converters.Navisworks2022/Speckle.Converters.Navisworks2022.csproj
@@ -6,7 +6,7 @@
     <Configurations>Debug;Release;Local</Configurations>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Speckle.Navisworks.API" VersionOverride="2022.0.0" />
+    <PackageReference Include="Speckle.Navisworks.API" VersionOverride="2022.0.0" ExcludeAssets="runtime"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/Converters/Navisworks/Speckle.Converters.Navisworks2023/Speckle.Converters.Navisworks2023.csproj
+++ b/Converters/Navisworks/Speckle.Converters.Navisworks2023/Speckle.Converters.Navisworks2023.csproj
@@ -6,7 +6,7 @@
     <Configurations>Debug;Release;Local</Configurations>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Speckle.Navisworks.API" VersionOverride="2023.0.0" />
+    <PackageReference Include="Speckle.Navisworks.API" VersionOverride="2023.0.0" ExcludeAssets="runtime"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/Converters/Navisworks/Speckle.Converters.Navisworks2024/Speckle.Converters.Navisworks2024.csproj
+++ b/Converters/Navisworks/Speckle.Converters.Navisworks2024/Speckle.Converters.Navisworks2024.csproj
@@ -6,7 +6,7 @@
     <Configurations>Debug;Release;Local</Configurations>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Speckle.Navisworks.API" VersionOverride="2024.0.0" />
+    <PackageReference Include="Speckle.Navisworks.API" VersionOverride="2024.0.0" ExcludeAssets="runtime"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/Converters/Navisworks/Speckle.Converters.Navisworks2025/Speckle.Converters.Navisworks2025.csproj
+++ b/Converters/Navisworks/Speckle.Converters.Navisworks2025/Speckle.Converters.Navisworks2025.csproj
@@ -6,7 +6,7 @@
     <Configurations>Debug;Release;Local</Configurations>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Speckle.Navisworks.API" VersionOverride="2025.0.0" />
+    <PackageReference Include="Speckle.Navisworks.API" VersionOverride="2025.0.0" ExcludeAssets="runtime"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/Converters/Revit/Speckle.Converters.Revit2022/Speckle.Converters.Revit2022.csproj
+++ b/Converters/Revit/Speckle.Converters.Revit2022/Speckle.Converters.Revit2022.csproj
@@ -10,7 +10,7 @@
   <Import Project="..\Speckle.Converters.RevitShared\Speckle.Converters.RevitShared.projitems" Label="Shared" />
 
   <ItemGroup>
-    <PackageReference Include="Speckle.Revit.API" VersionOverride="2022.0.2.1" />
+    <PackageReference Include="Speckle.Revit.API" VersionOverride="2022.0.2.1" ExcludeAssets="runtime"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/Converters/Revit/Speckle.Converters.Revit2023/Speckle.Converters.Revit2023.csproj
+++ b/Converters/Revit/Speckle.Converters.Revit2023/Speckle.Converters.Revit2023.csproj
@@ -10,7 +10,7 @@
   <Import Project="..\Speckle.Converters.RevitShared\Speckle.Converters.RevitShared.projitems" Label="Shared" />
 
   <ItemGroup>
-    <PackageReference Include="Speckle.Revit.API" VersionOverride="2023.0.0" />
+    <PackageReference Include="Speckle.Revit.API" VersionOverride="2023.0.0" ExcludeAssets="runtime"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/Converters/Revit/Speckle.Converters.Revit2024/Speckle.Converters.Revit2024.csproj
+++ b/Converters/Revit/Speckle.Converters.Revit2024/Speckle.Converters.Revit2024.csproj
@@ -10,7 +10,7 @@
   <Import Project="..\Speckle.Converters.RevitShared\Speckle.Converters.RevitShared.projitems" Label="Shared" />
 
   <ItemGroup>
-    <PackageReference Include="Speckle.Revit.API" VersionOverride="2024.0.0" />
+    <PackageReference Include="Speckle.Revit.API" VersionOverride="2024.0.0" ExcludeAssets="runtime"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/Converters/Revit/Speckle.Converters.Revit2025/Speckle.Converters.Revit2025.csproj
+++ b/Converters/Revit/Speckle.Converters.Revit2025/Speckle.Converters.Revit2025.csproj
@@ -10,7 +10,7 @@
   <Import Project="..\Speckle.Converters.RevitShared\Speckle.Converters.RevitShared.projitems" Label="Shared" />
 
   <ItemGroup>
-    <PackageReference Include="Speckle.Revit.API" VersionOverride="2025.0.0" />
+    <PackageReference Include="Speckle.Revit.API" VersionOverride="2025.0.0" ExcludeAssets="runtime"/>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
We were copying the host app assets to the output.  The assemblies are loaded by the host app and don't need to be included when packaging.


Fixes https://github.com/specklesystems/speckle-sharp-connectors/issues/693