### PR TITLE
fix(revit): send reference setting is broken

### DIFF
--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Bindings/RevitSendBinding.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Bindings/RevitSendBinding.cs
@@ -206,8 +206,13 @@ internal sealed class RevitSendBinding : RevitBaseBinding, ISendBinding
     var elementsOnMainModel = allElements.Where(el => el is not RevitLinkInstance).ToList();
     var linkedModels = allElements.OfType<RevitLinkInstance>().ToList();
 
-    // create context for main document elements
-    List<DocumentToConvert> documentElementContexts = [new(null, activeUIDoc.Document, elementsOnMainModel)];
+    // should ideally reuse the initialized value from the scoped IConverterSettingsStore<RevitConversionSettings>.
+    // but, it's scoped and to avoid bigger scarier changes I'm re-fetching the setting here (inexpensive operation?)
+    Transform? mainModelTransform = _toSpeckleSettingsManager.GetReferencePointSetting(modelCard);
+    List<DocumentToConvert> documentElementContexts =
+    [
+      new(mainModelTransform, activeUIDoc.Document, elementsOnMainModel)
+    ];
 
     // get the linked models setting - this decision belongs at this level
     bool includeLinkedModels = _toSpeckleSettingsManager.GetLinkedModelsSetting(modelCard);

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Bindings/RevitSendBinding.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Bindings/RevitSendBinding.cs
@@ -231,7 +231,11 @@ internal sealed class RevitSendBinding : RevitBaseBinding, ISendBinding
           continue;
         }
 
-        var transform = linkedModel.GetTotalTransform().Inverse;
+        // transform maps linked model elements into the main model's reference point coordinate system
+        // first apply the user's reference point transform (setting) then adjust for the linked model's placement relative to host.
+        Transform transform = (mainModelTransform ?? Transform.Identity).Multiply(
+          linkedModel.GetTotalTransform().Inverse
+        );
 
         // decision about whether to process elements is made here, not in the handler
         // only collects elements from linked models when the setting is enabled


### PR DESCRIPTION
## Description
Regardless of reference point setting, the model is always published relative to the `ProjectBase`.

- Testing Project: [Revit Reference Point](https://app.speckle.systems/projects/40b659a1da)
- Solves: [CNX-1578](https://linear.app/speckle/issue/CNX-1578/revit-send-reference-setting-is-broken)

## User Value
Correct spatial transforms applied according to what user set as the reference point.

## Changes:
- In `RevitSendBinding.cs` when collecting the `DocumentToConvert` the main model had a hard-coded `null` as the `DB.Transform`. Using the actual settings fixed the issue.
- For linked models, however, there was an additional step to consider. We needed to combine `mainModelTransform` and the `linkedModel.GetTotalTransform().Inverse` to align the linked model’s elements correctly under the main model’s chosen reference point.

## Validation of changes:
Ready for a screenshot spam? 😉 

### Validate Reference Setting (Legacy v Next-Gen)
#### Before Fix:
Federating models from the three different send modes results in three models in the exact same position(s). See federated model [here](https://app.speckle.systems/projects/40b659a1da/models/2cf1fe2d3a,870b7ce54e).

![federated-before](https://github.com/user-attachments/assets/ef7bffa3-c8ef-498d-b64d-502bc6cc266a)

#### After Fix:
Federating models now shows correct transforms applied, respecting user input. See federated model [here](https://app.speckle.systems/projects/40b659a1da/models/871dcadea8,b5a3ea52ce,e6f29fb811).

![federated-after](https://github.com/user-attachments/assets/e0f80b56-40a8-4fb4-a6fd-4cd8c46bac53)

#### Legacy v Next-Gen?
With fix applied, I wanted to make sure that legacy == next-gen. Federated model comparison below:
- [Survey](https://app.speckle.systems/projects/40b659a1da/models/5edb6afef8,b5a3ea52ce)
- [Project Base](https://app.speckle.systems/projects/40b659a1da/models/2e128a688b,871dcadea8)
- [Internal Origin](https://app.speckle.systems/projects/40b659a1da/models/77029de3ad,e6f29fb811)

### Validate Linked Models
Linked models needed some love too.

#### Before Fix:
Main model is being transformed correctly, but linked model not. See model [here](https://app.speckle.systems/projects/40b659a1da/models/4ebfbee18a@509b0e4dd5).

<img width="1280" alt="image" src="https://github.com/user-attachments/assets/63aa18ec-206d-402e-847f-d666e8eddfe6" />

#### After Fix:
Just need to multiply reference point transform w/ linked model total transform. See model [here](https://app.speckle.systems/projects/40b659a1da/models/4ebfbee18a@e4f6cae8be). (Arch and structural model transformed accordingly).

<img width="1280" alt="image" src="https://github.com/user-attachments/assets/f3ee62fb-122c-4f4b-8389-f57ec0d559e6" />


## Checklist:

- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] I have added appropriate tests.
- [x] I have updated or added relevant documentation.

