### PR TITLE
feat(grasshopper): add layer to model object casting

### DIFF
--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Collections/CreateCollection.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Collections/CreateCollection.cs
@@ -156,7 +156,7 @@ public class CreateCollection : GH_Component, IGH_VariableParameterComponent
   {
     var myParam = new Param_GenericObject
     {
-      Name = $"Collection {Params.Input.Count + 1}",
+      Name = $"Sub-Collection {Params.Input.Count + 1}",
       MutableNickName = true,
       Optional = true,
       Access = GH_ParamAccess.tree // always tree

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Collections/CreateCollection.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Collections/CreateCollection.cs
@@ -1,4 +1,3 @@
-using System.Collections.ObjectModel;
 using Grasshopper.Kernel;
 using Grasshopper.Kernel.Parameters;
 using Speckle.Connectors.GrasshopperShared.HostApp;
@@ -44,10 +43,11 @@ public class CreateCollection : GH_Component, IGH_VariableParameterComponent
     string rootName = "Unnamed";
     Collection rootCollection = new();
     SpeckleCollectionWrapper rootSpeckleCollectionWrapper =
-      new(new() { rootName })
+      new()
       {
         Base = rootCollection,
         Name = rootName,
+        Path = new() { rootName },
         Color = null,
         Material = null,
         ApplicationId = InstanceGuid.ToString()
@@ -61,8 +61,12 @@ public class CreateCollection : GH_Component, IGH_VariableParameterComponent
         continue;
       }
 
-      var inputCollections = data.OfType<SpeckleCollectionWrapperGoo>().Empty().ToList();
+      var inputCollections = data.OfType<SpeckleCollectionWrapperGoo>()
+        .Empty()
+        .Select(o => (SpeckleCollectionWrapperGoo)o.Duplicate())
+        .ToList();
       var inputNonCollections = data.Where(t => t is not SpeckleCollectionWrapperGoo).Empty().ToList();
+
       if (inputCollections.Count != 0 && inputNonCollections.Count != 0)
       {
         // TODO: error out! we want to disallow setting objects and collections in the same parent collection
@@ -76,10 +80,11 @@ public class CreateCollection : GH_Component, IGH_VariableParameterComponent
       List<string> childPath = new() { rootName };
       childPath.Add(inputParam.NickName);
       SpeckleCollectionWrapper childSpeckleCollectionWrapper =
-        new(childPath)
+        new()
         {
           Base = new Collection(),
           Name = inputParam.NickName,
+          Path = childPath,
           Color = null,
           Material = null,
           Topology = GrasshopperHelpers.GetParamTopology(inputParam),
@@ -95,7 +100,7 @@ public class CreateCollection : GH_Component, IGH_VariableParameterComponent
         foreach (SpeckleCollectionWrapperGoo wrapperGoo in inputCollections)
         {
           // update the speckle collection path
-          wrapperGoo.Value.Path = new ObservableCollection<string>(childPath);
+          wrapperGoo.Value.Path = childPath;
 
           foreach (
             string subCollectionName in wrapperGoo.Value.Elements.OfType<SpeckleCollectionWrapper>().Select(c => c.Name)

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Dev/DeconstructSpeckleParam.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Dev/DeconstructSpeckleParam.cs
@@ -214,7 +214,7 @@ public class DeconstructSpeckleParam : GH_Component, IGH_VariableParameterCompon
         {
           Base = @base,
           GeometryBase = null,
-          Name = @base["name"] as string ?? "",
+          Name = @base[Constants.NAME_PROP] as string ?? "",
           Color = null,
           Material = null,
           WrapperGuid = null,

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Operations/Receive/GrasshopperCollectionRebuilder.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Operations/Receive/GrasshopperCollectionRebuilder.cs
@@ -1,3 +1,4 @@
+using Speckle.Connectors.GrasshopperShared.HostApp;
 using Speckle.Connectors.GrasshopperShared.Parameters;
 using Speckle.Sdk.Models.Collections;
 
@@ -12,13 +13,14 @@ internal sealed class GrasshopperCollectionRebuilder
 
   public GrasshopperCollectionRebuilder(Collection baseCollection)
   {
-    RootCollectionWrapper = new SpeckleCollectionWrapper(new() { baseCollection.name })
+    RootCollectionWrapper = new SpeckleCollectionWrapper()
     {
       Base = new Collection(),
       Name = baseCollection.name,
       Color = null,
       Material = null,
       ApplicationId = baseCollection.applicationId ?? Guid.NewGuid().ToString(),
+      Path = new() { baseCollection.name }
     };
   }
 
@@ -79,11 +81,12 @@ internal sealed class GrasshopperCollectionRebuilder
 
       // create and cache if needed
       SpeckleCollectionWrapper newSpeckleCollectionWrapper =
-        new(currentLayerPath)
+        new()
         {
           Base = new Collection(),
           Name = collectionName,
           ApplicationId = collection.applicationId,
+          Path = currentLayerPath,
           Color = colorUnpacker.Cache.TryGetValue(collection.applicationId ?? "", out var cachedCollectionColor)
             ? cachedCollectionColor
             : null,
@@ -95,7 +98,7 @@ internal sealed class GrasshopperCollectionRebuilder
             : null,
         };
 
-      if (collection["topology"] is string topology)
+      if (collection[Constants.TOPOLOGY_PROP] is string topology)
       {
         newSpeckleCollectionWrapper.Topology = topology;
       }

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Operations/Receive/LocalToGlobalMapHandler.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Operations/Receive/LocalToGlobalMapHandler.cs
@@ -65,12 +65,12 @@ internal sealed class LocalToGlobalMapHandler
       }
       else
       {
-        if (map.AtomicObject["properties"] is Dictionary<string, object?> props)
+        if (map.AtomicObject[Constants.PROPERTIES_PROP] is Dictionary<string, object?> props)
         {
           propertyGroup.CastFrom(props);
         }
 
-        if (map.AtomicObject["name"] is string n)
+        if (map.AtomicObject[Constants.NAME_PROP] is string n)
         {
           name = n;
         }

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/SpeckleCollectionWrapper.ModelObjects.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/SpeckleCollectionWrapper.ModelObjects.cs
@@ -81,12 +81,13 @@ public partial class SpeckleCollectionWrapperGoo : GH_Goo<SpeckleCollectionWrapp
         layerMaterial = materialGoo.Value;
       }
 
-      Value = new SpeckleCollectionWrapper(GetModelLayerPath(modelLayer))
+      Value = new SpeckleCollectionWrapper()
       {
         Base = modelCollection,
         Name = modelLayer.Name,
         Color = layerColor,
-        Material = layerMaterial
+        Material = layerMaterial,
+        Path = GetModelLayerPath(modelLayer)
       };
 
       return true;

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/SpeckleCollectionWrapper.ModelObjects.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/SpeckleCollectionWrapper.ModelObjects.cs
@@ -83,8 +83,8 @@ public partial class SpeckleCollectionWrapperGoo : GH_Goo<SpeckleCollectionWrapp
 
       Value = new SpeckleCollectionWrapper(GetModelLayerPath(modelLayer))
       {
-        Name = modelLayer.Name,
         Base = modelCollection,
+        Name = modelLayer.Name,
         Color = layerColor,
         Material = layerMaterial
       };
@@ -95,21 +95,7 @@ public partial class SpeckleCollectionWrapperGoo : GH_Goo<SpeckleCollectionWrapp
     return false;
   }
 
-  private List<string> GetModelLayerPath(ModelLayer modellayer)
-  {
-    ModelContentName currentParent = modellayer.Parent;
-    ModelContentName stem = modellayer.Parent.Stem;
-    List<string> path = new() { modellayer.Name };
-    while (currentParent != stem)
-    {
-      path.Add(currentParent);
-      currentParent = currentParent.Parent;
-    }
-    path.Add(stem);
-
-    path.Reverse();
-    return path;
-  }
+  private List<string> GetModelLayerPath(ModelLayer modellayer) => modellayer.Path.Split().ToList();
 }
 
 #endif

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/SpeckleCollectionWrapper.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/SpeckleCollectionWrapper.cs
@@ -60,6 +60,11 @@ public class SpeckleCollectionWrapper : SpeckleWrapper
 
   public override string ToString() => $"{Name} [{Elements.Count}]";
 
+  /// <summary>
+  /// Constructor that will create an observable collection from the input path.
+  /// <see cref="Collection"/> MUST be set before <see cref="SpeckleWrapper.Name", since name will update the input collection's name as well./>
+  /// </summary>
+  /// <param name="path"></param>
   public SpeckleCollectionWrapper(List<string> path)
   {
     Path = new ObservableCollection<string>(path);
@@ -70,9 +75,17 @@ public class SpeckleCollectionWrapper : SpeckleWrapper
     Path.CollectionChanged += OnPathChanged;
   }
 
+  /// <summary>
+  /// Will attempt to retrieve an existing Layer from the <see cref="Path"/>.
+  /// </summary>
+  /// <returns>Index of existing layer if found, or -1 if not.</returns>
+  public int GetLayerIndex() => RhinoDoc.ActiveDoc.Layers.FindByFullPath(string.Join("::", Path), -1);
+
   private void OnPathChanged(object sender, NotifyCollectionChangedEventArgs e)
   {
     var newPath = e.NewItems.Cast<string>().ToList();
+
+    // then update paths of all children
     foreach (var element in Elements)
     {
       if (element is SpeckleObjectWrapper o)
@@ -81,6 +94,8 @@ public class SpeckleCollectionWrapper : SpeckleWrapper
       }
       else if (element is SpeckleCollectionWrapper c)
       {
+        // don't forget to add the child collection name to the path
+        newPath.Add(c.Name);
         c.Path = new ObservableCollection<string>(newPath);
       }
     }

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/SpeckleCollectionWrapper.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/SpeckleCollectionWrapper.cs
@@ -62,7 +62,7 @@ public class SpeckleCollectionWrapper : SpeckleWrapper
 
   /// <summary>
   /// Constructor that will create an observable collection from the input path.
-  /// <see cref="Collection"/> MUST be set before <see cref="SpeckleWrapper.Name", since name will update the input collection's name as well./>
+  /// <see cref="Collection"/> MUST be set before <see cref="SpeckleWrapper.Name"/> since name will update the input collection's name as well./>
   /// </summary>
   /// <param name="path"></param>
   public SpeckleCollectionWrapper(List<string> path)

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/SpeckleCollectionWrapper.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/SpeckleCollectionWrapper.cs
@@ -1,5 +1,3 @@
-using System.Collections.ObjectModel;
-using System.Collections.Specialized;
 using Grasshopper.Kernel;
 using Grasshopper.Kernel.Types;
 using Rhino;
@@ -14,6 +12,14 @@ using Layer = Rhino.DocObjects.Layer;
 
 namespace Speckle.Connectors.GrasshopperShared.Parameters;
 
+/// <summary>
+/// A Wrapper class representing a Speckle Collection to Rhino Layer relationship.
+/// </summary>
+/// <remarks>
+/// When constructing, the following properties need to be set in order:
+/// <see cref="SpeckleWrapper.Base"/>, then <see cref="SpeckleWrapper.Name"/> and <see cref="SpeckleWrapper.ApplicationId"/>
+/// This is because chanbging the Name or ApplicationId will update Collection.
+/// </remarks>
 #pragma warning disable CA1711 // Identifiers should not have incorrect suffix
 public class SpeckleCollectionWrapper : SpeckleWrapper
 #pragma warning restore CA1711 // Identifiers should not have incorrect suffix
@@ -34,8 +40,21 @@ public class SpeckleCollectionWrapper : SpeckleWrapper
 
   public Collection Collection { get; set; }
 
-  // the list of layer names that build up the path to this collection, including this collection name
-  public ObservableCollection<string> Path { get; set; }
+  private List<string> StoredPath { get; set; }
+
+  /// <summary>
+  /// List of Collection names that build up the path to this collection (inclusive of <see cref="SpeckleWrapper.Name"/>;
+  /// </summary>
+  /// <remarks>Setting this property will update all element paths inside <see cref="Elements"/></remarks>
+  public required List<string> Path
+  {
+    get => StoredPath;
+    set
+    {
+      StoredPath = value;
+      OnPathChanged();
+    }
+  }
 
   public List<SpeckleWrapper> Elements { get; set; } = new();
 
@@ -61,45 +80,52 @@ public class SpeckleCollectionWrapper : SpeckleWrapper
   public override string ToString() => $"{Name} [{Elements.Count}]";
 
   /// <summary>
-  /// Constructor that will create an observable collection from the input path.
-  /// <see cref="Collection"/> MUST be set before <see cref="SpeckleWrapper.Name"/> since name will update the input collection's name as well./>
-  /// </summary>
-  /// <param name="path"></param>
-  public SpeckleCollectionWrapper(List<string> path)
-  {
-    Path = new ObservableCollection<string>(path);
-
-    // add listener on path changing.
-    // this can be triggered by a create collection node, that changes the path of this collection.
-    // when this happens, we want to update the paths of all elements downstream
-    Path.CollectionChanged += OnPathChanged;
-  }
-
-  /// <summary>
   /// Will attempt to retrieve an existing Layer from the <see cref="Path"/>.
   /// </summary>
   /// <returns>Index of existing layer if found, or -1 if not.</returns>
   public int GetLayerIndex() => RhinoDoc.ActiveDoc.Layers.FindByFullPath(string.Join("::", Path), -1);
 
-  private void OnPathChanged(object sender, NotifyCollectionChangedEventArgs e)
+  // updates the elements' paths inside this collection
+  private void OnPathChanged()
   {
-    var newPath = e.NewItems.Cast<string>().ToList();
+    var newPath = StoredPath.ToList();
 
-    // then update paths of all children
+    // then update paths and parents of all children
     foreach (var element in Elements)
     {
       if (element is SpeckleObjectWrapper o)
       {
         o.Path = newPath;
+        o.Parent = this;
       }
       else if (element is SpeckleCollectionWrapper c)
       {
         // don't forget to add the child collection name to the path
         newPath.Add(c.Name);
-        c.Path = new ObservableCollection<string>(newPath);
+        c.Path = newPath;
       }
     }
   }
+
+  public SpeckleCollectionWrapper DeepCopy() =>
+    new()
+    {
+      Base = new Collection(Collection.name) { applicationId = Collection.applicationId, id = Collection.id },
+      Color = Color,
+      Material = Material,
+      ApplicationId = ApplicationId,
+      Name = Name,
+      Path = Path,
+      Elements = Elements
+        .Select(e =>
+          e is SpeckleCollectionWrapper c
+            ? c.DeepCopy()
+            : e is SpeckleObjectWrapper o
+              ? o.DeepCopy()
+              : e
+        )
+        .ToList()
+    };
 
   /// <summary>
   /// Bakes this collection as a layer, in its path structure.
@@ -110,8 +136,7 @@ public class SpeckleCollectionWrapper : SpeckleWrapper
   /// <returns>The index of the baked layer</returns>
   public int Bake(RhinoDoc doc, List<Guid> obj_ids, bool bakeObjects, int parentLayerIndex = -1)
   {
-    var path = Path.ToList();
-    if (!LayerExists(doc, path, out int currentLayerIndex))
+    if (!LayerExists(doc, Path, out int currentLayerIndex))
     {
       if (parentLayerIndex != -1)
       {
@@ -122,7 +147,7 @@ public class SpeckleCollectionWrapper : SpeckleWrapper
       }
       else
       {
-        currentLayerIndex = CreateLayerByPath(doc, path, Color, obj_ids);
+        currentLayerIndex = CreateLayerByPath(doc, Path, Color, obj_ids);
       }
     }
 
@@ -147,7 +172,7 @@ public class SpeckleCollectionWrapper : SpeckleWrapper
 
   private bool LayerExists(RhinoDoc doc, List<string> path, out int layerIndex)
   {
-    var fullPath = string.Join(Constants.LAYER_PATH_DELIMITER, path);
+    var fullPath = string.Join("::", path);
     layerIndex = doc.Layers.FindByFullPath(fullPath, -1);
     return layerIndex != -1;
   }
@@ -198,7 +223,7 @@ public class SpeckleCollectionWrapper : SpeckleWrapper
 
 public partial class SpeckleCollectionWrapperGoo : GH_Goo<SpeckleCollectionWrapper>, ISpeckleGoo //, IGH_PreviewData // can be made previewable later
 {
-  public override IGH_Goo Duplicate() => throw new NotImplementedException();
+  public override IGH_Goo Duplicate() => new SpeckleCollectionWrapperGoo(Value.DeepCopy());
 
   public override string ToString() => $@"Speckle Collection Goo [{m_value.Name} ({Value.Elements.Count})]";
 

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/SpeckleMaterialWrapper.ModelObjects.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/SpeckleMaterialWrapper.ModelObjects.cs
@@ -77,7 +77,13 @@ public partial class SpeckleMaterialWrapperGoo : GH_Goo<SpeckleMaterialWrapper>,
       }
       else
       {
-        target = (T)(object)(new ModelRenderMaterial(Value.RhinoMaterial));
+        var atts = new ModelRenderMaterial.Attributes()
+        {
+          Name = Value.Name,
+          RenderMaterial = RenderMaterial.CreateBasicMaterial(Value.RhinoMaterial, RhinoDoc.ActiveDoc)
+        };
+
+        target = (T)(object)(new ModelRenderMaterial(atts));
         return true;
       }
     }

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/SpeckleMaterialWrapper.ModelObjects.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/SpeckleMaterialWrapper.ModelObjects.cs
@@ -60,5 +60,29 @@ public partial class SpeckleMaterialWrapperGoo : GH_Goo<SpeckleMaterialWrapper>,
 
     return false;
   }
+
+  private bool CastToModelRenderMaterial<T>(ref T target)
+  {
+    var type = typeof(T);
+
+    if (type == typeof(ModelRenderMaterial))
+    {
+      if (
+        Value.RhinoRenderMaterialId is Guid matGuid
+        && RhinoDoc.ActiveDoc.RenderMaterials.Find(matGuid) is RenderMaterial existingMat
+      )
+      {
+        target = (T)(object)(new ModelRenderMaterial(existingMat));
+        return true;
+      }
+      else
+      {
+        target = (T)(object)(new ModelRenderMaterial(Value.RhinoMaterial));
+        return true;
+      }
+    }
+
+    return false;
+  }
 }
 #endif

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/SpeckleMaterialWrapper.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/SpeckleMaterialWrapper.cs
@@ -117,6 +117,8 @@ public partial class SpeckleMaterialWrapperGoo : GH_Goo<SpeckleMaterialWrapper>,
 
 #if !RHINO8_OR_GREATER
   private bool CastFromModelRenderMaterial(object _) => false;
+
+  private bool CastToModelRenderMaterial<T>(ref T _) => false;
 #endif
 
   public override bool CastTo<T>(ref T target)
@@ -129,7 +131,7 @@ public partial class SpeckleMaterialWrapperGoo : GH_Goo<SpeckleMaterialWrapper>,
       return true;
     }
 
-    return false;
+    return CastToModelRenderMaterial(ref target);
   }
 
   public SpeckleMaterialWrapperGoo(SpeckleMaterialWrapper value)

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/SpeckleObjectWrapper.ModelObjects.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/SpeckleObjectWrapper.ModelObjects.cs
@@ -8,6 +8,7 @@ using Grasshopper.Rhinoceros.Display;
 using Speckle.Connectors.GrasshopperShared.HostApp;
 using Speckle.Sdk.Models;
 using Rhino.DocObjects;
