### PR TITLE
fix(model cards) Avoid multiple enumeration issues when saving if we copy the list first

### DIFF
--- a/DUI3/Speckle.Connectors.DUI/Models/DocumentModelStore.cs
+++ b/DUI3/Speckle.Connectors.DUI/Models/DocumentModelStore.cs
@@ -128,7 +128,7 @@ public abstract class DocumentModelStore(IJsonSerializer serializer)
     }
   }
 
-  protected string Serialize() => serializer.Serialize(Models);
+  protected string Serialize() => serializer.Serialize(Models.ToList());
 
   // POC: this seemms more like a IModelsDeserializer?, seems disconnected from this class
   protected List<ModelCard> Deserialize(string models) => serializer.Deserialize<List<ModelCard>>(models).NotNull();


### PR DESCRIPTION
Got this when loading a Revit file with cards embedded.  Doing investigation for https://linear.app/speckle/issue/CNX-1497/revit-large-models-issues

```
Unhandled Exception: Speckle.Connectors.Revit.Plugin.SpeckleRevitTaskException: Revit operation failed ---> System.InvalidOperationException: Collection was modified; enumeration operation may not execute.
   at System.ThrowHelper.ThrowInvalidOperationException(ExceptionResource resource)
   at System.Collections.Generic.List`1.Enumerator.MoveNextRare()
   at Speckle.Newtonsoft.Json.Serialization.JsonSerializerInternalWriter.SerializeList(JsonWriter writer, IEnumerable values, JsonArrayContract contract, JsonProperty member, JsonContainerContract collectionContract, JsonProperty containerProperty)
   at Speckle.Newtonsoft.Json.Serialization.JsonSerializerInternalWriter.SerializeValue(JsonWriter writer, Object value, JsonContract valueContract, JsonProperty member, JsonContainerContract containerContract, JsonProperty containerProperty)
   at Speckle.Newtonsoft.Json.Serialization.JsonSerializerInternalWriter.Serialize(JsonWriter jsonWriter, Object value, Type objectType)
   at Speckle.Newtonsoft.Json.JsonSerializer.SerializeInternal(JsonWriter jsonWriter, Object value, Type objectType)
   at Speckle.Newtonsoft.Json.JsonSerializer.Serialize(JsonWriter jsonWriter, Object value, Type objectType)
   at Speckle.Newtonsoft.Json.JsonConvert.SerializeObjectInternal(Object value, Type type, JsonSerializer jsonSerializer)
   at Speckle.Newtonsoft.Json.JsonConvert.SerializeObject(Object value, Type type, JsonSerializerSettings settings)
   at Speckle.Newtonsoft.Json.JsonConvert.SerializeObject(Object value, JsonSerializerSettings settings)
   at Speckle.Connectors.DUI.Utils.JsonSerializer.Serialize(Object obj)
   at Speckle.Connectors.DUI.Models.DocumentModelStore.Serialize()
   at Speckle.Connectors.Revit.HostApp.RevitDocumentStore.<>c__DisplayClass9_0.<HostAppSaveState>b__0()
   at Speckle.Connectors.Common.Threading.ThreadContext.<>c__DisplayClass3_0.<RunOnThread>b__0()
   at Speckle.Connectors.Revit.Plugin.RevitThreadContext.<>c__DisplayClass7_0`1.<CatchExceptions>b__0(UIApplication _)
   --- End of inner exception stack trace ---
   at Speckle.Connectors.Revit.Plugin.RevitThreadContext.<CatchExceptions>d__7`1.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter`1.GetResult()
   at Speckle.Connectors.Common.Threading.ThreadContext.<RunOnThread>d__3.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.GetResult()
   at Speckle.Connectors.Common.Threading.TaskExtensions.<FireAndForget>d__0.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state, Boolean preserveSyncCtx)
   at System.Threading.ExecutionContext.Run(ExecutionContext executionContext, ContextCallback callback, Object state, Boolean preserveSyncCtx)
   at System.Threading.QueueUserWorkItemCallback.System.Threading.IThreadPoolWorkItem.ExecuteWorkItem()
   at System.Threading.ThreadPoolWorkQueue.Dispatch()

```