### PR TITLE
feat(revit): rebar `displayValue` options on send

### DIFF
--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Bindings/RevitReceiveBinding.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Bindings/RevitReceiveBinding.cs
@@ -79,7 +79,8 @@ internal sealed class RevitReceiveBinding : IReceiveBinding
             DetailLevelType.Coarse, // TODO figure out
             null,
             false,
-            true
+            true,
+            false
           )
         );
       // Receive host objects

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Bindings/RevitSendBinding.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Bindings/RevitSendBinding.cs
@@ -138,7 +138,8 @@ internal sealed class RevitSendBinding : RevitBaseBinding, ISendBinding
             _toSpeckleSettingsManager.GetDetailLevelSetting(modelCard),
             _toSpeckleSettingsManager.GetReferencePointSetting(modelCard),
             _toSpeckleSettingsManager.GetSendParameterNullOrEmptyStringsSetting(modelCard),
-            _toSpeckleSettingsManager.GetLinkedModelsSetting(modelCard)
+            _toSpeckleSettingsManager.GetLinkedModelsSetting(modelCard),
+            _toSpeckleSettingsManager.GetSendRebarsAsSolid(modelCard)
           )
         );
 

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Bindings/RevitSendBinding.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Bindings/RevitSendBinding.cs
@@ -110,7 +110,7 @@ internal sealed class RevitSendBinding : RevitBaseBinding, ISendBinding
       new ReferencePointSetting(ReferencePointType.InternalOrigin),
       new SendParameterNullOrEmptyStringsSetting(false),
       new LinkedModelsSetting(true),
-      new SendRebarsAsSolidSetting(false)
+      new SendRebarsAsVolumetricSetting(false)
     ];
 
   public void CancelSend(string modelCardId) => _cancellationManager.CancelOperation(modelCardId);
@@ -139,7 +139,7 @@ internal sealed class RevitSendBinding : RevitBaseBinding, ISendBinding
             _toSpeckleSettingsManager.GetReferencePointSetting(modelCard),
             _toSpeckleSettingsManager.GetSendParameterNullOrEmptyStringsSetting(modelCard),
             _toSpeckleSettingsManager.GetLinkedModelsSetting(modelCard),
-            _toSpeckleSettingsManager.GetSendRebarsAsSolid(modelCard)
+            _toSpeckleSettingsManager.GetSendRebarsAsVolumetric(modelCard)
           )
         );
 

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Bindings/RevitSendBinding.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Bindings/RevitSendBinding.cs
@@ -109,7 +109,8 @@ internal sealed class RevitSendBinding : RevitBaseBinding, ISendBinding
       new DetailLevelSetting(DetailLevelType.Medium),
       new ReferencePointSetting(ReferencePointType.InternalOrigin),
       new SendParameterNullOrEmptyStringsSetting(false),
-      new LinkedModelsSetting(true)
+      new LinkedModelsSetting(true),
+      new SendRebarsAsSolidSetting(false)
     ];
 
   public void CancelSend(string modelCardId) => _cancellationManager.CancelOperation(modelCardId);

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/Settings/SendRebarsAsSolidSetting.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/Settings/SendRebarsAsSolidSetting.cs
@@ -1,0 +1,12 @@
+using Speckle.Connectors.DUI.Settings;
+
+namespace Speckle.Connectors.Revit.Operations.Send.Settings;
+
+public class SendRebarsAsSolidSetting(bool value) : ICardSetting
+{
+  public string? Id { get; set; } = "sendRebarsAsSolid";
+  public string? Title { get; set; } = "Send Rebars As Solid";
+  public string? Type { get; set; } = "boolean";
+  public object? Value { get; set; } = value;
+  public List<string>? Enum { get; set; }
+}

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/Settings/SendRebarsAsVolumetricSetting.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/Settings/SendRebarsAsVolumetricSetting.cs
@@ -2,10 +2,10 @@ using Speckle.Connectors.DUI.Settings;
 
 namespace Speckle.Connectors.Revit.Operations.Send.Settings;
 
