### PR TITLE
fix(grasshopper): repackages objects into data objects on send

### DIFF
--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Objects/FilterSpeckleObjects.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Objects/FilterSpeckleObjects.cs
@@ -131,7 +131,7 @@ public class FilterSpeckleObjects : GH_Component
       }
 
       // filter by application id
-      if (!MatchesSearchPattern(appId, inputObjects[i].Value.applicationId ?? ""))
+      if (!MatchesSearchPattern(appId, inputObjects[i].Value.Base.applicationId ?? ""))
       {
         continue;
       }

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Operations/Receive/GrasshopperCollectionRebuilder.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Operations/Receive/GrasshopperCollectionRebuilder.cs
@@ -25,14 +25,14 @@ internal sealed class GrasshopperCollectionRebuilder
   {
     // add the object color and material
     speckleGrasshopperObjectWrapper.Color = colorUnpacker.Cache.TryGetValue(
-      speckleGrasshopperObjectWrapper.applicationId ?? "",
+      speckleGrasshopperObjectWrapper.Base.applicationId ?? "",
       out var cachedColor
     )
       ? cachedColor
       : null;
 
     speckleGrasshopperObjectWrapper.Material = materialUnpacker.Cache.TryGetValue(
-      speckleGrasshopperObjectWrapper.applicationId ?? "",
+      speckleGrasshopperObjectWrapper.Base.applicationId ?? "",
       out var cachedMaterial
     )
       ? cachedMaterial

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/SpeckleGrasshopperObject.ModelObjects.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/SpeckleGrasshopperObject.ModelObjects.cs
@@ -105,7 +105,7 @@ public partial class SpeckleObjectWrapperGoo : GH_Goo<SpeckleObjectWrapper>, IGH
             Color = color is null ? null : Color.FromArgb(color.Value.Color.ToArgb()),
             Material = materialWrapper.Value,
             Properties = propertyGroup,
-            applicationId = modelObject.Id?.ToString()
+            applicationId = null // keep this null, processed on send
           };
 
         Value = so;

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/SpeckleGrasshopperObject.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/SpeckleGrasshopperObject.cs
@@ -159,6 +159,34 @@ public class SpeckleObjectWrapper : Base
     Guid guid = doc.Objects.Add(GeometryBase, att);
     obj_ids.Add(guid);
   }
+
+  /// <summary>
+  /// Determines similarity of two SpeckleObjectWrappers.
+  /// If the path, name, and properties of the wrappers are the same, they should be considered similar.
+  /// This should be used to pack similar objects into one `DataObject` on send.
+  /// </summary>
+  /// <param name="objWrapper">The object wrapper to compare to</param>
+  /// <returns></returns>
+  /// <remarks> Application Id is not considered in similarity, because these can be unique to objects inside the same displayvalue for proxy reasons</remarks>
+  public bool SmellsLike(SpeckleObjectWrapper objWrapper)
+  {
+    if (Path != objWrapper.Path)
+    {
+      return false;
+    }
+
+    if (Name != objWrapper.Name)
+    {
+      return false;
+    }
+
+    if (!Properties.Equals(objWrapper.Properties))
+    {
+      return false;
+    }
+
+    return true;
+  }
 }
 
 public partial class SpeckleObjectWrapperGoo : GH_Goo<SpeckleObjectWrapper>, IGH_PreviewData, ISpeckleGoo
@@ -171,6 +199,12 @@ public partial class SpeckleObjectWrapperGoo : GH_Goo<SpeckleObjectWrapper>, IGH
   public override string TypeName => "Speckle object wrapper";
   public override string TypeDescription => "A wrapper around speckle grasshopper objects.";
 
+  /// <summary>
+  /// Casts from Speckle objects, geometry base, and model objects.
+  /// All non-Speckle objects will be converted to its geometry equivalent.
+  /// </summary>
+  /// <param name="source"></param>
+  /// <returns></returns>
   public override bool CastFrom(object source)
   {
     switch (source)
@@ -236,7 +270,17 @@ public partial class SpeckleObjectWrapperGoo : GH_Goo<SpeckleObjectWrapper>, IGH
     Value = value;
   }
 
-  public SpeckleObjectWrapperGoo() { }
+  public SpeckleObjectWrapperGoo()
+  {
+    Value = new()
+    {
+      Base = new(),
+      GeometryBase = null,
+      Color = null,
+      Material = null,
+      Name = ""
+    };
+  }
 }
 
 public class SpeckleObjectParam : GH_Param<SpeckleObjectWrapperGoo>, IGH_BakeAwareObject, IGH_PreviewObject

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/SpecklePropertyGroupWrapper.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/SpecklePropertyGroupWrapper.cs
@@ -104,6 +104,31 @@ public partial class SpecklePropertyGroupGoo : GH_Goo<Dictionary<string, Speckle
       }
     }
   }
+
+  public override bool Equals(object obj)
+  {
+    if (obj is not SpecklePropertyGroupGoo propertyGroupGoo || Value.Count != propertyGroupGoo.Value.Count)
+    {
+      return false;
+    }
+
+    foreach (var entry in Value)
+    {
+      if (
+        propertyGroupGoo.Value.TryGetValue(entry.Key, out SpecklePropertyGoo compareProp)
+        && entry.Value.Value != compareProp.Value
+      )
+      {
+        return false;
+      }
+
+      return false;
+    }
+
+    return true;
+  }
+
+  public override int GetHashCode() => base.GetHashCode();
 }
 
 public class SpecklePropertyGroupParam : GH_Param<SpecklePropertyGroupGoo>


### PR DESCRIPTION
<!---

Provide a short summary in the Title above. Use the following template:

category(project): summary

Categories:

* feat: (new feature for the user, not a new feature for build script)
* fix: (bug fix for the user, not a fix to a build script)
* docs: (changes to the documentation)
* style: (formatting, missing semi colons, etc; no production code change)
* refactor: (refactoring production code, eg. renaming a variable)
* test: (adding missing tests, refactoring tests; no production code change)
* chore: (updating grunt tasks etc; no production code change)

Example:

feat(revit): added category filter to send

-->

## Description
 All objects on receive will be decimated into a geometryBase + Speckle Geometry Base wrapped objects, and on send these will be repackaged into DataObjects based on similarity (name and props are the same).
This allows for mutations on individual display value objects (esp in dataobjects) to register as new objects, and also means the send output is consistent with ~only~ dataobjects (instead of a mix) => allows for consistent parsing of gh models by powerbi, automate, etc



