### PR TITLE
fix(civil3d): alignment spiral direction throws exception

### DIFF
--- a/Converters/Civil3d/Speckle.Converters.Civil3dShared/Helpers/CorridorHandler.cs
+++ b/Converters/Civil3d/Speckle.Converters.Civil3dShared/Helpers/CorridorHandler.cs
@@ -1,7 +1,6 @@
 using Speckle.Converters.Civil3dShared.Extensions;
 using Speckle.Converters.Common;
 using Speckle.Converters.Common.Objects;
-using Speckle.Sdk;
 using Speckle.Sdk.Models;
 
 namespace Speckle.Converters.Civil3dShared.Helpers;

--- a/Converters/Civil3d/Speckle.Converters.Civil3dShared/Helpers/CorridorHandler.cs
+++ b/Converters/Civil3d/Speckle.Converters.Civil3dShared/Helpers/CorridorHandler.cs
@@ -204,15 +204,12 @@ public sealed class CorridorHandler
 
           Dictionary<string, object?> appliedAssemblyDict =
             new() { ["assemblyId"] = appliedAssembly.AssemblyId.GetSpeckleApplicationId(), ["station"] = station };
-
-          try
-          {
-            appliedAssemblyDict["adjustedElevation"] = appliedAssembly.AdjustedElevation;
-          }
-          catch (ArgumentException e) when (!e.IsFatal())
-          {
-            // Do nothing. Leave the value as null. Not sure why accessing adjusted elevation sometimes throws.
-          }
+          PropertyHandler propHandler = new();
+          propHandler.TryAddToDictionary(
+            appliedAssemblyDict,
+            "adjustedElevation",
+            () => appliedAssembly.AdjustedElevation
+          ); // can throw
 
           // get the applied assembly's applied subassemblies
           Dictionary<string, object?> appliedSubassemblies = new();

--- a/Converters/Civil3d/Speckle.Converters.Civil3dShared/Helpers/PropertyHandler.cs
+++ b/Converters/Civil3d/Speckle.Converters.Civil3dShared/Helpers/PropertyHandler.cs
@@ -17,6 +17,7 @@ public sealed class PropertyHandler
     catch (Exception e)
       when (e is InvalidOperationException
         || e is ArgumentException argEx && !argEx.IsFatal()
+        || e is Autodesk.AutoCAD.Runtime.Exception acEx && !acEx.IsFatal() // eNotApplicable
         || e is Autodesk.Civil.CivilException civilEx && !civilEx.IsFatal()
       )
     {

--- a/Converters/Civil3d/Speckle.Converters.Civil3dShared/Helpers/PropertyHandler.cs
+++ b/Converters/Civil3d/Speckle.Converters.Civil3dShared/Helpers/PropertyHandler.cs
@@ -1,0 +1,43 @@
+using Speckle.Sdk;
+
+namespace Speckle.Converters.Civil3dShared.Helpers;
+
+/// <summary>
+/// Used to help with properties on classes that may throw exceptions when accessed
+/// </summary>
+public sealed class PropertyHandler
+{
+  public bool TryGetValue<T>(Func<T> getValue, out T? value)
+  {
+    try
+    {
+      value = getValue();
+      return true;
+    }
+    catch (Exception e)
+      when (e is InvalidOperationException
+        || e is ArgumentException argEx && !argEx.IsFatal()
+        || e is Autodesk.Civil.CivilException civilEx && !civilEx.IsFatal()
+      )
+    {
+      value = default;
+      return false;
+    }
+  }
+
+  public bool TryAddToDictionary<T>(Dictionary<string, object?> dict, string key, Func<T> getValue)
+  {
+    if (dict.ContainsKey(key))
+    {
+      return false;
+    }
+
+    if (TryGetValue<T>(getValue, out var value))
+    {
+      dict.Add(key, value);
+      return true;
+    }
+
+    return false;
+  }
+}

--- a/Converters/Civil3d/Speckle.Converters.Civil3dShared/Speckle.Converters.Civil3dShared.projitems
+++ b/Converters/Civil3d/Speckle.Converters.Civil3dShared/Speckle.Converters.Civil3dShared.projitems
@@ -15,6 +15,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Civil3dToSpeckleUnitConverter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\SpeckleApplicationIdExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)GlobalUsings.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Helpers\PropertyHandler.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Helpers\CorridorDisplayValueExtractor.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Helpers\CorridorHandler.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Helpers\BaseCurveExtractor.cs" />

