### PR TITLE
feat(grasshopper): add create data object node

### DIFF
--- a/Connectors/Rhino/Speckle.Connectors.Grasshopper8/Components/Collections/ExpandCollection.cs
+++ b/Connectors/Rhino/Speckle.Connectors.Grasshopper8/Components/Collections/ExpandCollection.cs
@@ -174,7 +174,12 @@ public class ExpandCollection : GH_Component, IGH_VariableParameterComponent
       if (element is SpeckleObjectWrapper sg)
       {
         _previewObjects.Add(sg);
-        var box = sg.GeometryBase.GetBoundingBox(false);
+        BoundingBox box = new();
+        foreach (var item in sg.GeometryBases)
+        {
+          box.Union(item.GetBoundingBox(false));
+        }
+
         _clippingBox.Union(box);
       }
     }

--- a/Connectors/Rhino/Speckle.Connectors.Grasshopper8/Components/ComponentUtils.cs
+++ b/Connectors/Rhino/Speckle.Connectors.Grasshopper8/Components/ComponentUtils.cs
@@ -3,11 +3,12 @@ namespace Speckle.Connectors.Grasshopper8.Components;
 // NOTE: The number of spaces determines the order in which they display in the ribbon (nice hack)
 public static class ComponentCategories
 {
-  public const string OPERATIONS = "  Operations";
-  public const string MODELS = " Model Management";
+  public const string OPERATIONS = "    Operations";
+  public const string MODELS = "   Model Management";
   public const string PARAMETERS = "Parameters";
-  public const string COLLECTIONS = "Collections";
+  public const string COLLECTIONS = "  Collections";
   public const string PRIMARY_RIBBON = "Speckle";
+  public const string OBJECTS = " Objects";
 }
 
 public enum ComponentState

--- a/Connectors/Rhino/Speckle.Connectors.Grasshopper8/Components/Operations/Receive/ReceiveAsyncComponent.cs
+++ b/Connectors/Rhino/Speckle.Connectors.Grasshopper8/Components/Operations/Receive/ReceiveAsyncComponent.cs
@@ -472,32 +472,28 @@ public class ReceiveComponentWorker : WorkerInstance
               converted.ForEach(res => res.Transform(mat));
             }
 
-            // note one to many not handled too nice here
-            foreach (var geometryBase in converted)
+            // get the collection
+            SpeckleCollectionWrapper objectCollection = collectionRebuilder.GetOrCreateSpeckleCollectionFromPath(path);
+
+            // get the properties
+            SpecklePropertyGroupGoo propertyGroup = new();
+            propertyGroup.CastFrom(
+              map.AtomicObject is Speckle.Objects.Data.DataObject da
+                ? da.properties
+                : map.AtomicObject["properties"] as Dictionary<string, object?> ?? new()
+            );
+
+            // create object
+            var gh = new SpeckleObjectWrapper()
             {
-              SpeckleCollectionWrapper objectCollection = collectionRebuilder.GetOrCreateSpeckleCollectionFromPath(
-                path
-              );
+              Base = map.AtomicObject,
+              Path = path.Select(p => p.name).ToList(),
+              Parent = objectCollection,
+              GeometryBases = converted,
+              Properties = propertyGroup
+            };
 
-              // get properties
-              SpecklePropertyGroupGoo propertyGroup = new();
-              propertyGroup.CastFrom(
-                map.AtomicObject is Speckle.Objects.Data.DataObject da
-                  ? da.properties
-                  : map.AtomicObject["properties"] as Dictionary<string, object?> ?? new()
-              );
-
-              var gh = new SpeckleObjectWrapper()
-              {
-                Base = map.AtomicObject,
-                Path = path.Select(p => p.name).ToList(),
-                Parent = objectCollection,
-                GeometryBase = geometryBase,
-                Properties = propertyGroup
-              };
-
-              collectionRebuilder.AppendSpeckleGrasshopperObject(gh, path);
-            }
+            collectionRebuilder.AppendSpeckleGrasshopperObject(gh, path);
           }
           catch (ConversionException)
           {

--- a/Connectors/Rhino/Speckle.Connectors.Grasshopper8/Components/Operations/Receive/ReceiveComponent.cs
+++ b/Connectors/Rhino/Speckle.Connectors.Grasshopper8/Components/Operations/Receive/ReceiveComponent.cs
@@ -117,7 +117,9 @@ public class ReceiveComponent : SpeckleScopedTaskCapableComponent<SpeckleUrlMode
       unpackedRoot.ObjectsToConvert.ToList()
     );
 
