### PR TITLE
fix(grasshopper): adds ability to expand base props in Expand Speckle Object component

### DIFF
--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Collections/FilterObjectsByCollectionPaths.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Collections/FilterObjectsByCollectionPaths.cs
@@ -33,9 +33,9 @@ public class FilterObjectsByCollectionPaths : GH_Component
 
   public FilterObjectsByCollectionPaths()
     : base(
-      "FilterObjectsByCollectionPaths",
-      "ocF",
-      "Filters model objects by their collection path",
+      "QuerySpeckleObjects",
+      "qO",
+      "Finds Speckle model objects by their collection path",
       ComponentCategories.PRIMARY_RIBBON,
       ComponentCategories.COLLECTIONS
     ) { }

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/SpeckleCollectionWrapper.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/SpeckleCollectionWrapper.cs
@@ -313,7 +313,7 @@ public class SpeckleCollectionParam : GH_Param<SpeckleCollectionWrapperGoo>, IGH
       if (element is SpeckleObjectWrapper sg)
       {
         _previewObjects.Add(sg);
-        var box = sg.GeometryBase.GetBoundingBox(false);
+        var box = sg.GeometryBase is null ? new() : sg.GeometryBase.GetBoundingBox(false);
         _clippingBox.Union(box);
       }
     }

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/SpeckleGrasshopperObject.ModelObjects.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/SpeckleGrasshopperObject.ModelObjects.cs
@@ -6,6 +6,7 @@ using Rhino.Geometry;
 using Grasshopper.Rhinoceros.Model;
 using Grasshopper.Rhinoceros.Display;
 using Speckle.Connectors.GrasshopperShared.HostApp;
+using Speckle.Sdk.Models;
 
 namespace Speckle.Connectors.GrasshopperShared.Parameters;
 
@@ -22,11 +23,12 @@ public partial class SpeckleObjectWrapperGoo : GH_Goo<SpeckleObjectWrapper>, IGH
     {
       if (GetGeometryFromModelObject(modelObject) is GeometryBase modelGB)
       {
-        var modelConverted = SpeckleConversionContext.ConvertToSpeckle(modelGB);
+        Base modelConverted = SpeckleConversionContext.ConvertToSpeckle(modelGB);
         SpecklePropertyGroupGoo propertyGroup = new();
         propertyGroup.CastFrom(modelObject.UserText);
 
         // update the converted Base with props as well
+        modelConverted.applicationId = modelObject.Id?.ToString();
         modelConverted["name"] = modelObject.Name.ToString();
         Dictionary<string, object?> propertyDict = new();
         foreach (var entry in propertyGroup.Value)

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/SpeckleGrasshopperObject.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/SpeckleGrasshopperObject.cs
@@ -21,7 +21,7 @@ public class SpeckleObjectWrapper : Base
   // note: how will we send intervals and other gh native objects? do we? maybe not for now
   // note: this does not handle on to many relationship well.
   // For receiving data objects, we are wrapping every value in the data object display value, and storing a reference to the same data object in each wrapped object.
-  public required GeometryBase GeometryBase { get; set; }
+  public required GeometryBase? GeometryBase { get; set; }
 
   // The list of layer/collection names that forms the full path to this object
   public List<string> Path { get; set; } = new();
@@ -34,7 +34,7 @@ public class SpeckleObjectWrapper : Base
   public required SpeckleMaterialWrapper? Material { get; set; }
 
   // RenderMaterial, ColorProxies, Properties (?)
-  public override string ToString() => $"Speckle Wrapper [{GeometryBase.GetType().Name}]";
+  public override string ToString() => $"Speckle Wrapper [{GeometryBase?.GetType().Name}]";
 
   public void DrawPreview(IGH_PreviewArgs args, bool isSelected = false)
   {
@@ -234,7 +234,8 @@ public partial class SpeckleObjectWrapperGoo : GH_Goo<SpeckleObjectWrapper>, IGH
     Value.DrawPreviewRaw(args.Pipeline, args.Material);
   }
 
-  BoundingBox IGH_PreviewData.ClippingBox => Value.GeometryBase.GetBoundingBox(false);
+  BoundingBox IGH_PreviewData.ClippingBox =>
+    Value.GeometryBase is null ? new() : Value.GeometryBase.GetBoundingBox(false);
 
   public SpeckleObjectWrapperGoo(SpeckleObjectWrapper value)
   {
@@ -318,9 +319,9 @@ public class SpeckleObjectParam : GH_Param<SpeckleObjectWrapperGoo>, IGH_BakeAwa
       // Iterate over all data stored in the parameter
       foreach (var item in VolatileData.AllData(true))
       {
-        if (item is SpeckleObjectWrapperGoo goo)
+        if (item is SpeckleObjectWrapperGoo goo && goo.Value.GeometryBase is GeometryBase gb)
         {
-          var box = goo.Value.GeometryBase.GetBoundingBox(false);
+          var box = gb.GetBoundingBox(false);
           clippingBox.Union(box);
         }
       }


### PR DESCRIPTION
Before, I was only passing the converted value of a `Base` property of a speckle object.
Now, the value should be a Wrapper Goo, which will be passed even in the event of an unsupported type conversion.

This should allow users to link expand components, and also to explore/reuse unsupport `Base` types.