### PR TITLE
fix(grasshopper): more material bugs

### DIFF
--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Objects/CreateSpeckleProperties.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Objects/CreateSpeckleProperties.cs
@@ -64,7 +64,7 @@ public class CreateSpeckleProperties : GH_Component, IGH_VariableParameterCompon
       if (!success || value == null || actualValue == null)
       {
         AddRuntimeMessage(
-          GH_RuntimeMessageLevel.Error,
+          GH_RuntimeMessageLevel.Warning,
           $"Parameter {Params.Input[i].NickName} should not contain anything other than strings, doubles, ints, and bools."
         );
 

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Operations/Send/GrasshopperSendOperation.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Operations/Send/GrasshopperSendOperation.cs
@@ -39,7 +39,7 @@ public class GrasshopperRootObjectBuilder() : IRootObjectBuilder<SpeckleCollecti
 
     // add proxies
     root[ProxyKeys.COLOR] = colorPacker.ColorProxies.Values.ToList();
-    root[ProxyKeys.MATERIAL] = materialPacker.RenderMaterialProxies.Values.ToList();
+    root[ProxyKeys.RENDER_MATERIAL] = materialPacker.RenderMaterialProxies.Values.ToList();
 
     // TODO: Not getting any conversion results yet
     var result = new RootObjectBuilderResult(root, []);


### PR DESCRIPTION
- fixes render material proxy bug in assigning all proxies to the right key on root collection
- fixes getting an object's color and material even if they are from another source (by layer, by material)
https://latest.speckle.systems/projects/3f895e614f/models/43cb043ee7@c92c54a26d
![{A053766E-BDF8-4C2A-A5B0-F6A57B46010D}](https://github.com/user-attachments/assets/5ad13803-fb74-497c-b0dd-05149ba5c292)
