### PR TITLE
feat(revit): collection structure for multiple linked model instances 

### DIFF
--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/RevitRootObjectBuilder.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/RevitRootObjectBuilder.cs
@@ -1,3 +1,4 @@
+using System.IO;
 using Autodesk.Revit.DB;
 using Microsoft.Extensions.Logging;
 using Speckle.Connectors.Common.Builders;
@@ -29,7 +30,8 @@ public class RevitRootObjectBuilder(
   RevitToSpeckleCacheSingleton revitToSpeckleCacheSingleton
 ) : IRootObjectBuilder<DocumentToConvert>
 {
-  // POC: SendSelection and RevitConversionContextStack should be interfaces, former needs interfaces
+  // Dictionary to track linked model display names
+  private readonly Dictionary<string, string> _linkedModelDisplayNames = new();
 
   public Task<RootObjectBuilderResult> Build(
     IReadOnlyList<DocumentToConvert> documentElementContexts,
@@ -63,6 +65,12 @@ public class RevitRootObjectBuilder(
     var filteredDocumentsToConvert = new List<DocumentToConvert>();
     bool sendWithLinkedModels = converterSettings.Current.SendLinkedModels;
     List<SendConversionResult> results = new();
+
+    // Prepare linked model display names if needed
+    if (sendWithLinkedModels)
+    {
+      PrepareLinkedModelNames(documentElementContexts);
+    }
 
     foreach (var documentElementContext in documentElementContexts)
     {
@@ -129,13 +137,23 @@ public class RevitRootObjectBuilder(
 
     foreach (var atomicObjectByDocumentAndTransform in atomicObjectsByDocumentAndTransform)
     {
+      string? modelDisplayName = null;
+      if (atomicObjectByDocumentAndTransform.Doc.IsLinked)
+      {
+        string id =
+          atomicObjectByDocumentAndTransform.Doc.GetHashCode()
+          + "-"
+          + (atomicObjectByDocumentAndTransform.Transform?.GetHashCode() ?? 0);
+        _linkedModelDisplayNames.TryGetValue(id, out modelDisplayName);
+      }
+
       // here we do magic for changing the transform and the related document according to model. first one is always the main model.
       using (
         converterSettings.Push(currentSettings =>
           currentSettings with
           {
             ReferencePointTransform = atomicObjectByDocumentAndTransform.Transform,
-            Document = atomicObjectByDocumentAndTransform.Doc
+            Document = atomicObjectByDocumentAndTransform.Doc,
           }
         )
       )
@@ -195,7 +213,8 @@ public class RevitRootObjectBuilder(
             var collection = sendCollectionManager.GetAndCreateObjectHostCollection(
               revitElement,
               rootObject,
-              sendWithLinkedModels
+              sendWithLinkedModels,
+              modelDisplayName
             );
 
             collection.elements.Add(converted);
@@ -250,5 +269,42 @@ public class RevitRootObjectBuilder(
       return BitConverter.ToString(hashBytes).Replace("-", "").ToLowerInvariant()[..8];
     }
 #pragma warning restore CA1850
+  }
+
+  /// <summary>
+  /// Prepares display names for linked model documents based on filename
+  /// </summary>
+  private void PrepareLinkedModelNames(IReadOnlyList<DocumentToConvert> documentElementContexts)
+  {
+    _linkedModelDisplayNames.Clear();
+
+    // Group linked models by filename
+    var linkedModels = documentElementContexts
+      .Where(ctx => ctx.Doc.IsLinked)
+      .GroupBy(ctx => Path.GetFileNameWithoutExtension(ctx.Doc.PathName))
+      .ToDictionary(g => g.Key, g => g.ToList());
+
+    // Create a unique key for each instance
+    foreach (var group in linkedModels)
+    {
+      string baseName = group.Key;
+      var instances = group.Value;
+
+      // Single instance - just use the base name
+      if (instances.Count == 1)
+      {
+        string id = instances[0].Doc.GetHashCode() + "-" + (instances[0].Transform?.GetHashCode() ?? 0);
+        _linkedModelDisplayNames[id] = baseName;
+      }
+      // Multiple instances - add numbering
+      else
+      {
+        for (int i = 0; i < instances.Count; i++)
+        {
+          string id = instances[i].Doc.GetHashCode() + "-" + (instances[i].Transform?.GetHashCode() ?? 0);
+          _linkedModelDisplayNames[id] = $"{baseName}_{i + 1}";
+        }
+      }
+    }
   }
 }

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/RevitRootObjectBuilder.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/RevitRootObjectBuilder.cs
@@ -140,10 +140,7 @@ public class RevitRootObjectBuilder(
       string? modelDisplayName = null;
       if (atomicObjectByDocumentAndTransform.Doc.IsLinked)
       {
-        string id =
-          atomicObjectByDocumentAndTransform.Doc.GetHashCode()
-          + "-"
-          + (atomicObjectByDocumentAndTransform.Transform?.GetHashCode() ?? 0);
+        string id = GetIdFromDocumentToConvert(atomicObjectByDocumentAndTransform);
         _linkedModelDisplayNames.TryGetValue(id, out modelDisplayName);
       }
 
@@ -293,7 +290,7 @@ public class RevitRootObjectBuilder(
       // Single instance - just use the base name
       if (instances.Count == 1)
       {
-        string id = instances[0].Doc.GetHashCode() + "-" + (instances[0].Transform?.GetHashCode() ?? 0);
+        string id = GetIdFromDocumentToConvert(instances[0]);
         _linkedModelDisplayNames[id] = baseName;
       }
       // Multiple instances - add numbering
@@ -301,10 +298,13 @@ public class RevitRootObjectBuilder(
       {
         for (int i = 0; i < instances.Count; i++)
         {
-          string id = instances[i].Doc.GetHashCode() + "-" + (instances[i].Transform?.GetHashCode() ?? 0);
+          string id = GetIdFromDocumentToConvert(instances[i]);
           _linkedModelDisplayNames[id] = $"{baseName}_{i + 1}";
         }
       }
     }
   }
+
+  private string GetIdFromDocumentToConvert(DocumentToConvert documentToConvert) =>
+    documentToConvert.Doc.GetHashCode() + "-" + (documentToConvert.Transform?.GetHashCode() ?? 0);
 }


### PR DESCRIPTION
## Description
When sending multiple instances of the same linked model, all elements were being grouped into a single collection named after the last instance. This PR fixes the issue by properly identifying and naming each linked model instance separately, making sure that instances of the same linked model file get appropriate suffixes (_1, _2, etc.) only when multiple instances exist.

FIxes [CNX-1485](https://linear.app/speckle/issue/CNX-1485/segregated-collection-structure-for-multiple-copies-of-the-same-linked).

## User Value
Users can now clearly identify and navigate elements from different instances of the same linked model in the Speckle viewer, improving the organization and navigation of complex models.

## Changes:
- Added model display name tracking to `RevitRootObjectBuilder` to identify unique linked model instances
- Modified `SendCollectionManager` to accept and use model display names
- Implemented naming logic to add suffixes only when multiple instances of the same model exist
- Improved instance identification using both document and transform information

## Screenshots:
### Before Changes
<img width="973" alt="image" src="https://github.com/user-attachments/assets/bdb42613-e301-4bf6-b50e-1e92dd82df22" />

### After Changes
Only the `rst_basic_sample_project` has instances, therefore only it receives suffixes.
<img width="985" alt="image" src="https://github.com/user-attachments/assets/4e3a7a67-7ffe-4fbf-8c27-9d4dc6ee8a7e" />


## Checklist:

- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [ ] I have added appropriate tests.
- [x] I have updated or added relevant documentation.