-public class SendRebarsAsSolidSetting(bool value) : ICardSetting
+public class SendRebarsAsVolumetricSetting(bool value) : ICardSetting
 {
-  public string? Id { get; set; } = "sendRebarsAsSolid";
-  public string? Title { get; set; } = "Send Rebars As Solid";
+  public string? Id { get; set; } = "sendRebarsAsVolumetric";
+  public string? Title { get; set; } = "Send Rebars As Volumetric";
   public string? Type { get; set; } = "boolean";
   public object? Value { get; set; } = value;
   public List<string>? Enum { get; set; }

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/Settings/ToSpeckleSettingsManager.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/Settings/ToSpeckleSettingsManager.cs
@@ -22,7 +22,7 @@ public class ToSpeckleSettingsManager : IToSpeckleSettingsManager
   private readonly Dictionary<string, Transform?> _referencePointCache = new();
   private readonly Dictionary<string, bool?> _sendNullParamsCache = new();
   private readonly Dictionary<string, bool?> _sendLinkedModelsCache = new();
-  private readonly Dictionary<string, bool?> _sendRebarsAsSolidCache = new();
+  private readonly Dictionary<string, bool?> _sendRebarsAsVolumetricCache = new();
 
   public ToSpeckleSettingsManager(
     RevitContext revitContext,
@@ -122,18 +122,18 @@ public class ToSpeckleSettingsManager : IToSpeckleSettingsManager
     return returnValue;
   }
 
-  public bool GetSendRebarsAsSolid(SenderModelCard modelCard)
+  public bool GetSendRebarsAsVolumetric(SenderModelCard modelCard)
   {
-    var value = modelCard.Settings?.First(s => s.Id == "sendRebarsAsSolid").Value as bool?;
+    var value = modelCard.Settings?.First(s => s.Id == "sendRebarsAsVolumetric").Value as bool?;
     var returnValue = value != null && value.NotNull();
-    if (_sendRebarsAsSolidCache.TryGetValue(modelCard.ModelCardId.NotNull(), out bool? previousValue))
+    if (_sendRebarsAsVolumetricCache.TryGetValue(modelCard.ModelCardId.NotNull(), out bool? previousValue))
     {
       if (previousValue != returnValue)
       {
         EvictCacheForModelCard(modelCard);
       }
     }
-    _sendRebarsAsSolidCache[modelCard.ModelCardId] = returnValue;
+    _sendRebarsAsVolumetricCache[modelCard.ModelCardId] = returnValue;
     return returnValue;
   }
 

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/Settings/ToSpeckleSettingsManager.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/Settings/ToSpeckleSettingsManager.cs
@@ -22,6 +22,7 @@ public class ToSpeckleSettingsManager : IToSpeckleSettingsManager
   private readonly Dictionary<string, Transform?> _referencePointCache = new();
   private readonly Dictionary<string, bool?> _sendNullParamsCache = new();
   private readonly Dictionary<string, bool?> _sendLinkedModelsCache = new();
+  private readonly Dictionary<string, bool?> _sendRebarsAsSolidCache = new();
 
   public ToSpeckleSettingsManager(
     RevitContext revitContext,
@@ -118,6 +119,21 @@ public class ToSpeckleSettingsManager : IToSpeckleSettingsManager
       }
     }
     _sendLinkedModelsCache[modelCard.ModelCardId] = returnValue;
+    return returnValue;
+  }
+
+  public bool GetSendRebarsAsSolid(SenderModelCard modelCard)
+  {
+    var value = modelCard.Settings?.First(s => s.Id == "sendRebarsAsSolid").Value as bool?;
+    var returnValue = value != null && value.NotNull();
+    if (_sendRebarsAsSolidCache.TryGetValue(modelCard.ModelCardId.NotNull(), out bool? previousValue))
+    {
+      if (previousValue != returnValue)
+      {
+        EvictCacheForModelCard(modelCard);
+      }
+    }
+    _sendRebarsAsSolidCache[modelCard.ModelCardId] = returnValue;
     return returnValue;
   }
 

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Speckle.Connectors.RevitShared.projitems
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Speckle.Connectors.RevitShared.projitems
@@ -45,7 +45,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Operations\Send\RevitRootObjectBuilder.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Operations\Send\Settings\LinkedModelsSetting.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Operations\Send\Settings\SendParameterNullOrEmptyStringsSetting.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Operations\Send\Settings\SendRebarsAsSolidSetting.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Operations\Send\Settings\SendRebarsAsVolumetricSetting.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Operations\Send\Settings\ToSpeckleSettingsManager.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Operations\Send\Settings\ReferencePointSetting.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Operations\Send\Settings\DetailLevelSetting.cs" />

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Speckle.Connectors.RevitShared.projitems
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Speckle.Connectors.RevitShared.projitems
@@ -45,6 +45,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Operations\Send\RevitRootObjectBuilder.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Operations\Send\Settings\LinkedModelsSetting.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Operations\Send\Settings\SendParameterNullOrEmptyStringsSetting.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Operations\Send\Settings\SendRebarsAsSolidSetting.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Operations\Send\Settings\ToSpeckleSettingsManager.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Operations\Send\Settings\ReferencePointSetting.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Operations\Send\Settings\DetailLevelSetting.cs" />

