### PR TITLE
feat(grasshopper): adds casting of collections to model layers

### DIFF
--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Receive/ReceiveAsyncComponent.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Receive/ReceiveAsyncComponent.cs
@@ -52,7 +52,7 @@ public class ReceiveAsyncComponent : GH_AsyncComponent
   public GrasshopperReceiveOperation ReceiveOperation { get; private set; }
   public RootObjectUnpacker RootObjectUnpacker { get; private set; }
   public static IServiceScope? Scope { get; private set; }
-  public AccountService AccountManager { get; private set; }
+  public IAccountService AccountManager { get; private set; }
   public IClientFactory ClientFactory { get; private set; }
 
   protected override void RegisterInputParams(GH_InputParamManager pManager)
@@ -79,7 +79,7 @@ public class ReceiveAsyncComponent : GH_AsyncComponent
     Scope = PriorityLoader.Container.CreateScope();
     ReceiveOperation = Scope.ServiceProvider.GetRequiredService<GrasshopperReceiveOperation>();
     RootObjectUnpacker = Scope.ServiceProvider.GetService<RootObjectUnpacker>();
-    AccountManager = Scope.ServiceProvider.GetRequiredService<AccountService>();
+    AccountManager = Scope.ServiceProvider.GetRequiredService<IAccountService>();
     ClientFactory = Scope.ServiceProvider.GetRequiredService<IClientFactory>();
 
     // We need to call this always in here to be able to react and set events :/

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Receive/ReceiveComponent.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Receive/ReceiveComponent.cs
@@ -103,7 +103,7 @@ public class ReceiveComponent : SpeckleScopedTaskCapableComponent<ReceiveCompone
     }
 
     // TODO: Resolving dependencies here may be overkill in most cases. Must re-evaluate.
-    var accountManager = scope.ServiceProvider.GetRequiredService<AccountService>();
+    var accountManager = scope.ServiceProvider.GetRequiredService<IAccountService>();
     var clientFactory = scope.ServiceProvider.GetRequiredService<IClientFactory>();
     var receiveOperation = scope.ServiceProvider.GetRequiredService<GrasshopperReceiveOperation>();
 

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Send/SendAsyncComponent.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Send/SendAsyncComponent.cs
@@ -131,7 +131,7 @@ public class SendAsyncComponent : GH_AsyncComponent
     Scope = PriorityLoader.Container.CreateScope();
     SendOperation = Scope.ServiceProvider.GetRequiredService<SendOperation<SpeckleCollectionWrapperGoo>>();
 
-    var accountManager = Scope.ServiceProvider.GetRequiredService<AccountService>();
+    var accountManager = Scope.ServiceProvider.GetRequiredService<IAccountService>();
     var clientFactory = Scope.ServiceProvider.GetRequiredService<IClientFactory>();
 
     // We need to call this always in here to be able to react and set events :/
@@ -215,7 +215,7 @@ public class SendAsyncComponent : GH_AsyncComponent
     base.DocumentContextChanged(document, context);
   }
 
-  private void ParseInput(IGH_DataAccess da, AccountService accountManager, IClientFactory clientFactory)
+  private void ParseInput(IGH_DataAccess da, IAccountService accountManager, IClientFactory clientFactory)
   {
     HostApp.SpeckleUrlModelResource? dataInput = null;
     da.GetData(0, ref dataInput);

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Send/SendComponent.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Send/SendComponent.cs
@@ -133,7 +133,7 @@ public class SendComponent : SpeckleScopedTaskCapableComponent<SendComponentInpu
       return new(null);
     }
 
-    var accountManager = scope.ServiceProvider.GetRequiredService<AccountService>();
+    var accountManager = scope.ServiceProvider.GetRequiredService<IAccountService>();
     var clientFactory = scope.ServiceProvider.GetRequiredService<IClientFactory>();
     var sendOperation = scope.ServiceProvider.GetRequiredService<SendOperation<SpeckleCollectionWrapperGoo>>();
 

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/SpeckleSelectModelComponent.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/SpeckleSelectModelComponent.cs
@@ -29,7 +29,7 @@ public class SpeckleSelectModelComponent : GH_Component
   private string? _storedModelId;
   private string? _storedVersionId;
 
-  private readonly AccountService _accountService;
+  private readonly IAccountService _accountService;
   private readonly AccountManager _accountManager;
   private readonly IClientFactory _clientFactory;
 
