### PR TITLE
fix(grasshopper): fixes material baking on objects

### DIFF
--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/SpeckleGrasshopperObject.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/SpeckleGrasshopperObject.cs
@@ -152,6 +152,7 @@ public class SpeckleObjectWrapper : Base
       if (matIndex >= 0)
       {
         att.MaterialIndex = matIndex;
+        att.MaterialSource = ObjectMaterialSource.MaterialFromObject;
       }
     }
 


### PR DESCRIPTION
forgot to set material source when baking objects 🥲