### PR TITLE
chore(grasshopper): improves enumeration of non-collection objects in create collection component

### DIFF
--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Collections/CreateCollection.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Collections/CreateCollection.cs
@@ -82,6 +82,7 @@ public class CreateCollection : GH_Component, IGH_VariableParameterComponent
       SpeckleCollectionWrapper childSpeckleCollectionWrapper =
         new(childCollection, childPath, null, null) { Topology = GrasshopperHelpers.GetParamTopology(inputParam) };
 
+      // handle collection inputs
       // if on this port we're only receiving collections, we should become "pass-through" to not create
       // needless nesting
       if (inputCollections.Count == data.Count)
@@ -116,7 +117,8 @@ public class CreateCollection : GH_Component, IGH_VariableParameterComponent
         continue;
       }
 
-      foreach (var obj in data)
+      // handle object inputs
+      foreach (var obj in inputNonCollections)
       {
         SpeckleObjectWrapperGoo wrapperGoo = new();
         if (wrapperGoo.CastFrom(obj))


### PR DESCRIPTION
Just a small optimization in the enumeration of non-collection inputs of the create collection component.

Couldn't reproduce the original issue, as model objects seem to be casting just fine:

![{F9EBE988-7D74-462F-99C7-EBABBB41A6A2}](https://github.com/user-attachments/assets/e628aac6-d15c-41f9-bb92-dc473640960a)