-    var collGen = new GrasshopperCollectionRebuilder((root as Collection) ?? new Collection() { name = "unnamed" });
+    var collectionRebuilder = new GrasshopperCollectionRebuilder(
+      (root as Collection) ?? new Collection() { name = "unnamed" }
+    );
 
     foreach (var map in localToGlobalMaps)
     {
@@ -132,17 +134,28 @@ public class ReceiveComponent : SpeckleScopedTaskCapableComponent<SpeckleUrlMode
           converted.ForEach(res => res.Transform(mat));
         }
 
-        // note one to many not handled too nice here
-        foreach (var geometryBase in converted)
+        // get the collection
+        SpeckleCollectionWrapper objectCollection = collectionRebuilder.GetOrCreateSpeckleCollectionFromPath(path);
+
+        // get the properties
+        SpecklePropertyGroupGoo propertyGroup = new();
+        propertyGroup.CastFrom(
+          map.AtomicObject is Speckle.Objects.Data.DataObject da
+            ? da.properties
+            : map.AtomicObject["properties"] as Dictionary<string, object?> ?? new()
+        );
+
+        // create object
+        var gh = new SpeckleObjectWrapper()
         {
-          var gh = new SpeckleObjectWrapper()
-          {
-            Base = map.AtomicObject,
-            Path = path.Select(o => o.name).ToList(),
-            GeometryBase = geometryBase
-          };
-          collGen.AppendSpeckleGrasshopperObject(gh, path);
-        }
+          Base = map.AtomicObject,
+          Path = path.Select(p => p.name).ToList(),
+          Parent = objectCollection,
+          GeometryBases = converted,
+          Properties = propertyGroup
+        };
+
+        collectionRebuilder.AppendSpeckleGrasshopperObject(gh, path);
       }
       catch (ConversionException)
       {
@@ -151,7 +164,7 @@ public class ReceiveComponent : SpeckleScopedTaskCapableComponent<SpeckleUrlMode
     }
 
     // var x = new SpeckleCollectionGoo { Value = collGen.RootCollection };
-    var goo = new SpeckleCollectionWrapperGoo(collGen.RootCollectionWrapper);
+    var goo = new SpeckleCollectionWrapperGoo(collectionRebuilder.RootCollectionWrapper);
     return new ReceiveComponentOutput { RootObject = goo };
   }
 

--- a/Connectors/Rhino/Speckle.Connectors.Grasshopper8/Components/Operations/Send/SendAsyncComponent.cs
+++ b/Connectors/Rhino/Speckle.Connectors.Grasshopper8/Components/Operations/Send/SendAsyncComponent.cs
@@ -48,7 +48,7 @@ public class SendAsyncComponent : GH_AsyncComponent
   public string? Url { get; set; }
   public Client ApiClient { get; set; }
   public HostApp.SpeckleUrlModelResource? UrlModelResource { get; set; }
-  public SpeckleCollectionWrapperGoo? RootCollection { get; set; }
+  public SpeckleCollectionWrapperGoo? RootCollectionWrapper { get; set; }
 
   public SpeckleUrlModelResource? OutputParam { get; set; }
   public SendOperation<SpeckleCollectionWrapperGoo> SendOperation { get; private set; }
@@ -253,11 +253,11 @@ public class SendAsyncComponent : GH_AsyncComponent
     da.GetData(1, ref rootCollectionWrapper);
     if (rootCollectionWrapper is null)
     {
-      RootCollection = null;
+      RootCollectionWrapper = null;
       TriggerAutoSave();
       return;
     }
-    RootCollection = rootCollectionWrapper;
+    RootCollectionWrapper = rootCollectionWrapper;
   }
 }
 
