### PR TITLE
feat(grasshopper): adds casting from speckle object to model object

### DIFF
--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/SpeckleGrasshopperObject.ModelObjects.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/SpeckleGrasshopperObject.ModelObjects.cs
@@ -7,6 +7,7 @@ using Grasshopper.Rhinoceros.Model;
 using Grasshopper.Rhinoceros.Display;
 using Speckle.Connectors.GrasshopperShared.HostApp;
 using Speckle.Sdk.Models;
+using Rhino.DocObjects;
 
 namespace Speckle.Connectors.GrasshopperShared.Parameters;
 
@@ -15,6 +16,23 @@ public partial class SpeckleObjectWrapperGoo : GH_Goo<SpeckleObjectWrapper>, IGH
   public SpeckleObjectWrapperGoo(ModelObject mo)
   {
     CastFrom(mo);
+  }
+
+  private bool CastToModelObject<T>(ref T target)
+  {
+    var type = typeof(T);
+
+    if (type == typeof(ModelObject))
+    {
+      // create attributes
+      ObjectAttributes atts = new();
+      CastTo<ObjectAttributes>(ref atts);
+      ModelObject modelObject = new(RhinoDoc.ActiveDoc, atts, Value.GeometryBase);
+      target = (T)(object)modelObject;
+      return true;
+    }
+
+    return false;
   }
 
   private bool CastFromModelObject(object source)

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/SpeckleMaterialWrapper.ModelObjects.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/SpeckleMaterialWrapper.ModelObjects.cs
@@ -14,12 +14,9 @@ public partial class SpeckleMaterialWrapperGoo : GH_Goo<SpeckleMaterialWrapper>,
 {
   private bool CastFromModelRenderMaterial(object source)
   {
-    if (source is ModelRenderMaterial modelMaterial)
+    switch (source)
     {
-      if (modelMaterial.Id is Guid id)
-      {
-        Rhino.Render.RenderMaterial renderMaterial = RhinoDoc.ActiveDoc.RenderMaterials.Find(id);
-
+      case Rhino.Render.RenderMaterial renderMaterial:
         renderMaterial.ToMaterial(RenderTexture.TextureGeneration.Allow);
         Value = new()
         {
@@ -28,8 +25,21 @@ public partial class SpeckleMaterialWrapperGoo : GH_Goo<SpeckleMaterialWrapper>,
         };
 
         return true;
-      }
-      return false;
+      case ModelRenderMaterial modelMaterial:
+        if (modelMaterial.Id is Guid id)
+        {
+          Rhino.Render.RenderMaterial renderMaterial = RhinoDoc.ActiveDoc.RenderMaterials.Find(id);
+          renderMaterial.ToMaterial(RenderTexture.TextureGeneration.Allow);
+          Value = new()
+          {
+            Base = ToSpeckleRenderMaterial(renderMaterial),
+            RhinoMaterial = renderMaterial.ToMaterial(RenderTexture.TextureGeneration.Allow)
+          };
+
+          return true;
+        }
+
+        return false;
     }
 
     return false;

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/SpecklePropertyGroupWrapper.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/SpecklePropertyGroupWrapper.cs
@@ -78,7 +78,6 @@ public partial class SpecklePropertyGroupGoo : GH_Goo<Dictionary<string, Speckle
       return true;
     }
 
-    // TODO: cast to material, model object, etc.
     return false;
   }
 


### PR DESCRIPTION
This casting will *exclude* render materials for now, because I'm avoiding baking anything to doc during cast.
We can later modify this to look for existing materials and pass that through, in the case of a speckle object with a mat that already exists, if needed.