--- a/Converters/Revit/Speckle.Converters.RevitShared/Helpers/DisplayValueExtractor.cs
+++ b/Converters/Revit/Speckle.Converters.RevitShared/Helpers/DisplayValueExtractor.cs
@@ -77,8 +77,8 @@ public sealed class DisplayValueExtractor
       // Rebar elements need special handling as get_Geometry() doesn't work properly
       // We either represent them as centerlines or as solids based on settings
       case DB.Structure.Rebar rebar:
-        return _converterSettings.Current.SendRebarsAsSolid
-          ? GetRebarSolidDisplayValue(rebar)
+        return _converterSettings.Current.SendRebarsAsVolumetric
+          ? GetRebarVolumetricDisplayValue(rebar)
           : GetRebarCenterlineDisplayValue(rebar);
 
       // handle specific types of objects with multiple parts or children
@@ -424,7 +424,7 @@ public sealed class DisplayValueExtractor
   /// Instead, we use GetFullGeometryForView() to obtain the geometry and then process it
   /// using the standard geometry sorting and conversion.
   /// </remarks>
-  private List<Base> GetRebarSolidDisplayValue(DB.Structure.Rebar rebar)
+  private List<Base> GetRebarVolumetricDisplayValue(DB.Structure.Rebar rebar)
   {
     var collections = new GeometryCollections();
 

--- a/Converters/Revit/Speckle.Converters.RevitShared/Helpers/DisplayValueExtractor.cs
+++ b/Converters/Revit/Speckle.Converters.RevitShared/Helpers/DisplayValueExtractor.cs
@@ -70,8 +70,34 @@ public sealed class DisplayValueExtractor
             }
           }
         }
-
         return areaDisplay;
+
+      // TODO: AreaReinforcement, RebarInSystem
+      case DB.Structure.Rebar rebar when !_converterSettings.Current.SendRebarsAsSolid:
+      {
+        int numberOfBarPositions = rebar.NumberOfBarPositions;
+        List<DB.Curve> curves = new();
+        for (int barPositionIndex = 0; barPositionIndex < numberOfBarPositions; barPositionIndex++)
+        {
+          curves.AddRange(
+            rebar.GetTransformedCenterlineCurves(
+              false,
+              false,
+              false,
+              DB.Structure.MultiplanarOption.IncludeAllMultiplanarCurves,
+              barPositionIndex
+            )
+          );
+        }
+
+        List<Base> displayValue = new();
+        foreach (var curve in curves)
+        {
+          displayValue.Add(GetCurveDisplayValue(curve));
+        }
+
+        return displayValue;
+      }
 
       // handle specific types of objects with multiple parts or children
       // curtain and stacked walls should have their display values in their children
@@ -85,7 +111,6 @@ public sealed class DisplayValueExtractor
           var topRail = _converterSettings.Current.Document.GetElement(railing.TopRail);
           railingDisplay.AddRange(GetGeometryDisplayValue(topRail));
         }
-
         return railingDisplay;
 
       // POC: footprint roofs can have curtain walls in them. Need to check if they can also have non-curtain wall parts, bc currently not skipping anything.

--- a/Converters/Revit/Speckle.Converters.RevitShared/Settings/RevitConversionSettings.cs
+++ b/Converters/Revit/Speckle.Converters.RevitShared/Settings/RevitConversionSettings.cs
@@ -7,5 +7,6 @@ public record RevitConversionSettings(
   string SpeckleUnits,
   bool SendParameterNullOrEmptyStrings,
   bool SendLinkedModels,
+  bool SendRebarsAsSolid,
   double Tolerance = 0.0164042 // 5mm in ft
 );

