### PR TITLE
feat(tekla): apply unit conversion factor

### DIFF
--- a/Converters/Tekla/Speckle.Converters.TeklaShared/ToSpeckle/Raw/GridToSpeckleConverter.cs
+++ b/Converters/Tekla/Speckle.Converters.TeklaShared/ToSpeckle/Raw/GridToSpeckleConverter.cs
@@ -1,6 +1,7 @@
 ﻿using System.Globalization;
 using Speckle.Converters.Common;
 using Speckle.Converters.Common.Objects;
+using Speckle.Sdk.Common;
 using Speckle.Sdk.Models;
 
 namespace Speckle.Converters.TeklaShared.ToSpeckle.Raw;
@@ -19,7 +20,7 @@ public class GridToSpeckleConverter : ITypedConverter<TSM.Grid, IEnumerable<Base
     _lineConverter = lineConverter;
   }
 
-  // this function is to check system global seperator
+  // this function gets the scale factor from the coordinate system
   // helps us to avoid conflicts between "," and "."
   private double GetScaleFactor(TG.CoordinateSystem coordinateSystem)
   {
@@ -78,35 +79,55 @@ public class GridToSpeckleConverter : ITypedConverter<TSM.Grid, IEnumerable<Base
       yield break;
     }
 
+    double conversionFactor = Units.GetConversionFactor(Units.Millimeters, _settingsStore.Current.SpeckleUnits);
     var scale = GetScaleFactor(coordinateSystem);
 
-    var xCoordinates = ParseCoordinateString(target.CoordinateX).Select(x => x / scale).ToList();
-    var yCoordinates = ParseCoordinateString(target.CoordinateY).Select(y => y / scale).ToList();
+    var xCoordinates = ParseCoordinateString(target.CoordinateX).Select(x => (x / scale) * conversionFactor).ToList();
+    var yCoordinates = ParseCoordinateString(target.CoordinateY).Select(y => (y / scale) * conversionFactor).ToList();
 
     double minX = xCoordinates.Min();
     double maxX = xCoordinates.Max();
     double minY = yCoordinates.Min();
     double maxY = yCoordinates.Max();
 
-    double extendedMinX = minX - (target.ExtensionLeftX / scale);
-    double extendedMaxX = maxX + (target.ExtensionRightX / scale);
-    double extendedMinY = minY - (target.ExtensionLeftY / scale);
-    double extendedMaxY = maxY + (target.ExtensionRightY / scale);
+    double extendedMinX = minX - ((target.ExtensionLeftX / scale) * conversionFactor);
+    double extendedMaxX = maxX + ((target.ExtensionRightX / scale) * conversionFactor);
+    double extendedMinY = minY - ((target.ExtensionLeftY / scale) * conversionFactor);
+    double extendedMaxY = maxY + ((target.ExtensionRightY / scale) * conversionFactor);
 
-    double scaledZ = coordinateSystem.Origin.Z / scale;
+    double scaledZ = (coordinateSystem.Origin.Z / scale) * conversionFactor;
 
     foreach (var x in xCoordinates)
     {
       var startPoint = new TG.Point(x, extendedMinY, scaledZ);
       var endPoint = new TG.Point(x, extendedMaxY, scaledZ);
-      yield return _lineConverter.Convert(new TG.LineSegment(startPoint, endPoint));
+
+      // we're using the Point converter indirectly through the Line converter
+      // since we've already applied the conversion factor to the coordinates,
+      // we need to tell the Point converter not to apply it again
+      var line = new SOG.Line
+      {
+        start = new SOG.Point(startPoint.X, startPoint.Y, startPoint.Z, _settingsStore.Current.SpeckleUnits),
+        end = new SOG.Point(endPoint.X, endPoint.Y, endPoint.Z, _settingsStore.Current.SpeckleUnits),
+        units = _settingsStore.Current.SpeckleUnits
+      };
+
+      yield return line;
     }
 
     foreach (var y in yCoordinates)
     {
       var startPoint = new TG.Point(extendedMinX, y, scaledZ);
       var endPoint = new TG.Point(extendedMaxX, y, scaledZ);
-      yield return _lineConverter.Convert(new TG.LineSegment(startPoint, endPoint));
+
+      var line = new SOG.Line
+      {
+        start = new SOG.Point(startPoint.X, startPoint.Y, startPoint.Z, _settingsStore.Current.SpeckleUnits),
+        end = new SOG.Point(endPoint.X, endPoint.Y, endPoint.Z, _settingsStore.Current.SpeckleUnits),
+        units = _settingsStore.Current.SpeckleUnits
+      };
+
+      yield return line;
     }
   }
 }

--- a/Converters/Tekla/Speckle.Converters.TeklaShared/ToSpeckle/Raw/PointToSpeckleConverter.cs
+++ b/Converters/Tekla/Speckle.Converters.TeklaShared/ToSpeckle/Raw/PointToSpeckleConverter.cs
@@ -1,5 +1,6 @@
 using Speckle.Converters.Common;
 using Speckle.Converters.Common.Objects;
