### PR TITLE
Chore(rhino): Include grasshopper sample files in build output for installers to copy to Components folder

### DIFF
--- a/Connectors/Rhino/Speckle.Connectors.Grasshopper7/Speckle.Connectors.Grasshopper7.csproj
+++ b/Connectors/Rhino/Speckle.Connectors.Grasshopper7/Speckle.Connectors.Grasshopper7.csproj
@@ -38,6 +38,12 @@
     <ProjectReference Include="..\..\..\Converters\Rhino\Speckle.Converters.Rhino7\Speckle.Converters.Rhino7.csproj" />
     <ProjectReference Include="..\..\..\Sdk\Speckle.Connectors.Common\Speckle.Connectors.Common.csproj" />
   </ItemGroup>
+  
+  <ItemGroup>
+    <Content Include="..\Sample Files\*.gh">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
 
   <Import Project="..\Speckle.Connectors.GrasshopperShared\Speckle.Connectors.GrasshopperShared.projitems" Label="Shared" />
   

--- a/Connectors/Rhino/Speckle.Connectors.Grasshopper7/Speckle.Connectors.Grasshopper7.csproj
+++ b/Connectors/Rhino/Speckle.Connectors.Grasshopper7/Speckle.Connectors.Grasshopper7.csproj
@@ -38,12 +38,6 @@
     <ProjectReference Include="..\..\..\Converters\Rhino\Speckle.Converters.Rhino7\Speckle.Converters.Rhino7.csproj" />
     <ProjectReference Include="..\..\..\Sdk\Speckle.Connectors.Common\Speckle.Connectors.Common.csproj" />
   </ItemGroup>
-  
-  <ItemGroup>
-    <Content Include="..\Sample Files\*.gh">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
 
   <Import Project="..\Speckle.Connectors.GrasshopperShared\Speckle.Connectors.GrasshopperShared.projitems" Label="Shared" />
   

--- a/Connectors/Rhino/Speckle.Connectors.Grasshopper8/Speckle.Connectors.Grasshopper8.csproj
+++ b/Connectors/Rhino/Speckle.Connectors.Grasshopper8/Speckle.Connectors.Grasshopper8.csproj
@@ -39,6 +39,17 @@
     <ProjectReference Include="..\..\..\Sdk\Speckle.Connectors.Common\Speckle.Connectors.Common.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <!--
+    *.gh files are copied by the rhino.iss file into %appdata%\Grasshopper\Libraries
+    Since that folder is not specific to any Rhino version, only one Speckle.Connectors.Grasshopper
+    project need copy it to the output dir (tho this needs to be aligned in the iss file)
+    -->
+    <Content Include="..\Sample Files\*.gh">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+  
   <Import Project="..\Speckle.Connectors.GrasshopperShared\Speckle.Connectors.GrasshopperShared.projitems" Label="Shared" />
   
 </Project>


### PR DESCRIPTION
Required for https://github.com/specklesystems/connector-installers/pull/110

![image](https://github.com/user-attachments/assets/c986849b-c9ea-4f1b-88f4-8cfd47393459)
