### PR TITLE
Feat(workspaces): Add workspace slug to model card

### DIFF
--- a/DUI3/Speckle.Connectors.DUI/Models/Card/ModelCard.cs
+++ b/DUI3/Speckle.Connectors.DUI/Models/Card/ModelCard.cs
@@ -27,6 +27,11 @@ public class ModelCard : DiscriminatedObject
   public string? WorkspaceId { get; set; }
 
   /// <summary>
+  /// Workspace slug.
+  /// </summary>
+  public string? WorkspaceSlug { get; set; }
+
+  /// <summary>
   /// Account id that model card created with it initially.
   /// </summary>
   public string? AccountId { get; set; }


### PR DESCRIPTION
We need to store this info in model card to be able to openUrls for later usage.

We need to align it with sketchup and archicad later (@kekesidavid)