### PR TITLE
Fix (revit): disable regions in revit

### DIFF
--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Receive/RevitHostObjectBuilder.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Receive/RevitHostObjectBuilder.cs
@@ -33,7 +33,6 @@ public sealed class RevitHostObjectBuilder(
   RevitGroupBaker groupManager,
   RevitMaterialBaker materialBaker,
   RootObjectUnpacker rootObjectUnpacker,
-  RevitViewManager viewManager,
   ILogger<RevitHostObjectBuilder> logger,
   IThreadContext threadContext,
   RevitToHostCacheSingleton revitToHostCacheSingleton,
@@ -62,13 +61,6 @@ public sealed class RevitHostObjectBuilder(
     CancellationToken cancellationToken
   )
   {
-    // ignore Receive in any other views (e.g. Section, Elevation, ViewSheet etc.)
-    View activeView = converterSettings.Current.Document.ActiveView;
-    if (!viewManager.IsSupportedReceiveView(activeView))
-    {
-      throw new ConversionException($"Receive in '{activeView.ViewType}' View is not supported");
-    }
-
     var baseGroupName = $"Project {projectName}: Model {modelName}"; // TODO: unify this across connectors!
 
     onOperationProgressed.Report(new("Converting", null));
@@ -208,16 +200,6 @@ public sealed class RevitHostObjectBuilder(
           conversionResults.Add(
             new(Status.SUCCESS, localToGlobalMap.AtomicObject, directShapes.UniqueId, "Direct Shape")
           );
-        }
-        else if (result is List<string> elementsIds)
-        {
-          // This is the case when conversion returns not a GeometryObject, but Documentation elements (Annotations, Details etc.)
-          // If Regions were a part of DataObject, it can return more than 1 native shape
-          foreach (var elementId in elementsIds)
-          {
-            conversionResults.Add(new(Status.SUCCESS, localToGlobalMap.AtomicObject, elementId, "Filled Region"));
-            bakedObjectIds.Add(elementId);
-          }
         }
         else
         {

--- a/Converters/Revit/Speckle.Converters.RevitShared/RevitRootToHostConverter.cs
+++ b/Converters/Revit/Speckle.Converters.RevitShared/RevitRootToHostConverter.cs
@@ -14,28 +14,26 @@ public class RevitRootToHostConverter : IRootToHostConverter
 {
   private readonly IConverterSettingsStore<RevitConversionSettings> _converterSettings;
   private readonly ITypedConverter<Base, List<DB.GeometryObject>> _baseToGeometryConverter;
-  private readonly ITypedConverter<Base, List<string>> _planViewToGeometryConverter;
 
   public RevitRootToHostConverter(
-    ITypedConverter<Base, List<string>> planViewToGeometryConverter,
     ITypedConverter<Base, List<DB.GeometryObject>> baseToGeometryConverter,
     IConverterSettingsStore<RevitConversionSettings> converterSettings
   )
   {
-    _planViewToGeometryConverter = planViewToGeometryConverter;
     _baseToGeometryConverter = baseToGeometryConverter;
     _converterSettings = converterSettings;
   }
 
   public object Convert(Base target)
   {
-    // If ActiveView is a 2d view, use PlanView converter (will ignore DirectShapes)
-    // Unsupported views already filtered out in HostObjectBuilder
-    View activeView = _converterSettings.Current.Document.ActiveView;
-    if (activeView.ViewType != ViewType.ThreeD)
-    {
-      return _planViewToGeometryConverter.Convert(target);
-    }
+    // TODO: We should scope 2d elements properly in revit. It is outside of reference geometry workflows right now.
+    // // If ActiveView is a 2d view, use PlanView converter (will ignore DirectShapes)
+    // // Unsupported views already filtered out in HostObjectBuilder
+    // View activeView = _converterSettings.Current.Document.ActiveView;
+    // if (activeView.ViewType != ViewType.ThreeD)
+    // {
+    //   return _planViewToGeometryConverter.Convert(target);
+    // }
 
     // Use default behavior and covert everything to DirectShapes
     List<DB.GeometryObject> geometryObjects = _baseToGeometryConverter.Convert(target);

--- a/Converters/Revit/Speckle.Converters.RevitShared/ToHost/Raw/BaseToHostGeometryObjectConverter.cs
+++ b/Converters/Revit/Speckle.Converters.RevitShared/ToHost/Raw/BaseToHostGeometryObjectConverter.cs
@@ -7,26 +7,13 @@ using Speckle.Sdk.Models.Extensions;
 
 namespace Speckle.Converters.RevitShared.ToSpeckle;
 
-public class BaseToHostGeometryObjectConverter : ITypedConverter<Base, List<DB.GeometryObject>>
+public class BaseToHostGeometryObjectConverter(
+  ITypedConverter<SOG.Point, DB.XYZ> pointConverter,
+  ITypedConverter<ICurve, DB.CurveArray> curveConverter,
+  ITypedConverter<SOG.Mesh, List<DB.GeometryObject>> meshConverter,
+  ITypedConverter<SOG.IRawEncodedObject, List<DB.GeometryObject>> encodedObjectConverter
+) : ITypedConverter<Base, List<DB.GeometryObject>>
 {
-  private readonly ITypedConverter<SOG.Point, DB.XYZ> _pointConverter;
-  private readonly ITypedConverter<ICurve, DB.CurveArray> _curveConverter;
-  private readonly ITypedConverter<SOG.Mesh, List<DB.GeometryObject>> _meshConverter;
-  private readonly ITypedConverter<SOG.IRawEncodedObject, List<DB.GeometryObject>> _encodedObjectConverter;
-
-  public BaseToHostGeometryObjectConverter(
-    ITypedConverter<SOG.Point, DB.XYZ> pointConverter,
-    ITypedConverter<ICurve, DB.CurveArray> curveConverter,
-    ITypedConverter<SOG.Mesh, List<DB.GeometryObject>> meshConverter,
-    ITypedConverter<SOG.IRawEncodedObject, List<DB.GeometryObject>> encodedObjectConverter
-  )
-  {
-    _pointConverter = pointConverter;
-    _curveConverter = curveConverter;
-    _meshConverter = meshConverter;
-    _encodedObjectConverter = encodedObjectConverter;
-  }
-
   public List<DB.GeometryObject> Convert(Base target)
   {
     List<DB.GeometryObject> result = new();
@@ -34,19 +21,19 @@ public class BaseToHostGeometryObjectConverter : ITypedConverter<Base, List<DB.G
     switch (target)
     {
       case SOG.Point point:
-        var xyz = _pointConverter.Convert(point);
+        var xyz = pointConverter.Convert(point);
         result.Add(DB.Point.Create(xyz));
         break;
       case ICurve curve:
-        var curves = _curveConverter.Convert(curve).Cast<DB.GeometryObject>();
+        var curves = curveConverter.Convert(curve).Cast<DB.GeometryObject>();
         result.AddRange(curves);
         break;
       case SOG.Mesh mesh:
-        var meshes = _meshConverter.Convert(mesh).Cast<DB.GeometryObject>();
+        var meshes = meshConverter.Convert(mesh).Cast<DB.GeometryObject>();
         result.AddRange(meshes);
         break;
       case SOG.IRawEncodedObject elon:
-        var res = _encodedObjectConverter.Convert(elon);
+        var res = encodedObjectConverter.Convert(elon);
         result.AddRange(res);
         break;
       default:

--- a/Converters/Revit/Speckle.Converters.RevitShared/ToHost/Raw/Geometry/RegionConverterToHost.cs
+++ b/Converters/Revit/Speckle.Converters.RevitShared/ToHost/Raw/Geometry/RegionConverterToHost.cs
@@ -1,63 +1,65 @@
-using Autodesk.Revit.DB;
-using Speckle.Converters.Common;
-using Speckle.Converters.Common.Objects;
-using Speckle.Converters.RevitShared.Settings;
-using Speckle.Objects;
+// TODO: We should scope 2d elements properly in revit. It is outside of reference geometry workflows right now.
 
-namespace Speckle.Converters.RevitShared.ToHost.TopLevel;
-
-public class RegionConverterToHost : ITypedConverter<SOG.Region, string>
-{
-  private readonly IConverterSettingsStore<RevitConversionSettings> _converterSettings;
-  private readonly ITypedConverter<ICurve, DB.CurveArray> _curveConverter;
-
-  public RegionConverterToHost(
-    IConverterSettingsStore<RevitConversionSettings> converterSettings,
-    ITypedConverter<ICurve, DB.CurveArray> curveConverter
-  )
-  {
-    _converterSettings = converterSettings;
-    _curveConverter = curveConverter;
-  }
-
-  public string Convert(SOG.Region target)
-  {
-    List<DB.GeometryObject> resultList = new();
-    List<CurveLoop> profileLoops = new();
-
-    // convert boundary loop and add to profileLoops list
-    CurveLoop boundaryLoop = new();
-    List<DB.Curve> outerLoop = _curveConverter.Convert(target.boundary).Cast<DB.Curve>().ToList();
-    outerLoop.ForEach(x => boundaryLoop.Append(x));
-    profileLoops.Add(boundaryLoop);
-
-    // convert inner loops and add to profileLoops list
-    List<List<DB.Curve>> innerLoops = target
-      .innerLoops.Select(x => _curveConverter.Convert(x).Cast<DB.Curve>().ToList())
-      .ToList();
-    foreach (var innerLoop in innerLoops)
-    {
-      CurveLoop voidLoop = new();
-      innerLoop.ForEach(x => voidLoop.Append(x));
-      profileLoops.Add(voidLoop);
-    }
-
-    // get FilledRegionType from the document to create a new FilledRegion element
-    using var filledRegionCollector = new FilteredElementCollector(_converterSettings.Current.Document);
-    Element filledRegionElementType = filledRegionCollector.OfClass(typeof(DB.FilledRegionType)).FirstElement();
-
-    // follow the pattern of the native CAD import: try to draw native FilledRegion in the Active view,
-    // or draw a linked CAD document, if imported into unsupported View (in our case: don't catch the error, so the converter will default to fallback)
-    View activeView = _converterSettings.Current.Document.ActiveView;
-
-    // Autodesk.Revit.Exceptions.ArgumentException will be thrown if ActiveView invalid
-    using FilledRegion filledRegion = FilledRegion.Create(
-      _converterSettings.Current.Document,
-      filledRegionElementType.Id,
-      activeView.Id,
-      profileLoops
-    );
-
-    return filledRegion.UniqueId;
-  }
-}
+// using Autodesk.Revit.DB;
+// using Speckle.Converters.Common;
+// using Speckle.Converters.Common.Objects;
+// using Speckle.Converters.RevitShared.Settings;
+// using Speckle.Objects;
+//
+// namespace Speckle.Converters.RevitShared.ToHost.TopLevel;
+//
+// public class RegionConverterToHost : ITypedConverter<SOG.Region, string>
+// {
+//   private readonly IConverterSettingsStore<RevitConversionSettings> _converterSettings;
+//   private readonly ITypedConverter<ICurve, DB.CurveArray> _curveConverter;
+//
+//   public RegionConverterToHost(
+//     IConverterSettingsStore<RevitConversionSettings> converterSettings,
+//     ITypedConverter<ICurve, DB.CurveArray> curveConverter
+//   )
+//   {
+//     _converterSettings = converterSettings;
+//     _curveConverter = curveConverter;
+//   }
+//
+//   public string Convert(SOG.Region target)
+//   {
+//     List<DB.GeometryObject> resultList = new();
+//     List<CurveLoop> profileLoops = new();
+//
+//     // convert boundary loop and add to profileLoops list
+//     CurveLoop boundaryLoop = new();
+//     List<DB.Curve> outerLoop = _curveConverter.Convert(target.boundary).Cast<DB.Curve>().ToList();
+//     outerLoop.ForEach(x => boundaryLoop.Append(x));
+//     profileLoops.Add(boundaryLoop);
+//
+//     // convert inner loops and add to profileLoops list
+//     List<List<DB.Curve>> innerLoops = target
+//       .innerLoops.Select(x => _curveConverter.Convert(x).Cast<DB.Curve>().ToList())
+//       .ToList();
+//     foreach (var innerLoop in innerLoops)
+//     {
+//       CurveLoop voidLoop = new();
+//       innerLoop.ForEach(x => voidLoop.Append(x));
+//       profileLoops.Add(voidLoop);
+//     }
+//
+//     // get FilledRegionType from the document to create a new FilledRegion element
+//     using var filledRegionCollector = new FilteredElementCollector(_converterSettings.Current.Document);
+//     Element filledRegionElementType = filledRegionCollector.OfClass(typeof(DB.FilledRegionType)).FirstElement();
+//
+//     // follow the pattern of the native CAD import: try to draw native FilledRegion in the Active view,
+//     // or draw a linked CAD document, if imported into unsupported View (in our case: don't catch the error, so the converter will default to fallback)
+//     View activeView = _converterSettings.Current.Document.ActiveView;
+//
+//     // Autodesk.Revit.Exceptions.ArgumentException will be thrown if ActiveView invalid
+//     using FilledRegion filledRegion = FilledRegion.Create(
+//       _converterSettings.Current.Document,
+//       filledRegionElementType.Id,
+//       activeView.Id,
+//       profileLoops
+//     );
+//
+//     return filledRegion.UniqueId;
+//   }
+// }

--- a/Converters/Revit/Speckle.Converters.RevitShared/ToHost/Raw/PlanViewToHostGeometryObjectConverter.cs
+++ b/Converters/Revit/Speckle.Converters.RevitShared/ToHost/Raw/PlanViewToHostGeometryObjectConverter.cs
@@ -1,47 +1,49 @@
-using System.Collections;
-using Speckle.Converters.Common.Objects;
-using Speckle.Objects.Data;
-using Speckle.Sdk.Common.Exceptions;
-using Speckle.Sdk.Models;
-using Speckle.Sdk.Models.Extensions;
+// TODO: We should scope 2d elements properly in revit. It is outside of reference geometry workflows right now.
 
-namespace Speckle.Converters.RevitShared.ToSpeckle;
-
-public class PlanViewToHostGeometryObjectConverter : ITypedConverter<Base, List<string>>
-{
-  private readonly ITypedConverter<SOG.Region, string> _regionToFilledRegionConverter;
-
-  public PlanViewToHostGeometryObjectConverter(ITypedConverter<SOG.Region, string> regionToFilledRegionConverter)
-  {
-    _regionToFilledRegionConverter = regionToFilledRegionConverter;
-  }
-
-  public List<string> Convert(Base target)
-  {
-    switch (target)
-    {
-      case SOG.Region region:
-        return new List<string>() { _regionToFilledRegionConverter.Convert(region) };
-
-      case DataObject dataObj:
-        List<string> results = new();
-
-        var displayValue = target.TryGetDisplayValue<Base>();
-        if ((displayValue is IList && !displayValue.Any()) || displayValue is null)
-        {
-          throw new ValidationException($"No display value found for {target.speckle_type}");
-        }
-        dataObj.displayValue.ForEach(x => results.AddRange(Convert(x)));
-
-        if (results.Count == 0)
-        {
-          throw new ConversionException($"No objects could be converted for {target.speckle_type}.");
-        }
-
-        return results;
-
-      default:
-        throw new ConversionException($"Objects of type {target.speckle_type} cannot be converted in 2d view.");
-    }
-  }
-}
+// using System.Collections;
+// using Speckle.Converters.Common.Objects;
+// using Speckle.Objects.Data;
+// using Speckle.Sdk.Common.Exceptions;
+// using Speckle.Sdk.Models;
+// using Speckle.Sdk.Models.Extensions;
+//
+// namespace Speckle.Converters.RevitShared.ToSpeckle;
+//
+// public class PlanViewToHostGeometryObjectConverter : ITypedConverter<Base, List<string>>
+// {
+//   private readonly ITypedConverter<SOG.Region, string> _regionToFilledRegionConverter;
+//
+//   public PlanViewToHostGeometryObjectConverter(ITypedConverter<SOG.Region, string> regionToFilledRegionConverter)
+//   {
+//     _regionToFilledRegionConverter = regionToFilledRegionConverter;
+//   }
+//
+//   public List<string> Convert(Base target)
+//   {
+//     switch (target)
+//     {
+//       case SOG.Region region:
+//         return new List<string>() { _regionToFilledRegionConverter.Convert(region) };
+//
+//       case DataObject dataObj:
+//         List<string> results = new();
+//
+//         var displayValue = target.TryGetDisplayValue<Base>();
+//         if ((displayValue is IList && !displayValue.Any()) || displayValue is null)
+//         {
+//           throw new ValidationException($"No display value found for {target.speckle_type}");
+//         }
+//         dataObj.displayValue.ForEach(x => results.AddRange(Convert(x)));
+//
+//         if (results.Count == 0)
+//         {
+//           throw new ConversionException($"No objects could be converted for {target.speckle_type}.");
+//         }
+//
+//         return results;
+//
+//       default:
+//         throw new ConversionException($"Objects of type {target.speckle_type} cannot be converted in 2d view.");
+//     }
+//   }
+// }


### PR DESCRIPTION
Now we can receive sketchup commits, and regions as fallback mesh

![image](https://github.com/user-attachments/assets/fef4dbbf-e2c2-444f-b174-5d5990216e45)