--- a/Converters/Revit/Speckle.Converters.RevitShared/Settings/RevitConversionSettings.cs
+++ b/Converters/Revit/Speckle.Converters.RevitShared/Settings/RevitConversionSettings.cs
@@ -7,6 +7,6 @@ public record RevitConversionSettings(
   string SpeckleUnits,
   bool SendParameterNullOrEmptyStrings,
   bool SendLinkedModels,
-  bool SendRebarsAsSolid,
+  bool SendRebarsAsVolumetric,
   double Tolerance = 0.0164042 // 5mm in ft
 );

--- a/Converters/Revit/Speckle.Converters.RevitShared/Settings/RevitConversionSettingsFactory.cs
+++ b/Converters/Revit/Speckle.Converters.RevitShared/Settings/RevitConversionSettingsFactory.cs
@@ -16,6 +16,7 @@ public class RevitConversionSettingsFactory(
     DB.Transform? referencePointTransform,
     bool sendEmptyOrNullParams,
     bool sendLinkedModels,
+    bool sendRebarsAsSolid,
     double tolerance = 0.0164042 // 5mm in ft
   )
   {
@@ -27,6 +28,7 @@ public class RevitConversionSettingsFactory(
       unitConverter.ConvertOrThrow(document.GetUnits().GetFormatOptions(DB.SpecTypeId.Length).GetUnitTypeId()),
       sendEmptyOrNullParams,
       sendLinkedModels,
+      sendRebarsAsSolid,
       tolerance
     );
   }

--- a/Converters/Revit/Speckle.Converters.RevitShared/Settings/RevitConversionSettingsFactory.cs
+++ b/Converters/Revit/Speckle.Converters.RevitShared/Settings/RevitConversionSettingsFactory.cs
@@ -16,7 +16,7 @@ public class RevitConversionSettingsFactory(
     DB.Transform? referencePointTransform,
     bool sendEmptyOrNullParams,
     bool sendLinkedModels,
-    bool sendRebarsAsSolid,
+    bool sendRebarsAsVolumetric,
     double tolerance = 0.0164042 // 5mm in ft
   )
   {
@@ -28,7 +28,7 @@ public class RevitConversionSettingsFactory(
       unitConverter.ConvertOrThrow(document.GetUnits().GetFormatOptions(DB.SpecTypeId.Length).GetUnitTypeId()),
       sendEmptyOrNullParams,
       sendLinkedModels,
-      sendRebarsAsSolid,
+      sendRebarsAsVolumetric,
       tolerance
     );
   }


### PR DESCRIPTION
## Description
Rebar elements had no `DisplayValue` because the standard `get_Geometry()` method returned null for rebars. This PR implements handling for rebar elements with two send modes: centerline and solid, controlled by a toggle: `Send Rebars As Solid` (like in Tekla).

Fixes [CNX-1697](https://linear.app/speckle/issue/CNX-1697/revit-rebar-displayvalue-options-on-send)

## User Value
Proper visualization of rebar.

## Changes:
- `case` for `DB.Structure.Rebar` elements in the `DisplayValueExtractor`
- Send modes for rebars: centerlines and solids (see below screenshot). Default is to send as centerlines (lighter).
- Refactored common geometry processing logic to reduce code duplication

<img width="308" alt="image" src="https://github.com/user-attachments/assets/5ec4dfcc-a6f9-4283-ba7d-66ddab1afbc7" />

## Screenshots:
### Before:

![image](https://github.com/user-attachments/assets/6e9a2f7d-a369-4091-97c0-f72a5a100f9f)

### After (`Send Rebars As Solid == false`)
Speckle model: [link](https://app.speckle.systems/projects/03074a2834/models/181c7a2411@1c4c3f4313)
<img width="1280" alt="image" src="https://github.com/user-attachments/assets/cea88ebd-aca1-4718-81fa-589ef98e7977" />

### After (`Send Rebars As Solid == true`)
Speckle model: [link](https://app.speckle.systems/projects/03074a2834/models/181c7a2411)
<img width="1280" alt="image" src="https://github.com/user-attachments/assets/608e2450-4692-40e0-b224-249b645224c8" />


## Validation of changes:
- Tested both centerline and solid representation modes work correctly

## Checklist:
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] I have added appropriate tests.
- [x] I have updated or added relevant documentation.