### PR TITLE
fix(revit): Enable view-based filtering for multiple linked model instances

### DIFF
--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Bindings/RevitSendBinding.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Bindings/RevitSendBinding.cs
@@ -233,7 +233,7 @@ internal sealed class RevitSendBinding : RevitBaseBinding, ISendBinding
         if (includeLinkedModels)
         {
           // handler is only responsible for element collection mechanics
-          var linkedElements = _linkedModelHandler.GetLinkedModelElements(modelCard.SendFilter, linkedDoc);
+          var linkedElements = _linkedModelHandler.GetLinkedModelElements(modelCard.SendFilter, linkedDoc, transform);
           linkedDocumentContexts.Add(new(transform, linkedDoc, linkedElements));
         }
         // ⚠️ when disabled, still adds empty contexts to maintain warning generation in RevitRootObjectBuilder
@@ -380,7 +380,7 @@ internal sealed class RevitSendBinding : RevitBaseBinding, ISendBinding
   /// </summary>
   private async Task CheckFilterExpiration()
   {
-    // NOTE: below code seems like more make sense in terms of performance but it causes unmanaged exception on Revit
+    // NOTE: below code seems like more make sense in terms of performance, but it causes unmanaged exception on Revit
     // using var viewCollector = new FilteredElementCollector(RevitContext.UIApplication?.ActiveUIDocument.Document);
     // var views = viewCollector.OfClass(typeof(View)).Cast<View>().Select(v => v.Id).ToList();
     // var intersection = ChangedObjectIds.Keys.Intersect(views).ToList();


### PR DESCRIPTION
## Description

This PR fixes an issue with the view-based filter in Revit where multiple instances of the same linked model were not being handled correctly. Previously, only the visibility of the first linked model instance was considered when determining which elements to include. This meant that if a user had multiple instances of the same linked model with different visibility settings in a view, the system would incorrectly use only the visibility of the first instance for all instances.

The fix leverages our existing transform hash mechanism to identify and match specific linked model instances, ensuring that each instance's visibility in the current view is correctly evaluated.

Fixes [CNX-1490](https://linear.app/speckle/issue/CNX-1490/section-boxes-and-linked-models)

## User Value

Users can now accurately send elements from specific instances of linked models based on their visibility in the current view, providing more precise control over which elements are included in a Speckle send.

## Changes:

- Changes to `LinkedModelHandler.FindLinkInstanceForDocument` to identify specific linked model instances based on transform hash
- Updated `GetLinkedModelElements` to pass transform information for proper instance matching

## Screenshots:

<img width="961" alt="Screenshot 2025-04-01 094231" src="https://github.com/user-attachments/assets/6936baa5-3c23-4303-99fc-5960aeef92e5" />

<img width="1280" alt="image" src="https://github.com/user-attachments/assets/037259f4-6016-4a17-8b10-94daead977c1" />


## Validation of changes:

- Sending linked models with multiple instances. Testing if the instances visibility on send are independant of the first instance.

## Checklist:

- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [ ] I have added appropriate tests.
- [x] I have updated or added relevant documentation.