--- a/Converters/Civil3d/Speckle.Converters.Civil3dShared/ToSpeckle/Properties/ClassPropertiesExtractor.cs
+++ b/Converters/Civil3d/Speckle.Converters.Civil3dShared/ToSpeckle/Properties/ClassPropertiesExtractor.cs
@@ -1,6 +1,7 @@
 using System.Reflection;
 using Autodesk.Civil.Runtime;
 using Speckle.Converters.Civil3dShared.Extensions;
+using Speckle.Converters.Civil3dShared.Helpers;
 using Speckle.Converters.Common;
 
 namespace Speckle.Converters.Civil3dShared.ToSpeckle;
@@ -419,12 +420,8 @@ public class ClassPropertiesExtractor
             ["isBreak"] = point.IsBreak
           };
 
-        // not all points have offsets. Accessing the offset property in this case will throw.
-        try
-        {
-          pointPropertiesDict["offset"] = point.Offset;
-        }
-        catch (ArgumentException) { } // do nothing - offset property will not be included
+        PropertyHandler propHandler = new();
+        propHandler.TryAddToDictionary(pointPropertiesDict, "offset", () => point.Offset); // not all points have offsets, will throw
 
         pointsDict[pointCount.ToString()] = pointPropertiesDict;
         pointCount++;
@@ -576,20 +573,19 @@ public class ClassPropertiesExtractor
     // get offset alignment props
     if (alignment.IsOffsetAlignment)
     {
-      try
+      // accessing "OffsetAlignmentInfo" on offset alignments will sometimes throw /shrug.
+      // this happens when an offset alignment is unlinked from the parent and the CreateMode is still set to "ManuallyCreation"
+      // https://help.autodesk.com/view/CIV3D/2024/ENU/?guid=2ecbe421-4c08-cbde-d078-56a9f03b93f9
+      PropertyHandler propHandler = new();
+      if (propHandler.TryGetValue(() => alignment.OffsetAlignmentInfo, out CDB.OffsetAlignmentInfo? offsetInfo))
       {
-        // accessing "OffsetAlignmentInfo" on offset alignments will sometimes throw /shrug.
-        // this happens when an offset alignment is unlinked from the parent and the CreateMode is still set to "ManuallyCreation"
-        // https://help.autodesk.com/view/CIV3D/2024/ENU/?guid=2ecbe421-4c08-cbde-d078-56a9f03b93f9
-        var offsetInfo = alignment.OffsetAlignmentInfo;
         properties["Offset Parameters"] = new Dictionary<string, object?>
         {
-          ["side"] = offsetInfo.Side.ToString(),
-          ["parentAlignmentId"] = offsetInfo.ParentAlignmentId.GetSpeckleApplicationId(),
-          ["nominalOffset"] = offsetInfo.NominalOffset
+          ["side"] = offsetInfo?.Side.ToString(),
+          ["parentAlignmentId"] = offsetInfo?.ParentAlignmentId.GetSpeckleApplicationId(),
+          ["nominalOffset"] = offsetInfo?.NominalOffset
         };
       }
-      catch (InvalidOperationException) { } // do nothing
     }
 
     return properties;

--- a/Converters/Civil3d/Speckle.Converters.Civil3dShared/ToSpeckle/Properties/PropertySetDefinitionHandler.cs
+++ b/Converters/Civil3d/Speckle.Converters.Civil3dShared/ToSpeckle/Properties/PropertySetDefinitionHandler.cs
@@ -1,4 +1,4 @@
-using Speckle.Sdk;
+using Speckle.Converters.Civil3dShared.Helpers;
 
 namespace Speckle.Converters.Civil3dShared.ToSpeckle;
 
