### PR TITLE
refactor(grasshopper): removes Base inheritance on wrappers

### DIFF
--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Collections/CollectionPathsSelector.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Collections/CollectionPathsSelector.cs
@@ -3,7 +3,6 @@ using Speckle.Connectors.GrasshopperShared.Components.BaseComponents;
 using Speckle.Connectors.GrasshopperShared.HostApp;
 using Speckle.Connectors.GrasshopperShared.Parameters;
 using Speckle.Connectors.GrasshopperShared.Properties;
-using Speckle.Sdk.Models.Collections;
 
 namespace Speckle.Connectors.GrasshopperShared.Components.Collections;
 
@@ -35,14 +34,14 @@ public class CollectionPathsSelector : ValueSet<IGH_Goo>
 
     // NOTE: supporting multiple collections? maybe? not really?
     var paths = new List<string>();
-    foreach (SpeckleCollectionWrapper col in collections)
+    foreach (SpeckleCollectionWrapper wrapper in collections)
     {
       // note: we are skipping the input collection, to make the output paths more intuitive
-      foreach (var element in col.Collection.elements)
+      foreach (var element in wrapper.Elements)
       {
         if (element is SpeckleCollectionWrapper childCollectionWrapper)
         {
-          paths.AddRange(GetPaths(childCollectionWrapper.Collection));
+          paths.AddRange(GetPaths(childCollectionWrapper));
         }
         else
         {
@@ -54,32 +53,32 @@ public class CollectionPathsSelector : ValueSet<IGH_Goo>
     m_data.AppendRange(paths.Select(s => new GH_String(s)));
   }
 
-  private List<string> GetPaths(Collection c)
+  private List<string> GetPaths(SpeckleCollectionWrapper wrapper)
   {
     var currentPath = new List<string>();
     var allPaths = new HashSet<string>();
 
-    void GetPathsInternal(Collection col)
+    void GetPathsInternal(SpeckleCollectionWrapper w)
     {
-      currentPath.Add(col.name);
-      var subCols = col.elements.OfType<SpeckleCollectionWrapper>().ToList();
+      currentPath.Add(w.Collection.name);
+      var subCols = w.Elements.OfType<SpeckleCollectionWrapper>().ToList();
 
       // NOTE: here we're basically outputting only paths that correspond to a collection
       // that has values inside of it.
-      if (subCols.Count != col.elements.Count)
+      if (subCols.Count != w.Elements.Count)
       {
         allPaths.Add(string.Join(Constants.LAYER_PATH_DELIMITER, currentPath));
       }
 
       foreach (var subCol in subCols)
       {
-        GetPathsInternal(subCol.Collection);
+        GetPathsInternal(subCol);
       }
+
       currentPath.RemoveAt(currentPath.Count - 1);
     }
 
-    GetPathsInternal(c);
-
+    GetPathsInternal(wrapper);
     return allPaths.ToList();
   }
 }

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Collections/CollectionPathsSelector.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Collections/CollectionPathsSelector.cs
@@ -60,7 +60,7 @@ public class CollectionPathsSelector : ValueSet<IGH_Goo>
 
     void GetPathsInternal(SpeckleCollectionWrapper w)
     {
-      currentPath.Add(w.Collection.name);
+      currentPath.Add(w.Name);
       var subCols = w.Elements.OfType<SpeckleCollectionWrapper>().ToList();
 
       // NOTE: here we're basically outputting only paths that correspond to a collection

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Collections/CreateCollection.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Collections/CreateCollection.cs
@@ -42,14 +42,15 @@ public class CreateCollection : GH_Component, IGH_VariableParameterComponent
   protected override void SolveInstance(IGH_DataAccess dataAccess)
   {
     string rootName = "Unnamed";
-    Collection rootCollection = new() { name = rootName, applicationId = InstanceGuid.ToString() };
+    Collection rootCollection = new();
     SpeckleCollectionWrapper rootSpeckleCollectionWrapper =
       new(new() { rootName })
       {
         Base = rootCollection,
+        Name = rootName,
         Color = null,
         Material = null,
-        WrapperGuid = null
+        ApplicationId = InstanceGuid.ToString()
       };
 
     foreach (var inputParam in Params.Input)
@@ -74,15 +75,15 @@ public class CreateCollection : GH_Component, IGH_VariableParameterComponent
 
       List<string> childPath = new() { rootName };
       childPath.Add(inputParam.NickName);
-      Collection childCollection = new(inputParam.NickName) { applicationId = inputParam.InstanceGuid.ToString() };
       SpeckleCollectionWrapper childSpeckleCollectionWrapper =
         new(childPath)
         {
-          Base = childCollection,
+          Base = new Collection(),
+          Name = inputParam.NickName,
           Color = null,
           Material = null,
-          WrapperGuid = null,
-          Topology = GrasshopperHelpers.GetParamTopology(inputParam)
+          Topology = GrasshopperHelpers.GetParamTopology(inputParam),
+          ApplicationId = inputParam.InstanceGuid.ToString(),
         };
 
       // handle collection inputs
@@ -97,9 +98,7 @@ public class CreateCollection : GH_Component, IGH_VariableParameterComponent
           wrapperGoo.Value.Path = new ObservableCollection<string>(childPath);
 
           foreach (
-            string subCollectionName in wrapperGoo
-              .Value.Elements.OfType<SpeckleCollectionWrapper>()
-              .Select(v => v.Collection.name)
+            string subCollectionName in wrapperGoo.Value.Elements.OfType<SpeckleCollectionWrapper>().Select(c => c.Name)
           )
           {
             var hasNotSeenNameBefore = nameTest.Add(subCollectionName);

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Collections/ExpandCollection.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Collections/ExpandCollection.cs
@@ -43,21 +43,21 @@ public class ExpandCollection : GH_Component, IGH_VariableParameterComponent
   {
     SpeckleCollectionWrapperGoo res = new();
     da.GetData(0, ref res);
-    var c = res.Value;
-    if (c is null)
+    SpeckleCollectionWrapper wrapper = res.Value;
+    if (wrapper is null)
     {
       return;
     }
-    Name = c.Collection.name;
-    NickName = c.Collection.name;
+    Name = wrapper.Collection.name;
+    NickName = wrapper.Collection.name;
 
-    var objects = c
-      .Collection.elements.Where(el => el is not SpeckleCollectionWrapper)
+    var objects = wrapper
+      .Elements.Where(el => el is not SpeckleCollectionWrapper)
       .OfType<SpeckleObjectWrapper>()
       .Select(o => new SpeckleObjectWrapperGoo(o))
       .ToList();
-    var collections = c
-      .Collection.elements.Where(el => el is SpeckleCollectionWrapper)
+    var collections = wrapper
+      .Elements.Where(el => el is SpeckleCollectionWrapper)
       .OfType<SpeckleCollectionWrapper>()
       .ToList();
 
@@ -76,26 +76,26 @@ public class ExpandCollection : GH_Component, IGH_VariableParameterComponent
       outputParams.Add(new OutputParamWrapper(param, objects, null));
     }
 
-    foreach (SpeckleCollectionWrapper collection in collections)
+    foreach (SpeckleCollectionWrapper childWrapper in collections)
     {
       // skip empty
-      if (collection.Collection.elements.Count == 0)
+      if (childWrapper.Elements.Count == 0)
       {
         continue;
       }
 
-      var hasInnerCollections = collection.Collection.elements.Any(el => el is SpeckleCollectionWrapper);
-      var topology = collection.Topology; // Note: this is a reminder for the future
-      var nickName = collection.Collection.name;
-      if (collection.Collection.name.Length > 16)
+      var hasInnerCollections = childWrapper.Elements.Any(el => el is SpeckleCollectionWrapper);
+      var topology = childWrapper.Topology; // Note: this is a reminder for the future
+      var nickName = childWrapper.Collection.name;
+      if (nickName.Length > 16)
       {
-        nickName = collection.Collection.name[..3];
-        nickName += "..." + collection.Collection.name[^3..];
+        nickName = nickName[..3];
+        nickName += "..." + nickName[^3..];
       }
 
       var param = new Param_GenericObject()
       {
-        Name = collection.Collection.name,
+        Name = childWrapper.Collection.name,
         NickName = nickName,
         Access = hasInnerCollections
           ? GH_ParamAccess.item
@@ -108,11 +108,8 @@ public class ExpandCollection : GH_Component, IGH_VariableParameterComponent
         new OutputParamWrapper(
           param,
           hasInnerCollections
-            ? new SpeckleCollectionWrapperGoo(collection)
-            : collection
-              .Collection.elements.OfType<SpeckleObjectWrapper>()
-              .Select(o => new SpeckleObjectWrapperGoo(o))
-              .ToList(),
+            ? new SpeckleCollectionWrapperGoo(childWrapper)
+            : childWrapper.Elements.OfType<SpeckleObjectWrapper>().Select(o => new SpeckleObjectWrapperGoo(o)).ToList(),
           topology
         )
       );

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Collections/ExpandCollection.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Collections/ExpandCollection.cs
@@ -48,8 +48,8 @@ public class ExpandCollection : GH_Component, IGH_VariableParameterComponent
     {
       return;
     }
-    Name = wrapper.Collection.name;
-    NickName = wrapper.Collection.name;
+    Name = wrapper.Name;
+    NickName = wrapper.Name;
 
     var objects = wrapper
       .Elements.Where(el => el is not SpeckleCollectionWrapper)
@@ -86,7 +86,7 @@ public class ExpandCollection : GH_Component, IGH_VariableParameterComponent
 
       var hasInnerCollections = childWrapper.Elements.Any(el => el is SpeckleCollectionWrapper);
       var topology = childWrapper.Topology; // Note: this is a reminder for the future
-      var nickName = childWrapper.Collection.name;
+      var nickName = childWrapper.Name;
       if (nickName.Length > 16)
       {
         nickName = nickName[..3];
@@ -95,7 +95,7 @@ public class ExpandCollection : GH_Component, IGH_VariableParameterComponent
 
       var param = new Param_GenericObject()
       {
-        Name = childWrapper.Collection.name,
+        Name = childWrapper.Name,
         NickName = nickName,
         Access = hasInnerCollections
           ? GH_ParamAccess.item

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Collections/GetCollectionObjects.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Collections/GetCollectionObjects.cs
@@ -4,7 +4,6 @@ using Speckle.Connectors.GrasshopperShared.HostApp;
 using Speckle.Connectors.GrasshopperShared.Parameters;
 using Speckle.Connectors.GrasshopperShared.Properties;
 using Speckle.Sdk;
-using Speckle.Sdk.Models;
 
 namespace Speckle.Connectors.GrasshopperShared.Components.Collections;
 
@@ -80,7 +79,7 @@ public class GetCollectionObjects : GH_Component
       targetCollectionWrapper =
         path == "_objects" ? collectionWrapperGoo.Value : FindCollection(collectionWrapperGoo.Value, path);
       filteredObjects = targetCollectionWrapper
-        .Collection.elements.Where(e => e is SpeckleObjectWrapper)
+        .Elements.Where(e => e is SpeckleObjectWrapper)
         .Select(e => (SpeckleObjectWrapper)e)
         .ToList();
     }
@@ -103,7 +102,7 @@ public class GetCollectionObjects : GH_Component
 
   private IEnumerable<SpeckleObjectWrapper> GetAllObjectsFromCollection(SpeckleCollectionWrapper collectionWrapper)
   {
-    foreach (Base element in collectionWrapper.Collection.elements)
+    foreach (SpeckleWrapper element in collectionWrapper.Elements)
     {
       switch (element)
       {
@@ -128,7 +127,7 @@ public class GetCollectionObjects : GH_Component
     while (paths.Count != 0)
     {
       currentCollectionWrapper = currentCollectionWrapper
-        .Collection.elements.OfType<SpeckleCollectionWrapper>()
+        .Elements.OfType<SpeckleCollectionWrapper>()
         .First(col => col.Collection.name == paths.First());
       paths.RemoveAt(0);
       if (paths.Count == 0)

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Collections/GetCollectionObjects.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Collections/GetCollectionObjects.cs
@@ -128,7 +128,7 @@ public class GetCollectionObjects : GH_Component
     {
       currentCollectionWrapper = currentCollectionWrapper
         .Elements.OfType<SpeckleCollectionWrapper>()
-        .First(col => col.Collection.name == paths.First());
+        .First(wrapper => wrapper.Name == paths.First());
       paths.RemoveAt(0);
       if (paths.Count == 0)
       {

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Dev/DeconstructSpeckleParam.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Dev/DeconstructSpeckleParam.cs
@@ -212,8 +212,10 @@ public class DeconstructSpeckleParam : GH_Component, IGH_VariableParameterCompon
             GeometryBase = g,
             Name = b["name"] as string ?? "",
             Color = null,
-            Material = null
+            Material = null,
+            WrapperGuid = null
           };
+
         convertedWrappers.Add(new(convertedWrapper));
       }
 
@@ -230,7 +232,8 @@ public class DeconstructSpeckleParam : GH_Component, IGH_VariableParameterCompon
           GeometryBase = null,
           Name = @base["name"] as string ?? "",
           Color = null,
-          Material = null
+          Material = null,
+          WrapperGuid = null,
         };
       return new() { new SpeckleObjectWrapperGoo(convertedWrapper) };
     }

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Dev/DeconstructSpeckleParam.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Dev/DeconstructSpeckleParam.cs
@@ -49,16 +49,16 @@ public class DeconstructSpeckleParam : GH_Component, IGH_VariableParameterCompon
     {
       case SpeckleObjectWrapperGoo obj:
         Name = string.IsNullOrEmpty(obj.Value.Name) ? obj.Value.Base.speckle_type : obj.Value.Name;
-        outputParams = CreateOutputParamsFromBase(obj.Value.Base, obj.Value.Color, obj.Value.Material);
+        outputParams = CreateOutputParamsFromBase(obj.Value.Base);
         break;
       case SpeckleCollectionWrapperGoo coll:
         Name = string.IsNullOrEmpty(coll.Value.Collection.name)
           ? coll.Value.Collection.speckle_type
           : coll.Value.Collection.name;
-        outputParams = CreateOutputParamsFromBase(coll.Value.Collection, coll.Value.Color, coll.Value.Material);
+        outputParams = CreateOutputParamsFromBase(coll.Value.Collection);
         break;
       case SpeckleMaterialWrapperGoo matGoo:
-        Name = string.IsNullOrEmpty(matGoo.Value.Base.name) ? matGoo.Value.Base.speckle_type : matGoo.Value.Base.name;
+        Name = string.IsNullOrEmpty(matGoo.Value.Name) ? matGoo.Value.Material.speckle_type : matGoo.Value.Name;
         outputParams = CreateOutputParamsFromBase(matGoo.Value.Base);
         break;
       default:
@@ -97,11 +97,7 @@ public class DeconstructSpeckleParam : GH_Component, IGH_VariableParameterCompon
     }
   }
 
-  private List<OutputParamWrapper> CreateOutputParamsFromBase(
-    Base @base,
-    Color? color = null,
-    SpeckleMaterialWrapper? materialWrapper = null
-  )
+  private List<OutputParamWrapper> CreateOutputParamsFromBase(Base @base)
   {
     List<OutputParamWrapper> result = new();
     if (@base == null)
@@ -179,18 +175,6 @@ public class DeconstructSpeckleParam : GH_Component, IGH_VariableParameterCompon
           result.Add(CreateOutputParamByKeyValue(prop.Key, prop.Value, GH_ParamAccess.item));
           break;
       }
-    }
-
-    // add color and render material
-    if (color is not null)
-    {
-      result.Add(CreateOutputParamByKeyValue("color", color, GH_ParamAccess.item));
-    }
-
-    if (materialWrapper is not null)
-    {
-      SpeckleMaterialWrapperGoo materialWrapperGoo = new(materialWrapper);
-      result.Add(CreateOutputParamByKeyValue("renderMaterial", materialWrapperGoo, GH_ParamAccess.item));
     }
 
     return result;

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Objects/CreateSpeckleObject.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Objects/CreateSpeckleObject.cs
@@ -76,10 +76,11 @@ public class CreateSpeckleObject : GH_Component
 
     pManager.AddColourParameter("Color", "c", "The color of the Speckle Object", GH_ParamAccess.item);
 
-    pManager.AddGenericParameter(
+    pManager.AddParameter(
+      new SpeckleMaterialParam(),
       "Material",
-      "m",
-      "The material of the Speckle Object. Display Materials, Model Materials, and Speckle Materials are accepted.",
+      "M",
+      "The material of the Speckle Object.",
       GH_ParamAccess.item
     );
   }
@@ -158,8 +159,6 @@ public class CreateSpeckleObject : GH_Component
       }
 
       result.Value.Properties = propGoo;
-      Dictionary<string, object?> props = new();
-      propGoo.CastTo(ref props);
       mutated = true;
     }
 

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Objects/CreateSpeckleObject.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Objects/CreateSpeckleObject.cs
@@ -186,12 +186,9 @@ public class CreateSpeckleObject : GH_Component
     }
 
     // process application Id. Use a new appId if mutated, or if this is a new object
-    string applicationId = mutated
+    result.Value.ApplicationId = mutated
       ? Guid.NewGuid().ToString()
-      : result.Value.applicationId != null
-        ? result.Value.applicationId
-        : Guid.NewGuid().ToString();
-    result.Value.Base.applicationId = applicationId;
+      : result.Value.ApplicationId ?? Guid.NewGuid().ToString();
 
     // set all the data
     da.SetData(0, result.Value);

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Objects/CreateSpeckleProperties.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Objects/CreateSpeckleProperties.cs
@@ -50,7 +50,7 @@ public class CreateSpeckleProperties : GH_Component, IGH_VariableParameterCompon
       string inputName = inputParam.NickName;
       if (branchCount != inputParam.VolatileData.PathCount)
       {
-        AddRuntimeMessage(GH_RuntimeMessageLevel.Error, $"Input property values had different branch structure.");
+        AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, $"Input property values had different branch structure.");
         return;
       }
 
@@ -73,7 +73,7 @@ public class CreateSpeckleProperties : GH_Component, IGH_VariableParameterCompon
         }
 
         SpecklePropertyGoo propGoo = new();
-        if (!propGoo.CastFrom(data.Count == 0 ? "" : data.First()))
+        if (!propGoo.CastFrom(data.Count == 0 ? null : data.First()))
         {
           AddRuntimeMessage(
             GH_RuntimeMessageLevel.Error,

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Objects/FilterSpeckleObjects.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Objects/FilterSpeckleObjects.cs
@@ -125,7 +125,7 @@ public class FilterSpeckleObjects : GH_Component
       }
 
       // filter by material name
-      if (!MatchesSearchPattern(material, inputObjects[i].Value.Material?.Base.name ?? ""))
+      if (!MatchesSearchPattern(material, inputObjects[i].Value.Material?.Name ?? ""))
       {
         continue;
       }

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Receive/ReceiveAsyncComponent.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Receive/ReceiveAsyncComponent.cs
@@ -48,7 +48,7 @@ public class ReceiveAsyncComponent : GH_AsyncComponent
   public HostApp.SpeckleUrlModelResource? UrlModelResource { get; set; }
 
   // DI props
-  public Client ApiClient { get; private set; }
+  public IClient ApiClient { get; private set; }
   public GrasshopperReceiveOperation ReceiveOperation { get; private set; }
   public RootObjectUnpacker RootObjectUnpacker { get; private set; }
   public static IServiceScope? Scope { get; private set; }

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Send/SendAsyncComponent.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Send/SendAsyncComponent.cs
@@ -45,7 +45,7 @@ public class SendAsyncComponent : GH_AsyncComponent
   public bool JustPastedIn { get; set; }
   public double OverallProgress { get; set; }
   public string? Url { get; set; }
-  public Client ApiClient { get; set; }
+  public IClient ApiClient { get; set; }
   public HostApp.SpeckleUrlModelResource? UrlModelResource { get; set; }
   public SpeckleCollectionWrapperGoo? RootCollectionWrapper { get; set; }
 

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/SpeckleSelectModelComponent.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/SpeckleSelectModelComponent.cs
@@ -341,7 +341,7 @@ public class SpeckleSelectModelComponent : GH_Component
       return;
     }
 
-    Client client = _clientFactory.Create(_account);
+    IClient client = _clientFactory.Create(_account);
 
     LastFetchedProjects = client.ActiveUser.GetProjects(10, null, null).Result;
     ProjectContextMenuButton.Enabled = true;
@@ -434,7 +434,7 @@ public class SpeckleSelectModelComponent : GH_Component
       throw new SpeckleException("No account found for server URL");
     }
 
