### PR TITLE
Kateryna/cnx 1762 texts inside dynamic blocks

### DIFF
--- a/Connectors/Autocad/Speckle.Connectors.AutocadShared/HostApp/AutocadInstanceUnpacker.cs
+++ b/Connectors/Autocad/Speckle.Connectors.AutocadShared/HostApp/AutocadInstanceUnpacker.cs
@@ -1,4 +1,5 @@
 using Autodesk.AutoCAD.DatabaseServices;
+using Autodesk.AutoCAD.Geometry;
 using Microsoft.Extensions.Logging;
 using Speckle.Connectors.Autocad.HostApp.Extensions;
 using Speckle.Connectors.Autocad.Operations.Send;
@@ -182,9 +183,27 @@ public class AutocadInstanceUnpacker : IInstanceUnpacker<AutocadRootObject>
 
   private string GetAttributeUniqueKey(DBText attributeText, string tag, Matrix4x4 matrix)
   {
-    Vector3 originalVector = new(attributeText.Position.X, attributeText.Position.Y, attributeText.Position.Z);
-    Vector4 transformed = Vector4.Transform(new Vector4(originalVector, 1), matrix);
-    Vector3 transformedVector = new(transformed.X, transformed.Y, transformed.Z);
+    var matrixArray = new[]
+    {
+      matrix.M11,
+      matrix.M12,
+      matrix.M13,
+      matrix.M14,
+      matrix.M21,
+      matrix.M22,
+      matrix.M23,
+      matrix.M24,
+      matrix.M31,
+      matrix.M32,
+      matrix.M33,
+      matrix.M34,
+      matrix.M41,
+      matrix.M42,
+      matrix.M43,
+      matrix.M44
+    };
+    var transformedPt = attributeText.Position.TransformBy(new Matrix3d(matrixArray));
+    Vector3 transformedVector = new(transformedPt.X, transformedPt.Y, transformedPt.Z);
 
     return $"{tag},{transformedVector},{attributeText.Justify}";
   }

--- a/Connectors/Autocad/Speckle.Connectors.AutocadShared/Operations/Send/AutocadRootObjectBaseBuilder.cs
+++ b/Connectors/Autocad/Speckle.Connectors.AutocadShared/Operations/Send/AutocadRootObjectBaseBuilder.cs
@@ -163,7 +163,11 @@ public abstract class AutocadRootObjectBaseBuilder : IRootObjectBuilder<AutocadR
       {
         converted = instanceProxy;
       }
-      else if (_sendConversionCache.TryGetValue(projectId, applicationId, out ObjectReference? value))
+      // don't read AttributeReference objects from cache: they will have the same id (the one of the AttributeDefinition)
+      else if (
+        _sendConversionCache.TryGetValue(projectId, applicationId, out ObjectReference? value)
+        && (entity is not AttributeReference)
+      )
       {
         converted = value;
       }


### PR DESCRIPTION
<!---

Provide a short summary in the Title above. Use the following template:

category(project): summary

Categories:

* feat: (new feature for the user, not a new feature for build script)
* fix: (bug fix for the user, not a fix to a build script)
* docs: (changes to the documentation)
* style: (formatting, missing semi colons, etc; no production code change)
* refactor: (refactoring production code, eg. renaming a variable)
* test: (adding missing tests, refactoring tests; no production code change)
* chore: (updating grunt tasks etc; no production code change)

Example:

feat(revit): added category filter to send

-->

## Description

<!---

Describe your changes, and why you're making them.

Link related github issues here ->
Fixes #85, Fixes #22, Connects #123

-->

## User Value

<!---

Describe in 1 sentence the user value.

This can also be a link to the relevant thread in Speckle community, or a link to the Linear issue.
-->


## Changes:

<!---

- Item 1
- Item 2

-->

## To-do before merge:

<!---

(Optional -- remove this section if not needed)

Include any notes about things that need to happen before this PR is merged, e.g.:

- [ ] Change the base branch

- [ ] Ensure PR #56 is merged

-->

## Screenshots:

<!---

Include a screenshot the before and after.  This can be a screenshot of a plugin, web frontend, or output in a terminal.

-->

## Validation of changes:

<!---

Describe what tests have been added or amended, and why these demonstrate it works and will prevent this feature being accidentally broken by future changes.

-->

## Checklist:

<!---

This checklist is a useful reminder of related tasks to uphold our repo quality. Amend this list as needed for the pr.

-->
- [ ] My commits are related to the pull request and do not amend unrelated code or documentation.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.

