### PR TITLE
fix(grasshopper): renames collections, publish, and load

### DIFF
--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Collections/CreateCollection.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Collections/CreateCollection.cs
@@ -30,7 +30,7 @@ public class CreateCollection : GH_Component, IGH_VariableParameterComponent
 
   protected override void RegisterOutputParams(GH_OutputParamManager pManager)
   {
-    pManager.AddGenericParameter("Layer", "L", "Collection that was created", GH_ParamAccess.tree);
+    pManager.AddGenericParameter("Collection", "C", "Created parent collection", GH_ParamAccess.tree);
   }
 
   protected override void SolveInstance(IGH_DataAccess dataAccess)
@@ -130,7 +130,7 @@ public class CreateCollection : GH_Component, IGH_VariableParameterComponent
   {
     var myParam = new Param_GenericObject
     {
-      Name = $"Layer {Params.Input.Count + 1}",
+      Name = $"Collection {Params.Input.Count + 1}",
       MutableNickName = true,
       Optional = true,
       Access = GH_ParamAccess.tree // always tree

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/ComponentUtils.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/ComponentUtils.cs
@@ -5,8 +5,8 @@ public static class ComponentCategories
 {
   public const string PRIMARY_RIBBON = "Speckle";
   public const string OPERATIONS = "    Operations";
-  public const string COLLECTIONS = "  Collections";
-  public const string OBJECTS = " Objects";
+  public const string COLLECTIONS = "   Collections";
+  public const string OBJECTS = "  Objects";
   public const string PARAMETERS = "Parameters";
 }
 

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/ComponentUtils.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/ComponentUtils.cs
@@ -3,12 +3,11 @@ namespace Speckle.Connectors.GrasshopperShared.Components;
 // NOTE: The number of spaces determines the order in which they display in the ribbon (nice hack)
 public static class ComponentCategories
 {
-  public const string OPERATIONS = "    Operations";
-  public const string MODELS = "   Model Management";
-  public const string PARAMETERS = "Parameters";
-  public const string COLLECTIONS = "  Collections";
   public const string PRIMARY_RIBBON = "Speckle";
+  public const string OPERATIONS = "    Operations";
+  public const string COLLECTIONS = "  Collections";
   public const string OBJECTS = " Objects";
+  public const string PARAMETERS = "Parameters";
 }
 
 public enum ComponentState

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Receive/ReceiveAsyncComponent.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Receive/ReceiveAsyncComponent.cs
@@ -27,13 +27,7 @@ namespace Speckle.Connectors.GrasshopperShared.Components.Operations.Receive;
 public class ReceiveAsyncComponent : GH_AsyncComponent
 {
   public ReceiveAsyncComponent()
-    : base(
-      "Async Receive",
-      "aR",
-      "Receive objects async from speckle",
-      ComponentCategories.PRIMARY_RIBBON,
-      ComponentCategories.OPERATIONS
-    )
+    : base("Load", "L", "Load a model from Speckle", ComponentCategories.PRIMARY_RIBBON, ComponentCategories.OPERATIONS)
   {
     BaseWorker = new ReceiveComponentWorker(this);
     Attributes = new ReceiveAsyncComponentAttributes(this);
@@ -41,7 +35,7 @@ public class ReceiveAsyncComponent : GH_AsyncComponent
 
   public override Guid ComponentGuid => GetType().GUID;
 
-  protected override Bitmap Icon => BitmapBuilder.CreateSquareIconBitmap("aR");
+  protected override Bitmap Icon => BitmapBuilder.CreateSquareIconBitmap("L");
 
   public string InputType { get; set; }
   public bool AutoReceive { get; set; }
@@ -70,9 +64,9 @@ public class ReceiveAsyncComponent : GH_AsyncComponent
   {
     pManager.AddParameter(
       new SpeckleCollectionParam(GH_ParamAccess.item),
-      "Model",
-      "model",
-      "The model object for the received version",
+      "Collection",
+      "collection",
+      "The model collection of the loaded version",
       GH_ParamAccess.item
     );
   }
@@ -381,7 +375,7 @@ public class ReceiveComponentWorker : WorkerInstance
     {
       if (UrlModelResource is null)
       {
-        throw new InvalidOperationException("Url Resource was null");
+        throw new InvalidOperationException("Model Resource was null");
       }
 
       // Means it's a copy paste of an empty non-init component; set the record and exit fast unless ReceiveOnOpen is true.
@@ -526,7 +520,7 @@ public class ReceiveAsyncComponentAttributes : GH_ComponentAttributes
           ButtonBounds,
           ButtonBounds,
           GH_Palette.Blue,
-          "Auto Receive",
+          "Auto Load",
           2,
           0
         );
@@ -540,7 +534,7 @@ public class ReceiveAsyncComponentAttributes : GH_ComponentAttributes
           state == ComponentState.Expired || state == ComponentState.UpToDate || state == ComponentState.Cancelled
             ? GH_Palette.Black
             : GH_Palette.Transparent;
-        var text = state != ComponentState.Receiving ? "Receive" : "Receiving...";
+        var text = state != ComponentState.Receiving ? "Load" : "Loading...";
 
         var button = GH_Capsule.CreateTextCapsule(
           ButtonBounds,

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Receive/ReceiveComponent.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Receive/ReceiveComponent.cs
@@ -23,15 +23,15 @@ public class ReceiveComponent : SpeckleScopedTaskCapableComponent<SpeckleUrlMode
 {
   public ReceiveComponent()
     : base(
-      "Receive from Speckle",
-      "RFS",
-      "Receive objects from speckle",
+      "(Sync) Load",
+      "sL",
+      "Load a model from Speckle, synchronously",
       ComponentCategories.PRIMARY_RIBBON,
       ComponentCategories.OPERATIONS
     ) { }
 
   public override Guid ComponentGuid => new("74954F59-B1B7-41FD-97DE-4C6B005F2801");
-  protected override Bitmap Icon => BitmapBuilder.CreateSquareIconBitmap("R");
+  protected override Bitmap Icon => BitmapBuilder.CreateSquareIconBitmap("sL");
 
   protected override void RegisterInputParams(GH_InputParamManager pManager)
   {
@@ -42,9 +42,9 @@ public class ReceiveComponent : SpeckleScopedTaskCapableComponent<SpeckleUrlMode
   {
     pManager.AddParameter(
       new SpeckleCollectionParam(GH_ParamAccess.item),
-      "Model",
-      "model",
-      "The model object for the received version",
+      "Collection",
+      "collection",
+      "The model collection of the loaded version",
       GH_ParamAccess.item
     );
   }
@@ -55,7 +55,7 @@ public class ReceiveComponent : SpeckleScopedTaskCapableComponent<SpeckleUrlMode
     da.GetData(0, ref url);
     if (url is null)
     {
-      throw new SpeckleException("Speckle url is null");
+      throw new SpeckleException("Speckle model resource is null");
     }
 
     return url;

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Send/SendAsyncComponent.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Send/SendAsyncComponent.cs
@@ -12,8 +12,6 @@ using Speckle.Connectors.Common.Operations;
 using Speckle.Connectors.GrasshopperShared.HostApp;
 using Speckle.Connectors.GrasshopperShared.Parameters;
 using Speckle.Connectors.GrasshopperShared.Registration;
-using Speckle.Converters.Common;
-using Speckle.Converters.Rhino;
 using Speckle.Sdk;
 using Speckle.Sdk.Api;
 using Speckle.Sdk.Credentials;
@@ -26,9 +24,9 @@ public class SendAsyncComponent : GH_AsyncComponent
 {
   public SendAsyncComponent()
     : base(
-      "Async Send",
-      "aS",
-      "Send objects async to speckle",
+      "Publish",
+      "P",
+      "Publish a collection to Speckle",
       ComponentCategories.PRIMARY_RIBBON,
       ComponentCategories.OPERATIONS
     )
@@ -39,7 +37,7 @@ public class SendAsyncComponent : GH_AsyncComponent
 
   public override Guid ComponentGuid => GetType().GUID;
 
-  protected override Bitmap Icon => BitmapBuilder.CreateSquareIconBitmap("aS");
+  protected override Bitmap Icon => BitmapBuilder.CreateSquareIconBitmap("P");
 
   public ComponentState CurrentComponentState { get; set; } = ComponentState.NeedsInput;
   public bool AutoSend { get; set; }
@@ -59,8 +57,8 @@ public class SendAsyncComponent : GH_AsyncComponent
     pManager.AddParameter(new SpeckleUrlModelResourceParam());
     pManager.AddParameter(
       new SpeckleCollectionParam(GH_ParamAccess.item),
-      "Model",
-      "model",
+      "Collection",
+      "collection",
       "The collection model object to send",
       GH_ParamAccess.item
     );
@@ -85,7 +83,7 @@ public class SendAsyncComponent : GH_AsyncComponent
 
     var autoSendMi = Menu_AppendItem(
       menu,
-      "Send automatically",
+      "Publish automatically",
       (s, e) =>
       {
         AutoSend = !AutoSend;
@@ -101,7 +99,7 @@ public class SendAsyncComponent : GH_AsyncComponent
       AutoSend
     );
     autoSendMi.ToolTipText =
-      "Toggle automatic data sending. If set, any change in any of the input parameters of this component will start sending.\n Please be aware that if a new send starts before an old one is finished, the previous operation is cancelled.";
+      "Toggle automatic data publishing. If set, any change in any of the input parameters of this component will start publishing.\n Please be aware that if a new publish starts before an old one is finished, the previous operation is cancelled.";
 
     if (Url != null)
     {
@@ -116,7 +114,7 @@ public class SendAsyncComponent : GH_AsyncComponent
     {
       Menu_AppendItem(
         menu,
-        "Cancel Send",
+        "Cancel Publish",
         (s, e) =>
         {
           CurrentComponentState = ComponentState.Expired;
@@ -131,10 +129,6 @@ public class SendAsyncComponent : GH_AsyncComponent
     // Dependency Injection
     Scope = PriorityLoader.Container.CreateScope();
     SendOperation = Scope.ServiceProvider.GetRequiredService<SendOperation<SpeckleCollectionWrapperGoo>>();
-    var rhinoConversionSettingsFactory = Scope.ServiceProvider.GetRequiredService<IRhinoConversionSettingsFactory>();
-    Scope
-      .ServiceProvider.GetRequiredService<IConverterSettingsStore<RhinoConversionSettings>>()
-      .Initialize(rhinoConversionSettingsFactory.Create(RhinoDoc.ActiveDoc));
 
     var accountManager = Scope.ServiceProvider.GetRequiredService<AccountService>();
     var clientFactory = Scope.ServiceProvider.GetRequiredService<IClientFactory>();
@@ -314,11 +308,11 @@ public class SendComponentWorker : WorkerInstance
     {
       Parent.AddRuntimeMessage(
         GH_RuntimeMessageLevel.Remark,
-        $"Successfully sent {((SendAsyncComponent)Parent).RootCollectionWrapper?.Value.GetTotalChildrenCount()} objects to Speckle."
+        $"Successfully published {((SendAsyncComponent)Parent).RootCollectionWrapper?.Value.GetTotalChildrenCount()} objects to Speckle."
       );
       Parent.AddRuntimeMessage(
         GH_RuntimeMessageLevel.Remark,
-        $"Send duration: {_stopwatch.ElapsedMilliseconds / 1000f}s"
+        $"Publish duration: {_stopwatch.ElapsedMilliseconds / 1000f}s"
       );
     }
   }
@@ -445,7 +439,7 @@ public class SendAsyncComponentAttributes : GH_ComponentAttributes
           ButtonBounds,
           ButtonBounds,
           GH_Palette.Blue,
-          "Auto Send",
+          "Auto Publish",
           2,
           0
         );
@@ -460,7 +454,7 @@ public class SendAsyncComponentAttributes : GH_ComponentAttributes
             ? GH_Palette.Black
             : GH_Palette.Transparent;
 
-        var text = state == ComponentState.Sending ? "Sending..." : "Send";
+        var text = state == ComponentState.Sending ? "Publishing..." : "Publish";
 
         var button = GH_Capsule.CreateTextCapsule(
           ButtonBounds,

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Send/SendComponent.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Send/SendComponent.cs
@@ -1,13 +1,10 @@
 using System.Diagnostics;
 using Grasshopper.Kernel;
 using Microsoft.Extensions.DependencyInjection;
-using Rhino;
 using Speckle.Connectors.Common.Operations;
 using Speckle.Connectors.GrasshopperShared.Components.BaseComponents;
 using Speckle.Connectors.GrasshopperShared.HostApp;
 using Speckle.Connectors.GrasshopperShared.Parameters;
-using Speckle.Converters.Common;
-using Speckle.Converters.Rhino;
 using Speckle.Sdk;
 using Speckle.Sdk.Api;
 using Speckle.Sdk.Common;
@@ -36,9 +33,9 @@ public class SendComponent : SpeckleScopedTaskCapableComponent<SendComponentInpu
 {
   public SendComponent()
     : base(
-      "Send to Speckle",
-      "STS",
-      "Send objects to speckle",
+      "(Sync) Publish",
+      "sP",
+      "Publish a collection to Speckle, synchronously",
       ComponentCategories.PRIMARY_RIBBON,
       ComponentCategories.OPERATIONS
     ) { }
@@ -47,16 +44,16 @@ public class SendComponent : SpeckleScopedTaskCapableComponent<SendComponentInpu
 
   public string? Url { get; private set; }
 
-  protected override Bitmap Icon => BitmapBuilder.CreateSquareIconBitmap("S");
+  protected override Bitmap Icon => BitmapBuilder.CreateSquareIconBitmap("sP");
 
   protected override void RegisterInputParams(GH_InputParamManager pManager)
   {
     pManager.AddParameter(new SpeckleUrlModelResourceParam());
     pManager.AddParameter(
       new SpeckleCollectionParam(GH_ParamAccess.item),
-      "Model",
-      "model",
-      "The collection model object to send",
+      "Collection",
+      "collection",
+      "The model collection to publish",
       GH_ParamAccess.item
     );
   }
@@ -115,11 +112,6 @@ public class SendComponent : SpeckleScopedTaskCapableComponent<SendComponentInpu
     CancellationToken cancellationToken = default
   )
   {
-    var rhinoConversionSettingsFactory = scope.ServiceProvider.GetRequiredService<IRhinoConversionSettingsFactory>();
-    scope
-      .ServiceProvider.GetRequiredService<IConverterSettingsStore<RhinoConversionSettings>>()
-      .Initialize(rhinoConversionSettingsFactory.Create(RhinoDoc.ActiveDoc));
-
     var accountManager = scope.ServiceProvider.GetRequiredService<AccountService>();
     var clientFactory = scope.ServiceProvider.GetRequiredService<IClientFactory>();
     var sendOperation = scope.ServiceProvider.GetRequiredService<SendOperation<SpeckleCollectionWrapperGoo>>();

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/SpeckleSelectModelComponent.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/SpeckleSelectModelComponent.cs
@@ -43,7 +43,13 @@ public class SpeckleSelectModelComponent : GH_Component
   protected override Bitmap Icon => BitmapBuilder.CreateSquareIconBitmap("URL");
 
   public SpeckleSelectModelComponent()
-    : base("Speckle Model URL", "URL", "User selectable model from speckle", "Speckle", "Models")
+    : base(
+      "Speckle Model URL",
+      "URL",
+      "User selectable model from Speckle",
+      ComponentCategories.PRIMARY_RIBBON,
+      ComponentCategories.OPERATIONS
+    )
   {
     ProjectContextMenuButton = new GhContextMenuButton(
       "Select Project",

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/SpeckleUrlModelResourceParam.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/SpeckleUrlModelResourceParam.cs
@@ -1,4 +1,6 @@
 using Grasshopper.Kernel;
+using Speckle.Connectors.GrasshopperShared.Components;
+using Speckle.Connectors.GrasshopperShared.HostApp;
 
 namespace Speckle.Connectors.GrasshopperShared.Parameters;
 
@@ -14,7 +16,16 @@ public class SpeckleUrlModelResourceParam : GH_Param<SpeckleUrlModelResourceGoo>
     : base(tag, access) { }
 
   public SpeckleUrlModelResourceParam(GH_ParamAccess access)
-    : base("Speckle URL", "spcklUrl", "A Speckle resource", "Speckle", "Resources", access) { }
+    : base(
+      "Speckle Model Resource",
+      "SMR",
+      "A Speckle model resource",
+      ComponentCategories.PRIMARY_RIBBON,
+      ComponentCategories.PARAMETERS,
+      access
+    ) { }
 
   public override Guid ComponentGuid => new Guid("E5421FC2-F10D-447F-BF23-5C934ABDB2D3");
+
+  protected override Bitmap Icon => BitmapBuilder.CreateHexagonalBitmap("SMR");
 }


### PR DESCRIPTION
Renames all outputs to be collection (instead of model / layer) and also publish and load instead of send/receive.
Also makes async the defualt nodes
also adds bool run toggle input to sync send and receive