-    Client client = _clientFactory.Create(_account);
+    IClient client = _clientFactory.Create(_account);
 
     var project = client.Project.Get(resource.ProjectId).Result;
     OnProjectSelected(project, false);

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/HostApp/Globals.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/HostApp/Globals.cs
@@ -4,4 +4,7 @@ public static class Constants
 {
   public const string LAYER_PATH_DELIMITER = "::";
   public const string PROPERTY_PATH_DELIMITER = ".";
+  public const string TOPOLOGY_PROP = "topology";
+  public const string NAME_PROP = "name";
+  public const string PROPERTIES_PROP = "properties";
 }

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/HostApp/Helpers.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/HostApp/Helpers.cs
@@ -58,7 +58,7 @@ public static class GrasshopperHelpers
     $"material_{mat.Transparency}_{mat.Diffuse}_{mat.Emission}_{mat.Shine}_{mat.Specular}";
 
   public static string GetSpeckleApplicationId(this SpeckleMaterialWrapper matWrapper) =>
-    $"material_{matWrapper.Base.opacity}_{matWrapper.Base.diffuse}_{matWrapper.Base.emissive}_{matWrapper.Base.metalness}_{matWrapper.Base.roughness}";
+    $"material_{matWrapper.Material.opacity}_{matWrapper.Material.diffuse}_{matWrapper.Material.emissive}_{matWrapper.Material.metalness}_{matWrapper.Material.roughness}";
 
   /// <summary>
   /// Retrieves a unique Speckle application id from the path of the collection

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/HostApp/SpeckleResource.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/HostApp/SpeckleResource.cs
@@ -8,15 +8,15 @@ namespace Speckle.Connectors.GrasshopperShared.HostApp;
 
 public abstract record SpeckleUrlModelResource(string Server, string ProjectId)
 {
-  public abstract Task<ReceiveInfo> GetReceiveInfo(Client client, CancellationToken cancellationToken = default);
+  public abstract Task<ReceiveInfo> GetReceiveInfo(IClient client, CancellationToken cancellationToken = default);
 
-  public abstract Task<SendInfo> GetSendInfo(Client client, CancellationToken cancellationToken = default);
+  public abstract Task<SendInfo> GetSendInfo(IClient client, CancellationToken cancellationToken = default);
 }
 
 public record SpeckleUrlLatestModelVersionResource(string Server, string ProjectId, string ModelId)
   : SpeckleUrlModelResource(Server, ProjectId)
 {
-  public override async Task<ReceiveInfo> GetReceiveInfo(Client client, CancellationToken cancellationToken = default)
+  public override async Task<ReceiveInfo> GetReceiveInfo(IClient client, CancellationToken cancellationToken = default)
   {
     Project project = await client.Project.Get(ProjectId, cancellationToken).ConfigureAwait(false);
     ModelWithVersions model = await client
@@ -38,7 +38,7 @@ public record SpeckleUrlLatestModelVersionResource(string Server, string Project
     return info;
   }
 
-  public override async Task<SendInfo> GetSendInfo(Client client, CancellationToken cancellationToken = default)
+  public override async Task<SendInfo> GetSendInfo(IClient client, CancellationToken cancellationToken = default)
   {
     // We don't care about the return info, we just want to be sure we have access and everything exists.
     await client.Project.Get(ProjectId, cancellationToken).ConfigureAwait(false);
@@ -57,7 +57,7 @@ public record SpeckleUrlLatestModelVersionResource(string Server, string Project
 public record SpeckleUrlModelVersionResource(string Server, string ProjectId, string ModelId, string VersionId)
   : SpeckleUrlModelResource(Server, ProjectId)
 {
-  public override async Task<ReceiveInfo> GetReceiveInfo(Client client, CancellationToken cancellationToken = default)
+  public override async Task<ReceiveInfo> GetReceiveInfo(IClient client, CancellationToken cancellationToken = default)
   {
     Project project = await client.Project.Get(ProjectId, cancellationToken).ConfigureAwait(false);
     Model model = await client.Model.Get(ModelId, ProjectId, cancellationToken).ConfigureAwait(false);
@@ -77,7 +77,7 @@ public record SpeckleUrlModelVersionResource(string Server, string ProjectId, st
     return info;
   }
 
-  public override async Task<SendInfo> GetSendInfo(Client client, CancellationToken cancellationToken = default)
+  public override async Task<SendInfo> GetSendInfo(IClient client, CancellationToken cancellationToken = default)
   {
     // We don't care about the return info, we just want to be sure we have access and everything exists.
     await client.Project.Get(ProjectId, cancellationToken).ConfigureAwait(false);
@@ -96,9 +96,9 @@ public record SpeckleUrlModelVersionResource(string Server, string ProjectId, st
 public record SpeckleUrlModelObjectResource(string Server, string ProjectId, string ObjectId)
   : SpeckleUrlModelResource(Server, ProjectId)
 {
-  public override Task<ReceiveInfo> GetReceiveInfo(Client client, CancellationToken cancellationToken = default) =>
+  public override Task<ReceiveInfo> GetReceiveInfo(IClient client, CancellationToken cancellationToken = default) =>
     throw new NotImplementedException("Object Resources are not supported yet");
 
-  public override Task<SendInfo> GetSendInfo(Client client, CancellationToken cancellationToken = default) =>
+  public override Task<SendInfo> GetSendInfo(IClient client, CancellationToken cancellationToken = default) =>
     throw new NotImplementedException("Object Resources are not supported yet");
 }

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Operations/Receive/GrasshopperCollectionRebuilder.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Operations/Receive/GrasshopperCollectionRebuilder.cs
@@ -12,8 +12,15 @@ internal sealed class GrasshopperCollectionRebuilder
 
   public GrasshopperCollectionRebuilder(Collection baseCollection)
   {
-    Collection newCollection = new() { name = baseCollection.name, applicationId = baseCollection.applicationId };
-    RootCollectionWrapper = new SpeckleCollectionWrapper(newCollection, new() { baseCollection.name }, null, null);
+    Collection newCollection = new() { name = baseCollection.name };
+    RootCollectionWrapper = new SpeckleCollectionWrapper(new() { baseCollection.name })
+    {
+      Base = newCollection,
+      Color = null,
+      Material = null,
+      ApplicationId = baseCollection.applicationId ?? Guid.NewGuid().ToString(),
+      WrapperGuid = null,
+    };
   }
 
   public void AppendSpeckleGrasshopperObject(
@@ -38,8 +45,8 @@ internal sealed class GrasshopperCollectionRebuilder
       ? cachedMaterial
       : null;
 
-    var collection = GetOrCreateSpeckleCollectionFromPath(collectionPath, colorUnpacker, materialUnpacker);
-    collection.Collection.elements.Add(speckleGrasshopperObjectWrapper);
+    var collWrapper = GetOrCreateSpeckleCollectionFromPath(collectionPath, colorUnpacker, materialUnpacker);
+    collWrapper.Elements.Add(speckleGrasshopperObjectWrapper);
   }
 
   public SpeckleCollectionWrapper GetOrCreateSpeckleCollectionFromPath(
@@ -74,8 +81,9 @@ internal sealed class GrasshopperCollectionRebuilder
       // create and cache if needed
       Collection newCollection = new() { name = collectionName, applicationId = collection.applicationId };
       SpeckleCollectionWrapper newSpeckleCollectionWrapper =
-        new(newCollection, currentLayerPath, null, null)
+        new(currentLayerPath)
         {
+          Base = newCollection,
           // get the collection color and material
           Color = colorUnpacker.Cache.TryGetValue(collection.applicationId ?? "", out var cachedCollectionColor)
             ? cachedCollectionColor
@@ -85,9 +93,9 @@ internal sealed class GrasshopperCollectionRebuilder
             out var cachedCollectionMaterial
           )
             ? cachedCollectionMaterial
-            : null
+            : null,
+          WrapperGuid = null,
         };
-      ;
 
       if (collection["topology"] is string topology)
       {
@@ -96,8 +104,7 @@ internal sealed class GrasshopperCollectionRebuilder
       }
 
       _cache[key] = newSpeckleCollectionWrapper;
-      previousCollectionWrapper.Collection.elements.Add(newSpeckleCollectionWrapper);
-
+      previousCollectionWrapper.Elements.Add(newSpeckleCollectionWrapper);
       previousCollectionWrapper = newSpeckleCollectionWrapper;
     }
 

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Operations/Receive/GrasshopperCollectionRebuilder.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Operations/Receive/GrasshopperCollectionRebuilder.cs
@@ -12,14 +12,13 @@ internal sealed class GrasshopperCollectionRebuilder
 
   public GrasshopperCollectionRebuilder(Collection baseCollection)
   {
-    Collection newCollection = new() { name = baseCollection.name };
     RootCollectionWrapper = new SpeckleCollectionWrapper(new() { baseCollection.name })
     {
-      Base = newCollection,
+      Base = new Collection(),
+      Name = baseCollection.name,
       Color = null,
       Material = null,
       ApplicationId = baseCollection.applicationId ?? Guid.NewGuid().ToString(),
-      WrapperGuid = null,
     };
   }
 
@@ -79,12 +78,12 @@ internal sealed class GrasshopperCollectionRebuilder
       }
 
       // create and cache if needed
-      Collection newCollection = new() { name = collectionName, applicationId = collection.applicationId };
       SpeckleCollectionWrapper newSpeckleCollectionWrapper =
         new(currentLayerPath)
         {
-          Base = newCollection,
-          // get the collection color and material
+          Base = new Collection(),
+          Name = collectionName,
+          ApplicationId = collection.applicationId,
           Color = colorUnpacker.Cache.TryGetValue(collection.applicationId ?? "", out var cachedCollectionColor)
             ? cachedCollectionColor
             : null,
@@ -94,13 +93,11 @@ internal sealed class GrasshopperCollectionRebuilder
           )
             ? cachedCollectionMaterial
             : null,
-          WrapperGuid = null,
         };
 
       if (collection["topology"] is string topology)
       {
         newSpeckleCollectionWrapper.Topology = topology;
-        newCollection["topology"] = topology;
       }
 
       _cache[key] = newSpeckleCollectionWrapper;

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Operations/Receive/GrasshopperMaterialUnpacker.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Operations/Receive/GrasshopperMaterialUnpacker.cs
@@ -32,7 +32,7 @@ internal sealed class GrasshopperMaterialUnpacker
       try
       {
         // get the material wrapper for the render material proxy
-        string materialId = materialProxy.applicationId ?? materialProxy.value.name;
+        string materialId = materialProxy.value.applicationId ?? materialProxy.value.id ?? Guid.NewGuid().ToString();
         if (ConvertedCache.TryGetValue(materialId, out SpeckleMaterialWrapper? materialWrapper))
         {
           ConvertedCache.Add(materialId, materialWrapper);
@@ -43,6 +43,7 @@ internal sealed class GrasshopperMaterialUnpacker
           SpeckleMaterialWrapperGoo wrapperGoo = new();
           wrapperGoo.CastFrom(materialProxy.value);
           materialWrapper = wrapperGoo.Value;
+          materialWrapper.ApplicationId = materialId; // update the id here in case it was mutated
           ConvertedCache.Add(materialId, materialWrapper);
         }
 

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Operations/Receive/GrasshopperReceiveOperation.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Operations/Receive/GrasshopperReceiveOperation.cs
@@ -44,7 +44,7 @@ public class GrasshopperReceiveOperation
     execute?.SetTag("receiveInfo", receiveInfo);
     // 2 - Check account exist
     Account account = _accountService.GetAccountWithServerUrlFallback(receiveInfo.AccountId, receiveInfo.ServerUrl);
-    using Client apiClient = _clientFactory.Create(account);
+    using IClient apiClient = _clientFactory.Create(account);
     using var userScope = ActivityScope.SetTag(Consts.USER_ID, account.GetHashedEmail());
 
     var version = await apiClient

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Operations/Receive/LocalToGlobalMapHandler.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Operations/Receive/LocalToGlobalMapHandler.cs
@@ -82,7 +82,6 @@ internal sealed class LocalToGlobalMapHandler
       // similar objects will be re-packaged on send
       foreach ((GeometryBase geometryBase, Base original) in converted)
       {
-        original.applicationId ??= map.AtomicObject.applicationId ?? Guid.NewGuid().ToString(); // check for null ids, we don't want nulls on the wrapped base
         var gh = new SpeckleObjectWrapper()
         {
           Base = original,
@@ -93,7 +92,8 @@ internal sealed class LocalToGlobalMapHandler
           Name = name,
           Color = null,
           Material = null,
-          applicationId = null // keep this null, as it will be generated on send after processing all wrappers
+          WrapperGuid = map.AtomicObject.applicationId,
+          ApplicationId = original.applicationId ?? Guid.NewGuid().ToString() // create if none
         };
 
         CollectionRebuilder.AppendSpeckleGrasshopperObject(gh, path, _colorUnpacker, _materialUnpacker);

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Operations/Send/GrasshopperMaterialPacker.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Operations/Send/GrasshopperMaterialPacker.cs
@@ -28,24 +28,23 @@ internal sealed class GrasshopperMaterialPacker
 
   private void AddObjectIdToMaterialProxy(string objectId, SpeckleMaterialWrapper matWrapper)
   {
-    string matId = matWrapper.applicationId ?? matWrapper.GetSpeckleApplicationId();
-    if (RenderMaterialProxies.TryGetValue(matId, out RenderMaterialProxy? proxy))
+    // set applicationid here if none
+    matWrapper.ApplicationId ??= matWrapper.GetSpeckleApplicationId();
+    if (RenderMaterialProxies.TryGetValue(matWrapper.ApplicationId, out RenderMaterialProxy? proxy))
     {
       proxy.objects.Add(objectId);
     }
     else
     {
-      matWrapper.Base.applicationId = matId;
       RenderMaterialProxy newMaterialProxy =
         new()
         {
-          value = matWrapper.Base,
-          applicationId = matId,
-          objects = new()
+          value = matWrapper.Material,
+          applicationId = matWrapper.ApplicationId,
+          objects = new() { objectId }
         };
 
-      newMaterialProxy.objects.Add(objectId);
-      RenderMaterialProxies[matId] = newMaterialProxy;
+      RenderMaterialProxies[matWrapper.ApplicationId] = newMaterialProxy;
     }
   }
 }

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Operations/Send/GrasshopperSendOperation.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Operations/Send/GrasshopperSendOperation.cs
@@ -140,7 +140,7 @@ public class GrasshopperRootObjectBuilder() : IRootObjectBuilder<SpeckleCollecti
         // check if the object wrapper smells like existing object wrappers.
         if (objectWrapper.SmellsLike(wrappers.FirstOrDefault()))
         {
-          objectWrapper.applicationId = processedId;
+          objectWrapper.WrapperGuid = processedId;
           _applicationIdCache[processedId].Add(objectWrapper);
           return;
         }
@@ -149,7 +149,7 @@ public class GrasshopperRootObjectBuilder() : IRootObjectBuilder<SpeckleCollecti
 
     // if no similar wrappers found, create a new appid and store this.
     string newId = Guid.NewGuid().ToString();
-    objectWrapper.applicationId = newId;
+    objectWrapper.WrapperGuid = newId;
     processedIds.Add(newId);
     _applicationIdCache.Add(newId, new() { objectWrapper });
     return;

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/SpeckleCollectionWrapper.ModelObjects.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/SpeckleCollectionWrapper.ModelObjects.cs
@@ -83,10 +83,10 @@ public partial class SpeckleCollectionWrapperGoo : GH_Goo<SpeckleCollectionWrapp
 
       Value = new SpeckleCollectionWrapper(GetModelLayerPath(modelLayer))
       {
+        Name = modelLayer.Name,
         Base = modelCollection,
         Color = layerColor,
-        Material = layerMaterial,
-        WrapperGuid = null
+        Material = layerMaterial
       };
 
       return true;

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/SpeckleCollectionWrapper.ModelObjects.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/SpeckleCollectionWrapper.ModelObjects.cs
@@ -81,7 +81,14 @@ public partial class SpeckleCollectionWrapperGoo : GH_Goo<SpeckleCollectionWrapp
         layerMaterial = materialGoo.Value;
       }
 
-      Value = new SpeckleCollectionWrapper(modelCollection, GetModelLayerPath(modelLayer), layerColor, layerMaterial);
+      Value = new SpeckleCollectionWrapper(GetModelLayerPath(modelLayer))
+      {
+        Base = modelCollection,
+        Color = layerColor,
+        Material = layerMaterial,
+        WrapperGuid = null
+      };
+
       return true;
     }
 

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/SpeckleCollectionWrapper.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/SpeckleCollectionWrapper.cs
@@ -18,11 +18,9 @@ namespace Speckle.Connectors.GrasshopperShared.Parameters;
 public class SpeckleCollectionWrapper : SpeckleWrapper
 #pragma warning restore CA1711 // Identifiers should not have incorrect suffix
 {
-  private Collection StoredCollection { get; set; }
-
   public override required Base Base
   {
-    get => StoredCollection;
+    get => Collection;
     set
     {
       if (value is not Collection coll)
@@ -30,20 +28,37 @@ public class SpeckleCollectionWrapper : SpeckleWrapper
         throw new ArgumentException("Cannot create collection wrapper from a non-Collection Base");
       }
 
-      StoredCollection = coll;
+      Collection = coll;
     }
   }
 
-  public Collection Collection => StoredCollection;
+  public Collection Collection { get; set; }
 
   // the list of layer names that build up the path to this collection, including this collection name
   public ObservableCollection<string> Path { get; set; }
 
   public List<SpeckleWrapper> Elements { get; set; } = new();
 
-  public string Topology { get; set; }
+  /// <summary>
+  /// The Grasshopper Topology of this collection. This setter also sets the "topology" prop dynamicall on <see cref="Collection"/>
+  /// </summary>
+  public string? Topology
+  {
+    get => Collection[Constants.TOPOLOGY_PROP] as string;
+    set => Collection[Constants.TOPOLOGY_PROP] = value;
+  }
 
-  public override string ToString() => $"{Collection.name} [{Collection.elements.Count}]";
+  /// <summary>
+  /// The color of the <see cref="Base"/>
+  /// </summary>
+  public required Color? Color { get; set; }
+
+  /// <summary>
+  /// The material of the <see cref="Base"/>
+  /// </summary>
+  public required SpeckleMaterialWrapper? Material { get; set; }
+
+  public override string ToString() => $"{Name} [{Elements.Count}]";
 
   public SpeckleCollectionWrapper(List<string> path)
   {
@@ -170,8 +185,7 @@ public partial class SpeckleCollectionWrapperGoo : GH_Goo<SpeckleCollectionWrapp
 {
   public override IGH_Goo Duplicate() => throw new NotImplementedException();
 
-  public override string ToString() =>
-    $@"Speckle Collection Goo [{m_value.Collection?.name} ({Value.Collection.elements.Count})]";
+  public override string ToString() => $@"Speckle Collection Goo [{m_value.Name} ({Value.Elements.Count})]";
 
   public override bool IsValid => true;
   public override string TypeName => "Speckle collection wrapper";

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/SpeckleGrasshopperObject.ModelObjects.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/SpeckleGrasshopperObject.ModelObjects.cs
@@ -105,7 +105,7 @@ public partial class SpeckleObjectWrapperGoo : GH_Goo<SpeckleObjectWrapper>, IGH
             Color = color is null ? null : Color.FromArgb(color.Value.Color.ToArgb()),
             Material = materialWrapper.Value,
             Properties = propertyGroup,
-            applicationId = null // keep this null, processed on send
+            WrapperGuid = null // keep this null, processed on send
           };
 
         Value = so;

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/SpeckleGrasshopperObject.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/SpeckleGrasshopperObject.cs
@@ -14,22 +14,28 @@ namespace Speckle.Connectors.GrasshopperShared.Parameters;
 /// <summary>
 /// Wrapper around a geometry base object and its converted speckle equivalent.
 /// </summary>
-public class SpeckleObjectWrapper : Base
+public class SpeckleObjectWrapper : SpeckleWrapper
 {
-  public required Base Base { get; set; }
+  public override required Base Base { get; set; }
 
-  // note: how will we send intervals and other gh native objects? do we? maybe not for now
-  // note: this does not handle on to many relationship well.
-  // For receiving data objects, we are wrapping every value in the data object display value, and storing a reference to the same data object in each wrapped object.
+  /// <summary>
+  /// The GeometryBase corresponding to the <see cref="SpeckleWrapper.Base"/>
+  /// </summary>
+  /// <remarks>
+  /// POC: how will we send intervals and other gh native objects? do we? maybe not for now?
+  /// Objects using fallback conversion (eg DataObjects) will create one wrapper per geometry in the display value.
+  /// </remarks>
   public required GeometryBase? GeometryBase { get; set; }
 
   // The list of layer/collection names that forms the full path to this object
   public List<string> Path { get; set; } = new();
   public SpeckleCollectionWrapper? Parent { get; set; }
   public SpecklePropertyGroupGoo Properties { get; set; } = new();
+
+  /// <summary>
+  /// The name of the object. If this wrapper is a result of fallback conversion, this will store the parent name.
+  /// </summary>
   public required string Name { get; set; } = "";
-  public required Color? Color { get; set; }
-  public required SpeckleMaterialWrapper? Material { get; set; }
 
   public override string ToString() => $"Speckle Wrapper [{GeometryBase?.GetType().Name}]";
 
@@ -224,7 +230,9 @@ public partial class SpeckleObjectWrapperGoo : GH_Goo<SpeckleObjectWrapper>, IGH
           Base = gooConverted,
           Name = "",
           Color = null,
-          Material = null
+          Material = null,
+          WrapperGuid = null,
+          ApplicationId = Guid.NewGuid().ToString()
         };
         return true;
     }
@@ -278,7 +286,8 @@ public partial class SpeckleObjectWrapperGoo : GH_Goo<SpeckleObjectWrapper>, IGH
       GeometryBase = null,
       Color = null,
       Material = null,
-      Name = ""
+      Name = "",
+      WrapperGuid = null,
     };
   }
 }

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/SpeckleMaterialWrapper.ModelObjects.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/SpeckleMaterialWrapper.ModelObjects.cs
@@ -32,6 +32,8 @@ public partial class SpeckleMaterialWrapperGoo : GH_Goo<SpeckleMaterialWrapper>,
         Value = new()
         {
           Base = ToSpeckleRenderMaterial(renderMaterial),
+          Name = renderMaterial.Name,
+          ApplicationId = renderMaterial.Id.ToString(),
           RhinoMaterial = renderMaterial.ToMaterial(RenderTexture.TextureGeneration.Allow),
           RhinoRenderMaterialId = renderMaterial.Id
         };

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/SpeckleMaterialWrapper.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/SpeckleMaterialWrapper.cs
@@ -14,9 +14,23 @@ namespace Speckle.Connectors.GrasshopperShared.Parameters;
 /// <summary>
 /// Wrapper around a render material base object and its converted speckle equivalent.
 /// </summary>
-public class SpeckleMaterialWrapper : Base
+public class SpeckleMaterialWrapper : SpeckleWrapper
 {
-  public required SpeckleRenderMaterial Base { get; set; }
+  public override required Base Base
+  {
+    get => Material;
+    set
+    {
+      if (value is not SpeckleRenderMaterial mat)
+      {
+        throw new ArgumentException("Cannot create material wrapper from a non-SpeckleRenderMaterial Base");
+      }
+
+      Material = mat;
+    }
+  }
+
+  public SpeckleRenderMaterial Material { get; set; }
 
   public required Material RhinoMaterial { get; set; }
 
@@ -51,7 +65,7 @@ public partial class SpeckleMaterialWrapperGoo : GH_Goo<SpeckleMaterialWrapper>,
 {
   public override IGH_Goo Duplicate() => throw new NotImplementedException();
 
-  public override string ToString() => $@"Speckle Material Goo [{Value.Base.name}]";
+  public override string ToString() => $@"Speckle Material Goo [{Value.Name}]";
 
   public override bool IsValid => true;
   public override string TypeName => "Speckle render material wrapper";
@@ -68,17 +82,20 @@ public partial class SpeckleMaterialWrapperGoo : GH_Goo<SpeckleMaterialWrapper>,
         Value = speckleGrasshopperMaterialGoo.Value;
         return true;
       case GH_Material materialGoo:
+        var gooMaterial = ToRhinoMaterial(materialGoo.Value);
         Value = new()
         {
           Base = ToSpeckleRenderMaterial(materialGoo.Value),
-          RhinoMaterial = ToRhinoMaterial(materialGoo.Value),
-          RhinoRenderMaterialId = Guid.Empty
+          Name = gooMaterial.Name,
+          RhinoMaterial = gooMaterial,
+          RhinoRenderMaterialId = Guid.Empty,
         };
         return true;
       case Material material:
         Value = new()
         {
           Base = ToSpeckleRenderMaterial(material),
+          Name = material.Name,
           RhinoMaterial = material,
           RhinoRenderMaterialId = Guid.Empty
         };
@@ -87,8 +104,10 @@ public partial class SpeckleMaterialWrapperGoo : GH_Goo<SpeckleMaterialWrapper>,
         Value = new()
         {
           Base = speckleMaterial,
+          Name = speckleMaterial.name,
           RhinoMaterial = ToRhinoMaterial(speckleMaterial),
-          RhinoRenderMaterialId = Guid.Empty
+          RhinoRenderMaterialId = Guid.Empty,
+          ApplicationId = speckleMaterial.applicationId,
         };
         return true;
     }
@@ -125,7 +144,7 @@ public partial class SpeckleMaterialWrapperGoo : GH_Goo<SpeckleMaterialWrapper>,
     SpeckleRenderMaterial speckleRenderMaterial =
       new()
       {
-        name = "",
+        name = mat.GetSpeckleApplicationId(),
         opacity = 1 - mat.Transparency,
         metalness = mat.Shine,
         diffuse = mat.Diffuse.ToArgb(),
@@ -257,7 +276,7 @@ public class SpeckleMaterialParam : GH_Param<SpeckleMaterialWrapperGoo>, IGH_Bak
         string? name =
           NickName != NICKNAME
             ? NickName
-            : string.IsNullOrEmpty(goo.Value.RhinoMaterial.Name)
+            : string.IsNullOrEmpty(goo.Value.Name)
               ? NickName
               : null;
 
@@ -284,7 +303,7 @@ public class SpeckleMaterialParam : GH_Param<SpeckleMaterialWrapperGoo>, IGH_Bak
         string? name =
           NickName != NICKNAME
             ? NickName
-            : string.IsNullOrEmpty(goo.Value.RhinoMaterial.Name)
+            : string.IsNullOrEmpty(goo.Value.Name)
               ? NickName
               : null;
 

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/SpecklePropertyWrapper.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/SpecklePropertyWrapper.cs
@@ -26,11 +26,11 @@ public class SpecklePropertyGoo : GH_Goo<object>, ISpeckleGoo
     }
     else
     {
-      //TODO: throw
+      // todo: throw
     }
   }
 
-  public override bool CastFrom(object source)
+  public override bool CastFrom(object? source)
   {
     switch (source)
     {

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/SpeckleWrapper.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/SpeckleWrapper.cs
@@ -1,0 +1,39 @@
+using Speckle.Sdk.Models;
+
+namespace Speckle.Connectors.GrasshopperShared.Parameters;
+
+public abstract class SpeckleWrapper
+{
+  public abstract required Base Base { get; set; }
+
+  private string? _applicationId;
+
+  /// <summary>
+  /// Represents the <see cref="Base.applicationId"/>. When set, this will also update the applicationId of <see cref="Base"/>.
+  /// </summary>
+  public string? ApplicationId
+  {
+    get => _applicationId;
+    set
+    {
+      _applicationId = value;
+      Base.applicationId = value;
+    }
+  }
+
+  /// <summary>
+  /// The color of the <see cref="Base"/>
+  /// </summary>
+  public required Color? Color { get; set; }
+
+  /// <summary>
+  /// The material of the <see cref="Base"/>
+  /// </summary>
+  public required SpeckleMaterialWrapper? Material { get; set; }
+
+  /// <summary>
+  /// Represents the guid of this <see cref="SpeckleWrapper"/>
+  /// </summary>
+  /// <remarks>This property will usually be assigned in create components, or in publish components</remarks>
+  public required string? WrapperGuid { get; set; }
+}

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/SpeckleWrapper.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/SpeckleWrapper.cs
@@ -1,39 +1,27 @@
+using Speckle.Connectors.GrasshopperShared.HostApp;
 using Speckle.Sdk.Models;
 
 namespace Speckle.Connectors.GrasshopperShared.Parameters;
 
 public abstract class SpeckleWrapper
 {
-  public abstract required Base Base { get; set; }
+  /// <summary>
+  /// The name of the object. When set, this will also update the "name" property of <see cref="Base"/>.
+  /// </summary>
+  public string Name
+  {
+    get => Base[Constants.NAME_PROP] as string ?? "";
+    set => Base[Constants.NAME_PROP] = value;
+  }
 
-  private string? _applicationId;
+  public abstract Base Base { get; set; }
 
   /// <summary>
   /// Represents the <see cref="Base.applicationId"/>. When set, this will also update the applicationId of <see cref="Base"/>.
   /// </summary>
   public string? ApplicationId
   {
-    get => _applicationId;
-    set
-    {
-      _applicationId = value;
-      Base.applicationId = value;
-    }
+    get => Base.applicationId;
+    set => Base.applicationId = value;
   }
-
-  /// <summary>
-  /// The color of the <see cref="Base"/>
-  /// </summary>
-  public required Color? Color { get; set; }
-
-  /// <summary>
-  /// The material of the <see cref="Base"/>
-  /// </summary>
-  public required SpeckleMaterialWrapper? Material { get; set; }
-
-  /// <summary>
-  /// Represents the guid of this <see cref="SpeckleWrapper"/>
-  /// </summary>
-  /// <remarks>This property will usually be assigned in create components, or in publish components</remarks>
-  public required string? WrapperGuid { get; set; }
 }

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Registration/PriorityLoader.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Registration/PriorityLoader.cs
@@ -11,7 +11,6 @@ using Speckle.Connectors.GrasshopperShared.Parameters;
 using Speckle.Converters.Rhino;
 using Speckle.Sdk;
 using Speckle.Sdk.Credentials;
-using Speckle.Sdk.Host;
 using Speckle.Sdk.Models.GraphTraversal;
 
 namespace Speckle.Connectors.GrasshopperShared.Registration;

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Speckle.Connectors.GrasshopperShared.projitems
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Speckle.Connectors.GrasshopperShared.projitems
@@ -44,7 +44,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)HostApp\Helpers.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HostApp\SpeckleResource.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HostApp\SpeckleResourceBuilder.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Parameters\ISpeckleWrapper.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Parameters\SpeckleWrapper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Parameters\SpeckleMaterialWrapper.ModelObjects.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Parameters\SpeckleMaterialWrapper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Properties\Resources.Designer.cs" />
@@ -55,7 +55,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Parameters\SpeckleCollectionWrapper.ModelObjects.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Parameters\SpeckleCollectionWrapper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Parameters\SpeckleGrasshopperObject.ModelObjects.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Parameters\SpeckleGrasshopperObject.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Parameters\SpeckleObjectWrapper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Parameters\SpecklePropertyGroupWrapper.ModelObjects.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Parameters\SpecklePropertyGroupWrapper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Parameters\SpecklePropertyWrapper.cs" />

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Speckle.Connectors.GrasshopperShared.projitems
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Speckle.Connectors.GrasshopperShared.projitems
@@ -44,6 +44,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)HostApp\Helpers.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HostApp\SpeckleResource.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HostApp\SpeckleResourceBuilder.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Parameters\ISpeckleWrapper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Parameters\SpeckleMaterialWrapper.ModelObjects.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Parameters\SpeckleMaterialWrapper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Properties\Resources.Designer.cs" />


### PR DESCRIPTION
Removes all base inheritance on wrappers. This is a decently big refactor including:
- Add an abstract SpeckleWrapper class to define common props of wrappers.
- Add an Elements (List<SpeckleWrapper>) to the CollectionWrapper, to replace Base inheritance hack (to allow collection wrappers to store other collections and objects.