### PR TITLE
Feat(rhino): send filter for layers

### DIFF
--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/Bindings/RhinoSendBinding.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/Bindings/RhinoSendBinding.cs
@@ -16,6 +16,7 @@ using Speckle.Connectors.DUI.Models;
 using Speckle.Connectors.DUI.Models.Card;
 using Speckle.Connectors.DUI.Models.Card.SendFilter;
 using Speckle.Connectors.DUI.Settings;
+using Speckle.Connectors.Rhino.Operations.Send.Filters;
 using Speckle.Converters.Common;
 using Speckle.Converters.Rhino;
 using Speckle.Sdk;
@@ -32,7 +33,8 @@ public sealed class RhinoSendBinding : ISendBinding
 
   private readonly DocumentModelStore _store;
   private readonly IServiceProvider _serviceProvider;
-  private readonly List<ISendFilter> _sendFilters;
+
+  //private readonly List<ISendFilter> _sendFilters;
   private readonly ICancellationManager _cancellationManager;
   private readonly ISendConversionCache _sendConversionCache;
   private readonly IOperationProgressManager _operationProgressManager;
@@ -65,7 +67,7 @@ public sealed class RhinoSendBinding : ISendBinding
     DocumentModelStore store,
     IAppIdleManager idleManager,
     IBrowserBridge parent,
-    IEnumerable<ISendFilter> sendFilters,
+    //IEnumerable<ISendFilter> sendFilters,
     IServiceProvider serviceProvider,
     ICancellationManager cancellationManager,
     ISendConversionCache sendConversionCache,
@@ -80,7 +82,7 @@ public sealed class RhinoSendBinding : ISendBinding
     _store = store;
     _idleManager = idleManager;
     _serviceProvider = serviceProvider;
-    _sendFilters = sendFilters.ToList();
+    //_sendFilters = sendFilters.ToList();
     _cancellationManager = cancellationManager;
     _sendConversionCache = sendConversionCache;
     _operationProgressManager = operationProgressManager;
@@ -277,7 +279,10 @@ public sealed class RhinoSendBinding : ISendBinding
       });
   }
 
-  public List<ISendFilter> GetSendFilters() => _sendFilters;
+  //public List<ISendFilter> GetSendFilters() => _sendFilters;
+
+  public List<ISendFilter> GetSendFilters() =>
+    [new RhinoSelectionFilter() { IsDefault = true }, new RhinoLayersFilter()];
 
   public List<ICardSetting> GetSendSettings() => [];
 

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/Bindings/RhinoSendBinding.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/Bindings/RhinoSendBinding.cs
@@ -33,8 +33,6 @@ public sealed class RhinoSendBinding : ISendBinding
 
   private readonly DocumentModelStore _store;
   private readonly IServiceProvider _serviceProvider;
-
-  //private readonly List<ISendFilter> _sendFilters;
   private readonly ICancellationManager _cancellationManager;
   private readonly ISendConversionCache _sendConversionCache;
   private readonly IOperationProgressManager _operationProgressManager;
@@ -67,7 +65,6 @@ public sealed class RhinoSendBinding : ISendBinding
     DocumentModelStore store,
     IAppIdleManager idleManager,
     IBrowserBridge parent,
-    //IEnumerable<ISendFilter> sendFilters,
     IServiceProvider serviceProvider,
     ICancellationManager cancellationManager,
     ISendConversionCache sendConversionCache,
@@ -82,7 +79,6 @@ public sealed class RhinoSendBinding : ISendBinding
     _store = store;
     _idleManager = idleManager;
     _serviceProvider = serviceProvider;
-    //_sendFilters = sendFilters.ToList();
     _cancellationManager = cancellationManager;
     _sendConversionCache = sendConversionCache;
     _operationProgressManager = operationProgressManager;
@@ -278,8 +274,6 @@ public sealed class RhinoSendBinding : ISendBinding
         _idleManager.SubscribeToIdle(nameof(RunExpirationChecks), RunExpirationChecks);
       });
   }
-
-  //public List<ISendFilter> GetSendFilters() => _sendFilters;
 
   public List<ISendFilter> GetSendFilters() =>
     [new RhinoSelectionFilter() { IsDefault = true }, new RhinoLayersFilter()];

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/Bindings/RhinoSendBinding.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/Bindings/RhinoSendBinding.cs
@@ -188,7 +188,7 @@ public sealed class RhinoSendBinding : ISendBinding
       });
 
     RhinoDoc.LayerTableEvent += (_, args) =>
