### PR TITLE
fix(revit): respect view visibility in linked models when sending

### DIFF
--- a/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/LinkedModelHandler.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/LinkedModelHandler.cs
@@ -53,6 +53,12 @@ public class LinkedModelHandler
         linkedDocument.PathName,
         _revitContext.UIApplication.NotNull().ActiveUIDocument.Document
       );
+
+      // if a section box is "hiding" a linked model, this will make sure it won't be sent
+      if (linkInstance.IsHidden(viewFilter.GetView().NotNull()))
+      {
+        return new List<Element>();
+      }
 #if REVIT2024_OR_GREATER
       // revit 2024 and 2025 we can use the three-parameter constructor to get only visible elements
       using var viewCollector = new FilteredElementCollector(
@@ -70,7 +76,7 @@ public class LinkedModelHandler
         return new List<Element>(); // if the linked model is hidden, return no elements
       }
       // 💩 fallback to getting all elements if the linked model is visible
-      return GetAllElements(linkedDocument);
+      return GetAllElementsForLinkedModelSelection(linkedDocument);
 #endif
     }
 

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/LinkedModelHandler.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/LinkedModelHandler.cs
@@ -54,11 +54,6 @@ public class LinkedModelHandler
         _revitContext.UIApplication.NotNull().ActiveUIDocument.Document
       );
 
-      // if a section box is "hiding" a linked model, this will make sure it won't be sent
-      if (linkInstance.IsHidden(viewFilter.GetView().NotNull()))
-      {
-        return new List<Element>();
-      }
 #if REVIT2024_OR_GREATER
       // revit 2024 and 2025 we can use the three-parameter constructor to get only visible elements
       using var viewCollector = new FilteredElementCollector(

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/LinkedModelHandler.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/LinkedModelHandler.cs
@@ -49,12 +49,12 @@ public class LinkedModelHandler
     // send mode → Views (taken from the legacy code)
     if (sendFilter is RevitViewsFilter viewFilter && viewFilter.GetView() != null)
     {
-#if REVIT2024_OR_GREATER
-      // revit 2024 and 2025 we can use the three-parameter constructor to get only visible elements
       RevitLinkInstance linkInstance = FindLinkInstanceForDocument(
         linkedDocument.PathName,
         _revitContext.UIApplication.NotNull().ActiveUIDocument.Document
       );
+#if REVIT2024_OR_GREATER
+      // revit 2024 and 2025 we can use the three-parameter constructor to get only visible elements
       using var viewCollector = new FilteredElementCollector(
         _revitContext.UIApplication.ActiveUIDocument.Document,
         viewFilter.GetView().NotNull().Id,

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/LinkedModelHandler.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/LinkedModelHandler.cs
@@ -49,12 +49,12 @@ public class LinkedModelHandler
     // send mode → Views (taken from the legacy code)
     if (sendFilter is RevitViewsFilter viewFilter && viewFilter.GetView() != null)
     {
-#if REVIT2024_OR_GREATER
-      // revit 2024 and 2025 we can use the three-parameter constructor to get only visible elements
       RevitLinkInstance linkInstance = FindLinkInstanceForDocument(
         linkedDocument,
         _revitContext.UIApplication.NotNull().ActiveUIDocument.Document
       );
+#if REVIT2024_OR_GREATER
+      // revit 2024 and 2025 we can use the three-parameter constructor to get only visible elements
       using var viewCollector = new FilteredElementCollector(
         _revitContext.UIApplication.ActiveUIDocument.Document,
         viewFilter.GetView().NotNull().Id,
@@ -63,10 +63,6 @@ public class LinkedModelHandler
       return viewCollector.WhereElementIsNotElementType().ToElements().ToList();
 #else
       // revit 2023 and below, we can only check if the entire linked model is visible
-      RevitLinkInstance linkInstance = FindLinkInstanceForDocument(
-        linkedDocument,
-        _revitContext.UIApplication.ActiveUIDocument.Document
-      );
       if (linkInstance.IsHidden(viewFilter.GetView().NotNull()))
       {
         return new List<Element>(); // If the linked model is hidden, return no elements

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/LinkedModelHandler.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/LinkedModelHandler.cs
@@ -49,12 +49,12 @@ public class LinkedModelHandler
     // send mode → Views (taken from the legacy code)
     if (sendFilter is RevitViewsFilter viewFilter && viewFilter.GetView() != null)
     {
+#if REVIT2024_OR_GREATER
+      // revit 2024 and 2025 we can use the three-parameter constructor to get only visible elements
       RevitLinkInstance linkInstance = FindLinkInstanceForDocument(
         linkedDocument.PathName,
         _revitContext.UIApplication.NotNull().ActiveUIDocument.Document
       );
-#if REVIT2024_OR_GREATER
-      // revit 2024 and 2025 we can use the three-parameter constructor to get only visible elements
       using var viewCollector = new FilteredElementCollector(
         _revitContext.UIApplication.ActiveUIDocument.Document,
         viewFilter.GetView().NotNull().Id,

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/LinkedModelHandler.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/LinkedModelHandler.cs
@@ -62,14 +62,15 @@ public class LinkedModelHandler
       );
       return viewCollector.WhereElementIsNotElementType().ToElements().ToList();
 #else
-      // revit 2023 and below, we can only check if the entire linked model is visible
+      // 🚨 LIMITATION: in Revit 2023 and below, we can only check if the entire linked model is visible,
+      // not individual elements within it. If the linked model is visible, all its elements will be included.
+      // constructor overload pertaining to searching and filtering visible elements from a revit link only added 2024.
       if (linkInstance.IsHidden(viewFilter.GetView().NotNull()))
       {
-        return new List<Element>(); // If the linked model is hidden, return no elements
+        return new List<Element>(); // if the linked model is hidden, return no elements
       }
-      // Fallback to getting all elements if the linked model is visible
-      using var collector = new FilteredElementCollector(linkedDocument);
-      return collector.WhereElementIsNotElementType().WhereElementIsViewIndependent().ToList();
+      // 💩 fallback to getting all elements if the linked model is visible
+      return GetAllElements(linkedDocument);
 #endif
     }
 


### PR DESCRIPTION
## Description

Fixed an issue where when sending by views, elements in linked models were being sent regardless of their visibility in the selected view. Now only elements visible in the specified view are included, matching the behavior of the main model.

Fixed [CNX-1491](https://linear.app/speckle/issue/CNX-1491/hiding-categories-in-view-and-linked-models).

## User Value

Ensures only visible elements in linked models are sent when using view filtering, significantly improving the send operation's accuracy and reducing unnecessary data transfer.

## Changes:

- Added version-specific handling in `LinkedModelHandler` for view filtering:
  - For RVT 2024 and RCT 2025: Uses the three-parameter `FilteredElementCollector` constructor to filter visible elements
  - For older Revit versions: Checks if the linked model is visible in the view before collecting elements
- Added helper method to find the `RevitLinkInstance` corresponding to a linked document

## Screenshots:

https://github.com/user-attachments/assets/1a1c3307-df8b-46bd-aea8-e9a898aaa9dc


## Validation of changes:

Tested with linked models in multiple views, confirming that only elements visible in the selected view are sent when using the view filter mode.

## Checklist:

- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [ ] I have added appropriate tests.
- [x] I have updated or added relevant documentation.