@@ -37,12 +37,9 @@ public class PropertySetDefinitionHandler
         ["defaultValue"] = propertyDefinition.DefaultData
       };
 
-      try
-      {
-        // accessing unit type prop can be expected to throw if it's not applicable to the definition
-        propertyDict["units"] = propertyDefinition.UnitType.GetTypeDisplayName(true);
-      }
-      catch (Exception e) when (!e.IsFatal()) { }
+      // accessing unit type prop can be expected to throw if it's not applicable to the definition
+      PropertyHandler propHandler = new();
+      propHandler.TryAddToDictionary(propertyDict, "units", () => propertyDefinition.UnitType.GetTypeDisplayName(true));
 
       propertyDefinitionsDict[propertyName] = propertyDict;
     }

--- a/Converters/Civil3d/Speckle.Converters.Civil3dShared/ToSpeckle/Properties/PropertySetExtractor.cs
+++ b/Converters/Civil3d/Speckle.Converters.Civil3dShared/ToSpeckle/Properties/PropertySetExtractor.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.Logging;
+using Speckle.Converters.Civil3dShared.Helpers;
 using Speckle.Converters.Common;
 using Speckle.Sdk;
 
@@ -92,14 +93,9 @@ public class PropertySetExtractor
 
         var value = GetValue(data);
 
-        var propertyValueDict = new Dictionary<string, object?>() { ["value"] = value, ["name"] = dataName };
-
-        try
-        {
-          // accessing unit type prop can be expected to throw if it's not applicable to the definition
-          propertyValueDict["units"] = data.UnitType.GetTypeDisplayName(true);
-        }
-        catch (Exception e) when (!e.IsFatal()) { }
+        Dictionary<string, object?> propertyValueDict = new() { ["value"] = value, ["name"] = dataName };
+        PropertyHandler propHandler = new();
+        propHandler.TryAddToDictionary(propertyValueDict, "units", () => data.UnitType.GetTypeDisplayName(true)); // units not always applicable to def, will throw
 
         properties[dataName] = propertyValueDict;
       }

--- a/Converters/Civil3d/Speckle.Converters.Civil3dShared/ToSpeckle/Raw/AlignmentSubentityArcToSpeckleRawConverter.cs
+++ b/Converters/Civil3d/Speckle.Converters.Civil3dShared/ToSpeckle/Raw/AlignmentSubentityArcToSpeckleRawConverter.cs
@@ -1,3 +1,4 @@
+using Speckle.Converters.Civil3dShared.Helpers;
 using Speckle.Converters.Common;
 using Speckle.Converters.Common.Objects;
 
@@ -74,16 +75,18 @@ public class AlignmentSubentityArcToSpeckleRawConverter : ITypedConverter<CDB.Al
           units = units
         },
         plane = _planeConverter.Convert(plane),
-        units = units,
-
-        // additional alignment subentity props
-        ["startStation"] = target.StartStation,
-        ["endStation"] = target.EndStation,
-        ["startDirection"] = target.StartDirection,
-        ["endDirection"] = target.EndDirection,
-        ["deflectedAngle"] = target.DeflectedAngle,
-        ["minumumRadius"] = target.MinimumRadius
+        units = units
       };
+
+    // create a properties dictionary for additional props
+    Dictionary<string, object?> props =
+      new() { ["startStation"] = target.StartStation, ["endStation"] = target.EndStation };
+    PropertyHandler propHandler = new();
+    propHandler.TryAddToDictionary(props, "startDirection", () => target.StartDirection); // might throw
+    propHandler.TryAddToDictionary(props, "endDirection", () => target.EndDirection); // might throw
+    propHandler.TryAddToDictionary(props, "deflectedAngle", () => target.DeflectedAngle); // might throw
+    propHandler.TryAddToDictionary(props, "minumumRadius", () => target.MinimumRadius); // might throw
+    arc["properties"] = props;
 
     return arc;
   }