+using Grasshopper.Rhinoceros.Render;
 
 namespace Speckle.Connectors.GrasshopperShared.Parameters;
 
@@ -77,6 +78,34 @@ public partial class SpeckleObjectWrapperGoo : GH_Goo<SpeckleObjectWrapper>, IGH
 
       target = (T)(object)atts;
       return true;
+    }
+
+    if (type == typeof(ModelRenderMaterial))
+    {
+      if (Value.Material is SpeckleMaterialWrapper matWrapper)
+      {
+        SpeckleMaterialWrapperGoo matWrapperGoo = new(matWrapper);
+        ModelRenderMaterial modelMat = new();
+        if (matWrapperGoo.CastTo<ModelRenderMaterial>(ref modelMat))
+        {
+          target = (T)(object)modelMat;
+          return true;
+        }
+      }
+    }
+
+    if (type == typeof(ModelLayer))
+    {
+      if (Value.Parent is SpeckleCollectionWrapper collWrapper)
+      {
+        SpeckleCollectionWrapperGoo collWrapperGoo = new(collWrapper);
+        ModelLayer modelLayer = new();
+        if (collWrapperGoo.CastTo<ModelLayer>(ref modelLayer))
+        {
+          target = (T)(object)modelLayer;
+          return true;
+        }
+      }
     }
 
     return false;

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/SpeckleObjectWrapper.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/SpeckleObjectWrapper.cs
@@ -210,11 +210,11 @@ public class SpeckleObjectWrapper : SpeckleWrapper
     return true;
   }
 
-  public SpeckleObjectWrapper Copy() =>
+  public SpeckleObjectWrapper DeepCopy() =>
     new()
     {
       Base = Base.ShallowCopy(),
-      GeometryBase = GeometryBase,
+      GeometryBase = GeometryBase?.Duplicate(),
       Color = Color,
       Material = Material,
       WrapperGuid = WrapperGuid,
@@ -228,7 +228,10 @@ public class SpeckleObjectWrapper : SpeckleWrapper
 
 public partial class SpeckleObjectWrapperGoo : GH_Goo<SpeckleObjectWrapper>, IGH_PreviewData, ISpeckleGoo
 {
-  public override IGH_Goo Duplicate() => throw new NotImplementedException();
+  public override IGH_Goo Duplicate()
+  {
+    return new SpeckleObjectWrapperGoo(Value.DeepCopy());
+  }
 
   public override string ToString() => $@"Speckle Object Goo [{m_value.Base.speckle_type}]";
 
@@ -247,10 +250,10 @@ public partial class SpeckleObjectWrapperGoo : GH_Goo<SpeckleObjectWrapper>, IGH
     switch (source)
     {
       case SpeckleObjectWrapper wrapper:
-        Value = wrapper.Copy();
+        Value = wrapper.DeepCopy();
         return true;
       case GH_Goo<SpeckleObjectWrapper> speckleGrasshopperObjectGoo:
-        Value = speckleGrasshopperObjectGoo.Value.Copy();
+        Value = speckleGrasshopperObjectGoo.Value.DeepCopy();
         return true;
       case IGH_GeometricGoo geometricGoo:
         var gooGB = geometricGoo.GeometricGooToGeometryBase();

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/SpeckleUrlModelResourceParam.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/SpeckleUrlModelResourceParam.cs
@@ -27,4 +27,7 @@ public class SpeckleUrlModelResourceParam : GH_Param<SpeckleUrlModelResourceGoo>
 
   public override Guid ComponentGuid => new Guid("E5421FC2-F10D-447F-BF23-5C934ABDB2D3");
   protected override Bitmap Icon => Resources.speckle_param_model;
+
+  // hide this param since we don't do anything with it
+  public override GH_Exposure Exposure => GH_Exposure.hidden;
 }

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Speckle.Connectors.GrasshopperShared.projitems
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Speckle.Connectors.GrasshopperShared.projitems
@@ -55,7 +55,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Parameters\ISpeckleGoo.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Parameters\SpeckleCollectionWrapper.ModelObjects.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Parameters\SpeckleCollectionWrapper.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Parameters\SpeckleGrasshopperObject.ModelObjects.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Parameters\SpeckleObjectWrapper.ModelObjects.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Parameters\SpeckleObjectWrapper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Parameters\SpecklePropertyGroupWrapper.ModelObjects.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Parameters\SpecklePropertyGroupWrapper.cs" />


### PR DESCRIPTION
Adds the layer when casting speckle object to model object, if the layer already exists in the doc.
Also adds "Duplicate()" to wrapper classes, and fixes a bunch of mutation issues