### PR TITLE
fix(ci): Don't build everything when nothing is detected

### DIFF
--- a/Build/Affected.cs
+++ b/Build/Affected.cs
@@ -66,10 +66,7 @@ public static class Affected
         Console.WriteLine("Affected project group being built: " + group.HostAppSlug);
       }
 
-      if (groups.Count > 0)
-      {
-        return groups.ToArray();
-      }
+      return groups.ToArray();
     }
 
     Console.WriteLine("Using all project groups: " + string.Join(',', Consts.ProjectGroups));


### PR DESCRIPTION
There was some logic in the CI that if zero connector (slugs) were affected, we'd still build everything.

This conflicts with the ability to publish a nuget for the IFC parser, since I want to just publish the nuget without triggering connector installers