--- a/Converters/Civil3d/Speckle.Converters.Civil3dShared/ToSpeckle/Raw/AlignmentSubentityLineToSpeckleRawConverter.cs
+++ b/Converters/Civil3d/Speckle.Converters.Civil3dShared/ToSpeckle/Raw/AlignmentSubentityLineToSpeckleRawConverter.cs
@@ -1,3 +1,4 @@
+using Speckle.Converters.Civil3dShared.Helpers;
 using Speckle.Converters.Common;
 using Speckle.Converters.Common.Objects;
 
@@ -34,16 +35,20 @@ public class AlignmentSubentityLineToSpeckleRawConverter : ITypedConverter<CDB.A
         units = _settingsStore.Current.SpeckleUnits
       };
 
-    return new()
-    {
-      start = start,
-      end = end,
-      units = _settingsStore.Current.SpeckleUnits,
+    SOG.Line line =
+      new()
+      {
+        start = start,
+        end = end,
+        units = _settingsStore.Current.SpeckleUnits
+      };
 
-      // additional alignment props
-      ["direction"] = target.Direction,
-      ["startStation"] = target.StartStation,
-      ["endStation"] = target.EndStation
-    };
+    // create a properties dictionary for additional props
+    PropertyHandler propHandler = new();
+    Dictionary<string, object?> props =
+      new() { ["startStation"] = target.StartStation, ["endStation"] = target.EndStation };
+    propHandler.TryAddToDictionary(props, "direction", () => target.Direction); // may throw
+    line["properties"] = props;
+    return line;
   }
 }

--- a/Converters/Civil3d/Speckle.Converters.Civil3dShared/ToSpeckle/TopLevel/CivilEntityToSpeckleTopLevelConverter.cs
+++ b/Converters/Civil3d/Speckle.Converters.Civil3dShared/ToSpeckle/TopLevel/CivilEntityToSpeckleTopLevelConverter.cs
@@ -4,7 +4,6 @@ using Speckle.Converters.Common;
 using Speckle.Converters.Common.Objects;
 using Speckle.Objects;
 using Speckle.Objects.Data;
-using Speckle.Sdk;
 using Speckle.Sdk.Models;
 
 namespace Speckle.Converters.Civil3dShared.ToSpeckle.TopLevel;
