### PR TITLE
Fix(revit): object tracking for next session

### DIFF
--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Bindings/RevitSendBinding.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Bindings/RevitSendBinding.cs
@@ -263,6 +263,10 @@ internal sealed class RevitSendBinding : RevitBaseBinding, ISendBinding
         modelCard.SendFilter.IdMap,
         newSelectedObjectIds
       );
+
+      // In UI, we are not explicitly trigger UpdateModel to save the state into file for some edge cases. Instead we save it directly via document model store.
+      // Comment in the UI -> """ otherwise it is leading cleanup on document store bc of deferred action when we switched to the another doc"""
+      _store.SaveState();
     }
 
     return documentElementContexts;

--- a/DUI3/Speckle.Connectors.DUI/Models/DocumentModelStore.cs
+++ b/DUI3/Speckle.Connectors.DUI/Models/DocumentModelStore.cs
@@ -133,7 +133,7 @@ public abstract class DocumentModelStore(IJsonSerializer serializer)
   // POC: this seemms more like a IModelsDeserializer?, seems disconnected from this class
   protected List<ModelCard> Deserialize(string models) => serializer.Deserialize<List<ModelCard>>(models).NotNull();
 
-  protected void SaveState()
+  public void SaveState()
   {
     lock (_models)
     {


### PR DESCRIPTION
It was a regression while fixing the https://linear.app/speckle/issue/CNX-1213/revit-when-moving-between-documents-cards-can-get-lost-between-them