@@ -72,7 +72,7 @@ public class SpeckleSelectModelComponent : GH_Component
     );
 
     Attributes = new SpeckleSelectModelComponentAttributes(this);
-    _accountService = PriorityLoader.Container.GetRequiredService<AccountService>();
+    _accountService = PriorityLoader.Container.GetRequiredService<IAccountService>();
     _accountManager = PriorityLoader.Container.GetRequiredService<AccountManager>();
     _clientFactory = PriorityLoader.Container.GetRequiredService<IClientFactory>();
     var account = _accountManager.GetDefaultAccount();

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Operations/Receive/GrasshopperReceiveOperation.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Operations/Receive/GrasshopperReceiveOperation.cs
@@ -10,7 +10,7 @@ namespace Speckle.Connectors.GrasshopperShared.Operations.Receive;
 
 public class GrasshopperReceiveOperation
 {
-  private readonly AccountService _accountService;
+  private readonly IAccountService _accountService;
   private readonly IServerTransportFactory _serverTransportFactory;
   private readonly IProgressDisplayManager _progressDisplayManager;
   private readonly ISdkActivityFactory _activityFactory;
@@ -18,7 +18,7 @@ public class GrasshopperReceiveOperation
   private readonly IClientFactory _clientFactory;
 
   public GrasshopperReceiveOperation(
-    AccountService accountService,
+    IAccountService accountService,
     IServerTransportFactory serverTransportFactory,
     IProgressDisplayManager progressDisplayManager,
     ISdkActivityFactory activityFactory,

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/SpeckleCollectionWrapper.ModelObjects.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/SpeckleCollectionWrapper.ModelObjects.cs
@@ -9,6 +9,50 @@ namespace Speckle.Connectors.GrasshopperShared.Parameters;
 
 public partial class SpeckleCollectionWrapperGoo : GH_Goo<SpeckleCollectionWrapper>, ISpeckleGoo //, IGH_PreviewData // can be made previewable later
 {
+  private bool CastToModelLayer<T>(ref T target)
+  {
+    var type = typeof(T);
+
+    if (type == typeof(ModelLayer))
+    {
+      // create attributes
+      ModelLayer.Attributes atts = new();
+      CastTo<ModelLayer.Attributes>(ref atts);
+      ModelLayer modelLayer = new(atts);
+      target = (T)(object)modelLayer;
+      return true;
+    }
+
+    if (type == typeof(ModelLayer.Attributes))
+    {
+      ModelContentName path = string.Join(ModelContentName.Separator, Value.Path);
+      ModelLayer.Attributes atts = new() { Name = Value.Collection.name, Path = path };
+
+      if (Value.Color is Color color)
+      {
+        atts.DisplayColor = color;
+      }
+
+      // POC: only set material if it exists in the doc. Avoiding baking during cast.
+      if (
+        Value.Material is SpeckleMaterialWrapper materialWrapper
+        && materialWrapper.RhinoRenderMaterialId != Guid.Empty
+      )
+      {
+        Rhino.Render.RenderMaterial renderMaterial = RhinoDoc.ActiveDoc.RenderMaterials.Find(
+          materialWrapper.RhinoRenderMaterialId
+        );
+
+        atts.Material = renderMaterial;
+      }
+
+      target = (T)(object)atts;
+      return true;
+    }
+
+    return false;
+  }
+
   private bool CastFromModelLayer(object source)
   {
     if (source is ModelLayer modelLayer)

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/SpeckleCollectionWrapper.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/SpeckleCollectionWrapper.cs
@@ -191,7 +191,14 @@ public partial class SpeckleCollectionWrapperGoo : GH_Goo<SpeckleCollectionWrapp
 
 #if !RHINO8_OR_GREATER
   private bool CastFromModelLayer(object _) => false;
+
+  private bool CastToModelLayer<T>(ref T _) => false;
 #endif
+
+  public override bool CastTo<T>(ref T target)
+  {
+    return CastToModelLayer(ref target);
+  }
 
   public SpeckleCollectionWrapperGoo() { }
 


### PR DESCRIPTION
Adds casting of collections to model layers
should preserve name, path, color, and material (if exists in doc)

![{955B8DCA-6FD7-4BC6-BCCA-7356C6EF8E42}](https://github.com/user-attachments/assets/cedc6d0f-fc72-44b8-8e5b-a96978b861b6)