+using Speckle.Sdk.Common;
 
 namespace Speckle.Converters.TeklaShared.ToSpeckle.Raw;
 
@@ -12,6 +13,15 @@ public class TeklaPointConverter : ITypedConverter<TG.Point, SOG.Point>
     _settingsStore = settingsStore;
   }
 
-  public SOG.Point Convert(TG.Point target) =>
-    new SOG.Point(target.X, target.Y, target.Z, _settingsStore.Current.SpeckleUnits);
+  public SOG.Point Convert(TG.Point target)
+  {
+    double conversionFactor = Units.GetConversionFactor(Units.Millimeters, _settingsStore.Current.SpeckleUnits);
+
+    return new SOG.Point(
+      target.X * conversionFactor,
+      target.Y * conversionFactor,
+      target.Z * conversionFactor,
+      _settingsStore.Current.SpeckleUnits
+    );
+  }
 }

--- a/Converters/Tekla/Speckle.Converters.TeklaShared/ToSpeckle/Raw/SolidToSpeckleConverter.cs
+++ b/Converters/Tekla/Speckle.Converters.TeklaShared/ToSpeckle/Raw/SolidToSpeckleConverter.cs
@@ -2,6 +2,7 @@ using Speckle.Common.MeshTriangulation;
 using Speckle.Converters.Common;
 using Speckle.Converters.Common.Objects;
 using Speckle.DoubleNumerics;
+using Speckle.Sdk.Common;
 using Tekla.Structures.Solid;
 
 namespace Speckle.Converters.TeklaShared.ToSpeckle.Raw;
@@ -17,7 +18,8 @@ public class SolidToSpeckleConverter : ITypedConverter<TSM.Solid, SOG.Mesh>
 
   public SOG.Mesh Convert(TSM.Solid target)
   {
-    // early return extruded Mesh
+    double conversionFactor = Units.GetConversionFactor(Units.Millimeters, _settingsStore.Current.SpeckleUnits);
+
     // if there are exactly 2 opposite facing contours with holes (inner loops)
     var facesAsPolygons = GetFacesAsPolygons(target);
     var facesToExtrude = facesAsPolygons.Where(lst => lst.Count > 1).ToList();
@@ -66,9 +68,9 @@ public class SolidToSpeckleConverter : ITypedConverter<TSM.Solid, SOG.Mesh>
           }
 
           int index = currentIndex++;
-          vertices.Add(vertex.X);
-          vertices.Add(vertex.Y);
-          vertices.Add(vertex.Z);
+          vertices.Add(vertex.X * conversionFactor);
+          vertices.Add(vertex.Y * conversionFactor);
+          vertices.Add(vertex.Z * conversionFactor);
           faceVertices.Add(index);
         }
 
@@ -104,14 +106,15 @@ public class SolidToSpeckleConverter : ITypedConverter<TSM.Solid, SOG.Mesh>
 
   private SOG.Mesh Mesh3ToSpeckleMesh(Mesh3 mesh3)
   {
+    double conversionFactor = Units.GetConversionFactor(Units.Millimeters, _settingsStore.Current.SpeckleUnits);
     var vertices = new List<double>();
     var faces = new List<int>();
 
     foreach (var v in mesh3.Vertices)
     {
-      vertices.Add(v.X);
-      vertices.Add(v.Y);
-      vertices.Add(v.Z);
+      vertices.Add(v.X * conversionFactor);
+      vertices.Add(v.Y * conversionFactor);
+      vertices.Add(v.Z * conversionFactor);
     }
 
     for (int i = 0; i < mesh3.Triangles.Count; i += 3)

--- a/Converters/Tekla/Speckle.Converters.TeklaShared/ToSpeckle/Raw/VectorToSpeckleConverter.cs
+++ b/Converters/Tekla/Speckle.Converters.TeklaShared/ToSpeckle/Raw/VectorToSpeckleConverter.cs
@@ -1,5 +1,6 @@
 using Speckle.Converters.Common;
 using Speckle.Converters.Common.Objects;
+using Speckle.Sdk.Common;
 
 namespace Speckle.Converters.TeklaShared.ToSpeckle.Raw;
 
@@ -12,5 +13,14 @@ public class VectorToSpeckleConverter : ITypedConverter<TG.Vector, SOG.Vector>
     _settingsStore = settingsStore;
   }
 
-  public SOG.Vector Convert(TG.Vector target) => new(target.X, target.Y, target.Z, _settingsStore.Current.SpeckleUnits);
+  public SOG.Vector Convert(TG.Vector target)
+  {
+    double conversionFactor = Units.GetConversionFactor(Units.Millimeters, _settingsStore.Current.SpeckleUnits);
+    return new(
+      target.X * conversionFactor,
+      target.Y * conversionFactor,
+      target.Z * conversionFactor,
+      _settingsStore.Current.SpeckleUnits
+    );
+  }
 }


### PR DESCRIPTION
Tekla always operates on milimeters, just making cosmetic changes on unit changes. The problem reported in the following community post;
https://speckle.community/t/tekla-connector-beta/17347

This PR applies a conversion factor -which we already have a function in our sdk- to the converted geometries.