@@ -314,7 +314,7 @@ public class SendComponentWorker : WorkerInstance
     {
       Parent.AddRuntimeMessage(
         GH_RuntimeMessageLevel.Remark,
-        $"Successfully sent {((SendAsyncComponent)Parent).RootCollection?.Value.GetTotalChildrenCount()} objects to Speckle."
+        $"Successfully sent {((SendAsyncComponent)Parent).RootCollectionWrapper?.Value.GetTotalChildrenCount()} objects to Speckle."
       );
       Parent.AddRuntimeMessage(
         GH_RuntimeMessageLevel.Remark,
@@ -347,8 +347,8 @@ public class SendComponentWorker : WorkerInstance
         throw new InvalidOperationException("Url Resource was null");
       }
 
-      SpeckleCollectionWrapperGoo? rootCollection = sendComponent.RootCollection;
-      if (rootCollection is null)
+      SpeckleCollectionWrapperGoo? rootCollectionWrapper = sendComponent.RootCollectionWrapper;
+      if (rootCollectionWrapper is null)
       {
         throw new InvalidOperationException("Root Collection was null");
       }
@@ -374,7 +374,7 @@ public class SendComponentWorker : WorkerInstance
 
         var result = await sendComponent
           .SendOperation.Execute(
-            new List<SpeckleCollectionWrapperGoo>() { rootCollection },
+            new List<SpeckleCollectionWrapperGoo>() { rootCollectionWrapper },
             sendInfo,
             progress,
             CancellationToken

--- a/Connectors/Rhino/Speckle.Connectors.Grasshopper8/Components/Properties/CreateSpeckleDataObject.cs
+++ b/Connectors/Rhino/Speckle.Connectors.Grasshopper8/Components/Properties/CreateSpeckleDataObject.cs
@@ -1,0 +1,93 @@
+using System.Runtime.InteropServices;
+using Grasshopper.Kernel;
+using Grasshopper.Kernel.Types;
+using Rhino.Geometry;
+using Speckle.Connectors.Grasshopper8.HostApp;
+using Speckle.Connectors.Grasshopper8.Parameters;
+using Speckle.Sdk.Models;
+
+namespace Speckle.Connectors.Grasshopper8.Components.Properties;
+
+[Guid("F9418610-ACAE-4417-B010-19EBEA6A121F")]
+public class CreateSpeckleObject : GH_Component
+{
+  public CreateSpeckleObject()
+    : base(
+      "Create Speckle Object",
+      "CSO",
+      "Creates a Speckle Object",
+      ComponentCategories.PRIMARY_RIBBON,
+      ComponentCategories.OBJECTS
+    ) { }
+
+  public override Guid ComponentGuid => GetType().GUID;
+
+  protected override Bitmap Icon => BitmapBuilder.CreateCircleIconBitmap("cO");
+
+  protected override void RegisterInputParams(GH_InputParamManager pManager)
+  {
+    pManager.AddGenericParameter("Geometry", "G", "The geometry of the new Speckle Object", GH_ParamAccess.list);
+
+    pManager.AddTextParameter("Name", "N", "Name of the new Speckle Object", GH_ParamAccess.item);
+    Params.Input[1].Optional = true;
+
+    pManager.AddParameter(
+      new SpecklePropertyGroupParam(),
+      "Properties",
+      "P",
+      "The properties of the new Speckle Object",
+      GH_ParamAccess.item
+    );
+    Params.Input[2].Optional = true;
+
+    // TODO: add render material and color
+  }
+
+  protected override void RegisterOutputParams(GH_OutputParamManager pManager)
+  {
+    pManager.AddGenericParameter("Speckle Data Object", "DO", "The created Speckle Data Object", GH_ParamAccess.item);
+  }
+
+  protected override void SolveInstance(IGH_DataAccess da)
+  {
+    List<IGH_GeometricGoo> gooGeometries = new();
+    da.GetDataList(0, gooGeometries);
+    List<GeometryBase> geometries = gooGeometries.Select(o => o.GeometricGooToGeometryBase()).ToList();
+
+    string name = "";
+    da.GetData(1, ref name);
+
+    SpecklePropertyGroupGoo properties = new();
+    da.GetData(2, ref properties);
+
+    // convert the properties
+    Dictionary<string, object?> props = new();
+    properties.CastTo(ref props);
+
+    // convert the geometries
+    List<Base> converted = new();
+    foreach (GeometryBase geo in geometries)
+    {
+      var geoConverted = ToSpeckleConversionContext.ToSpeckleConverter.Convert(geo);
+      converted.Add(geoConverted);
+    }
+
+    Objects.Data.DataObject grasshopperObject =
+      new()
+      {
+        name = name,
+        displayValue = converted,
+        properties = props
+      };
+
+    SpeckleObjectWrapper so =
+      new()
+      {
+        Base = grasshopperObject,
+        GeometryBases = geometries,
+        Properties = properties
+      };
+
+    da.SetData(0, new SpeckleObjectWrapperGoo(so));
+  }
+}

--- a/Connectors/Rhino/Speckle.Connectors.Grasshopper8/Components/Properties/CreateSpeckleDataObject.cs
+++ b/Connectors/Rhino/Speckle.Connectors.Grasshopper8/Components/Properties/CreateSpeckleDataObject.cs
@@ -9,9 +9,9 @@ using Speckle.Sdk.Models;
 namespace Speckle.Connectors.Grasshopper8.Components.Properties;
 
 [Guid("F9418610-ACAE-4417-B010-19EBEA6A121F")]
-public class CreateSpeckleObject : GH_Component
+public class CreateSpeckleDataObject : GH_Component
 {
-  public CreateSpeckleObject()
+  public CreateSpeckleDataObject()
     : base(
       "Create Speckle Object",
       "CSO",

--- a/Connectors/Rhino/Speckle.Connectors.Grasshopper8/Parameters/SpeckleGrasshopperObject.cs
+++ b/Connectors/Rhino/Speckle.Connectors.Grasshopper8/Parameters/SpeckleGrasshopperObject.cs
@@ -226,12 +226,21 @@ public class SpeckleObjectWrapperGoo : GH_Goo<SpeckleObjectWrapper>, IGH_Preview
           SpecklePropertyGroupGoo propertyGroup = new();
           propertyGroup.CastFrom(modelObject.UserText);
 
+          // update the converted Base with props as well
+          modelConverted["name"] = modelObject.Name.ToString();
+          Dictionary<string, object?> propertyDict = new();
+          foreach (var entry in propertyGroup.Value)
+          {
+            propertyDict.Add(entry.Key, entry.Value.Value);
+          }
+          modelConverted["properties"] = propertyDict;
+
           SpeckleObjectWrapper so =
             new()
             {
               GeometryBases = new() { modelGB },
               Base = modelConverted,
-              Name = modelObject.Name,
+              Name = modelObject.Name.ToString(),
               Color = modelObject.Display.Color?.Color.ToArgb(),
               RenderMaterialName = modelObject.Render.Material?.Material?.Name,
               Properties = propertyGroup

--- a/Connectors/Rhino/Speckle.Connectors.Grasshopper8/Parameters/SpeckleGrasshopperObject.cs
+++ b/Connectors/Rhino/Speckle.Connectors.Grasshopper8/Parameters/SpeckleGrasshopperObject.cs
@@ -112,7 +112,9 @@ public class SpeckleObjectWrapper : Base
           display.DrawBrepWires(b, material.Diffuse);
           break;
         case Extrusion e:
-          display.DrawMeshShaded(e.GetMesh(MeshType.Any), material);
+          var eBrep = e.ToBrep();
+          display.DrawBrepShaded(eBrep, material);
+          display.DrawBrepShaded(eBrep, material);
           break;
         case SubD d:
           display.DrawSubDShaded(d, material);

--- a/Connectors/Rhino/Speckle.Connectors.Grasshopper8/Parameters/SpecklePropertyGroupWrapper.cs
+++ b/Connectors/Rhino/Speckle.Connectors.Grasshopper8/Parameters/SpecklePropertyGroupWrapper.cs
@@ -20,7 +20,10 @@ public class SpecklePropertyGroupGoo : GH_Goo<Dictionary<string, SpeckleProperty
   public override string TypeName => "Speckle property group wrapper";
   public override string TypeDescription => "Speckle property group wrapper";
 
-  public SpecklePropertyGroupGoo() { }
+  public SpecklePropertyGroupGoo()
+  {
+    Value = new();
+  }
 
   public SpecklePropertyGroupGoo(Dictionary<string, SpecklePropertyGoo> value)
   {
@@ -64,6 +67,25 @@ public class SpecklePropertyGroupGoo : GH_Goo<Dictionary<string, SpeckleProperty
         return true;
     }
 
+    return false;
+  }
+
+  public override bool CastTo<T>(ref T target)
+  {
+    var type = typeof(T);
+    if (type == typeof(Dictionary<string, object?>))
+    {
+      Dictionary<string, object?> dictionary = new();
+      foreach (var entry in Value)
+      {
+        dictionary.Add(entry.Key, entry.Value);
+      }
+
+      target = (T)(object)dictionary;
+      return true;
+    }
+
+    // TODO: cast to material, model object, etc.
     return false;
   }
 

--- a/Connectors/Rhino/Speckle.Connectors.Grasshopper8/Parameters/SpecklePropertyGroupWrapper.cs
+++ b/Connectors/Rhino/Speckle.Connectors.Grasshopper8/Parameters/SpecklePropertyGroupWrapper.cs
@@ -45,7 +45,7 @@ public class SpecklePropertyGroupGoo : GH_Goo<Dictionary<string, SpeckleProperty
 
       case ModelUserText userText:
         Dictionary<string, SpecklePropertyGoo> dictionary = new();
-        foreach (var entry in userText)
+        foreach (KeyValuePair<string, string> entry in userText)
         {
           string key = entry.Key;
           SpecklePropertyGoo value = new() { Path = key, Value = entry.Value };

--- a/DUI3/Speckle.Connectors.DUI/Models/DocumentModelStore.cs
+++ b/DUI3/Speckle.Connectors.DUI/Models/DocumentModelStore.cs
@@ -128,7 +128,7 @@ public abstract class DocumentModelStore(IJsonSerializer serializer)
     }
   }
 
-  protected string Serialize() => serializer.Serialize(Models);
+  protected string Serialize() => serializer.Serialize(Models.ToList());
 
   // POC: this seemms more like a IModelsDeserializer?, seems disconnected from this class
   protected List<ModelCard> Deserialize(string models) => serializer.Deserialize<List<ModelCard>>(models).NotNull();

--- a/Speckle.Connectors.sln
+++ b/Speckle.Connectors.sln
@@ -10,9 +10,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Config", "Config", "{85A13E
 		CodeMetricsConfig.txt = CodeMetricsConfig.txt
 		Directory.Build.props = Directory.Build.props
 		Directory.Packages.props = Directory.Packages.props
+		.config\dotnet-tools.json = .config\dotnet-tools.json
 		global.json = global.json
 		README.md = README.md
-		.config\dotnet-tools.json = .config\dotnet-tools.json
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Revit", "Revit", "{D92751C8-1039-4005-90B2-913E55E0B8BD}"
@@ -200,6 +200,7 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Speckle.Converter.Tekla2023", "Converters\Tekla\Speckle.Converter.Tekla2023\Speckle.Converter.Tekla2023.csproj", "{8F9181C2-1808-44C0-A33A-5BAE40C49E63}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Speckle.Connectors.Grasshopper8", "Connectors\Rhino\Speckle.Connectors.Grasshopper8\Speckle.Connectors.Grasshopper8.csproj", "{8F6AD59B-FE43-41AE-8F47-7B9752BA0085}"
+EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "CSi", "CSi", "{073F40A8-6C95-41C1-A2F3-369FFFCB9520}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Speckle.Connectors.ETABS22", "Connectors\CSi\Speckle.Connectors.ETABS22\Speckle.Connectors.ETABS22.csproj", "{7C49337A-6F7B-47AB-B549-42E799E89CF2}"


### PR DESCRIPTION
Adds a create data object node.

This requires changing the SpeckleObject class to support one to many relationships: `GeometryBases` property now is a list

This also means now: it's possible to send a mix of geometry objects and data objects from grasshopper...