-      _topLevelExceptionHandler.CatchUnhandled(() =>
+      _topLevelExceptionHandler.CatchUnhandled(async () =>
       {
         if (!_store.IsDocumentInit)
         {
@@ -218,6 +218,7 @@ public sealed class RhinoSendBinding : ISendBinding
           }
         }
         _idleManager.SubscribeToIdle(nameof(RunExpirationChecks), RunExpirationChecks);
+        await Commands.RefreshSendFilters();
       });
 
     // Catches and stores changed material ids. These are then used in the expiry checks to invalidate all objects that have assigned any of those material ids.

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/Operations/Send/Filters/RhinoLayersFilter.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/Operations/Send/Filters/RhinoLayersFilter.cs
@@ -1,0 +1,87 @@
+using Rhino;
+using Rhino.DocObjects;
+using Speckle.Connectors.DUI.Models.Card.SendFilter;
+using Speckle.Connectors.DUI.Utils;
+
+namespace Speckle.Connectors.Rhino.Operations.Send.Filters;
+
+public class RhinoLayersFilter : DiscriminatedObject, ISendFilter
+{
+  // TODO we will probably need to make changes on UI side
+  // because currently "Saved Sets" text shows up using the "navisworksSavedSets" id
+  public string Id { get; set; } = "navisworksSavedSets";
+  public string Name { get; set; } = "Layers";
+  public string? Summary { get; set; }
+  public bool IsDefault { get; set; }
+  public List<string> SelectedObjectIds { get; set; } = [];
+  public Dictionary<string, string>? IdMap { get; set; }
+
+  public bool IsMultiSelectable { get; set; } = true;
+  public List<SendFilterSelectItem> SelectedItems { get; set; }
+  public List<SendFilterSelectItem> Items => GetFilterItems();
+
+  public RhinoLayersFilter() { }
+
+  public List<string> RefreshObjectIds()
+  {
+    SelectedObjectIds.Clear();
+    RhinoDoc doc = RhinoDoc.ActiveDoc;
+    if (doc == null)
+    {
+      return SelectedObjectIds;
+    }
+
+    foreach (var item in SelectedItems)
+    {
+      if (Guid.TryParse(item.Id, out Guid layerId))
+      {
+        Layer layer = doc.Layers.FindId(layerId);
+        if (layer != null)
+        {
+          var objectIds = doc.Objects.FindByLayer(layer).Select(obj => obj.Id.ToString());
+          SelectedObjectIds.AddRange(objectIds);
+        }
+      }
+    }
+
+    return SelectedObjectIds;
+  }
+
+  private List<SendFilterSelectItem> GetFilterItems()
+  {
+    List<SendFilterSelectItem> filterItems = new List<SendFilterSelectItem>();
+    RhinoDoc doc = RhinoDoc.ActiveDoc;
+    if (doc == null)
+    {
+      return filterItems;
+    }
+
+    foreach (Layer layer in doc.Layers)
+    {
+      if (!layer.IsDeleted)
+      {
+        filterItems.Add(new SendFilterSelectItem(layer.Id.ToString(), GetFullLayerPath(layer)));
+      }
+    }
+
+    return filterItems;
+  }
+
+  private string GetFullLayerPath(Layer layer)
+  {
+    string fullPath = layer.Name;
+    Guid parentIndex = layer.ParentLayerId;
+    while (parentIndex != Guid.Empty)
+    {
+      Layer parentLayer = RhinoDoc.ActiveDoc.Layers.FindId(parentIndex);
+      if (parentLayer == null)
+      {
+        break;
+      }
+
+      fullPath = parentLayer.Name + "/" + fullPath;
+      parentIndex = parentLayer.ParentLayerId;
+    }
+    return fullPath;
+  }
+}

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/Operations/Send/Filters/RhinoLayersFilter.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/Operations/Send/Filters/RhinoLayersFilter.cs
@@ -7,10 +7,9 @@ namespace Speckle.Connectors.Rhino.Operations.Send.Filters;
 
 public class RhinoLayersFilter : DiscriminatedObject, ISendFilter
 {
-  // TODO we will probably need to make changes on UI side
-  // because currently "Saved Sets" text shows up using the "navisworksSavedSets" id
-  public string Id { get; set; } = "navisworksSavedSets";
+  public string Id { get; set; } = "rhinoLayers";
   public string Name { get; set; } = "Layers";
+  public string Type { get; set; } = "Select";
   public string? Summary { get; set; }
   public bool IsDefault { get; set; }
   public List<string> SelectedObjectIds { get; set; } = [];

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/Operations/Send/Filters/RhinoSelectionFilter.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/Operations/Send/Filters/RhinoSelectionFilter.cs
@@ -1,0 +1,13 @@
+using Speckle.Connectors.DUI.Models.Card.SendFilter;
+
+namespace Speckle.Connectors.Rhino.Operations.Send.Filters;
+
+public class RhinoSelectionFilter : DirectSelectionSendFilter
+{
+  public RhinoSelectionFilter()
+  {
+    IsDefault = true;
+  }
+
+  public override List<string> RefreshObjectIds() => SelectedObjectIds;
+}

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/Speckle.Connectors.RhinoShared.projitems
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/Speckle.Connectors.RhinoShared.projitems
@@ -23,6 +23,8 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bindings\RhinoSelectionBinding.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HostApp\Properties\PropertiesExtractor.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HostApp\RhinoIdleManager.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Operations\Send\Filters\RhinoSelectionFilter.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Operations\Send\Filters\RhinoLayersFilter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)RhinoEvents.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Registration\ServiceRegistration.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\BoundingBox.cs" />


### PR DESCRIPTION
- Rhino Layers Filter implemented
- Sublayers will be shown with full path like layer01/layer02
- If user selects a sublayer only the direct child elements of that layer will be published
- Users can multiselect layers
- We will probably need to add a new id on UI side, currently "navisworksSavedSets" is used

<img width="532" alt="rhino_layers" src="https://github.com/user-attachments/assets/e0b277d0-7bd0-4a86-864e-ed8b848e425c" />

I don't see Rhino here:

<img width="545" alt="filters" src="https://github.com/user-attachments/assets/f0bd2f26-b358-47c8-aead-ecb5d70bbb01" />