@@ -40,12 +39,10 @@ public class CivilEntityToSpeckleTopLevelConverter : IToSpeckleTopLevelConverter
 
   public Civil3dObject Convert(CDB.Entity target)
   {
-    string name = target.DisplayName;
-    try
-    {
-      name = target.Name; // this will throw for some entities like labels
-    }
-    catch (Exception e) when (!e.IsFatal()) { }
+    PropertyHandler propHandler = new();
+    string name = propHandler.TryGetValue(() => target.Name, out string? tarName)
+      ? tarName ?? target.DisplayName
+      : target.DisplayName; // this will throw for some entities like labels
 
     // get basecurve
     List<ICurve>? baseCurves = _baseCurveExtractor.GetBaseCurves(target);

--- a/Converters/Civil3d/Speckle.Converters.Civil3dShared/ToSpeckle/TopLevel/CogoPointToSpeckleTopLevelConverter.cs
+++ b/Converters/Civil3d/Speckle.Converters.Civil3dShared/ToSpeckle/TopLevel/CogoPointToSpeckleTopLevelConverter.cs
@@ -1,8 +1,8 @@
 using Speckle.Converters.Civil3dShared.Extensions;
+using Speckle.Converters.Civil3dShared.Helpers;
 using Speckle.Converters.Common;
 using Speckle.Converters.Common.Objects;
 using Speckle.Objects.Data;
-using Speckle.Sdk;
 using Speckle.Sdk.Models;
 
 namespace Speckle.Converters.Civil3dShared.ToSpeckle.TopLevel;
@@ -31,12 +31,8 @@ public class CogoPointToSpeckleTopLevelConverter : IToSpeckleTopLevelConverter
 
   public Civil3dObject Convert(CDB.CogoPoint target)
   {
-    string name = "";
-    try
-    {
-      name = target.PointName;
-    }
-    catch (Autodesk.Civil.CivilException e) when (!e.IsFatal()) { } // throws if name doesn't exist
+    PropertyHandler propHandler = new();
+    string? name = propHandler.TryGetValue(() => target.PointName, out string? pointName) ? pointName : ""; // throws if name doesnt exist
 
     // extract display value as point
     SOG.Point displayPoint = _pointConverter.Convert(target.Location);
@@ -47,7 +43,7 @@ public class CogoPointToSpeckleTopLevelConverter : IToSpeckleTopLevelConverter
     Civil3dObject civilObject =
       new()
       {
-        name = name,
+        name = name ?? "",
         type = target.GetType().ToString().Split('.').Last(),
         baseCurves = null,
         elements = new(),

--- a/Speckle.Connectors.sln
+++ b/Speckle.Connectors.sln
@@ -10,9 +10,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Config", "Config", "{85A13E
 		CodeMetricsConfig.txt = CodeMetricsConfig.txt
 		Directory.Build.props = Directory.Build.props
 		Directory.Packages.props = Directory.Packages.props
+		.config\dotnet-tools.json = .config\dotnet-tools.json
 		global.json = global.json
 		README.md = README.md
-		.config\dotnet-tools.json = .config\dotnet-tools.json
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Revit", "Revit", "{D92751C8-1039-4005-90B2-913E55E0B8BD}"
@@ -867,6 +867,8 @@ Global
 		Converters\Navisworks\Speckle.Converters.NavisworksShared\Speckle.Converters.NavisworksShared.projitems*{0b5ab325-3791-4a81-b0ef-bca040381be2}*SharedItemsImports = 5
 		Connectors\CSi\Speckle.Connectors.CsiShared\Speckle.Connectors.CsiShared.projitems*{115d6106-1801-484a-b4e5-bcc94b6e5c7f}*SharedItemsImports = 5
 		Connectors\CSi\Speckle.Connectors.ETABSShared\Speckle.Connectors.ETABSShared.projitems*{115d6106-1801-484a-b4e5-bcc94b6e5c7f}*SharedItemsImports = 5
+		Converters\Autocad\Speckle.Converters.AutocadShared\Speckle.Converters.AutocadShared.projitems*{17afd669-aecb-4a45-ae09-bd1bf8248bda}*SharedItemsImports = 5
+		Converters\Civil3d\Speckle.Converters.Civil3dShared\Speckle.Converters.Civil3dShared.projitems*{17afd669-aecb-4a45-ae09-bd1bf8248bda}*SharedItemsImports = 5
 		Converters\Revit\Speckle.Converters.RevitShared\Speckle.Converters.RevitShared.projitems*{19424b55-058c-4e9c-b86f-700aef9eaec3}*SharedItemsImports = 5
 		Converters\CSi\Speckle.Converters.CSiShared\Speckle.Converters.CSiShared.projitems*{1b5c5fb2-3b22-4371-9aa5-3edf3b4d62de}*SharedItemsImports = 13
 		Connectors\Rhino\Speckle.Connectors.RhinoShared\Speckle.Connectors.RhinoShared.projitems*{1e2644a9-6b31-4350-8772-ceaad6ee0b21}*SharedItemsImports = 5
@@ -887,6 +889,7 @@ Global
 		Converters\Navisworks\Speckle.Converters.NavisworksShared\Speckle.Converters.NavisworksShared.projitems*{56680ea7-3599-4d88-83a5-b43ba93ac046}*SharedItemsImports = 5
 		Converters\Rhino\Speckle.Converters.RhinoShared\Speckle.Converters.RhinoShared.projitems*{56a909ae-6e99-4d4d-a22e-38bdc5528b8e}*SharedItemsImports = 5
 		Converters\Navisworks\Speckle.Converters.NavisworksShared\Speckle.Converters.NavisworksShared.projitems*{57afb8cb-b310-49e4-9c53-621a614063cf}*SharedItemsImports = 5
+		Converters\Autocad\Speckle.Converters.AutocadShared\Speckle.Converters.AutocadShared.projitems*{57d5eec9-082c-4882-ba7a-956088a2b820}*SharedItemsImports = 5
 		Converters\Autocad\Speckle.Converters.AutocadShared\Speckle.Converters.AutocadShared.projitems*{5cdec958-708e-4d19-a79e-0c1db23a6039}*SharedItemsImports = 5
 		Converters\Civil3d\Speckle.Converters.Civil3dShared\Speckle.Converters.Civil3dShared.projitems*{5cdec958-708e-4d19-a79e-0c1db23a6039}*SharedItemsImports = 5
 		Connectors\CSi\Speckle.Connectors.ETABSShared\Speckle.Connectors.ETABSShared.projitems*{5d1e0b0d-56a7-4e13-b9a9-8633e02b8f17}*SharedItemsImports = 13
@@ -897,14 +900,13 @@ Global
 		Converters\Autocad\Speckle.Converters.AutocadShared\Speckle.Converters.AutocadShared.projitems*{631c295a-7ccf-4b42-8686-7034e31469e7}*SharedItemsImports = 5
 		Converters\Rhino\Speckle.Converters.RhinoShared\Speckle.Converters.RhinoShared.projitems*{65a2f556-f14a-49f3-8a92-7f2e1e7ed3b5}*SharedItemsImports = 5
 		Converters\Revit\Speckle.Converters.RevitShared\Speckle.Converters.RevitShared.projitems*{67b888d9-c6c4-49f1-883c-5b964151d889}*SharedItemsImports = 5
-		Converters\Revit\Speckle.Converters.RevitShared.Tests\Speckle.Converters.RevitShared.Tests.projitems*{68cf9bdf-94ac-4d2d-a7bd-d1c064f97051}*SharedItemsImports = 5
-		Converters\Revit\Speckle.Converters.RevitShared\Speckle.Converters.RevitShared.projitems*{68cf9bdf-94ac-4d2d-a7bd-d1c064f97051}*SharedItemsImports = 5
 		Connectors\Revit\Speckle.Connectors.RevitShared.Cef\Speckle.Connectors.RevitShared.Cef.projitems*{6a40cbe4-ecab-4ced-9917-5c64cbf75da6}*SharedItemsImports = 13
 		Connectors\Navisworks\Speckle.Connectors.NavisworksShared\Speckle.Connectors.NavisworksShared.projitems*{7791806e-7531-41d8-9c9d-4a1249d9f99c}*SharedItemsImports = 5
 		Converters\CSi\Speckle.Converters.CSiShared\Speckle.Converters.CSiShared.projitems*{791e3288-8001-4d54-8eab-03d1d7f51044}*SharedItemsImports = 5
 		Converters\CSi\Speckle.Converters.ETABSShared\Speckle.Converters.ETABSShared.projitems*{791e3288-8001-4d54-8eab-03d1d7f51044}*SharedItemsImports = 5
 		Connectors\CSi\Speckle.Connectors.CsiShared\Speckle.Connectors.CsiShared.projitems*{7c49337a-6f7b-47ab-b549-42e799e89cf2}*SharedItemsImports = 5
 		Connectors\CSi\Speckle.Connectors.ETABSShared\Speckle.Connectors.ETABSShared.projitems*{7c49337a-6f7b-47ab-b549-42e799e89cf2}*SharedItemsImports = 5
+		Connectors\Autocad\Speckle.Connectors.AutocadShared\Speckle.Connectors.AutocadShared.projitems*{7d3e31a4-9c75-4b9b-835d-afde85a25469}*SharedItemsImports = 5
 		Connectors\Revit\Speckle.Connectors.RevitShared.Cef\Speckle.Connectors.RevitShared.Cef.projitems*{7f1fdcf2-0ce8-4119-b3c1-f2cc6d7e1c36}*SharedItemsImports = 5
 		Connectors\Revit\Speckle.Connectors.RevitShared\Speckle.Connectors.RevitShared.projitems*{7f1fdcf2-0ce8-4119-b3c1-f2cc6d7e1c36}*SharedItemsImports = 5
 		Connectors\Autocad\Speckle.Connectors.AutocadShared\Speckle.Connectors.AutocadShared.projitems*{81fcee13-feac-475d-9ef9-71132ef26909}*SharedItemsImports = 5
@@ -923,7 +925,6 @@ Global
 		Connectors\Revit\Speckle.Connectors.RevitShared\Speckle.Connectors.RevitShared.projitems*{a6de3da0-b242-4f49-aef0-4e26af92d16c}*SharedItemsImports = 5
 		Connectors\Rhino\Speckle.Connectors.RhinoShared\Speckle.Connectors.RhinoShared.projitems*{a6e3a82f-4696-4d92-aba1-38aa80752067}*SharedItemsImports = 5
 		Connectors\CSi\Speckle.Connectors.CsiShared\Speckle.Connectors.CsiShared.projitems*{a8e949b8-aa55-4909-99f0-8b551791a1f8}*SharedItemsImports = 13
-		Converters\Rhino\Speckle.Converters.RhinoShared\Speckle.Converters.RhinoShared.projitems*{ac2db416-f05c-4296-9040-56d6ad4fcd27}*SharedItemsImports = 5
 		Converters\Tekla\Speckle.Converters.TeklaShared\Speckle.Converters.TeklaShared.projitems*{acf75860-7fce-4ae9-8c45-68ad1043550b}*SharedItemsImports = 5
 		Connectors\Autocad\Speckle.Connectors.AutocadShared\Speckle.Connectors.AutocadShared.projitems*{afab80bd-a4dd-4cad-9937-acbfed668a48}*SharedItemsImports = 5
 		Connectors\Autocad\Speckle.Connectors.Civil3dShared\Speckle.Connectors.Civil3dShared.projitems*{afab80bd-a4dd-4cad-9937-acbfed668a48}*SharedItemsImports = 5
@@ -932,22 +933,22 @@ Global
 		Connectors\Navisworks\Speckle.Connectors.NavisworksShared\Speckle.Connectors.NavisworksShared.projitems*{b6985672-4704-4f86-a3e0-2310bf8e6d73}*SharedItemsImports = 5
 		Connectors\Autocad\Speckle.Connectors.AutocadShared\Speckle.Connectors.AutocadShared.projitems*{bbf2c19e-221e-4aa0-8521-fe75d8f4a2b0}*SharedItemsImports = 5
 		Converters\Autocad\Speckle.Converters.AutocadShared\Speckle.Converters.AutocadShared.projitems*{c2de264a-aa87-4012-b954-17e3f403a237}*SharedItemsImports = 5
-		Converters\Revit\Speckle.Converters.RevitShared.Tests\Speckle.Converters.RevitShared.Tests.projitems*{c32274d9-1b66-4d5c-82f9-eb3f10f46752}*SharedItemsImports = 5
-		Converters\Revit\Speckle.Converters.RevitShared\Speckle.Converters.RevitShared.projitems*{c32274d9-1b66-4d5c-82f9-eb3f10f46752}*SharedItemsImports = 5
 		Connectors\Navisworks\Speckle.Connectors.NavisworksShared\Speckle.Connectors.NavisworksShared.projitems*{c635619c-2938-4e6f-9e25-56ce1632a7ec}*SharedItemsImports = 5
 		Connectors\Autocad\Speckle.Connectors.AutocadShared\Speckle.Connectors.AutocadShared.projitems*{c70ebb84-ba5b-4f2f-819e-25e0985ba13c}*SharedItemsImports = 5
 		Connectors\Autocad\Speckle.Connectors.AutocadShared\Speckle.Connectors.AutocadShared.projitems*{ca8eae01-ab9f-4ec1-b6f3-73721487e9e1}*SharedItemsImports = 5
 		Connectors\Autocad\Speckle.Connectors.Civil3dShared\Speckle.Connectors.Civil3dShared.projitems*{ca8eae01-ab9f-4ec1-b6f3-73721487e9e1}*SharedItemsImports = 5
 		Converters\CSi\Speckle.Converters.CSiShared\Speckle.Converters.CSiShared.projitems*{d61ecd90-3d17-4af0-8b1a-0e0ad302dff9}*SharedItemsImports = 5
 		Converters\CSi\Speckle.Converters.ETABSShared\Speckle.Converters.ETABSShared.projitems*{d61ecd90-3d17-4af0-8b1a-0e0ad302dff9}*SharedItemsImports = 5
-		Converters\Revit\Speckle.Converters.RevitShared.Tests\Speckle.Converters.RevitShared.Tests.projitems*{d8069a23-ad2e-4c9e-8574-7e8c45296a46}*SharedItemsImports = 5
-		Converters\Revit\Speckle.Converters.RevitShared\Speckle.Converters.RevitShared.projitems*{d8069a23-ad2e-4c9e-8574-7e8c45296a46}*SharedItemsImports = 5
 		Converters\Autocad\Speckle.Converters.AutocadShared\Speckle.Converters.AutocadShared.projitems*{db31e57b-60fc-49be-91e0-1374290bcf03}*SharedItemsImports = 5
 		Converters\Civil3d\Speckle.Converters.Civil3dShared\Speckle.Converters.Civil3dShared.projitems*{db31e57b-60fc-49be-91e0-1374290bcf03}*SharedItemsImports = 5
 		Connectors\Revit\Speckle.Connectors.RevitShared\Speckle.Connectors.RevitShared.projitems*{dc570fff-6fe5-47bd-8bc1-b471a6067786}*SharedItemsImports = 13
 		Converters\Revit\Speckle.Converters.RevitShared\Speckle.Converters.RevitShared.projitems*{e1c43415-3200-45f4-8bf9-a4dd7d7f2ed6}*SharedItemsImports = 13
 		Converters\Rhino\Speckle.Converters.RhinoShared\Speckle.Converters.RhinoShared.projitems*{e1c43415-3200-45f4-8bf9-a4dd7d7f2ed9}*SharedItemsImports = 13
 		Converters\Revit\Speckle.Converters.RevitShared.Tests\Speckle.Converters.RevitShared.Tests.projitems*{e1c43415-3202-45f4-8bf9-a4dd7d7f2ed6}*SharedItemsImports = 13
+		Connectors\Autocad\Speckle.Connectors.AutocadShared\Speckle.Connectors.AutocadShared.projitems*{ec0e8472-2c5f-424b-b868-7bba272df611}*SharedItemsImports = 5
+		Connectors\Autocad\Speckle.Connectors.Civil3dShared\Speckle.Connectors.Civil3dShared.projitems*{ec0e8472-2c5f-424b-b868-7bba272df611}*SharedItemsImports = 5
+		Converters\Navisworks\Speckle.Converters.NavisworksShared\Speckle.Converters.NavisworksShared.projitems*{f8cc203d-e0dc-42da-99c1-ca07fdbceccc}*SharedItemsImports = 5
 		Connectors\Navisworks\Speckle.Connectors.NavisworksShared\Speckle.Connectors.NavisworksShared.projitems*{fd44e1f0-d20a-49b6-adc9-482d911a74fb}*SharedItemsImports = 5
+		Connectors\Navisworks\Speckle.Connectors.NavisworksShared\Speckle.Connectors.NavisworksShared.projitems*{fe797118-07cb-44a7-a779-68ff3b69ee40}*SharedItemsImports = 5
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
## Description
 Fixes exceptions thrown by accessing props on alignments.
Adds a `PropertyHandler` class to do so, and refactors other converters to use this class for consistent handling.

Fixes: #691

## User Value

no more borked conversions due to properties throwing.


## Changes:

- Civil converter

## Screenshots:

https://app.speckle.systems/projects/275e9da5c4/models/66da2623d1

## Validation of changes:

Tested on provided file

## Checklist:

