### PR TITLE
fix(grasshopper): materials stuff

### DIFF
--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Objects/CreateSpeckleObject.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Objects/CreateSpeckleObject.cs
@@ -137,7 +137,7 @@ public class CreateSpeckleObject : GH_Component
       {
         AddRuntimeMessage(
           GH_RuntimeMessageLevel.Warning,
-          $"Object input is not valid. Only Speckle Objects, Model Object, and Geometry are accepted."
+          $"Object input is not valid. Only Speckle Objects, Baked Model Objects, and Geometry are accepted."
         );
         return;
       }
@@ -196,7 +196,7 @@ public class CreateSpeckleObject : GH_Component
       {
         AddRuntimeMessage(
           GH_RuntimeMessageLevel.Warning,
-          $"Material input is not valid. Only Display Materials, Model Materials, and Speckle Materials are accepted."
+          $"Material input is not valid. Only Display Materials, Baked Model Materials, and Speckle Materials are accepted."
         );
         return;
       }

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Operations/Send/GrasshopperSendOperation.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Operations/Send/GrasshopperSendOperation.cs
@@ -80,7 +80,7 @@ public class GrasshopperRootObjectBuilder() : IRootObjectBuilder<SpeckleCollecti
         //ProcessObjectWrapper(so, ref collObjectIds);
         DataObject dataObject = ConvertWrappersToDataObject(
           new List<SpeckleObjectWrapper>() { so },
-          so.ApplicationId ?? Guid.NewGuid().ToString()
+          Guid.NewGuid().ToString() // note: we are always generating a new id here, do *not* use the Base appid as this will cause conflicts in viewer for color and material proxy application
         );
         currentColl.elements.Add(dataObject);
 


### PR DESCRIPTION
figured out that in the viewer, if you have a dataobject with the same applicationId as the geometry inside the displayvalue, then the viewer will only apply the material proxy to the first found applicationId (seems random which one it finds first)

solving this by generating a new id for the dataobject always on publish