### PR TITLE
Bump SDK version

### DIFF
--- a/Connectors/ArcGIS/Speckle.Connectors.ArcGIS3/packages.lock.json
+++ b/Connectors/ArcGIS/Speckle.Connectors.ArcGIS3/packages.lock.json
@@ -233,9 +233,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.3.4, )",
-          "Speckle.Sdk": "[3.3.4, )",
-          "Speckle.Sdk.Dependencies": "[3.3.4, )"
+          "Speckle.Objects": "[3.3.5, )",
+          "Speckle.Sdk": "[3.3.5, )",
+          "Speckle.Sdk.Dependencies": "[3.3.5, )"
         }
       },
       "speckle.connectors.dui": {
@@ -267,7 +267,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.3.4, )"
+          "Speckle.Objects": "[3.3.5, )"
         }
       },
       "LibTessDotNet": {
@@ -311,18 +311,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "MaZQFVtKGpntTwKL8go5zKIzjDJfXQQVpKXEvBPT/7SZISkpLTgmetizcQHZ1DGrA+Tps14dYFEWp7Ai+zCCCA==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "VPbYI8TyPDlKlNUHPLPAL1HveN9649LKVxw8opgGypoqq0MC5I7WxQjDcuB8xKnQ1PCSO8suu4hEJgdyPcEvWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.3.4"
+          "Speckle.Sdk": "3.3.5"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "I7HzhT3PaE+Gd+T2LgqL5kqvc+SPJYnRofJhCv8smsUjADEonxUf+dAEV3AHM31CWGZT6SNe876+drXm60fUDg==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "7r8CmugwinniEF6v0N0bWuC+xpJaRfa/EnEjzj8NLpFG1b3uAjOxteGlQgR+evVacxTCEsuNkio7Mdv97odgpg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -332,14 +332,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.3.4"
+          "Speckle.Sdk.Dependencies": "3.3.5"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "0iGDakpkQIApAD3RCS8D0e5oM6yvvklDQFAEU30IvcQ+wpiEMqKJ2vidWG2vOrHMVPyiN7O457TXB41AhEWNlg=="
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "RukqLb0lVNgtmhKPeZJCncibnyutQ6Dr6+UQCa4PjWinIXpSm3A3ywK9ISkU+5StW1QoejiR7kc9a6qmiLys6w=="
       }
     },
     "net6.0-windows7.0/win-x64": {

--- a/Connectors/Autocad/Speckle.Connectors.Autocad2022/packages.lock.json
+++ b/Connectors/Autocad/Speckle.Connectors.Autocad2022/packages.lock.json
@@ -259,9 +259,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.3.4, )",
-          "Speckle.Sdk": "[3.3.4, )",
-          "Speckle.Sdk.Dependencies": "[3.3.4, )"
+          "Speckle.Objects": "[3.3.5, )",
+          "Speckle.Sdk": "[3.3.5, )",
+          "Speckle.Sdk.Dependencies": "[3.3.5, )"
         }
       },
       "speckle.connectors.dui": {
@@ -292,7 +292,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.3.4, )"
+          "Speckle.Objects": "[3.3.5, )"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -336,18 +336,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "MaZQFVtKGpntTwKL8go5zKIzjDJfXQQVpKXEvBPT/7SZISkpLTgmetizcQHZ1DGrA+Tps14dYFEWp7Ai+zCCCA==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "VPbYI8TyPDlKlNUHPLPAL1HveN9649LKVxw8opgGypoqq0MC5I7WxQjDcuB8xKnQ1PCSO8suu4hEJgdyPcEvWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.3.4"
+          "Speckle.Sdk": "3.3.5"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "I7HzhT3PaE+Gd+T2LgqL5kqvc+SPJYnRofJhCv8smsUjADEonxUf+dAEV3AHM31CWGZT6SNe876+drXm60fUDg==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "7r8CmugwinniEF6v0N0bWuC+xpJaRfa/EnEjzj8NLpFG1b3uAjOxteGlQgR+evVacxTCEsuNkio7Mdv97odgpg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -357,14 +357,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.3.4"
+          "Speckle.Sdk.Dependencies": "3.3.5"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "0iGDakpkQIApAD3RCS8D0e5oM6yvvklDQFAEU30IvcQ+wpiEMqKJ2vidWG2vOrHMVPyiN7O457TXB41AhEWNlg=="
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "RukqLb0lVNgtmhKPeZJCncibnyutQ6Dr6+UQCa4PjWinIXpSm3A3ywK9ISkU+5StW1QoejiR7kc9a6qmiLys6w=="
       }
     }
   }

--- a/Connectors/Autocad/Speckle.Connectors.Autocad2023/packages.lock.json
+++ b/Connectors/Autocad/Speckle.Connectors.Autocad2023/packages.lock.json
@@ -259,9 +259,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.3.4, )",
-          "Speckle.Sdk": "[3.3.4, )",
-          "Speckle.Sdk.Dependencies": "[3.3.4, )"
+          "Speckle.Objects": "[3.3.5, )",
+          "Speckle.Sdk": "[3.3.5, )",
+          "Speckle.Sdk.Dependencies": "[3.3.5, )"
         }
       },
       "speckle.connectors.dui": {
@@ -292,7 +292,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.3.4, )"
+          "Speckle.Objects": "[3.3.5, )"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -336,18 +336,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "MaZQFVtKGpntTwKL8go5zKIzjDJfXQQVpKXEvBPT/7SZISkpLTgmetizcQHZ1DGrA+Tps14dYFEWp7Ai+zCCCA==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "VPbYI8TyPDlKlNUHPLPAL1HveN9649LKVxw8opgGypoqq0MC5I7WxQjDcuB8xKnQ1PCSO8suu4hEJgdyPcEvWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.3.4"
+          "Speckle.Sdk": "3.3.5"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "I7HzhT3PaE+Gd+T2LgqL5kqvc+SPJYnRofJhCv8smsUjADEonxUf+dAEV3AHM31CWGZT6SNe876+drXm60fUDg==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "7r8CmugwinniEF6v0N0bWuC+xpJaRfa/EnEjzj8NLpFG1b3uAjOxteGlQgR+evVacxTCEsuNkio7Mdv97odgpg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -357,14 +357,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.3.4"
+          "Speckle.Sdk.Dependencies": "3.3.5"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "0iGDakpkQIApAD3RCS8D0e5oM6yvvklDQFAEU30IvcQ+wpiEMqKJ2vidWG2vOrHMVPyiN7O457TXB41AhEWNlg=="
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "RukqLb0lVNgtmhKPeZJCncibnyutQ6Dr6+UQCa4PjWinIXpSm3A3ywK9ISkU+5StW1QoejiR7kc9a6qmiLys6w=="
       }
     }
   }

--- a/Connectors/Autocad/Speckle.Connectors.Autocad2024/packages.lock.json
+++ b/Connectors/Autocad/Speckle.Connectors.Autocad2024/packages.lock.json
@@ -259,9 +259,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.3.4, )",
-          "Speckle.Sdk": "[3.3.4, )",
-          "Speckle.Sdk.Dependencies": "[3.3.4, )"
+          "Speckle.Objects": "[3.3.5, )",
+          "Speckle.Sdk": "[3.3.5, )",
+          "Speckle.Sdk.Dependencies": "[3.3.5, )"
         }
       },
       "speckle.connectors.dui": {
@@ -293,7 +293,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.3.4, )"
+          "Speckle.Objects": "[3.3.5, )"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -337,18 +337,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "MaZQFVtKGpntTwKL8go5zKIzjDJfXQQVpKXEvBPT/7SZISkpLTgmetizcQHZ1DGrA+Tps14dYFEWp7Ai+zCCCA==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "VPbYI8TyPDlKlNUHPLPAL1HveN9649LKVxw8opgGypoqq0MC5I7WxQjDcuB8xKnQ1PCSO8suu4hEJgdyPcEvWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.3.4"
+          "Speckle.Sdk": "3.3.5"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "I7HzhT3PaE+Gd+T2LgqL5kqvc+SPJYnRofJhCv8smsUjADEonxUf+dAEV3AHM31CWGZT6SNe876+drXm60fUDg==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "7r8CmugwinniEF6v0N0bWuC+xpJaRfa/EnEjzj8NLpFG1b3uAjOxteGlQgR+evVacxTCEsuNkio7Mdv97odgpg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -358,14 +358,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.3.4"
+          "Speckle.Sdk.Dependencies": "3.3.5"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "0iGDakpkQIApAD3RCS8D0e5oM6yvvklDQFAEU30IvcQ+wpiEMqKJ2vidWG2vOrHMVPyiN7O457TXB41AhEWNlg=="
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "RukqLb0lVNgtmhKPeZJCncibnyutQ6Dr6+UQCa4PjWinIXpSm3A3ywK9ISkU+5StW1QoejiR7kc9a6qmiLys6w=="
       }
     }
   }

--- a/Connectors/Autocad/Speckle.Connectors.Autocad2025/packages.lock.json
+++ b/Connectors/Autocad/Speckle.Connectors.Autocad2025/packages.lock.json
@@ -215,9 +215,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.3.4, )",
-          "Speckle.Sdk": "[3.3.4, )",
-          "Speckle.Sdk.Dependencies": "[3.3.4, )"
+          "Speckle.Objects": "[3.3.5, )",
+          "Speckle.Sdk": "[3.3.5, )",
+          "Speckle.Sdk.Dependencies": "[3.3.5, )"
         }
       },
       "speckle.connectors.dui": {
@@ -249,7 +249,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.3.4, )"
+          "Speckle.Objects": "[3.3.5, )"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -293,18 +293,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "MaZQFVtKGpntTwKL8go5zKIzjDJfXQQVpKXEvBPT/7SZISkpLTgmetizcQHZ1DGrA+Tps14dYFEWp7Ai+zCCCA==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "VPbYI8TyPDlKlNUHPLPAL1HveN9649LKVxw8opgGypoqq0MC5I7WxQjDcuB8xKnQ1PCSO8suu4hEJgdyPcEvWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.3.4"
+          "Speckle.Sdk": "3.3.5"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "I7HzhT3PaE+Gd+T2LgqL5kqvc+SPJYnRofJhCv8smsUjADEonxUf+dAEV3AHM31CWGZT6SNe876+drXm60fUDg==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "7r8CmugwinniEF6v0N0bWuC+xpJaRfa/EnEjzj8NLpFG1b3uAjOxteGlQgR+evVacxTCEsuNkio7Mdv97odgpg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -313,14 +313,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.3.4"
+          "Speckle.Sdk.Dependencies": "3.3.5"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "0iGDakpkQIApAD3RCS8D0e5oM6yvvklDQFAEU30IvcQ+wpiEMqKJ2vidWG2vOrHMVPyiN7O457TXB41AhEWNlg=="
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "RukqLb0lVNgtmhKPeZJCncibnyutQ6Dr6+UQCa4PjWinIXpSm3A3ywK9ISkU+5StW1QoejiR7kc9a6qmiLys6w=="
       }
     },
     "net8.0-windows7.0/win-x64": {

--- a/Connectors/Autocad/Speckle.Connectors.Autocad2026/packages.lock.json
+++ b/Connectors/Autocad/Speckle.Connectors.Autocad2026/packages.lock.json
@@ -215,9 +215,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.3.4, )",
-          "Speckle.Sdk": "[3.3.4, )",
-          "Speckle.Sdk.Dependencies": "[3.3.4, )"
+          "Speckle.Objects": "[3.3.5, )",
+          "Speckle.Sdk": "[3.3.5, )",
+          "Speckle.Sdk.Dependencies": "[3.3.5, )"
         }
       },
       "speckle.connectors.dui": {
@@ -249,7 +249,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.3.4, )"
+          "Speckle.Objects": "[3.3.5, )"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -293,18 +293,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "MaZQFVtKGpntTwKL8go5zKIzjDJfXQQVpKXEvBPT/7SZISkpLTgmetizcQHZ1DGrA+Tps14dYFEWp7Ai+zCCCA==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "VPbYI8TyPDlKlNUHPLPAL1HveN9649LKVxw8opgGypoqq0MC5I7WxQjDcuB8xKnQ1PCSO8suu4hEJgdyPcEvWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.3.4"
+          "Speckle.Sdk": "3.3.5"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "I7HzhT3PaE+Gd+T2LgqL5kqvc+SPJYnRofJhCv8smsUjADEonxUf+dAEV3AHM31CWGZT6SNe876+drXm60fUDg==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "7r8CmugwinniEF6v0N0bWuC+xpJaRfa/EnEjzj8NLpFG1b3uAjOxteGlQgR+evVacxTCEsuNkio7Mdv97odgpg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -313,14 +313,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.3.4"
+          "Speckle.Sdk.Dependencies": "3.3.5"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "0iGDakpkQIApAD3RCS8D0e5oM6yvvklDQFAEU30IvcQ+wpiEMqKJ2vidWG2vOrHMVPyiN7O457TXB41AhEWNlg=="
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "RukqLb0lVNgtmhKPeZJCncibnyutQ6Dr6+UQCa4PjWinIXpSm3A3ywK9ISkU+5StW1QoejiR7kc9a6qmiLys6w=="
       }
     },
     "net8.0-windows7.0/win-x64": {

--- a/Connectors/Autocad/Speckle.Connectors.Civil3d2022/packages.lock.json
+++ b/Connectors/Autocad/Speckle.Connectors.Civil3d2022/packages.lock.json
@@ -268,9 +268,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.3.4, )",
-          "Speckle.Sdk": "[3.3.4, )",
-          "Speckle.Sdk.Dependencies": "[3.3.4, )"
+          "Speckle.Objects": "[3.3.5, )",
+          "Speckle.Sdk": "[3.3.5, )",
+          "Speckle.Sdk.Dependencies": "[3.3.5, )"
         }
       },
       "speckle.connectors.dui": {
@@ -302,7 +302,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.3.4, )"
+          "Speckle.Objects": "[3.3.5, )"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -346,18 +346,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "MaZQFVtKGpntTwKL8go5zKIzjDJfXQQVpKXEvBPT/7SZISkpLTgmetizcQHZ1DGrA+Tps14dYFEWp7Ai+zCCCA==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "VPbYI8TyPDlKlNUHPLPAL1HveN9649LKVxw8opgGypoqq0MC5I7WxQjDcuB8xKnQ1PCSO8suu4hEJgdyPcEvWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.3.4"
+          "Speckle.Sdk": "3.3.5"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "I7HzhT3PaE+Gd+T2LgqL5kqvc+SPJYnRofJhCv8smsUjADEonxUf+dAEV3AHM31CWGZT6SNe876+drXm60fUDg==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "7r8CmugwinniEF6v0N0bWuC+xpJaRfa/EnEjzj8NLpFG1b3uAjOxteGlQgR+evVacxTCEsuNkio7Mdv97odgpg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -367,14 +367,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.3.4"
+          "Speckle.Sdk.Dependencies": "3.3.5"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "0iGDakpkQIApAD3RCS8D0e5oM6yvvklDQFAEU30IvcQ+wpiEMqKJ2vidWG2vOrHMVPyiN7O457TXB41AhEWNlg=="
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "RukqLb0lVNgtmhKPeZJCncibnyutQ6Dr6+UQCa4PjWinIXpSm3A3ywK9ISkU+5StW1QoejiR7kc9a6qmiLys6w=="
       }
     }
   }

--- a/Connectors/Autocad/Speckle.Connectors.Civil3d2023/packages.lock.json
+++ b/Connectors/Autocad/Speckle.Connectors.Civil3d2023/packages.lock.json
@@ -268,9 +268,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.3.4, )",
-          "Speckle.Sdk": "[3.3.4, )",
-          "Speckle.Sdk.Dependencies": "[3.3.4, )"
+          "Speckle.Objects": "[3.3.5, )",
+          "Speckle.Sdk": "[3.3.5, )",
+          "Speckle.Sdk.Dependencies": "[3.3.5, )"
         }
       },
       "speckle.connectors.dui": {
@@ -302,7 +302,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.3.4, )"
+          "Speckle.Objects": "[3.3.5, )"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -346,18 +346,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "MaZQFVtKGpntTwKL8go5zKIzjDJfXQQVpKXEvBPT/7SZISkpLTgmetizcQHZ1DGrA+Tps14dYFEWp7Ai+zCCCA==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "VPbYI8TyPDlKlNUHPLPAL1HveN9649LKVxw8opgGypoqq0MC5I7WxQjDcuB8xKnQ1PCSO8suu4hEJgdyPcEvWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.3.4"
+          "Speckle.Sdk": "3.3.5"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "I7HzhT3PaE+Gd+T2LgqL5kqvc+SPJYnRofJhCv8smsUjADEonxUf+dAEV3AHM31CWGZT6SNe876+drXm60fUDg==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "7r8CmugwinniEF6v0N0bWuC+xpJaRfa/EnEjzj8NLpFG1b3uAjOxteGlQgR+evVacxTCEsuNkio7Mdv97odgpg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -367,14 +367,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.3.4"
+          "Speckle.Sdk.Dependencies": "3.3.5"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "0iGDakpkQIApAD3RCS8D0e5oM6yvvklDQFAEU30IvcQ+wpiEMqKJ2vidWG2vOrHMVPyiN7O457TXB41AhEWNlg=="
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "RukqLb0lVNgtmhKPeZJCncibnyutQ6Dr6+UQCa4PjWinIXpSm3A3ywK9ISkU+5StW1QoejiR7kc9a6qmiLys6w=="
       }
     }
   }

--- a/Connectors/Autocad/Speckle.Connectors.Civil3d2024/packages.lock.json
+++ b/Connectors/Autocad/Speckle.Connectors.Civil3d2024/packages.lock.json
@@ -268,9 +268,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.3.4, )",
-          "Speckle.Sdk": "[3.3.4, )",
-          "Speckle.Sdk.Dependencies": "[3.3.4, )"
+          "Speckle.Objects": "[3.3.5, )",
+          "Speckle.Sdk": "[3.3.5, )",
+          "Speckle.Sdk.Dependencies": "[3.3.5, )"
         }
       },
       "speckle.connectors.dui": {
@@ -302,7 +302,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.3.4, )"
+          "Speckle.Objects": "[3.3.5, )"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -346,18 +346,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "MaZQFVtKGpntTwKL8go5zKIzjDJfXQQVpKXEvBPT/7SZISkpLTgmetizcQHZ1DGrA+Tps14dYFEWp7Ai+zCCCA==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "VPbYI8TyPDlKlNUHPLPAL1HveN9649LKVxw8opgGypoqq0MC5I7WxQjDcuB8xKnQ1PCSO8suu4hEJgdyPcEvWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.3.4"
+          "Speckle.Sdk": "3.3.5"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "I7HzhT3PaE+Gd+T2LgqL5kqvc+SPJYnRofJhCv8smsUjADEonxUf+dAEV3AHM31CWGZT6SNe876+drXm60fUDg==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "7r8CmugwinniEF6v0N0bWuC+xpJaRfa/EnEjzj8NLpFG1b3uAjOxteGlQgR+evVacxTCEsuNkio7Mdv97odgpg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -367,14 +367,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.3.4"
+          "Speckle.Sdk.Dependencies": "3.3.5"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "0iGDakpkQIApAD3RCS8D0e5oM6yvvklDQFAEU30IvcQ+wpiEMqKJ2vidWG2vOrHMVPyiN7O457TXB41AhEWNlg=="
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "RukqLb0lVNgtmhKPeZJCncibnyutQ6Dr6+UQCa4PjWinIXpSm3A3ywK9ISkU+5StW1QoejiR7kc9a6qmiLys6w=="
       }
     }
   }

--- a/Connectors/Autocad/Speckle.Connectors.Civil3d2025/packages.lock.json
+++ b/Connectors/Autocad/Speckle.Connectors.Civil3d2025/packages.lock.json
@@ -224,9 +224,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.3.4, )",
-          "Speckle.Sdk": "[3.3.4, )",
-          "Speckle.Sdk.Dependencies": "[3.3.4, )"
+          "Speckle.Objects": "[3.3.5, )",
+          "Speckle.Sdk": "[3.3.5, )",
+          "Speckle.Sdk.Dependencies": "[3.3.5, )"
         }
       },
       "speckle.connectors.dui": {
@@ -259,7 +259,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.3.4, )"
+          "Speckle.Objects": "[3.3.5, )"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -303,18 +303,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "MaZQFVtKGpntTwKL8go5zKIzjDJfXQQVpKXEvBPT/7SZISkpLTgmetizcQHZ1DGrA+Tps14dYFEWp7Ai+zCCCA==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "VPbYI8TyPDlKlNUHPLPAL1HveN9649LKVxw8opgGypoqq0MC5I7WxQjDcuB8xKnQ1PCSO8suu4hEJgdyPcEvWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.3.4"
+          "Speckle.Sdk": "3.3.5"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "I7HzhT3PaE+Gd+T2LgqL5kqvc+SPJYnRofJhCv8smsUjADEonxUf+dAEV3AHM31CWGZT6SNe876+drXm60fUDg==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "7r8CmugwinniEF6v0N0bWuC+xpJaRfa/EnEjzj8NLpFG1b3uAjOxteGlQgR+evVacxTCEsuNkio7Mdv97odgpg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -323,14 +323,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.3.4"
+          "Speckle.Sdk.Dependencies": "3.3.5"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "0iGDakpkQIApAD3RCS8D0e5oM6yvvklDQFAEU30IvcQ+wpiEMqKJ2vidWG2vOrHMVPyiN7O457TXB41AhEWNlg=="
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "RukqLb0lVNgtmhKPeZJCncibnyutQ6Dr6+UQCa4PjWinIXpSm3A3ywK9ISkU+5StW1QoejiR7kc9a6qmiLys6w=="
       }
     },
     "net8.0-windows7.0/win-x64": {

--- a/Connectors/Autocad/Speckle.Connectors.Civil3d2026/packages.lock.json
+++ b/Connectors/Autocad/Speckle.Connectors.Civil3d2026/packages.lock.json
@@ -224,9 +224,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.3.4, )",
-          "Speckle.Sdk": "[3.3.4, )",
-          "Speckle.Sdk.Dependencies": "[3.3.4, )"
+          "Speckle.Objects": "[3.3.5, )",
+          "Speckle.Sdk": "[3.3.5, )",
+          "Speckle.Sdk.Dependencies": "[3.3.5, )"
         }
       },
       "speckle.connectors.dui": {
@@ -259,7 +259,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.3.4, )"
+          "Speckle.Objects": "[3.3.5, )"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -303,18 +303,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "MaZQFVtKGpntTwKL8go5zKIzjDJfXQQVpKXEvBPT/7SZISkpLTgmetizcQHZ1DGrA+Tps14dYFEWp7Ai+zCCCA==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "VPbYI8TyPDlKlNUHPLPAL1HveN9649LKVxw8opgGypoqq0MC5I7WxQjDcuB8xKnQ1PCSO8suu4hEJgdyPcEvWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.3.4"
+          "Speckle.Sdk": "3.3.5"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "I7HzhT3PaE+Gd+T2LgqL5kqvc+SPJYnRofJhCv8smsUjADEonxUf+dAEV3AHM31CWGZT6SNe876+drXm60fUDg==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "7r8CmugwinniEF6v0N0bWuC+xpJaRfa/EnEjzj8NLpFG1b3uAjOxteGlQgR+evVacxTCEsuNkio7Mdv97odgpg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -323,14 +323,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.3.4"
+          "Speckle.Sdk.Dependencies": "3.3.5"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "0iGDakpkQIApAD3RCS8D0e5oM6yvvklDQFAEU30IvcQ+wpiEMqKJ2vidWG2vOrHMVPyiN7O457TXB41AhEWNlg=="
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "RukqLb0lVNgtmhKPeZJCncibnyutQ6Dr6+UQCa4PjWinIXpSm3A3ywK9ISkU+5StW1QoejiR7kc9a6qmiLys6w=="
       }
     },
     "net8.0-windows7.0/win-x64": {

--- a/Connectors/CSi/Speckle.Connectors.ETABS21/packages.lock.json
+++ b/Connectors/CSi/Speckle.Connectors.ETABS21/packages.lock.json
@@ -259,9 +259,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.3.4, )",
-          "Speckle.Sdk": "[3.3.4, )",
-          "Speckle.Sdk.Dependencies": "[3.3.4, )"
+          "Speckle.Objects": "[3.3.5, )",
+          "Speckle.Sdk": "[3.3.5, )",
+          "Speckle.Sdk.Dependencies": "[3.3.5, )"
         }
       },
       "speckle.connectors.dui": {
@@ -285,7 +285,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.3.4, )"
+          "Speckle.Objects": "[3.3.5, )"
         }
       },
       "speckle.converters.etabs21": {
@@ -335,18 +335,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "MaZQFVtKGpntTwKL8go5zKIzjDJfXQQVpKXEvBPT/7SZISkpLTgmetizcQHZ1DGrA+Tps14dYFEWp7Ai+zCCCA==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "VPbYI8TyPDlKlNUHPLPAL1HveN9649LKVxw8opgGypoqq0MC5I7WxQjDcuB8xKnQ1PCSO8suu4hEJgdyPcEvWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.3.4"
+          "Speckle.Sdk": "3.3.5"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "I7HzhT3PaE+Gd+T2LgqL5kqvc+SPJYnRofJhCv8smsUjADEonxUf+dAEV3AHM31CWGZT6SNe876+drXm60fUDg==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "7r8CmugwinniEF6v0N0bWuC+xpJaRfa/EnEjzj8NLpFG1b3uAjOxteGlQgR+evVacxTCEsuNkio7Mdv97odgpg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -356,14 +356,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.3.4"
+          "Speckle.Sdk.Dependencies": "3.3.5"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "0iGDakpkQIApAD3RCS8D0e5oM6yvvklDQFAEU30IvcQ+wpiEMqKJ2vidWG2vOrHMVPyiN7O457TXB41AhEWNlg=="
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "RukqLb0lVNgtmhKPeZJCncibnyutQ6Dr6+UQCa4PjWinIXpSm3A3ywK9ISkU+5StW1QoejiR7kc9a6qmiLys6w=="
       }
     }
   }

--- a/Connectors/CSi/Speckle.Connectors.ETABS22/packages.lock.json
+++ b/Connectors/CSi/Speckle.Connectors.ETABS22/packages.lock.json
@@ -215,9 +215,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.3.4, )",
-          "Speckle.Sdk": "[3.3.4, )",
-          "Speckle.Sdk.Dependencies": "[3.3.4, )"
+          "Speckle.Objects": "[3.3.5, )",
+          "Speckle.Sdk": "[3.3.5, )",
+          "Speckle.Sdk.Dependencies": "[3.3.5, )"
         }
       },
       "speckle.connectors.dui": {
@@ -241,7 +241,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.3.4, )"
+          "Speckle.Objects": "[3.3.5, )"
         }
       },
       "speckle.converters.etabs22": {
@@ -291,18 +291,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "MaZQFVtKGpntTwKL8go5zKIzjDJfXQQVpKXEvBPT/7SZISkpLTgmetizcQHZ1DGrA+Tps14dYFEWp7Ai+zCCCA==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "VPbYI8TyPDlKlNUHPLPAL1HveN9649LKVxw8opgGypoqq0MC5I7WxQjDcuB8xKnQ1PCSO8suu4hEJgdyPcEvWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.3.4"
+          "Speckle.Sdk": "3.3.5"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "I7HzhT3PaE+Gd+T2LgqL5kqvc+SPJYnRofJhCv8smsUjADEonxUf+dAEV3AHM31CWGZT6SNe876+drXm60fUDg==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "7r8CmugwinniEF6v0N0bWuC+xpJaRfa/EnEjzj8NLpFG1b3uAjOxteGlQgR+evVacxTCEsuNkio7Mdv97odgpg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -311,14 +311,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.3.4"
+          "Speckle.Sdk.Dependencies": "3.3.5"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "0iGDakpkQIApAD3RCS8D0e5oM6yvvklDQFAEU30IvcQ+wpiEMqKJ2vidWG2vOrHMVPyiN7O457TXB41AhEWNlg=="
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "RukqLb0lVNgtmhKPeZJCncibnyutQ6Dr6+UQCa4PjWinIXpSm3A3ywK9ISkU+5StW1QoejiR7kc9a6qmiLys6w=="
       }
     }
   }

--- a/Connectors/Navisworks/Speckle.Connectors.Navisworks2020/packages.lock.json
+++ b/Connectors/Navisworks/Speckle.Connectors.Navisworks2020/packages.lock.json
@@ -259,9 +259,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.3.4, )",
-          "Speckle.Sdk": "[3.3.4, )",
-          "Speckle.Sdk.Dependencies": "[3.3.4, )"
+          "Speckle.Objects": "[3.3.5, )",
+          "Speckle.Sdk": "[3.3.5, )",
+          "Speckle.Sdk.Dependencies": "[3.3.5, )"
         }
       },
       "speckle.connectors.dui": {
@@ -285,7 +285,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.3.4, )"
+          "Speckle.Objects": "[3.3.5, )"
         }
       },
       "speckle.converters.navisworks2020": {
@@ -337,18 +337,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "MaZQFVtKGpntTwKL8go5zKIzjDJfXQQVpKXEvBPT/7SZISkpLTgmetizcQHZ1DGrA+Tps14dYFEWp7Ai+zCCCA==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "VPbYI8TyPDlKlNUHPLPAL1HveN9649LKVxw8opgGypoqq0MC5I7WxQjDcuB8xKnQ1PCSO8suu4hEJgdyPcEvWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.3.4"
+          "Speckle.Sdk": "3.3.5"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "I7HzhT3PaE+Gd+T2LgqL5kqvc+SPJYnRofJhCv8smsUjADEonxUf+dAEV3AHM31CWGZT6SNe876+drXm60fUDg==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "7r8CmugwinniEF6v0N0bWuC+xpJaRfa/EnEjzj8NLpFG1b3uAjOxteGlQgR+evVacxTCEsuNkio7Mdv97odgpg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -358,14 +358,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.3.4"
+          "Speckle.Sdk.Dependencies": "3.3.5"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "0iGDakpkQIApAD3RCS8D0e5oM6yvvklDQFAEU30IvcQ+wpiEMqKJ2vidWG2vOrHMVPyiN7O457TXB41AhEWNlg=="
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "RukqLb0lVNgtmhKPeZJCncibnyutQ6Dr6+UQCa4PjWinIXpSm3A3ywK9ISkU+5StW1QoejiR7kc9a6qmiLys6w=="
       }
     },
     ".NETFramework,Version=v4.8/win-x64": {

--- a/Connectors/Navisworks/Speckle.Connectors.Navisworks2021/packages.lock.json
+++ b/Connectors/Navisworks/Speckle.Connectors.Navisworks2021/packages.lock.json
@@ -259,9 +259,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.3.4, )",
-          "Speckle.Sdk": "[3.3.4, )",
-          "Speckle.Sdk.Dependencies": "[3.3.4, )"
+          "Speckle.Objects": "[3.3.5, )",
+          "Speckle.Sdk": "[3.3.5, )",
+          "Speckle.Sdk.Dependencies": "[3.3.5, )"
         }
       },
       "speckle.connectors.dui": {
@@ -285,7 +285,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.3.4, )"
+          "Speckle.Objects": "[3.3.5, )"
         }
       },
       "speckle.converters.navisworks2021": {
@@ -337,18 +337,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "MaZQFVtKGpntTwKL8go5zKIzjDJfXQQVpKXEvBPT/7SZISkpLTgmetizcQHZ1DGrA+Tps14dYFEWp7Ai+zCCCA==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "VPbYI8TyPDlKlNUHPLPAL1HveN9649LKVxw8opgGypoqq0MC5I7WxQjDcuB8xKnQ1PCSO8suu4hEJgdyPcEvWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.3.4"
+          "Speckle.Sdk": "3.3.5"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "I7HzhT3PaE+Gd+T2LgqL5kqvc+SPJYnRofJhCv8smsUjADEonxUf+dAEV3AHM31CWGZT6SNe876+drXm60fUDg==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "7r8CmugwinniEF6v0N0bWuC+xpJaRfa/EnEjzj8NLpFG1b3uAjOxteGlQgR+evVacxTCEsuNkio7Mdv97odgpg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -358,14 +358,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.3.4"
+          "Speckle.Sdk.Dependencies": "3.3.5"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "0iGDakpkQIApAD3RCS8D0e5oM6yvvklDQFAEU30IvcQ+wpiEMqKJ2vidWG2vOrHMVPyiN7O457TXB41AhEWNlg=="
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "RukqLb0lVNgtmhKPeZJCncibnyutQ6Dr6+UQCa4PjWinIXpSm3A3ywK9ISkU+5StW1QoejiR7kc9a6qmiLys6w=="
       }
     },
     ".NETFramework,Version=v4.8/win-x64": {

--- a/Connectors/Navisworks/Speckle.Connectors.Navisworks2022/packages.lock.json
+++ b/Connectors/Navisworks/Speckle.Connectors.Navisworks2022/packages.lock.json
@@ -259,9 +259,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.3.4, )",
-          "Speckle.Sdk": "[3.3.4, )",
-          "Speckle.Sdk.Dependencies": "[3.3.4, )"
+          "Speckle.Objects": "[3.3.5, )",
+          "Speckle.Sdk": "[3.3.5, )",
+          "Speckle.Sdk.Dependencies": "[3.3.5, )"
         }
       },
       "speckle.connectors.dui": {
@@ -285,7 +285,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.3.4, )"
+          "Speckle.Objects": "[3.3.5, )"
         }
       },
       "speckle.converters.navisworks2022": {
@@ -337,18 +337,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "MaZQFVtKGpntTwKL8go5zKIzjDJfXQQVpKXEvBPT/7SZISkpLTgmetizcQHZ1DGrA+Tps14dYFEWp7Ai+zCCCA==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "VPbYI8TyPDlKlNUHPLPAL1HveN9649LKVxw8opgGypoqq0MC5I7WxQjDcuB8xKnQ1PCSO8suu4hEJgdyPcEvWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.3.4"
+          "Speckle.Sdk": "3.3.5"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "I7HzhT3PaE+Gd+T2LgqL5kqvc+SPJYnRofJhCv8smsUjADEonxUf+dAEV3AHM31CWGZT6SNe876+drXm60fUDg==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "7r8CmugwinniEF6v0N0bWuC+xpJaRfa/EnEjzj8NLpFG1b3uAjOxteGlQgR+evVacxTCEsuNkio7Mdv97odgpg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -358,14 +358,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.3.4"
+          "Speckle.Sdk.Dependencies": "3.3.5"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "0iGDakpkQIApAD3RCS8D0e5oM6yvvklDQFAEU30IvcQ+wpiEMqKJ2vidWG2vOrHMVPyiN7O457TXB41AhEWNlg=="
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "RukqLb0lVNgtmhKPeZJCncibnyutQ6Dr6+UQCa4PjWinIXpSm3A3ywK9ISkU+5StW1QoejiR7kc9a6qmiLys6w=="
       }
     },
     ".NETFramework,Version=v4.8/win-x64": {

--- a/Connectors/Navisworks/Speckle.Connectors.Navisworks2023/packages.lock.json
+++ b/Connectors/Navisworks/Speckle.Connectors.Navisworks2023/packages.lock.json
@@ -259,9 +259,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.3.4, )",
-          "Speckle.Sdk": "[3.3.4, )",
-          "Speckle.Sdk.Dependencies": "[3.3.4, )"
+          "Speckle.Objects": "[3.3.5, )",
+          "Speckle.Sdk": "[3.3.5, )",
+          "Speckle.Sdk.Dependencies": "[3.3.5, )"
         }
       },
       "speckle.connectors.dui": {
@@ -285,7 +285,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.3.4, )"
+          "Speckle.Objects": "[3.3.5, )"
         }
       },
       "speckle.converters.navisworks2023": {
@@ -337,18 +337,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "MaZQFVtKGpntTwKL8go5zKIzjDJfXQQVpKXEvBPT/7SZISkpLTgmetizcQHZ1DGrA+Tps14dYFEWp7Ai+zCCCA==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "VPbYI8TyPDlKlNUHPLPAL1HveN9649LKVxw8opgGypoqq0MC5I7WxQjDcuB8xKnQ1PCSO8suu4hEJgdyPcEvWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.3.4"
+          "Speckle.Sdk": "3.3.5"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "I7HzhT3PaE+Gd+T2LgqL5kqvc+SPJYnRofJhCv8smsUjADEonxUf+dAEV3AHM31CWGZT6SNe876+drXm60fUDg==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "7r8CmugwinniEF6v0N0bWuC+xpJaRfa/EnEjzj8NLpFG1b3uAjOxteGlQgR+evVacxTCEsuNkio7Mdv97odgpg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -358,14 +358,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.3.4"
+          "Speckle.Sdk.Dependencies": "3.3.5"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "0iGDakpkQIApAD3RCS8D0e5oM6yvvklDQFAEU30IvcQ+wpiEMqKJ2vidWG2vOrHMVPyiN7O457TXB41AhEWNlg=="
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "RukqLb0lVNgtmhKPeZJCncibnyutQ6Dr6+UQCa4PjWinIXpSm3A3ywK9ISkU+5StW1QoejiR7kc9a6qmiLys6w=="
       }
     },
     ".NETFramework,Version=v4.8/win-x64": {

--- a/Connectors/Navisworks/Speckle.Connectors.Navisworks2024/packages.lock.json
+++ b/Connectors/Navisworks/Speckle.Connectors.Navisworks2024/packages.lock.json
@@ -259,9 +259,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.3.4, )",
-          "Speckle.Sdk": "[3.3.4, )",
-          "Speckle.Sdk.Dependencies": "[3.3.4, )"
+          "Speckle.Objects": "[3.3.5, )",
+          "Speckle.Sdk": "[3.3.5, )",
+          "Speckle.Sdk.Dependencies": "[3.3.5, )"
         }
       },
       "speckle.connectors.dui": {
@@ -285,7 +285,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.3.4, )"
+          "Speckle.Objects": "[3.3.5, )"
         }
       },
       "speckle.converters.navisworks2024": {
@@ -337,18 +337,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "MaZQFVtKGpntTwKL8go5zKIzjDJfXQQVpKXEvBPT/7SZISkpLTgmetizcQHZ1DGrA+Tps14dYFEWp7Ai+zCCCA==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "VPbYI8TyPDlKlNUHPLPAL1HveN9649LKVxw8opgGypoqq0MC5I7WxQjDcuB8xKnQ1PCSO8suu4hEJgdyPcEvWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.3.4"
+          "Speckle.Sdk": "3.3.5"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "I7HzhT3PaE+Gd+T2LgqL5kqvc+SPJYnRofJhCv8smsUjADEonxUf+dAEV3AHM31CWGZT6SNe876+drXm60fUDg==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "7r8CmugwinniEF6v0N0bWuC+xpJaRfa/EnEjzj8NLpFG1b3uAjOxteGlQgR+evVacxTCEsuNkio7Mdv97odgpg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -358,14 +358,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.3.4"
+          "Speckle.Sdk.Dependencies": "3.3.5"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "0iGDakpkQIApAD3RCS8D0e5oM6yvvklDQFAEU30IvcQ+wpiEMqKJ2vidWG2vOrHMVPyiN7O457TXB41AhEWNlg=="
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "RukqLb0lVNgtmhKPeZJCncibnyutQ6Dr6+UQCa4PjWinIXpSm3A3ywK9ISkU+5StW1QoejiR7kc9a6qmiLys6w=="
       }
     },
     ".NETFramework,Version=v4.8/win-x64": {

--- a/Connectors/Navisworks/Speckle.Connectors.Navisworks2025/packages.lock.json
+++ b/Connectors/Navisworks/Speckle.Connectors.Navisworks2025/packages.lock.json
@@ -265,9 +265,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.3.4, )",
-          "Speckle.Sdk": "[3.3.4, )",
-          "Speckle.Sdk.Dependencies": "[3.3.4, )"
+          "Speckle.Objects": "[3.3.5, )",
+          "Speckle.Sdk": "[3.3.5, )",
+          "Speckle.Sdk.Dependencies": "[3.3.5, )"
         }
       },
       "speckle.connectors.dui": {
@@ -291,7 +291,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.3.4, )"
+          "Speckle.Objects": "[3.3.5, )"
         }
       },
       "speckle.converters.navisworks2025": {
@@ -337,18 +337,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "MaZQFVtKGpntTwKL8go5zKIzjDJfXQQVpKXEvBPT/7SZISkpLTgmetizcQHZ1DGrA+Tps14dYFEWp7Ai+zCCCA==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "VPbYI8TyPDlKlNUHPLPAL1HveN9649LKVxw8opgGypoqq0MC5I7WxQjDcuB8xKnQ1PCSO8suu4hEJgdyPcEvWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.3.4"
+          "Speckle.Sdk": "3.3.5"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "I7HzhT3PaE+Gd+T2LgqL5kqvc+SPJYnRofJhCv8smsUjADEonxUf+dAEV3AHM31CWGZT6SNe876+drXm60fUDg==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "7r8CmugwinniEF6v0N0bWuC+xpJaRfa/EnEjzj8NLpFG1b3uAjOxteGlQgR+evVacxTCEsuNkio7Mdv97odgpg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -358,14 +358,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.3.4"
+          "Speckle.Sdk.Dependencies": "3.3.5"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "0iGDakpkQIApAD3RCS8D0e5oM6yvvklDQFAEU30IvcQ+wpiEMqKJ2vidWG2vOrHMVPyiN7O457TXB41AhEWNlg=="
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "RukqLb0lVNgtmhKPeZJCncibnyutQ6Dr6+UQCa4PjWinIXpSm3A3ywK9ISkU+5StW1QoejiR7kc9a6qmiLys6w=="
       }
     },
     ".NETFramework,Version=v4.8/win-x64": {

--- a/Connectors/Navisworks/Speckle.Connectors.Navisworks2026/packages.lock.json
+++ b/Connectors/Navisworks/Speckle.Connectors.Navisworks2026/packages.lock.json
@@ -266,9 +266,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.3.4, )",
-          "Speckle.Sdk": "[3.3.4, )",
-          "Speckle.Sdk.Dependencies": "[3.3.4, )"
+          "Speckle.Objects": "[3.3.5, )",
+          "Speckle.Sdk": "[3.3.5, )",
+          "Speckle.Sdk.Dependencies": "[3.3.5, )"
         }
       },
       "speckle.connectors.dui": {
@@ -292,7 +292,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.3.4, )"
+          "Speckle.Objects": "[3.3.5, )"
         }
       },
       "speckle.converters.navisworks2026": {
@@ -339,18 +339,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "MaZQFVtKGpntTwKL8go5zKIzjDJfXQQVpKXEvBPT/7SZISkpLTgmetizcQHZ1DGrA+Tps14dYFEWp7Ai+zCCCA==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "VPbYI8TyPDlKlNUHPLPAL1HveN9649LKVxw8opgGypoqq0MC5I7WxQjDcuB8xKnQ1PCSO8suu4hEJgdyPcEvWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.3.4"
+          "Speckle.Sdk": "3.3.5"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "I7HzhT3PaE+Gd+T2LgqL5kqvc+SPJYnRofJhCv8smsUjADEonxUf+dAEV3AHM31CWGZT6SNe876+drXm60fUDg==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "7r8CmugwinniEF6v0N0bWuC+xpJaRfa/EnEjzj8NLpFG1b3uAjOxteGlQgR+evVacxTCEsuNkio7Mdv97odgpg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -360,14 +360,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.3.4"
+          "Speckle.Sdk.Dependencies": "3.3.5"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "0iGDakpkQIApAD3RCS8D0e5oM6yvvklDQFAEU30IvcQ+wpiEMqKJ2vidWG2vOrHMVPyiN7O457TXB41AhEWNlg=="
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "RukqLb0lVNgtmhKPeZJCncibnyutQ6Dr6+UQCa4PjWinIXpSm3A3ywK9ISkU+5StW1QoejiR7kc9a6qmiLys6w=="
       }
     },
     ".NETFramework,Version=v4.8/win-x64": {

--- a/Connectors/Revit/Speckle.Connectors.Revit2022/packages.lock.json
+++ b/Connectors/Revit/Speckle.Connectors.Revit2022/packages.lock.json
@@ -287,9 +287,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.3.4, )",
-          "Speckle.Sdk": "[3.3.4, )",
-          "Speckle.Sdk.Dependencies": "[3.3.4, )"
+          "Speckle.Objects": "[3.3.5, )",
+          "Speckle.Sdk": "[3.3.5, )",
+          "Speckle.Sdk.Dependencies": "[3.3.5, )"
         }
       },
       "speckle.connectors.dui": {
@@ -306,7 +306,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.3.4, )"
+          "Speckle.Objects": "[3.3.5, )"
         }
       },
       "speckle.converters.revit2022": {
@@ -351,11 +351,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "MaZQFVtKGpntTwKL8go5zKIzjDJfXQQVpKXEvBPT/7SZISkpLTgmetizcQHZ1DGrA+Tps14dYFEWp7Ai+zCCCA==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "VPbYI8TyPDlKlNUHPLPAL1HveN9649LKVxw8opgGypoqq0MC5I7WxQjDcuB8xKnQ1PCSO8suu4hEJgdyPcEvWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.3.4"
+          "Speckle.Sdk": "3.3.5"
         }
       },
       "Speckle.Revit.API": {
@@ -366,9 +366,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "I7HzhT3PaE+Gd+T2LgqL5kqvc+SPJYnRofJhCv8smsUjADEonxUf+dAEV3AHM31CWGZT6SNe876+drXm60fUDg==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "7r8CmugwinniEF6v0N0bWuC+xpJaRfa/EnEjzj8NLpFG1b3uAjOxteGlQgR+evVacxTCEsuNkio7Mdv97odgpg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -378,14 +378,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.3.4"
+          "Speckle.Sdk.Dependencies": "3.3.5"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "0iGDakpkQIApAD3RCS8D0e5oM6yvvklDQFAEU30IvcQ+wpiEMqKJ2vidWG2vOrHMVPyiN7O457TXB41AhEWNlg=="
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "RukqLb0lVNgtmhKPeZJCncibnyutQ6Dr6+UQCa4PjWinIXpSm3A3ywK9ISkU+5StW1QoejiR7kc9a6qmiLys6w=="
       }
     }
   }

--- a/Connectors/Revit/Speckle.Connectors.Revit2023/packages.lock.json
+++ b/Connectors/Revit/Speckle.Connectors.Revit2023/packages.lock.json
@@ -287,9 +287,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.3.4, )",
-          "Speckle.Sdk": "[3.3.4, )",
-          "Speckle.Sdk.Dependencies": "[3.3.4, )"
+          "Speckle.Objects": "[3.3.5, )",
+          "Speckle.Sdk": "[3.3.5, )",
+          "Speckle.Sdk.Dependencies": "[3.3.5, )"
         }
       },
       "speckle.connectors.dui": {
@@ -306,7 +306,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.3.4, )"
+          "Speckle.Objects": "[3.3.5, )"
         }
       },
       "speckle.converters.revit2023": {
@@ -351,11 +351,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "MaZQFVtKGpntTwKL8go5zKIzjDJfXQQVpKXEvBPT/7SZISkpLTgmetizcQHZ1DGrA+Tps14dYFEWp7Ai+zCCCA==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "VPbYI8TyPDlKlNUHPLPAL1HveN9649LKVxw8opgGypoqq0MC5I7WxQjDcuB8xKnQ1PCSO8suu4hEJgdyPcEvWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.3.4"
+          "Speckle.Sdk": "3.3.5"
         }
       },
       "Speckle.Revit.API": {
@@ -366,9 +366,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "I7HzhT3PaE+Gd+T2LgqL5kqvc+SPJYnRofJhCv8smsUjADEonxUf+dAEV3AHM31CWGZT6SNe876+drXm60fUDg==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "7r8CmugwinniEF6v0N0bWuC+xpJaRfa/EnEjzj8NLpFG1b3uAjOxteGlQgR+evVacxTCEsuNkio7Mdv97odgpg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -378,14 +378,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.3.4"
+          "Speckle.Sdk.Dependencies": "3.3.5"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "0iGDakpkQIApAD3RCS8D0e5oM6yvvklDQFAEU30IvcQ+wpiEMqKJ2vidWG2vOrHMVPyiN7O457TXB41AhEWNlg=="
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "RukqLb0lVNgtmhKPeZJCncibnyutQ6Dr6+UQCa4PjWinIXpSm3A3ywK9ISkU+5StW1QoejiR7kc9a6qmiLys6w=="
       }
     }
   }

--- a/Connectors/Revit/Speckle.Connectors.Revit2024/packages.lock.json
+++ b/Connectors/Revit/Speckle.Connectors.Revit2024/packages.lock.json
@@ -287,9 +287,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.3.4, )",
-          "Speckle.Sdk": "[3.3.4, )",
-          "Speckle.Sdk.Dependencies": "[3.3.4, )"
+          "Speckle.Objects": "[3.3.5, )",
+          "Speckle.Sdk": "[3.3.5, )",
+          "Speckle.Sdk.Dependencies": "[3.3.5, )"
         }
       },
       "speckle.connectors.dui": {
@@ -306,7 +306,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.3.4, )"
+          "Speckle.Objects": "[3.3.5, )"
         }
       },
       "speckle.converters.revit2024": {
@@ -351,11 +351,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "MaZQFVtKGpntTwKL8go5zKIzjDJfXQQVpKXEvBPT/7SZISkpLTgmetizcQHZ1DGrA+Tps14dYFEWp7Ai+zCCCA==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "VPbYI8TyPDlKlNUHPLPAL1HveN9649LKVxw8opgGypoqq0MC5I7WxQjDcuB8xKnQ1PCSO8suu4hEJgdyPcEvWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.3.4"
+          "Speckle.Sdk": "3.3.5"
         }
       },
       "Speckle.Revit.API": {
@@ -366,9 +366,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "I7HzhT3PaE+Gd+T2LgqL5kqvc+SPJYnRofJhCv8smsUjADEonxUf+dAEV3AHM31CWGZT6SNe876+drXm60fUDg==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "7r8CmugwinniEF6v0N0bWuC+xpJaRfa/EnEjzj8NLpFG1b3uAjOxteGlQgR+evVacxTCEsuNkio7Mdv97odgpg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -378,14 +378,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.3.4"
+          "Speckle.Sdk.Dependencies": "3.3.5"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "0iGDakpkQIApAD3RCS8D0e5oM6yvvklDQFAEU30IvcQ+wpiEMqKJ2vidWG2vOrHMVPyiN7O457TXB41AhEWNlg=="
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "RukqLb0lVNgtmhKPeZJCncibnyutQ6Dr6+UQCa4PjWinIXpSm3A3ywK9ISkU+5StW1QoejiR7kc9a6qmiLys6w=="
       }
     }
   }

--- a/Connectors/Revit/Speckle.Connectors.Revit2025/packages.lock.json
+++ b/Connectors/Revit/Speckle.Connectors.Revit2025/packages.lock.json
@@ -237,9 +237,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.3.4, )",
-          "Speckle.Sdk": "[3.3.4, )",
-          "Speckle.Sdk.Dependencies": "[3.3.4, )"
+          "Speckle.Objects": "[3.3.5, )",
+          "Speckle.Sdk": "[3.3.5, )",
+          "Speckle.Sdk.Dependencies": "[3.3.5, )"
         }
       },
       "speckle.connectors.dui": {
@@ -256,7 +256,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.3.4, )"
+          "Speckle.Objects": "[3.3.5, )"
         }
       },
       "speckle.converters.revit2025": {
@@ -301,11 +301,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "MaZQFVtKGpntTwKL8go5zKIzjDJfXQQVpKXEvBPT/7SZISkpLTgmetizcQHZ1DGrA+Tps14dYFEWp7Ai+zCCCA==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "VPbYI8TyPDlKlNUHPLPAL1HveN9649LKVxw8opgGypoqq0MC5I7WxQjDcuB8xKnQ1PCSO8suu4hEJgdyPcEvWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.3.4"
+          "Speckle.Sdk": "3.3.5"
         }
       },
       "Speckle.Revit.API": {
@@ -316,9 +316,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "I7HzhT3PaE+Gd+T2LgqL5kqvc+SPJYnRofJhCv8smsUjADEonxUf+dAEV3AHM31CWGZT6SNe876+drXm60fUDg==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "7r8CmugwinniEF6v0N0bWuC+xpJaRfa/EnEjzj8NLpFG1b3uAjOxteGlQgR+evVacxTCEsuNkio7Mdv97odgpg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -327,14 +327,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.3.4"
+          "Speckle.Sdk.Dependencies": "3.3.5"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "0iGDakpkQIApAD3RCS8D0e5oM6yvvklDQFAEU30IvcQ+wpiEMqKJ2vidWG2vOrHMVPyiN7O457TXB41AhEWNlg=="
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "RukqLb0lVNgtmhKPeZJCncibnyutQ6Dr6+UQCa4PjWinIXpSm3A3ywK9ISkU+5StW1QoejiR7kc9a6qmiLys6w=="
       }
     },
     "net8.0-windows7.0/win-x64": {

--- a/Connectors/Revit/Speckle.Connectors.Revit2026/packages.lock.json
+++ b/Connectors/Revit/Speckle.Connectors.Revit2026/packages.lock.json
@@ -230,9 +230,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.3.4, )",
-          "Speckle.Sdk": "[3.3.4, )",
-          "Speckle.Sdk.Dependencies": "[3.3.4, )"
+          "Speckle.Objects": "[3.3.5, )",
+          "Speckle.Sdk": "[3.3.5, )",
+          "Speckle.Sdk.Dependencies": "[3.3.5, )"
         }
       },
       "speckle.connectors.dui": {
@@ -249,7 +249,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.3.4, )"
+          "Speckle.Objects": "[3.3.5, )"
         }
       },
       "speckle.converters.revit2026": {
@@ -285,11 +285,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "MaZQFVtKGpntTwKL8go5zKIzjDJfXQQVpKXEvBPT/7SZISkpLTgmetizcQHZ1DGrA+Tps14dYFEWp7Ai+zCCCA==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "VPbYI8TyPDlKlNUHPLPAL1HveN9649LKVxw8opgGypoqq0MC5I7WxQjDcuB8xKnQ1PCSO8suu4hEJgdyPcEvWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.3.4"
+          "Speckle.Sdk": "3.3.5"
         }
       },
       "Speckle.Revit.API": {
@@ -300,9 +300,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "I7HzhT3PaE+Gd+T2LgqL5kqvc+SPJYnRofJhCv8smsUjADEonxUf+dAEV3AHM31CWGZT6SNe876+drXm60fUDg==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "7r8CmugwinniEF6v0N0bWuC+xpJaRfa/EnEjzj8NLpFG1b3uAjOxteGlQgR+evVacxTCEsuNkio7Mdv97odgpg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -311,14 +311,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.3.4"
+          "Speckle.Sdk.Dependencies": "3.3.5"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "0iGDakpkQIApAD3RCS8D0e5oM6yvvklDQFAEU30IvcQ+wpiEMqKJ2vidWG2vOrHMVPyiN7O457TXB41AhEWNlg=="
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "RukqLb0lVNgtmhKPeZJCncibnyutQ6Dr6+UQCa4PjWinIXpSm3A3ywK9ISkU+5StW1QoejiR7kc9a6qmiLys6w=="
       }
     },
     "net8.0-windows7.0/win-x64": {

--- a/Connectors/Rhino/Speckle.Connectors.Grasshopper7/packages.lock.json
+++ b/Connectors/Rhino/Speckle.Connectors.Grasshopper7/packages.lock.json
@@ -322,9 +322,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.3.4, )",
-          "Speckle.Sdk": "[3.3.4, )",
-          "Speckle.Sdk.Dependencies": "[3.3.4, )"
+          "Speckle.Objects": "[3.3.5, )",
+          "Speckle.Sdk": "[3.3.5, )",
+          "Speckle.Sdk.Dependencies": "[3.3.5, )"
         }
       },
       "speckle.connectors.logging": {
@@ -334,7 +334,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.3.4, )"
+          "Speckle.Objects": "[3.3.5, )"
         }
       },
       "speckle.converters.rhino7": {
@@ -379,18 +379,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "MaZQFVtKGpntTwKL8go5zKIzjDJfXQQVpKXEvBPT/7SZISkpLTgmetizcQHZ1DGrA+Tps14dYFEWp7Ai+zCCCA==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "VPbYI8TyPDlKlNUHPLPAL1HveN9649LKVxw8opgGypoqq0MC5I7WxQjDcuB8xKnQ1PCSO8suu4hEJgdyPcEvWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.3.4"
+          "Speckle.Sdk": "3.3.5"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "I7HzhT3PaE+Gd+T2LgqL5kqvc+SPJYnRofJhCv8smsUjADEonxUf+dAEV3AHM31CWGZT6SNe876+drXm60fUDg==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "7r8CmugwinniEF6v0N0bWuC+xpJaRfa/EnEjzj8NLpFG1b3uAjOxteGlQgR+evVacxTCEsuNkio7Mdv97odgpg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -400,14 +400,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.3.4"
+          "Speckle.Sdk.Dependencies": "3.3.5"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "0iGDakpkQIApAD3RCS8D0e5oM6yvvklDQFAEU30IvcQ+wpiEMqKJ2vidWG2vOrHMVPyiN7O457TXB41AhEWNlg=="
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "RukqLb0lVNgtmhKPeZJCncibnyutQ6Dr6+UQCa4PjWinIXpSm3A3ywK9ISkU+5StW1QoejiR7kc9a6qmiLys6w=="
       }
     }
   }

--- a/Connectors/Rhino/Speckle.Connectors.Grasshopper8/packages.lock.json
+++ b/Connectors/Rhino/Speckle.Connectors.Grasshopper8/packages.lock.json
@@ -322,9 +322,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.3.4, )",
-          "Speckle.Sdk": "[3.3.4, )",
-          "Speckle.Sdk.Dependencies": "[3.3.4, )"
+          "Speckle.Objects": "[3.3.5, )",
+          "Speckle.Sdk": "[3.3.5, )",
+          "Speckle.Sdk.Dependencies": "[3.3.5, )"
         }
       },
       "speckle.connectors.logging": {
@@ -334,7 +334,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.3.4, )"
+          "Speckle.Objects": "[3.3.5, )"
         }
       },
       "speckle.converters.rhino8": {
@@ -379,18 +379,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "MaZQFVtKGpntTwKL8go5zKIzjDJfXQQVpKXEvBPT/7SZISkpLTgmetizcQHZ1DGrA+Tps14dYFEWp7Ai+zCCCA==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "VPbYI8TyPDlKlNUHPLPAL1HveN9649LKVxw8opgGypoqq0MC5I7WxQjDcuB8xKnQ1PCSO8suu4hEJgdyPcEvWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.3.4"
+          "Speckle.Sdk": "3.3.5"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "I7HzhT3PaE+Gd+T2LgqL5kqvc+SPJYnRofJhCv8smsUjADEonxUf+dAEV3AHM31CWGZT6SNe876+drXm60fUDg==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "7r8CmugwinniEF6v0N0bWuC+xpJaRfa/EnEjzj8NLpFG1b3uAjOxteGlQgR+evVacxTCEsuNkio7Mdv97odgpg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -400,14 +400,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.3.4"
+          "Speckle.Sdk.Dependencies": "3.3.5"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "0iGDakpkQIApAD3RCS8D0e5oM6yvvklDQFAEU30IvcQ+wpiEMqKJ2vidWG2vOrHMVPyiN7O457TXB41AhEWNlg=="
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "RukqLb0lVNgtmhKPeZJCncibnyutQ6Dr6+UQCa4PjWinIXpSm3A3ywK9ISkU+5StW1QoejiR7kc9a6qmiLys6w=="
       }
     }
   }

--- a/Connectors/Rhino/Speckle.Connectors.Rhino7/packages.lock.json
+++ b/Connectors/Rhino/Speckle.Connectors.Rhino7/packages.lock.json
@@ -306,9 +306,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.3.4, )",
-          "Speckle.Sdk": "[3.3.4, )",
-          "Speckle.Sdk.Dependencies": "[3.3.4, )"
+          "Speckle.Objects": "[3.3.5, )",
+          "Speckle.Sdk": "[3.3.5, )",
+          "Speckle.Sdk.Dependencies": "[3.3.5, )"
         }
       },
       "speckle.connectors.dui": {
@@ -341,7 +341,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.3.4, )"
+          "Speckle.Objects": "[3.3.5, )"
         }
       },
       "speckle.converters.rhino7": {
@@ -398,18 +398,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "MaZQFVtKGpntTwKL8go5zKIzjDJfXQQVpKXEvBPT/7SZISkpLTgmetizcQHZ1DGrA+Tps14dYFEWp7Ai+zCCCA==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "VPbYI8TyPDlKlNUHPLPAL1HveN9649LKVxw8opgGypoqq0MC5I7WxQjDcuB8xKnQ1PCSO8suu4hEJgdyPcEvWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.3.4"
+          "Speckle.Sdk": "3.3.5"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "I7HzhT3PaE+Gd+T2LgqL5kqvc+SPJYnRofJhCv8smsUjADEonxUf+dAEV3AHM31CWGZT6SNe876+drXm60fUDg==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "7r8CmugwinniEF6v0N0bWuC+xpJaRfa/EnEjzj8NLpFG1b3uAjOxteGlQgR+evVacxTCEsuNkio7Mdv97odgpg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -419,14 +419,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.3.4"
+          "Speckle.Sdk.Dependencies": "3.3.5"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "0iGDakpkQIApAD3RCS8D0e5oM6yvvklDQFAEU30IvcQ+wpiEMqKJ2vidWG2vOrHMVPyiN7O457TXB41AhEWNlg=="
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "RukqLb0lVNgtmhKPeZJCncibnyutQ6Dr6+UQCa4PjWinIXpSm3A3ywK9ISkU+5StW1QoejiR7kc9a6qmiLys6w=="
       },
       "System.Resources.Extensions": {
         "type": "CentralTransitive",

--- a/Connectors/Rhino/Speckle.Connectors.Rhino8/packages.lock.json
+++ b/Connectors/Rhino/Speckle.Connectors.Rhino8/packages.lock.json
@@ -306,9 +306,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.3.4, )",
-          "Speckle.Sdk": "[3.3.4, )",
-          "Speckle.Sdk.Dependencies": "[3.3.4, )"
+          "Speckle.Objects": "[3.3.5, )",
+          "Speckle.Sdk": "[3.3.5, )",
+          "Speckle.Sdk.Dependencies": "[3.3.5, )"
         }
       },
       "speckle.connectors.dui": {
@@ -341,7 +341,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.3.4, )"
+          "Speckle.Objects": "[3.3.5, )"
         }
       },
       "speckle.converters.rhino8": {
@@ -398,18 +398,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "MaZQFVtKGpntTwKL8go5zKIzjDJfXQQVpKXEvBPT/7SZISkpLTgmetizcQHZ1DGrA+Tps14dYFEWp7Ai+zCCCA==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "VPbYI8TyPDlKlNUHPLPAL1HveN9649LKVxw8opgGypoqq0MC5I7WxQjDcuB8xKnQ1PCSO8suu4hEJgdyPcEvWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.3.4"
+          "Speckle.Sdk": "3.3.5"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "I7HzhT3PaE+Gd+T2LgqL5kqvc+SPJYnRofJhCv8smsUjADEonxUf+dAEV3AHM31CWGZT6SNe876+drXm60fUDg==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "7r8CmugwinniEF6v0N0bWuC+xpJaRfa/EnEjzj8NLpFG1b3uAjOxteGlQgR+evVacxTCEsuNkio7Mdv97odgpg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -419,14 +419,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.3.4"
+          "Speckle.Sdk.Dependencies": "3.3.5"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "0iGDakpkQIApAD3RCS8D0e5oM6yvvklDQFAEU30IvcQ+wpiEMqKJ2vidWG2vOrHMVPyiN7O457TXB41AhEWNlg=="
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "RukqLb0lVNgtmhKPeZJCncibnyutQ6Dr6+UQCa4PjWinIXpSm3A3ywK9ISkU+5StW1QoejiR7kc9a6qmiLys6w=="
       },
       "System.Resources.Extensions": {
         "type": "CentralTransitive",

--- a/Connectors/Tekla/Speckle.Connector.Tekla2023/packages.lock.json
+++ b/Connectors/Tekla/Speckle.Connector.Tekla2023/packages.lock.json
@@ -325,9 +325,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.3.4, )",
-          "Speckle.Sdk": "[3.3.4, )",
-          "Speckle.Sdk.Dependencies": "[3.3.4, )"
+          "Speckle.Objects": "[3.3.5, )",
+          "Speckle.Sdk": "[3.3.5, )",
+          "Speckle.Sdk.Dependencies": "[3.3.5, )"
         }
       },
       "speckle.connectors.dui": {
@@ -360,7 +360,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.3.4, )"
+          "Speckle.Objects": "[3.3.5, )"
         }
       },
       "LibTessDotNet": {
@@ -410,18 +410,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "MaZQFVtKGpntTwKL8go5zKIzjDJfXQQVpKXEvBPT/7SZISkpLTgmetizcQHZ1DGrA+Tps14dYFEWp7Ai+zCCCA==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "VPbYI8TyPDlKlNUHPLPAL1HveN9649LKVxw8opgGypoqq0MC5I7WxQjDcuB8xKnQ1PCSO8suu4hEJgdyPcEvWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.3.4"
+          "Speckle.Sdk": "3.3.5"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "I7HzhT3PaE+Gd+T2LgqL5kqvc+SPJYnRofJhCv8smsUjADEonxUf+dAEV3AHM31CWGZT6SNe876+drXm60fUDg==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "7r8CmugwinniEF6v0N0bWuC+xpJaRfa/EnEjzj8NLpFG1b3uAjOxteGlQgR+evVacxTCEsuNkio7Mdv97odgpg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -431,14 +431,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.3.4"
+          "Speckle.Sdk.Dependencies": "3.3.5"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "0iGDakpkQIApAD3RCS8D0e5oM6yvvklDQFAEU30IvcQ+wpiEMqKJ2vidWG2vOrHMVPyiN7O457TXB41AhEWNlg=="
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "RukqLb0lVNgtmhKPeZJCncibnyutQ6Dr6+UQCa4PjWinIXpSm3A3ywK9ISkU+5StW1QoejiR7kc9a6qmiLys6w=="
       }
     }
   }

--- a/Connectors/Tekla/Speckle.Connector.Tekla2024/packages.lock.json
+++ b/Connectors/Tekla/Speckle.Connector.Tekla2024/packages.lock.json
@@ -406,9 +406,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.3.4, )",
-          "Speckle.Sdk": "[3.3.4, )",
-          "Speckle.Sdk.Dependencies": "[3.3.4, )"
+          "Speckle.Objects": "[3.3.5, )",
+          "Speckle.Sdk": "[3.3.5, )",
+          "Speckle.Sdk.Dependencies": "[3.3.5, )"
         }
       },
       "speckle.connectors.dui": {
@@ -441,7 +441,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.3.4, )"
+          "Speckle.Objects": "[3.3.5, )"
         }
       },
       "LibTessDotNet": {
@@ -491,18 +491,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "MaZQFVtKGpntTwKL8go5zKIzjDJfXQQVpKXEvBPT/7SZISkpLTgmetizcQHZ1DGrA+Tps14dYFEWp7Ai+zCCCA==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "VPbYI8TyPDlKlNUHPLPAL1HveN9649LKVxw8opgGypoqq0MC5I7WxQjDcuB8xKnQ1PCSO8suu4hEJgdyPcEvWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.3.4"
+          "Speckle.Sdk": "3.3.5"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "I7HzhT3PaE+Gd+T2LgqL5kqvc+SPJYnRofJhCv8smsUjADEonxUf+dAEV3AHM31CWGZT6SNe876+drXm60fUDg==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "7r8CmugwinniEF6v0N0bWuC+xpJaRfa/EnEjzj8NLpFG1b3uAjOxteGlQgR+evVacxTCEsuNkio7Mdv97odgpg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -512,14 +512,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.3.4"
+          "Speckle.Sdk.Dependencies": "3.3.5"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "0iGDakpkQIApAD3RCS8D0e5oM6yvvklDQFAEU30IvcQ+wpiEMqKJ2vidWG2vOrHMVPyiN7O457TXB41AhEWNlg=="
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "RukqLb0lVNgtmhKPeZJCncibnyutQ6Dr6+UQCa4PjWinIXpSm3A3ywK9ISkU+5StW1QoejiR7kc9a6qmiLys6w=="
       }
     }
   }

--- a/Converters/ArcGIS/Speckle.Converters.ArcGIS3/packages.lock.json
+++ b/Converters/ArcGIS/Speckle.Converters.ArcGIS3/packages.lock.json
@@ -226,7 +226,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.3.4, )"
+          "Speckle.Objects": "[3.3.5, )"
         }
       },
       "LibTessDotNet": {
@@ -261,18 +261,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "MaZQFVtKGpntTwKL8go5zKIzjDJfXQQVpKXEvBPT/7SZISkpLTgmetizcQHZ1DGrA+Tps14dYFEWp7Ai+zCCCA==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "VPbYI8TyPDlKlNUHPLPAL1HveN9649LKVxw8opgGypoqq0MC5I7WxQjDcuB8xKnQ1PCSO8suu4hEJgdyPcEvWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.3.4"
+          "Speckle.Sdk": "3.3.5"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "I7HzhT3PaE+Gd+T2LgqL5kqvc+SPJYnRofJhCv8smsUjADEonxUf+dAEV3AHM31CWGZT6SNe876+drXm60fUDg==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "7r8CmugwinniEF6v0N0bWuC+xpJaRfa/EnEjzj8NLpFG1b3uAjOxteGlQgR+evVacxTCEsuNkio7Mdv97odgpg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -282,14 +282,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.3.4"
+          "Speckle.Sdk.Dependencies": "3.3.5"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "0iGDakpkQIApAD3RCS8D0e5oM6yvvklDQFAEU30IvcQ+wpiEMqKJ2vidWG2vOrHMVPyiN7O457TXB41AhEWNlg=="
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "RukqLb0lVNgtmhKPeZJCncibnyutQ6Dr6+UQCa4PjWinIXpSm3A3ywK9ISkU+5StW1QoejiR7kc9a6qmiLys6w=="
       }
     }
   }

--- a/Converters/Autocad/Speckle.Converters.Autocad2022/packages.lock.json
+++ b/Converters/Autocad/Speckle.Converters.Autocad2022/packages.lock.json
@@ -258,7 +258,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.3.4, )"
+          "Speckle.Objects": "[3.3.5, )"
         }
       },
       "Microsoft.Extensions.Logging": {
@@ -287,18 +287,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "MaZQFVtKGpntTwKL8go5zKIzjDJfXQQVpKXEvBPT/7SZISkpLTgmetizcQHZ1DGrA+Tps14dYFEWp7Ai+zCCCA==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "VPbYI8TyPDlKlNUHPLPAL1HveN9649LKVxw8opgGypoqq0MC5I7WxQjDcuB8xKnQ1PCSO8suu4hEJgdyPcEvWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.3.4"
+          "Speckle.Sdk": "3.3.5"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "I7HzhT3PaE+Gd+T2LgqL5kqvc+SPJYnRofJhCv8smsUjADEonxUf+dAEV3AHM31CWGZT6SNe876+drXm60fUDg==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "7r8CmugwinniEF6v0N0bWuC+xpJaRfa/EnEjzj8NLpFG1b3uAjOxteGlQgR+evVacxTCEsuNkio7Mdv97odgpg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -308,14 +308,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.3.4"
+          "Speckle.Sdk.Dependencies": "3.3.5"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "0iGDakpkQIApAD3RCS8D0e5oM6yvvklDQFAEU30IvcQ+wpiEMqKJ2vidWG2vOrHMVPyiN7O457TXB41AhEWNlg=="
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "RukqLb0lVNgtmhKPeZJCncibnyutQ6Dr6+UQCa4PjWinIXpSm3A3ywK9ISkU+5StW1QoejiR7kc9a6qmiLys6w=="
       }
     }
   }

--- a/Converters/Autocad/Speckle.Converters.Autocad2023/packages.lock.json
+++ b/Converters/Autocad/Speckle.Converters.Autocad2023/packages.lock.json
@@ -258,7 +258,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.3.4, )"
+          "Speckle.Objects": "[3.3.5, )"
         }
       },
       "Microsoft.Extensions.Logging": {
@@ -287,18 +287,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "MaZQFVtKGpntTwKL8go5zKIzjDJfXQQVpKXEvBPT/7SZISkpLTgmetizcQHZ1DGrA+Tps14dYFEWp7Ai+zCCCA==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "VPbYI8TyPDlKlNUHPLPAL1HveN9649LKVxw8opgGypoqq0MC5I7WxQjDcuB8xKnQ1PCSO8suu4hEJgdyPcEvWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.3.4"
+          "Speckle.Sdk": "3.3.5"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "I7HzhT3PaE+Gd+T2LgqL5kqvc+SPJYnRofJhCv8smsUjADEonxUf+dAEV3AHM31CWGZT6SNe876+drXm60fUDg==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "7r8CmugwinniEF6v0N0bWuC+xpJaRfa/EnEjzj8NLpFG1b3uAjOxteGlQgR+evVacxTCEsuNkio7Mdv97odgpg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -308,14 +308,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.3.4"
+          "Speckle.Sdk.Dependencies": "3.3.5"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "0iGDakpkQIApAD3RCS8D0e5oM6yvvklDQFAEU30IvcQ+wpiEMqKJ2vidWG2vOrHMVPyiN7O457TXB41AhEWNlg=="
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "RukqLb0lVNgtmhKPeZJCncibnyutQ6Dr6+UQCa4PjWinIXpSm3A3ywK9ISkU+5StW1QoejiR7kc9a6qmiLys6w=="
       }
     }
   }

--- a/Converters/Autocad/Speckle.Converters.Autocad2024/packages.lock.json
+++ b/Converters/Autocad/Speckle.Converters.Autocad2024/packages.lock.json
@@ -259,9 +259,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.3.4, )",
-          "Speckle.Sdk": "[3.3.4, )",
-          "Speckle.Sdk.Dependencies": "[3.3.4, )"
+          "Speckle.Objects": "[3.3.5, )",
+          "Speckle.Sdk": "[3.3.5, )",
+          "Speckle.Sdk.Dependencies": "[3.3.5, )"
         }
       },
       "speckle.connectors.dui": {
@@ -285,7 +285,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.3.4, )"
+          "Speckle.Objects": "[3.3.5, )"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -329,18 +329,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "MaZQFVtKGpntTwKL8go5zKIzjDJfXQQVpKXEvBPT/7SZISkpLTgmetizcQHZ1DGrA+Tps14dYFEWp7Ai+zCCCA==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "VPbYI8TyPDlKlNUHPLPAL1HveN9649LKVxw8opgGypoqq0MC5I7WxQjDcuB8xKnQ1PCSO8suu4hEJgdyPcEvWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.3.4"
+          "Speckle.Sdk": "3.3.5"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "I7HzhT3PaE+Gd+T2LgqL5kqvc+SPJYnRofJhCv8smsUjADEonxUf+dAEV3AHM31CWGZT6SNe876+drXm60fUDg==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "7r8CmugwinniEF6v0N0bWuC+xpJaRfa/EnEjzj8NLpFG1b3uAjOxteGlQgR+evVacxTCEsuNkio7Mdv97odgpg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -350,14 +350,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.3.4"
+          "Speckle.Sdk.Dependencies": "3.3.5"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "0iGDakpkQIApAD3RCS8D0e5oM6yvvklDQFAEU30IvcQ+wpiEMqKJ2vidWG2vOrHMVPyiN7O457TXB41AhEWNlg=="
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "RukqLb0lVNgtmhKPeZJCncibnyutQ6Dr6+UQCa4PjWinIXpSm3A3ywK9ISkU+5StW1QoejiR7kc9a6qmiLys6w=="
       }
     }
   }

--- a/Converters/Autocad/Speckle.Converters.Autocad2025/packages.lock.json
+++ b/Converters/Autocad/Speckle.Converters.Autocad2025/packages.lock.json
@@ -215,9 +215,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.3.4, )",
-          "Speckle.Sdk": "[3.3.4, )",
-          "Speckle.Sdk.Dependencies": "[3.3.4, )"
+          "Speckle.Objects": "[3.3.5, )",
+          "Speckle.Sdk": "[3.3.5, )",
+          "Speckle.Sdk.Dependencies": "[3.3.5, )"
         }
       },
       "speckle.connectors.dui": {
@@ -241,7 +241,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.3.4, )"
+          "Speckle.Objects": "[3.3.5, )"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -285,18 +285,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "MaZQFVtKGpntTwKL8go5zKIzjDJfXQQVpKXEvBPT/7SZISkpLTgmetizcQHZ1DGrA+Tps14dYFEWp7Ai+zCCCA==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "VPbYI8TyPDlKlNUHPLPAL1HveN9649LKVxw8opgGypoqq0MC5I7WxQjDcuB8xKnQ1PCSO8suu4hEJgdyPcEvWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.3.4"
+          "Speckle.Sdk": "3.3.5"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "I7HzhT3PaE+Gd+T2LgqL5kqvc+SPJYnRofJhCv8smsUjADEonxUf+dAEV3AHM31CWGZT6SNe876+drXm60fUDg==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "7r8CmugwinniEF6v0N0bWuC+xpJaRfa/EnEjzj8NLpFG1b3uAjOxteGlQgR+evVacxTCEsuNkio7Mdv97odgpg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -305,14 +305,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.3.4"
+          "Speckle.Sdk.Dependencies": "3.3.5"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "0iGDakpkQIApAD3RCS8D0e5oM6yvvklDQFAEU30IvcQ+wpiEMqKJ2vidWG2vOrHMVPyiN7O457TXB41AhEWNlg=="
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "RukqLb0lVNgtmhKPeZJCncibnyutQ6Dr6+UQCa4PjWinIXpSm3A3ywK9ISkU+5StW1QoejiR7kc9a6qmiLys6w=="
       }
     }
   }

--- a/Converters/Autocad/Speckle.Converters.Autocad2026/packages.lock.json
+++ b/Converters/Autocad/Speckle.Converters.Autocad2026/packages.lock.json
@@ -215,9 +215,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.3.4, )",
-          "Speckle.Sdk": "[3.3.4, )",
-          "Speckle.Sdk.Dependencies": "[3.3.4, )"
+          "Speckle.Objects": "[3.3.5, )",
+          "Speckle.Sdk": "[3.3.5, )",
+          "Speckle.Sdk.Dependencies": "[3.3.5, )"
         }
       },
       "speckle.connectors.dui": {
@@ -241,7 +241,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.3.4, )"
+          "Speckle.Objects": "[3.3.5, )"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -285,18 +285,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "MaZQFVtKGpntTwKL8go5zKIzjDJfXQQVpKXEvBPT/7SZISkpLTgmetizcQHZ1DGrA+Tps14dYFEWp7Ai+zCCCA==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "VPbYI8TyPDlKlNUHPLPAL1HveN9649LKVxw8opgGypoqq0MC5I7WxQjDcuB8xKnQ1PCSO8suu4hEJgdyPcEvWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.3.4"
+          "Speckle.Sdk": "3.3.5"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "I7HzhT3PaE+Gd+T2LgqL5kqvc+SPJYnRofJhCv8smsUjADEonxUf+dAEV3AHM31CWGZT6SNe876+drXm60fUDg==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "7r8CmugwinniEF6v0N0bWuC+xpJaRfa/EnEjzj8NLpFG1b3uAjOxteGlQgR+evVacxTCEsuNkio7Mdv97odgpg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -305,14 +305,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.3.4"
+          "Speckle.Sdk.Dependencies": "3.3.5"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "0iGDakpkQIApAD3RCS8D0e5oM6yvvklDQFAEU30IvcQ+wpiEMqKJ2vidWG2vOrHMVPyiN7O457TXB41AhEWNlg=="
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "RukqLb0lVNgtmhKPeZJCncibnyutQ6Dr6+UQCa4PjWinIXpSm3A3ywK9ISkU+5StW1QoejiR7kc9a6qmiLys6w=="
       }
     }
   }

--- a/Converters/CSi/Speckle.Converters.ETABS21/packages.lock.json
+++ b/Converters/CSi/Speckle.Converters.ETABS21/packages.lock.json
@@ -258,7 +258,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.3.4, )"
+          "Speckle.Objects": "[3.3.5, )"
         }
       },
       "Microsoft.Extensions.Logging": {
@@ -287,18 +287,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "MaZQFVtKGpntTwKL8go5zKIzjDJfXQQVpKXEvBPT/7SZISkpLTgmetizcQHZ1DGrA+Tps14dYFEWp7Ai+zCCCA==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "VPbYI8TyPDlKlNUHPLPAL1HveN9649LKVxw8opgGypoqq0MC5I7WxQjDcuB8xKnQ1PCSO8suu4hEJgdyPcEvWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.3.4"
+          "Speckle.Sdk": "3.3.5"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "I7HzhT3PaE+Gd+T2LgqL5kqvc+SPJYnRofJhCv8smsUjADEonxUf+dAEV3AHM31CWGZT6SNe876+drXm60fUDg==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "7r8CmugwinniEF6v0N0bWuC+xpJaRfa/EnEjzj8NLpFG1b3uAjOxteGlQgR+evVacxTCEsuNkio7Mdv97odgpg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -308,14 +308,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.3.4"
+          "Speckle.Sdk.Dependencies": "3.3.5"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "0iGDakpkQIApAD3RCS8D0e5oM6yvvklDQFAEU30IvcQ+wpiEMqKJ2vidWG2vOrHMVPyiN7O457TXB41AhEWNlg=="
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "RukqLb0lVNgtmhKPeZJCncibnyutQ6Dr6+UQCa4PjWinIXpSm3A3ywK9ISkU+5StW1QoejiR7kc9a6qmiLys6w=="
       }
     }
   }

--- a/Converters/CSi/Speckle.Converters.ETABS22/packages.lock.json
+++ b/Converters/CSi/Speckle.Converters.ETABS22/packages.lock.json
@@ -214,7 +214,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.3.4, )"
+          "Speckle.Objects": "[3.3.5, )"
         }
       },
       "Microsoft.Extensions.Logging": {
@@ -243,18 +243,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "MaZQFVtKGpntTwKL8go5zKIzjDJfXQQVpKXEvBPT/7SZISkpLTgmetizcQHZ1DGrA+Tps14dYFEWp7Ai+zCCCA==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "VPbYI8TyPDlKlNUHPLPAL1HveN9649LKVxw8opgGypoqq0MC5I7WxQjDcuB8xKnQ1PCSO8suu4hEJgdyPcEvWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.3.4"
+          "Speckle.Sdk": "3.3.5"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "I7HzhT3PaE+Gd+T2LgqL5kqvc+SPJYnRofJhCv8smsUjADEonxUf+dAEV3AHM31CWGZT6SNe876+drXm60fUDg==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "7r8CmugwinniEF6v0N0bWuC+xpJaRfa/EnEjzj8NLpFG1b3uAjOxteGlQgR+evVacxTCEsuNkio7Mdv97odgpg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -263,14 +263,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.3.4"
+          "Speckle.Sdk.Dependencies": "3.3.5"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "0iGDakpkQIApAD3RCS8D0e5oM6yvvklDQFAEU30IvcQ+wpiEMqKJ2vidWG2vOrHMVPyiN7O457TXB41AhEWNlg=="
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "RukqLb0lVNgtmhKPeZJCncibnyutQ6Dr6+UQCa4PjWinIXpSm3A3ywK9ISkU+5StW1QoejiR7kc9a6qmiLys6w=="
       }
     }
   }

--- a/Converters/Civil3d/Speckle.Converters.Civil3d2022/packages.lock.json
+++ b/Converters/Civil3d/Speckle.Converters.Civil3d2022/packages.lock.json
@@ -267,7 +267,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.3.4, )"
+          "Speckle.Objects": "[3.3.5, )"
         }
       },
       "Microsoft.Extensions.Logging": {
@@ -296,18 +296,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "MaZQFVtKGpntTwKL8go5zKIzjDJfXQQVpKXEvBPT/7SZISkpLTgmetizcQHZ1DGrA+Tps14dYFEWp7Ai+zCCCA==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "VPbYI8TyPDlKlNUHPLPAL1HveN9649LKVxw8opgGypoqq0MC5I7WxQjDcuB8xKnQ1PCSO8suu4hEJgdyPcEvWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.3.4"
+          "Speckle.Sdk": "3.3.5"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "I7HzhT3PaE+Gd+T2LgqL5kqvc+SPJYnRofJhCv8smsUjADEonxUf+dAEV3AHM31CWGZT6SNe876+drXm60fUDg==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "7r8CmugwinniEF6v0N0bWuC+xpJaRfa/EnEjzj8NLpFG1b3uAjOxteGlQgR+evVacxTCEsuNkio7Mdv97odgpg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -317,14 +317,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.3.4"
+          "Speckle.Sdk.Dependencies": "3.3.5"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "0iGDakpkQIApAD3RCS8D0e5oM6yvvklDQFAEU30IvcQ+wpiEMqKJ2vidWG2vOrHMVPyiN7O457TXB41AhEWNlg=="
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "RukqLb0lVNgtmhKPeZJCncibnyutQ6Dr6+UQCa4PjWinIXpSm3A3ywK9ISkU+5StW1QoejiR7kc9a6qmiLys6w=="
       }
     }
   }

--- a/Converters/Civil3d/Speckle.Converters.Civil3d2023/packages.lock.json
+++ b/Converters/Civil3d/Speckle.Converters.Civil3d2023/packages.lock.json
@@ -267,7 +267,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.3.4, )"
+          "Speckle.Objects": "[3.3.5, )"
         }
       },
       "Microsoft.Extensions.Logging": {
@@ -296,18 +296,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "MaZQFVtKGpntTwKL8go5zKIzjDJfXQQVpKXEvBPT/7SZISkpLTgmetizcQHZ1DGrA+Tps14dYFEWp7Ai+zCCCA==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "VPbYI8TyPDlKlNUHPLPAL1HveN9649LKVxw8opgGypoqq0MC5I7WxQjDcuB8xKnQ1PCSO8suu4hEJgdyPcEvWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.3.4"
+          "Speckle.Sdk": "3.3.5"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "I7HzhT3PaE+Gd+T2LgqL5kqvc+SPJYnRofJhCv8smsUjADEonxUf+dAEV3AHM31CWGZT6SNe876+drXm60fUDg==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "7r8CmugwinniEF6v0N0bWuC+xpJaRfa/EnEjzj8NLpFG1b3uAjOxteGlQgR+evVacxTCEsuNkio7Mdv97odgpg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -317,14 +317,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.3.4"
+          "Speckle.Sdk.Dependencies": "3.3.5"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "0iGDakpkQIApAD3RCS8D0e5oM6yvvklDQFAEU30IvcQ+wpiEMqKJ2vidWG2vOrHMVPyiN7O457TXB41AhEWNlg=="
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "RukqLb0lVNgtmhKPeZJCncibnyutQ6Dr6+UQCa4PjWinIXpSm3A3ywK9ISkU+5StW1QoejiR7kc9a6qmiLys6w=="
       }
     }
   }

--- a/Converters/Civil3d/Speckle.Converters.Civil3d2024/packages.lock.json
+++ b/Converters/Civil3d/Speckle.Converters.Civil3d2024/packages.lock.json
@@ -267,7 +267,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.3.4, )"
+          "Speckle.Objects": "[3.3.5, )"
         }
       },
       "Microsoft.Extensions.Logging": {
@@ -296,18 +296,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "MaZQFVtKGpntTwKL8go5zKIzjDJfXQQVpKXEvBPT/7SZISkpLTgmetizcQHZ1DGrA+Tps14dYFEWp7Ai+zCCCA==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "VPbYI8TyPDlKlNUHPLPAL1HveN9649LKVxw8opgGypoqq0MC5I7WxQjDcuB8xKnQ1PCSO8suu4hEJgdyPcEvWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.3.4"
+          "Speckle.Sdk": "3.3.5"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "I7HzhT3PaE+Gd+T2LgqL5kqvc+SPJYnRofJhCv8smsUjADEonxUf+dAEV3AHM31CWGZT6SNe876+drXm60fUDg==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "7r8CmugwinniEF6v0N0bWuC+xpJaRfa/EnEjzj8NLpFG1b3uAjOxteGlQgR+evVacxTCEsuNkio7Mdv97odgpg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -317,14 +317,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.3.4"
+          "Speckle.Sdk.Dependencies": "3.3.5"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "0iGDakpkQIApAD3RCS8D0e5oM6yvvklDQFAEU30IvcQ+wpiEMqKJ2vidWG2vOrHMVPyiN7O457TXB41AhEWNlg=="
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "RukqLb0lVNgtmhKPeZJCncibnyutQ6Dr6+UQCa4PjWinIXpSm3A3ywK9ISkU+5StW1QoejiR7kc9a6qmiLys6w=="
       }
     }
   }

--- a/Converters/Civil3d/Speckle.Converters.Civil3d2025/packages.lock.json
+++ b/Converters/Civil3d/Speckle.Converters.Civil3d2025/packages.lock.json
@@ -224,9 +224,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.3.4, )",
-          "Speckle.Sdk": "[3.3.4, )",
-          "Speckle.Sdk.Dependencies": "[3.3.4, )"
+          "Speckle.Objects": "[3.3.5, )",
+          "Speckle.Sdk": "[3.3.5, )",
+          "Speckle.Sdk.Dependencies": "[3.3.5, )"
         }
       },
       "speckle.connectors.dui": {
@@ -250,7 +250,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.3.4, )"
+          "Speckle.Objects": "[3.3.5, )"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -294,18 +294,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "MaZQFVtKGpntTwKL8go5zKIzjDJfXQQVpKXEvBPT/7SZISkpLTgmetizcQHZ1DGrA+Tps14dYFEWp7Ai+zCCCA==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "VPbYI8TyPDlKlNUHPLPAL1HveN9649LKVxw8opgGypoqq0MC5I7WxQjDcuB8xKnQ1PCSO8suu4hEJgdyPcEvWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.3.4"
+          "Speckle.Sdk": "3.3.5"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "I7HzhT3PaE+Gd+T2LgqL5kqvc+SPJYnRofJhCv8smsUjADEonxUf+dAEV3AHM31CWGZT6SNe876+drXm60fUDg==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "7r8CmugwinniEF6v0N0bWuC+xpJaRfa/EnEjzj8NLpFG1b3uAjOxteGlQgR+evVacxTCEsuNkio7Mdv97odgpg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -314,14 +314,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.3.4"
+          "Speckle.Sdk.Dependencies": "3.3.5"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "0iGDakpkQIApAD3RCS8D0e5oM6yvvklDQFAEU30IvcQ+wpiEMqKJ2vidWG2vOrHMVPyiN7O457TXB41AhEWNlg=="
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "RukqLb0lVNgtmhKPeZJCncibnyutQ6Dr6+UQCa4PjWinIXpSm3A3ywK9ISkU+5StW1QoejiR7kc9a6qmiLys6w=="
       }
     }
   }

--- a/Converters/Civil3d/Speckle.Converters.Civil3d2026/packages.lock.json
+++ b/Converters/Civil3d/Speckle.Converters.Civil3d2026/packages.lock.json
@@ -224,9 +224,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.3.4, )",
-          "Speckle.Sdk": "[3.3.4, )",
-          "Speckle.Sdk.Dependencies": "[3.3.4, )"
+          "Speckle.Objects": "[3.3.5, )",
+          "Speckle.Sdk": "[3.3.5, )",
+          "Speckle.Sdk.Dependencies": "[3.3.5, )"
         }
       },
       "speckle.connectors.dui": {
@@ -250,7 +250,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.3.4, )"
+          "Speckle.Objects": "[3.3.5, )"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -294,18 +294,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "MaZQFVtKGpntTwKL8go5zKIzjDJfXQQVpKXEvBPT/7SZISkpLTgmetizcQHZ1DGrA+Tps14dYFEWp7Ai+zCCCA==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "VPbYI8TyPDlKlNUHPLPAL1HveN9649LKVxw8opgGypoqq0MC5I7WxQjDcuB8xKnQ1PCSO8suu4hEJgdyPcEvWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.3.4"
+          "Speckle.Sdk": "3.3.5"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "I7HzhT3PaE+Gd+T2LgqL5kqvc+SPJYnRofJhCv8smsUjADEonxUf+dAEV3AHM31CWGZT6SNe876+drXm60fUDg==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "7r8CmugwinniEF6v0N0bWuC+xpJaRfa/EnEjzj8NLpFG1b3uAjOxteGlQgR+evVacxTCEsuNkio7Mdv97odgpg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -314,14 +314,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.3.4"
+          "Speckle.Sdk.Dependencies": "3.3.5"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "0iGDakpkQIApAD3RCS8D0e5oM6yvvklDQFAEU30IvcQ+wpiEMqKJ2vidWG2vOrHMVPyiN7O457TXB41AhEWNlg=="
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "RukqLb0lVNgtmhKPeZJCncibnyutQ6Dr6+UQCa4PjWinIXpSm3A3ywK9ISkU+5StW1QoejiR7kc9a6qmiLys6w=="
       }
     }
   }

--- a/Converters/Navisworks/Speckle.Converters.Navisworks2020/packages.lock.json
+++ b/Converters/Navisworks/Speckle.Converters.Navisworks2020/packages.lock.json
@@ -259,9 +259,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.3.4, )",
-          "Speckle.Sdk": "[3.3.4, )",
-          "Speckle.Sdk.Dependencies": "[3.3.4, )"
+          "Speckle.Objects": "[3.3.5, )",
+          "Speckle.Sdk": "[3.3.5, )",
+          "Speckle.Sdk.Dependencies": "[3.3.5, )"
         }
       },
       "speckle.connectors.dui": {
@@ -278,7 +278,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.3.4, )"
+          "Speckle.Objects": "[3.3.5, )"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -316,18 +316,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "MaZQFVtKGpntTwKL8go5zKIzjDJfXQQVpKXEvBPT/7SZISkpLTgmetizcQHZ1DGrA+Tps14dYFEWp7Ai+zCCCA==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "VPbYI8TyPDlKlNUHPLPAL1HveN9649LKVxw8opgGypoqq0MC5I7WxQjDcuB8xKnQ1PCSO8suu4hEJgdyPcEvWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.3.4"
+          "Speckle.Sdk": "3.3.5"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "I7HzhT3PaE+Gd+T2LgqL5kqvc+SPJYnRofJhCv8smsUjADEonxUf+dAEV3AHM31CWGZT6SNe876+drXm60fUDg==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "7r8CmugwinniEF6v0N0bWuC+xpJaRfa/EnEjzj8NLpFG1b3uAjOxteGlQgR+evVacxTCEsuNkio7Mdv97odgpg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -337,14 +337,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.3.4"
+          "Speckle.Sdk.Dependencies": "3.3.5"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "0iGDakpkQIApAD3RCS8D0e5oM6yvvklDQFAEU30IvcQ+wpiEMqKJ2vidWG2vOrHMVPyiN7O457TXB41AhEWNlg=="
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "RukqLb0lVNgtmhKPeZJCncibnyutQ6Dr6+UQCa4PjWinIXpSm3A3ywK9ISkU+5StW1QoejiR7kc9a6qmiLys6w=="
       }
     }
   }

--- a/Converters/Navisworks/Speckle.Converters.Navisworks2021/packages.lock.json
+++ b/Converters/Navisworks/Speckle.Converters.Navisworks2021/packages.lock.json
@@ -259,9 +259,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.3.4, )",
-          "Speckle.Sdk": "[3.3.4, )",
-          "Speckle.Sdk.Dependencies": "[3.3.4, )"
+          "Speckle.Objects": "[3.3.5, )",
+          "Speckle.Sdk": "[3.3.5, )",
+          "Speckle.Sdk.Dependencies": "[3.3.5, )"
         }
       },
       "speckle.connectors.dui": {
@@ -278,7 +278,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.3.4, )"
+          "Speckle.Objects": "[3.3.5, )"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -316,18 +316,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "MaZQFVtKGpntTwKL8go5zKIzjDJfXQQVpKXEvBPT/7SZISkpLTgmetizcQHZ1DGrA+Tps14dYFEWp7Ai+zCCCA==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "VPbYI8TyPDlKlNUHPLPAL1HveN9649LKVxw8opgGypoqq0MC5I7WxQjDcuB8xKnQ1PCSO8suu4hEJgdyPcEvWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.3.4"
+          "Speckle.Sdk": "3.3.5"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "I7HzhT3PaE+Gd+T2LgqL5kqvc+SPJYnRofJhCv8smsUjADEonxUf+dAEV3AHM31CWGZT6SNe876+drXm60fUDg==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "7r8CmugwinniEF6v0N0bWuC+xpJaRfa/EnEjzj8NLpFG1b3uAjOxteGlQgR+evVacxTCEsuNkio7Mdv97odgpg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -337,14 +337,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.3.4"
+          "Speckle.Sdk.Dependencies": "3.3.5"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "0iGDakpkQIApAD3RCS8D0e5oM6yvvklDQFAEU30IvcQ+wpiEMqKJ2vidWG2vOrHMVPyiN7O457TXB41AhEWNlg=="
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "RukqLb0lVNgtmhKPeZJCncibnyutQ6Dr6+UQCa4PjWinIXpSm3A3ywK9ISkU+5StW1QoejiR7kc9a6qmiLys6w=="
       }
     }
   }

--- a/Converters/Navisworks/Speckle.Converters.Navisworks2022/packages.lock.json
+++ b/Converters/Navisworks/Speckle.Converters.Navisworks2022/packages.lock.json
@@ -259,9 +259,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.3.4, )",
-          "Speckle.Sdk": "[3.3.4, )",
-          "Speckle.Sdk.Dependencies": "[3.3.4, )"
+          "Speckle.Objects": "[3.3.5, )",
+          "Speckle.Sdk": "[3.3.5, )",
+          "Speckle.Sdk.Dependencies": "[3.3.5, )"
         }
       },
       "speckle.connectors.dui": {
@@ -278,7 +278,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.3.4, )"
+          "Speckle.Objects": "[3.3.5, )"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -316,18 +316,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "MaZQFVtKGpntTwKL8go5zKIzjDJfXQQVpKXEvBPT/7SZISkpLTgmetizcQHZ1DGrA+Tps14dYFEWp7Ai+zCCCA==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "VPbYI8TyPDlKlNUHPLPAL1HveN9649LKVxw8opgGypoqq0MC5I7WxQjDcuB8xKnQ1PCSO8suu4hEJgdyPcEvWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.3.4"
+          "Speckle.Sdk": "3.3.5"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "I7HzhT3PaE+Gd+T2LgqL5kqvc+SPJYnRofJhCv8smsUjADEonxUf+dAEV3AHM31CWGZT6SNe876+drXm60fUDg==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "7r8CmugwinniEF6v0N0bWuC+xpJaRfa/EnEjzj8NLpFG1b3uAjOxteGlQgR+evVacxTCEsuNkio7Mdv97odgpg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -337,14 +337,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.3.4"
+          "Speckle.Sdk.Dependencies": "3.3.5"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "0iGDakpkQIApAD3RCS8D0e5oM6yvvklDQFAEU30IvcQ+wpiEMqKJ2vidWG2vOrHMVPyiN7O457TXB41AhEWNlg=="
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "RukqLb0lVNgtmhKPeZJCncibnyutQ6Dr6+UQCa4PjWinIXpSm3A3ywK9ISkU+5StW1QoejiR7kc9a6qmiLys6w=="
       }
     }
   }

--- a/Converters/Navisworks/Speckle.Converters.Navisworks2023/packages.lock.json
+++ b/Converters/Navisworks/Speckle.Converters.Navisworks2023/packages.lock.json
@@ -259,9 +259,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.3.4, )",
-          "Speckle.Sdk": "[3.3.4, )",
-          "Speckle.Sdk.Dependencies": "[3.3.4, )"
+          "Speckle.Objects": "[3.3.5, )",
+          "Speckle.Sdk": "[3.3.5, )",
+          "Speckle.Sdk.Dependencies": "[3.3.5, )"
         }
       },
       "speckle.connectors.dui": {
@@ -278,7 +278,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.3.4, )"
+          "Speckle.Objects": "[3.3.5, )"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -316,18 +316,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "MaZQFVtKGpntTwKL8go5zKIzjDJfXQQVpKXEvBPT/7SZISkpLTgmetizcQHZ1DGrA+Tps14dYFEWp7Ai+zCCCA==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "VPbYI8TyPDlKlNUHPLPAL1HveN9649LKVxw8opgGypoqq0MC5I7WxQjDcuB8xKnQ1PCSO8suu4hEJgdyPcEvWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.3.4"
+          "Speckle.Sdk": "3.3.5"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "I7HzhT3PaE+Gd+T2LgqL5kqvc+SPJYnRofJhCv8smsUjADEonxUf+dAEV3AHM31CWGZT6SNe876+drXm60fUDg==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "7r8CmugwinniEF6v0N0bWuC+xpJaRfa/EnEjzj8NLpFG1b3uAjOxteGlQgR+evVacxTCEsuNkio7Mdv97odgpg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -337,14 +337,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.3.4"
+          "Speckle.Sdk.Dependencies": "3.3.5"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "0iGDakpkQIApAD3RCS8D0e5oM6yvvklDQFAEU30IvcQ+wpiEMqKJ2vidWG2vOrHMVPyiN7O457TXB41AhEWNlg=="
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "RukqLb0lVNgtmhKPeZJCncibnyutQ6Dr6+UQCa4PjWinIXpSm3A3ywK9ISkU+5StW1QoejiR7kc9a6qmiLys6w=="
       }
     }
   }

--- a/Converters/Navisworks/Speckle.Converters.Navisworks2024/packages.lock.json
+++ b/Converters/Navisworks/Speckle.Converters.Navisworks2024/packages.lock.json
@@ -259,9 +259,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.3.4, )",
-          "Speckle.Sdk": "[3.3.4, )",
-          "Speckle.Sdk.Dependencies": "[3.3.4, )"
+          "Speckle.Objects": "[3.3.5, )",
+          "Speckle.Sdk": "[3.3.5, )",
+          "Speckle.Sdk.Dependencies": "[3.3.5, )"
         }
       },
       "speckle.connectors.dui": {
@@ -278,7 +278,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.3.4, )"
+          "Speckle.Objects": "[3.3.5, )"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -316,18 +316,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "MaZQFVtKGpntTwKL8go5zKIzjDJfXQQVpKXEvBPT/7SZISkpLTgmetizcQHZ1DGrA+Tps14dYFEWp7Ai+zCCCA==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "VPbYI8TyPDlKlNUHPLPAL1HveN9649LKVxw8opgGypoqq0MC5I7WxQjDcuB8xKnQ1PCSO8suu4hEJgdyPcEvWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.3.4"
+          "Speckle.Sdk": "3.3.5"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "I7HzhT3PaE+Gd+T2LgqL5kqvc+SPJYnRofJhCv8smsUjADEonxUf+dAEV3AHM31CWGZT6SNe876+drXm60fUDg==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "7r8CmugwinniEF6v0N0bWuC+xpJaRfa/EnEjzj8NLpFG1b3uAjOxteGlQgR+evVacxTCEsuNkio7Mdv97odgpg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -337,14 +337,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.3.4"
+          "Speckle.Sdk.Dependencies": "3.3.5"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "0iGDakpkQIApAD3RCS8D0e5oM6yvvklDQFAEU30IvcQ+wpiEMqKJ2vidWG2vOrHMVPyiN7O457TXB41AhEWNlg=="
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "RukqLb0lVNgtmhKPeZJCncibnyutQ6Dr6+UQCa4PjWinIXpSm3A3ywK9ISkU+5StW1QoejiR7kc9a6qmiLys6w=="
       }
     }
   }

--- a/Converters/Navisworks/Speckle.Converters.Navisworks2025/packages.lock.json
+++ b/Converters/Navisworks/Speckle.Converters.Navisworks2025/packages.lock.json
@@ -259,9 +259,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.3.4, )",
-          "Speckle.Sdk": "[3.3.4, )",
-          "Speckle.Sdk.Dependencies": "[3.3.4, )"
+          "Speckle.Objects": "[3.3.5, )",
+          "Speckle.Sdk": "[3.3.5, )",
+          "Speckle.Sdk.Dependencies": "[3.3.5, )"
         }
       },
       "speckle.connectors.dui": {
@@ -278,7 +278,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.3.4, )"
+          "Speckle.Objects": "[3.3.5, )"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -316,18 +316,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "MaZQFVtKGpntTwKL8go5zKIzjDJfXQQVpKXEvBPT/7SZISkpLTgmetizcQHZ1DGrA+Tps14dYFEWp7Ai+zCCCA==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "VPbYI8TyPDlKlNUHPLPAL1HveN9649LKVxw8opgGypoqq0MC5I7WxQjDcuB8xKnQ1PCSO8suu4hEJgdyPcEvWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.3.4"
+          "Speckle.Sdk": "3.3.5"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "I7HzhT3PaE+Gd+T2LgqL5kqvc+SPJYnRofJhCv8smsUjADEonxUf+dAEV3AHM31CWGZT6SNe876+drXm60fUDg==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "7r8CmugwinniEF6v0N0bWuC+xpJaRfa/EnEjzj8NLpFG1b3uAjOxteGlQgR+evVacxTCEsuNkio7Mdv97odgpg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -337,14 +337,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.3.4"
+          "Speckle.Sdk.Dependencies": "3.3.5"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "0iGDakpkQIApAD3RCS8D0e5oM6yvvklDQFAEU30IvcQ+wpiEMqKJ2vidWG2vOrHMVPyiN7O457TXB41AhEWNlg=="
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "RukqLb0lVNgtmhKPeZJCncibnyutQ6Dr6+UQCa4PjWinIXpSm3A3ywK9ISkU+5StW1QoejiR7kc9a6qmiLys6w=="
       }
     }
   }

--- a/Converters/Navisworks/Speckle.Converters.Navisworks2026/packages.lock.json
+++ b/Converters/Navisworks/Speckle.Converters.Navisworks2026/packages.lock.json
@@ -260,9 +260,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.3.4, )",
-          "Speckle.Sdk": "[3.3.4, )",
-          "Speckle.Sdk.Dependencies": "[3.3.4, )"
+          "Speckle.Objects": "[3.3.5, )",
+          "Speckle.Sdk": "[3.3.5, )",
+          "Speckle.Sdk.Dependencies": "[3.3.5, )"
         }
       },
       "speckle.connectors.dui": {
@@ -279,7 +279,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.3.4, )"
+          "Speckle.Objects": "[3.3.5, )"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -317,18 +317,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "MaZQFVtKGpntTwKL8go5zKIzjDJfXQQVpKXEvBPT/7SZISkpLTgmetizcQHZ1DGrA+Tps14dYFEWp7Ai+zCCCA==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "VPbYI8TyPDlKlNUHPLPAL1HveN9649LKVxw8opgGypoqq0MC5I7WxQjDcuB8xKnQ1PCSO8suu4hEJgdyPcEvWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.3.4"
+          "Speckle.Sdk": "3.3.5"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "I7HzhT3PaE+Gd+T2LgqL5kqvc+SPJYnRofJhCv8smsUjADEonxUf+dAEV3AHM31CWGZT6SNe876+drXm60fUDg==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "7r8CmugwinniEF6v0N0bWuC+xpJaRfa/EnEjzj8NLpFG1b3uAjOxteGlQgR+evVacxTCEsuNkio7Mdv97odgpg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -338,14 +338,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.3.4"
+          "Speckle.Sdk.Dependencies": "3.3.5"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "0iGDakpkQIApAD3RCS8D0e5oM6yvvklDQFAEU30IvcQ+wpiEMqKJ2vidWG2vOrHMVPyiN7O457TXB41AhEWNlg=="
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "RukqLb0lVNgtmhKPeZJCncibnyutQ6Dr6+UQCa4PjWinIXpSm3A3ywK9ISkU+5StW1QoejiR7kc9a6qmiLys6w=="
       }
     }
   }

--- a/Converters/Revit/Speckle.Converters.Revit2022/packages.lock.json
+++ b/Converters/Revit/Speckle.Converters.Revit2022/packages.lock.json
@@ -258,7 +258,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.3.4, )"
+          "Speckle.Objects": "[3.3.5, )"
         }
       },
       "Microsoft.Extensions.Logging": {
@@ -287,18 +287,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "MaZQFVtKGpntTwKL8go5zKIzjDJfXQQVpKXEvBPT/7SZISkpLTgmetizcQHZ1DGrA+Tps14dYFEWp7Ai+zCCCA==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "VPbYI8TyPDlKlNUHPLPAL1HveN9649LKVxw8opgGypoqq0MC5I7WxQjDcuB8xKnQ1PCSO8suu4hEJgdyPcEvWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.3.4"
+          "Speckle.Sdk": "3.3.5"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "I7HzhT3PaE+Gd+T2LgqL5kqvc+SPJYnRofJhCv8smsUjADEonxUf+dAEV3AHM31CWGZT6SNe876+drXm60fUDg==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "7r8CmugwinniEF6v0N0bWuC+xpJaRfa/EnEjzj8NLpFG1b3uAjOxteGlQgR+evVacxTCEsuNkio7Mdv97odgpg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -308,14 +308,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.3.4"
+          "Speckle.Sdk.Dependencies": "3.3.5"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "0iGDakpkQIApAD3RCS8D0e5oM6yvvklDQFAEU30IvcQ+wpiEMqKJ2vidWG2vOrHMVPyiN7O457TXB41AhEWNlg=="
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "RukqLb0lVNgtmhKPeZJCncibnyutQ6Dr6+UQCa4PjWinIXpSm3A3ywK9ISkU+5StW1QoejiR7kc9a6qmiLys6w=="
       }
     }
   }

--- a/Converters/Revit/Speckle.Converters.Revit2023/packages.lock.json
+++ b/Converters/Revit/Speckle.Converters.Revit2023/packages.lock.json
@@ -258,7 +258,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.3.4, )"
+          "Speckle.Objects": "[3.3.5, )"
         }
       },
       "Microsoft.Extensions.Logging": {
@@ -287,18 +287,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "MaZQFVtKGpntTwKL8go5zKIzjDJfXQQVpKXEvBPT/7SZISkpLTgmetizcQHZ1DGrA+Tps14dYFEWp7Ai+zCCCA==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "VPbYI8TyPDlKlNUHPLPAL1HveN9649LKVxw8opgGypoqq0MC5I7WxQjDcuB8xKnQ1PCSO8suu4hEJgdyPcEvWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.3.4"
+          "Speckle.Sdk": "3.3.5"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "I7HzhT3PaE+Gd+T2LgqL5kqvc+SPJYnRofJhCv8smsUjADEonxUf+dAEV3AHM31CWGZT6SNe876+drXm60fUDg==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "7r8CmugwinniEF6v0N0bWuC+xpJaRfa/EnEjzj8NLpFG1b3uAjOxteGlQgR+evVacxTCEsuNkio7Mdv97odgpg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -308,14 +308,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.3.4"
+          "Speckle.Sdk.Dependencies": "3.3.5"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "0iGDakpkQIApAD3RCS8D0e5oM6yvvklDQFAEU30IvcQ+wpiEMqKJ2vidWG2vOrHMVPyiN7O457TXB41AhEWNlg=="
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "RukqLb0lVNgtmhKPeZJCncibnyutQ6Dr6+UQCa4PjWinIXpSm3A3ywK9ISkU+5StW1QoejiR7kc9a6qmiLys6w=="
       }
     }
   }

--- a/Converters/Revit/Speckle.Converters.Revit2024/packages.lock.json
+++ b/Converters/Revit/Speckle.Converters.Revit2024/packages.lock.json
@@ -258,7 +258,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.3.4, )"
+          "Speckle.Objects": "[3.3.5, )"
         }
       },
       "Microsoft.Extensions.Logging": {
@@ -287,18 +287,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "MaZQFVtKGpntTwKL8go5zKIzjDJfXQQVpKXEvBPT/7SZISkpLTgmetizcQHZ1DGrA+Tps14dYFEWp7Ai+zCCCA==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "VPbYI8TyPDlKlNUHPLPAL1HveN9649LKVxw8opgGypoqq0MC5I7WxQjDcuB8xKnQ1PCSO8suu4hEJgdyPcEvWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.3.4"
+          "Speckle.Sdk": "3.3.5"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "I7HzhT3PaE+Gd+T2LgqL5kqvc+SPJYnRofJhCv8smsUjADEonxUf+dAEV3AHM31CWGZT6SNe876+drXm60fUDg==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "7r8CmugwinniEF6v0N0bWuC+xpJaRfa/EnEjzj8NLpFG1b3uAjOxteGlQgR+evVacxTCEsuNkio7Mdv97odgpg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -308,14 +308,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.3.4"
+          "Speckle.Sdk.Dependencies": "3.3.5"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "0iGDakpkQIApAD3RCS8D0e5oM6yvvklDQFAEU30IvcQ+wpiEMqKJ2vidWG2vOrHMVPyiN7O457TXB41AhEWNlg=="
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "RukqLb0lVNgtmhKPeZJCncibnyutQ6Dr6+UQCa4PjWinIXpSm3A3ywK9ISkU+5StW1QoejiR7kc9a6qmiLys6w=="
       }
     }
   }

--- a/Converters/Revit/Speckle.Converters.Revit2025/packages.lock.json
+++ b/Converters/Revit/Speckle.Converters.Revit2025/packages.lock.json
@@ -214,7 +214,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.3.4, )"
+          "Speckle.Objects": "[3.3.5, )"
         }
       },
       "Microsoft.Extensions.Logging": {
@@ -243,18 +243,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "MaZQFVtKGpntTwKL8go5zKIzjDJfXQQVpKXEvBPT/7SZISkpLTgmetizcQHZ1DGrA+Tps14dYFEWp7Ai+zCCCA==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "VPbYI8TyPDlKlNUHPLPAL1HveN9649LKVxw8opgGypoqq0MC5I7WxQjDcuB8xKnQ1PCSO8suu4hEJgdyPcEvWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.3.4"
+          "Speckle.Sdk": "3.3.5"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "I7HzhT3PaE+Gd+T2LgqL5kqvc+SPJYnRofJhCv8smsUjADEonxUf+dAEV3AHM31CWGZT6SNe876+drXm60fUDg==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "7r8CmugwinniEF6v0N0bWuC+xpJaRfa/EnEjzj8NLpFG1b3uAjOxteGlQgR+evVacxTCEsuNkio7Mdv97odgpg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -263,14 +263,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.3.4"
+          "Speckle.Sdk.Dependencies": "3.3.5"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "0iGDakpkQIApAD3RCS8D0e5oM6yvvklDQFAEU30IvcQ+wpiEMqKJ2vidWG2vOrHMVPyiN7O457TXB41AhEWNlg=="
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "RukqLb0lVNgtmhKPeZJCncibnyutQ6Dr6+UQCa4PjWinIXpSm3A3ywK9ISkU+5StW1QoejiR7kc9a6qmiLys6w=="
       }
     }
   }

--- a/Converters/Revit/Speckle.Converters.Revit2026/packages.lock.json
+++ b/Converters/Revit/Speckle.Converters.Revit2026/packages.lock.json
@@ -214,7 +214,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.3.4, )"
+          "Speckle.Objects": "[3.3.5, )"
         }
       },
       "Microsoft.Extensions.Logging": {
@@ -243,18 +243,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "MaZQFVtKGpntTwKL8go5zKIzjDJfXQQVpKXEvBPT/7SZISkpLTgmetizcQHZ1DGrA+Tps14dYFEWp7Ai+zCCCA==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "VPbYI8TyPDlKlNUHPLPAL1HveN9649LKVxw8opgGypoqq0MC5I7WxQjDcuB8xKnQ1PCSO8suu4hEJgdyPcEvWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.3.4"
+          "Speckle.Sdk": "3.3.5"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "I7HzhT3PaE+Gd+T2LgqL5kqvc+SPJYnRofJhCv8smsUjADEonxUf+dAEV3AHM31CWGZT6SNe876+drXm60fUDg==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "7r8CmugwinniEF6v0N0bWuC+xpJaRfa/EnEjzj8NLpFG1b3uAjOxteGlQgR+evVacxTCEsuNkio7Mdv97odgpg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -263,14 +263,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.3.4"
+          "Speckle.Sdk.Dependencies": "3.3.5"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "0iGDakpkQIApAD3RCS8D0e5oM6yvvklDQFAEU30IvcQ+wpiEMqKJ2vidWG2vOrHMVPyiN7O457TXB41AhEWNlg=="
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "RukqLb0lVNgtmhKPeZJCncibnyutQ6Dr6+UQCa4PjWinIXpSm3A3ywK9ISkU+5StW1QoejiR7kc9a6qmiLys6w=="
       }
     }
   }

--- a/Converters/Rhino/Speckle.Converters.Rhino7/packages.lock.json
+++ b/Converters/Rhino/Speckle.Converters.Rhino7/packages.lock.json
@@ -258,7 +258,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.3.4, )"
+          "Speckle.Objects": "[3.3.5, )"
         }
       },
       "Microsoft.Extensions.Logging": {
@@ -287,18 +287,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "MaZQFVtKGpntTwKL8go5zKIzjDJfXQQVpKXEvBPT/7SZISkpLTgmetizcQHZ1DGrA+Tps14dYFEWp7Ai+zCCCA==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "VPbYI8TyPDlKlNUHPLPAL1HveN9649LKVxw8opgGypoqq0MC5I7WxQjDcuB8xKnQ1PCSO8suu4hEJgdyPcEvWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.3.4"
+          "Speckle.Sdk": "3.3.5"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "I7HzhT3PaE+Gd+T2LgqL5kqvc+SPJYnRofJhCv8smsUjADEonxUf+dAEV3AHM31CWGZT6SNe876+drXm60fUDg==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "7r8CmugwinniEF6v0N0bWuC+xpJaRfa/EnEjzj8NLpFG1b3uAjOxteGlQgR+evVacxTCEsuNkio7Mdv97odgpg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -308,14 +308,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.3.4"
+          "Speckle.Sdk.Dependencies": "3.3.5"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "0iGDakpkQIApAD3RCS8D0e5oM6yvvklDQFAEU30IvcQ+wpiEMqKJ2vidWG2vOrHMVPyiN7O457TXB41AhEWNlg=="
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "RukqLb0lVNgtmhKPeZJCncibnyutQ6Dr6+UQCa4PjWinIXpSm3A3ywK9ISkU+5StW1QoejiR7kc9a6qmiLys6w=="
       }
     }
   }

--- a/Converters/Rhino/Speckle.Converters.Rhino8/packages.lock.json
+++ b/Converters/Rhino/Speckle.Converters.Rhino8/packages.lock.json
@@ -258,7 +258,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.3.4, )"
+          "Speckle.Objects": "[3.3.5, )"
         }
       },
       "Microsoft.Extensions.Logging": {
@@ -287,18 +287,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "MaZQFVtKGpntTwKL8go5zKIzjDJfXQQVpKXEvBPT/7SZISkpLTgmetizcQHZ1DGrA+Tps14dYFEWp7Ai+zCCCA==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "VPbYI8TyPDlKlNUHPLPAL1HveN9649LKVxw8opgGypoqq0MC5I7WxQjDcuB8xKnQ1PCSO8suu4hEJgdyPcEvWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.3.4"
+          "Speckle.Sdk": "3.3.5"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "I7HzhT3PaE+Gd+T2LgqL5kqvc+SPJYnRofJhCv8smsUjADEonxUf+dAEV3AHM31CWGZT6SNe876+drXm60fUDg==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "7r8CmugwinniEF6v0N0bWuC+xpJaRfa/EnEjzj8NLpFG1b3uAjOxteGlQgR+evVacxTCEsuNkio7Mdv97odgpg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -308,14 +308,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.3.4"
+          "Speckle.Sdk.Dependencies": "3.3.5"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "0iGDakpkQIApAD3RCS8D0e5oM6yvvklDQFAEU30IvcQ+wpiEMqKJ2vidWG2vOrHMVPyiN7O457TXB41AhEWNlg=="
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "RukqLb0lVNgtmhKPeZJCncibnyutQ6Dr6+UQCa4PjWinIXpSm3A3ywK9ISkU+5StW1QoejiR7kc9a6qmiLys6w=="
       }
     }
   }

--- a/Converters/Tekla/Speckle.Converter.Tekla2023/packages.lock.json
+++ b/Converters/Tekla/Speckle.Converter.Tekla2023/packages.lock.json
@@ -302,7 +302,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.3.4, )"
+          "Speckle.Objects": "[3.3.5, )"
         }
       },
       "LibTessDotNet": {
@@ -337,18 +337,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "MaZQFVtKGpntTwKL8go5zKIzjDJfXQQVpKXEvBPT/7SZISkpLTgmetizcQHZ1DGrA+Tps14dYFEWp7Ai+zCCCA==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "VPbYI8TyPDlKlNUHPLPAL1HveN9649LKVxw8opgGypoqq0MC5I7WxQjDcuB8xKnQ1PCSO8suu4hEJgdyPcEvWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.3.4"
+          "Speckle.Sdk": "3.3.5"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "I7HzhT3PaE+Gd+T2LgqL5kqvc+SPJYnRofJhCv8smsUjADEonxUf+dAEV3AHM31CWGZT6SNe876+drXm60fUDg==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "7r8CmugwinniEF6v0N0bWuC+xpJaRfa/EnEjzj8NLpFG1b3uAjOxteGlQgR+evVacxTCEsuNkio7Mdv97odgpg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -358,14 +358,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.3.4"
+          "Speckle.Sdk.Dependencies": "3.3.5"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "0iGDakpkQIApAD3RCS8D0e5oM6yvvklDQFAEU30IvcQ+wpiEMqKJ2vidWG2vOrHMVPyiN7O457TXB41AhEWNlg=="
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "RukqLb0lVNgtmhKPeZJCncibnyutQ6Dr6+UQCa4PjWinIXpSm3A3ywK9ISkU+5StW1QoejiR7kc9a6qmiLys6w=="
       },
       "Tekla.Structures.Dialog": {
         "type": "CentralTransitive",

--- a/Converters/Tekla/Speckle.Converter.Tekla2024/packages.lock.json
+++ b/Converters/Tekla/Speckle.Converter.Tekla2024/packages.lock.json
@@ -343,7 +343,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.3.4, )"
+          "Speckle.Objects": "[3.3.5, )"
         }
       },
       "LibTessDotNet": {
@@ -378,18 +378,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "MaZQFVtKGpntTwKL8go5zKIzjDJfXQQVpKXEvBPT/7SZISkpLTgmetizcQHZ1DGrA+Tps14dYFEWp7Ai+zCCCA==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "VPbYI8TyPDlKlNUHPLPAL1HveN9649LKVxw8opgGypoqq0MC5I7WxQjDcuB8xKnQ1PCSO8suu4hEJgdyPcEvWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.3.4"
+          "Speckle.Sdk": "3.3.5"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "I7HzhT3PaE+Gd+T2LgqL5kqvc+SPJYnRofJhCv8smsUjADEonxUf+dAEV3AHM31CWGZT6SNe876+drXm60fUDg==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "7r8CmugwinniEF6v0N0bWuC+xpJaRfa/EnEjzj8NLpFG1b3uAjOxteGlQgR+evVacxTCEsuNkio7Mdv97odgpg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -399,14 +399,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.3.4"
+          "Speckle.Sdk.Dependencies": "3.3.5"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "0iGDakpkQIApAD3RCS8D0e5oM6yvvklDQFAEU30IvcQ+wpiEMqKJ2vidWG2vOrHMVPyiN7O457TXB41AhEWNlg=="
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "RukqLb0lVNgtmhKPeZJCncibnyutQ6Dr6+UQCa4PjWinIXpSm3A3ywK9ISkU+5StW1QoejiR7kc9a6qmiLys6w=="
       },
       "Tekla.Structures.Plugins": {
         "type": "CentralTransitive",

--- a/DUI3/Speckle.Connectors.DUI.Tests/packages.lock.json
+++ b/DUI3/Speckle.Connectors.DUI.Tests/packages.lock.json
@@ -319,9 +319,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.3.4, )",
-          "Speckle.Sdk": "[3.3.4, )",
-          "Speckle.Sdk.Dependencies": "[3.3.4, )"
+          "Speckle.Objects": "[3.3.5, )",
+          "Speckle.Sdk": "[3.3.5, )",
+          "Speckle.Sdk.Dependencies": "[3.3.5, )"
         }
       },
       "speckle.connectors.dui": {
@@ -340,7 +340,7 @@
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Moq": "[4.20.70, )",
           "NUnit": "[4.1.0, )",
-          "Speckle.Sdk": "[3.3.4, )"
+          "Speckle.Sdk": "[3.3.5, )"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -378,18 +378,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "MaZQFVtKGpntTwKL8go5zKIzjDJfXQQVpKXEvBPT/7SZISkpLTgmetizcQHZ1DGrA+Tps14dYFEWp7Ai+zCCCA==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "VPbYI8TyPDlKlNUHPLPAL1HveN9649LKVxw8opgGypoqq0MC5I7WxQjDcuB8xKnQ1PCSO8suu4hEJgdyPcEvWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.3.4"
+          "Speckle.Sdk": "3.3.5"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "I7HzhT3PaE+Gd+T2LgqL5kqvc+SPJYnRofJhCv8smsUjADEonxUf+dAEV3AHM31CWGZT6SNe876+drXm60fUDg==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "7r8CmugwinniEF6v0N0bWuC+xpJaRfa/EnEjzj8NLpFG1b3uAjOxteGlQgR+evVacxTCEsuNkio7Mdv97odgpg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -398,14 +398,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.3.4"
+          "Speckle.Sdk.Dependencies": "3.3.5"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "0iGDakpkQIApAD3RCS8D0e5oM6yvvklDQFAEU30IvcQ+wpiEMqKJ2vidWG2vOrHMVPyiN7O457TXB41AhEWNlg=="
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "RukqLb0lVNgtmhKPeZJCncibnyutQ6Dr6+UQCa4PjWinIXpSm3A3ywK9ISkU+5StW1QoejiR7kc9a6qmiLys6w=="
       }
     }
   }

--- a/DUI3/Speckle.Connectors.DUI.WebView/packages.lock.json
+++ b/DUI3/Speckle.Connectors.DUI.WebView/packages.lock.json
@@ -259,9 +259,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.3.4, )",
-          "Speckle.Sdk": "[3.3.4, )",
-          "Speckle.Sdk.Dependencies": "[3.3.4, )"
+          "Speckle.Objects": "[3.3.5, )",
+          "Speckle.Sdk": "[3.3.5, )",
+          "Speckle.Sdk.Dependencies": "[3.3.5, )"
         }
       },
       "speckle.connectors.dui": {
@@ -309,18 +309,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "MaZQFVtKGpntTwKL8go5zKIzjDJfXQQVpKXEvBPT/7SZISkpLTgmetizcQHZ1DGrA+Tps14dYFEWp7Ai+zCCCA==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "VPbYI8TyPDlKlNUHPLPAL1HveN9649LKVxw8opgGypoqq0MC5I7WxQjDcuB8xKnQ1PCSO8suu4hEJgdyPcEvWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.3.4"
+          "Speckle.Sdk": "3.3.5"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "I7HzhT3PaE+Gd+T2LgqL5kqvc+SPJYnRofJhCv8smsUjADEonxUf+dAEV3AHM31CWGZT6SNe876+drXm60fUDg==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "7r8CmugwinniEF6v0N0bWuC+xpJaRfa/EnEjzj8NLpFG1b3uAjOxteGlQgR+evVacxTCEsuNkio7Mdv97odgpg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -330,14 +330,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.3.4"
+          "Speckle.Sdk.Dependencies": "3.3.5"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "0iGDakpkQIApAD3RCS8D0e5oM6yvvklDQFAEU30IvcQ+wpiEMqKJ2vidWG2vOrHMVPyiN7O457TXB41AhEWNlg=="
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "RukqLb0lVNgtmhKPeZJCncibnyutQ6Dr6+UQCa4PjWinIXpSm3A3ywK9ISkU+5StW1QoejiR7kc9a6qmiLys6w=="
       }
     },
     "net6.0-windows7.0": {
@@ -559,9 +559,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.3.4, )",
-          "Speckle.Sdk": "[3.3.4, )",
-          "Speckle.Sdk.Dependencies": "[3.3.4, )"
+          "Speckle.Objects": "[3.3.5, )",
+          "Speckle.Sdk": "[3.3.5, )",
+          "Speckle.Sdk.Dependencies": "[3.3.5, )"
         }
       },
       "speckle.connectors.dui": {
@@ -609,18 +609,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "MaZQFVtKGpntTwKL8go5zKIzjDJfXQQVpKXEvBPT/7SZISkpLTgmetizcQHZ1DGrA+Tps14dYFEWp7Ai+zCCCA==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "VPbYI8TyPDlKlNUHPLPAL1HveN9649LKVxw8opgGypoqq0MC5I7WxQjDcuB8xKnQ1PCSO8suu4hEJgdyPcEvWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.3.4"
+          "Speckle.Sdk": "3.3.5"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "I7HzhT3PaE+Gd+T2LgqL5kqvc+SPJYnRofJhCv8smsUjADEonxUf+dAEV3AHM31CWGZT6SNe876+drXm60fUDg==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "7r8CmugwinniEF6v0N0bWuC+xpJaRfa/EnEjzj8NLpFG1b3uAjOxteGlQgR+evVacxTCEsuNkio7Mdv97odgpg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -630,14 +630,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.3.4"
+          "Speckle.Sdk.Dependencies": "3.3.5"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "0iGDakpkQIApAD3RCS8D0e5oM6yvvklDQFAEU30IvcQ+wpiEMqKJ2vidWG2vOrHMVPyiN7O457TXB41AhEWNlg=="
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "RukqLb0lVNgtmhKPeZJCncibnyutQ6Dr6+UQCa4PjWinIXpSm3A3ywK9ISkU+5StW1QoejiR7kc9a6qmiLys6w=="
       }
     },
     "net8.0-windows7.0": {
@@ -854,9 +854,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.3.4, )",
-          "Speckle.Sdk": "[3.3.4, )",
-          "Speckle.Sdk.Dependencies": "[3.3.4, )"
+          "Speckle.Objects": "[3.3.5, )",
+          "Speckle.Sdk": "[3.3.5, )",
+          "Speckle.Sdk.Dependencies": "[3.3.5, )"
         }
       },
       "speckle.connectors.dui": {
@@ -904,18 +904,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "MaZQFVtKGpntTwKL8go5zKIzjDJfXQQVpKXEvBPT/7SZISkpLTgmetizcQHZ1DGrA+Tps14dYFEWp7Ai+zCCCA==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "VPbYI8TyPDlKlNUHPLPAL1HveN9649LKVxw8opgGypoqq0MC5I7WxQjDcuB8xKnQ1PCSO8suu4hEJgdyPcEvWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.3.4"
+          "Speckle.Sdk": "3.3.5"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "I7HzhT3PaE+Gd+T2LgqL5kqvc+SPJYnRofJhCv8smsUjADEonxUf+dAEV3AHM31CWGZT6SNe876+drXm60fUDg==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "7r8CmugwinniEF6v0N0bWuC+xpJaRfa/EnEjzj8NLpFG1b3uAjOxteGlQgR+evVacxTCEsuNkio7Mdv97odgpg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -924,14 +924,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.3.4"
+          "Speckle.Sdk.Dependencies": "3.3.5"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "0iGDakpkQIApAD3RCS8D0e5oM6yvvklDQFAEU30IvcQ+wpiEMqKJ2vidWG2vOrHMVPyiN7O457TXB41AhEWNlg=="
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "RukqLb0lVNgtmhKPeZJCncibnyutQ6Dr6+UQCa4PjWinIXpSm3A3ywK9ISkU+5StW1QoejiR7kc9a6qmiLys6w=="
       }
     }
   }

--- a/DUI3/Speckle.Connectors.DUI/packages.lock.json
+++ b/DUI3/Speckle.Connectors.DUI/packages.lock.json
@@ -259,9 +259,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.3.4, )",
-          "Speckle.Sdk": "[3.3.4, )",
-          "Speckle.Sdk.Dependencies": "[3.3.4, )"
+          "Speckle.Objects": "[3.3.5, )",
+          "Speckle.Sdk": "[3.3.5, )",
+          "Speckle.Sdk.Dependencies": "[3.3.5, )"
         }
       },
       "speckle.connectors.logging": {
@@ -296,18 +296,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "MaZQFVtKGpntTwKL8go5zKIzjDJfXQQVpKXEvBPT/7SZISkpLTgmetizcQHZ1DGrA+Tps14dYFEWp7Ai+zCCCA==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "VPbYI8TyPDlKlNUHPLPAL1HveN9649LKVxw8opgGypoqq0MC5I7WxQjDcuB8xKnQ1PCSO8suu4hEJgdyPcEvWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.3.4"
+          "Speckle.Sdk": "3.3.5"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "I7HzhT3PaE+Gd+T2LgqL5kqvc+SPJYnRofJhCv8smsUjADEonxUf+dAEV3AHM31CWGZT6SNe876+drXm60fUDg==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "7r8CmugwinniEF6v0N0bWuC+xpJaRfa/EnEjzj8NLpFG1b3uAjOxteGlQgR+evVacxTCEsuNkio7Mdv97odgpg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -317,14 +317,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.3.4"
+          "Speckle.Sdk.Dependencies": "3.3.5"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "0iGDakpkQIApAD3RCS8D0e5oM6yvvklDQFAEU30IvcQ+wpiEMqKJ2vidWG2vOrHMVPyiN7O457TXB41AhEWNlg=="
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "RukqLb0lVNgtmhKPeZJCncibnyutQ6Dr6+UQCa4PjWinIXpSm3A3ywK9ISkU+5StW1QoejiR7kc9a6qmiLys6w=="
       }
     },
     "net6.0": {
@@ -546,9 +546,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.3.4, )",
-          "Speckle.Sdk": "[3.3.4, )",
-          "Speckle.Sdk.Dependencies": "[3.3.4, )"
+          "Speckle.Objects": "[3.3.5, )",
+          "Speckle.Sdk": "[3.3.5, )",
+          "Speckle.Sdk.Dependencies": "[3.3.5, )"
         }
       },
       "speckle.connectors.logging": {
@@ -583,18 +583,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "MaZQFVtKGpntTwKL8go5zKIzjDJfXQQVpKXEvBPT/7SZISkpLTgmetizcQHZ1DGrA+Tps14dYFEWp7Ai+zCCCA==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "VPbYI8TyPDlKlNUHPLPAL1HveN9649LKVxw8opgGypoqq0MC5I7WxQjDcuB8xKnQ1PCSO8suu4hEJgdyPcEvWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.3.4"
+          "Speckle.Sdk": "3.3.5"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "I7HzhT3PaE+Gd+T2LgqL5kqvc+SPJYnRofJhCv8smsUjADEonxUf+dAEV3AHM31CWGZT6SNe876+drXm60fUDg==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "7r8CmugwinniEF6v0N0bWuC+xpJaRfa/EnEjzj8NLpFG1b3uAjOxteGlQgR+evVacxTCEsuNkio7Mdv97odgpg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -604,14 +604,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.3.4"
+          "Speckle.Sdk.Dependencies": "3.3.5"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "0iGDakpkQIApAD3RCS8D0e5oM6yvvklDQFAEU30IvcQ+wpiEMqKJ2vidWG2vOrHMVPyiN7O457TXB41AhEWNlg=="
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "RukqLb0lVNgtmhKPeZJCncibnyutQ6Dr6+UQCa4PjWinIXpSm3A3ywK9ISkU+5StW1QoejiR7kc9a6qmiLys6w=="
       }
     },
     "net8.0": {
@@ -828,9 +828,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.3.4, )",
-          "Speckle.Sdk": "[3.3.4, )",
-          "Speckle.Sdk.Dependencies": "[3.3.4, )"
+          "Speckle.Objects": "[3.3.5, )",
+          "Speckle.Sdk": "[3.3.5, )",
+          "Speckle.Sdk.Dependencies": "[3.3.5, )"
         }
       },
       "speckle.connectors.logging": {
@@ -865,18 +865,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "MaZQFVtKGpntTwKL8go5zKIzjDJfXQQVpKXEvBPT/7SZISkpLTgmetizcQHZ1DGrA+Tps14dYFEWp7Ai+zCCCA==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "VPbYI8TyPDlKlNUHPLPAL1HveN9649LKVxw8opgGypoqq0MC5I7WxQjDcuB8xKnQ1PCSO8suu4hEJgdyPcEvWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.3.4"
+          "Speckle.Sdk": "3.3.5"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "I7HzhT3PaE+Gd+T2LgqL5kqvc+SPJYnRofJhCv8smsUjADEonxUf+dAEV3AHM31CWGZT6SNe876+drXm60fUDg==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "7r8CmugwinniEF6v0N0bWuC+xpJaRfa/EnEjzj8NLpFG1b3uAjOxteGlQgR+evVacxTCEsuNkio7Mdv97odgpg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -885,14 +885,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.3.4"
+          "Speckle.Sdk.Dependencies": "3.3.5"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "0iGDakpkQIApAD3RCS8D0e5oM6yvvklDQFAEU30IvcQ+wpiEMqKJ2vidWG2vOrHMVPyiN7O457TXB41AhEWNlg=="
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "RukqLb0lVNgtmhKPeZJCncibnyutQ6Dr6+UQCa4PjWinIXpSm3A3ywK9ISkU+5StW1QoejiR7kc9a6qmiLys6w=="
       }
     }
   }

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -47,9 +47,9 @@
     <PackageVersion Include="Speckle.Civil3D.API" Version="2022.0.2" />
     <PackageVersion Include="Speckle.Revit.API" Version="2023.0.0" />
     <PackageVersion Include="Speckle.Navisworks.API" Version="2024.0.0" />
-    <PackageVersion Include="Speckle.Objects" Version="3.3.4" />
-    <PackageVersion Include="Speckle.Sdk" Version="3.3.4" />
-    <PackageVersion Include="Speckle.Sdk.Dependencies" Version="3.3.4" />
+    <PackageVersion Include="Speckle.Objects" Version="3.3.5" />
+    <PackageVersion Include="Speckle.Sdk" Version="3.3.5" />
+    <PackageVersion Include="Speckle.Sdk.Dependencies" Version="3.3.5" />
     <PackageVersion Include="SimpleExec" Version="12.0.0" />
     <GlobalPackageReference Include="PolySharp" Version="1.14.1" />
     <GlobalPackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />

--- a/Importers/Ifc/Speckle.Importers.Ifc.Tester/packages.lock.json
+++ b/Importers/Ifc/Speckle.Importers.Ifc.Tester/packages.lock.json
@@ -209,9 +209,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.3.4, )",
-          "Speckle.Sdk": "[3.3.4, )",
-          "Speckle.Sdk.Dependencies": "[3.3.4, )"
+          "Speckle.Objects": "[3.3.5, )",
+          "Speckle.Sdk": "[3.3.5, )",
+          "Speckle.Sdk.Dependencies": "[3.3.5, )"
         }
       },
       "speckle.connectors.logging": {
@@ -225,8 +225,8 @@
           "Ara3D.Utils": "[1.4.5, )",
           "Microsoft.Extensions.DependencyInjection": "[8.0.0, )",
           "Speckle.Connectors.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.3.4, )",
-          "Speckle.Sdk": "[3.3.4, )"
+          "Speckle.Objects": "[3.3.5, )",
+          "Speckle.Sdk": "[3.3.5, )"
         }
       },
       "Ara3D.Buffers": {
@@ -288,18 +288,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "MaZQFVtKGpntTwKL8go5zKIzjDJfXQQVpKXEvBPT/7SZISkpLTgmetizcQHZ1DGrA+Tps14dYFEWp7Ai+zCCCA==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "VPbYI8TyPDlKlNUHPLPAL1HveN9649LKVxw8opgGypoqq0MC5I7WxQjDcuB8xKnQ1PCSO8suu4hEJgdyPcEvWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.3.4"
+          "Speckle.Sdk": "3.3.5"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "I7HzhT3PaE+Gd+T2LgqL5kqvc+SPJYnRofJhCv8smsUjADEonxUf+dAEV3AHM31CWGZT6SNe876+drXm60fUDg==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "7r8CmugwinniEF6v0N0bWuC+xpJaRfa/EnEjzj8NLpFG1b3uAjOxteGlQgR+evVacxTCEsuNkio7Mdv97odgpg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -308,14 +308,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.3.4"
+          "Speckle.Sdk.Dependencies": "3.3.5"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "0iGDakpkQIApAD3RCS8D0e5oM6yvvklDQFAEU30IvcQ+wpiEMqKJ2vidWG2vOrHMVPyiN7O457TXB41AhEWNlg=="
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "RukqLb0lVNgtmhKPeZJCncibnyutQ6Dr6+UQCa4PjWinIXpSm3A3ywK9ISkU+5StW1QoejiR7kc9a6qmiLys6w=="
       }
     }
   }

--- a/Importers/Ifc/Speckle.Importers.Ifc.Tester2/packages.lock.json
+++ b/Importers/Ifc/Speckle.Importers.Ifc.Tester2/packages.lock.json
@@ -209,9 +209,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.3.4, )",
-          "Speckle.Sdk": "[3.3.4, )",
-          "Speckle.Sdk.Dependencies": "[3.3.4, )"
+          "Speckle.Objects": "[3.3.5, )",
+          "Speckle.Sdk": "[3.3.5, )",
+          "Speckle.Sdk.Dependencies": "[3.3.5, )"
         }
       },
       "speckle.connectors.logging": {
@@ -225,8 +225,8 @@
           "Ara3D.Utils": "[1.4.5, )",
           "Microsoft.Extensions.DependencyInjection": "[8.0.0, )",
           "Speckle.Connectors.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.3.4, )",
-          "Speckle.Sdk": "[3.3.4, )"
+          "Speckle.Objects": "[3.3.5, )",
+          "Speckle.Sdk": "[3.3.5, )"
         }
       },
       "Ara3D.Buffers": {
@@ -288,18 +288,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "MaZQFVtKGpntTwKL8go5zKIzjDJfXQQVpKXEvBPT/7SZISkpLTgmetizcQHZ1DGrA+Tps14dYFEWp7Ai+zCCCA==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "VPbYI8TyPDlKlNUHPLPAL1HveN9649LKVxw8opgGypoqq0MC5I7WxQjDcuB8xKnQ1PCSO8suu4hEJgdyPcEvWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.3.4"
+          "Speckle.Sdk": "3.3.5"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "I7HzhT3PaE+Gd+T2LgqL5kqvc+SPJYnRofJhCv8smsUjADEonxUf+dAEV3AHM31CWGZT6SNe876+drXm60fUDg==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "7r8CmugwinniEF6v0N0bWuC+xpJaRfa/EnEjzj8NLpFG1b3uAjOxteGlQgR+evVacxTCEsuNkio7Mdv97odgpg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -308,14 +308,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.3.4"
+          "Speckle.Sdk.Dependencies": "3.3.5"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "0iGDakpkQIApAD3RCS8D0e5oM6yvvklDQFAEU30IvcQ+wpiEMqKJ2vidWG2vOrHMVPyiN7O457TXB41AhEWNlg=="
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "RukqLb0lVNgtmhKPeZJCncibnyutQ6Dr6+UQCa4PjWinIXpSm3A3ywK9ISkU+5StW1QoejiR7kc9a6qmiLys6w=="
       }
     }
   }

--- a/Importers/Ifc/Speckle.Importers.Ifc/packages.lock.json
+++ b/Importers/Ifc/Speckle.Importers.Ifc/packages.lock.json
@@ -68,18 +68,18 @@
       },
       "Speckle.Objects": {
         "type": "Direct",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "MaZQFVtKGpntTwKL8go5zKIzjDJfXQQVpKXEvBPT/7SZISkpLTgmetizcQHZ1DGrA+Tps14dYFEWp7Ai+zCCCA==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "VPbYI8TyPDlKlNUHPLPAL1HveN9649LKVxw8opgGypoqq0MC5I7WxQjDcuB8xKnQ1PCSO8suu4hEJgdyPcEvWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.3.4"
+          "Speckle.Sdk": "3.3.5"
         }
       },
       "Speckle.Sdk": {
         "type": "Direct",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "I7HzhT3PaE+Gd+T2LgqL5kqvc+SPJYnRofJhCv8smsUjADEonxUf+dAEV3AHM31CWGZT6SNe876+drXm60fUDg==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "7r8CmugwinniEF6v0N0bWuC+xpJaRfa/EnEjzj8NLpFG1b3uAjOxteGlQgR+evVacxTCEsuNkio7Mdv97odgpg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -88,7 +88,7 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.3.4"
+          "Speckle.Sdk.Dependencies": "3.3.5"
         }
       },
       "GraphQL.Client": {
@@ -267,9 +267,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.3.4, )",
-          "Speckle.Sdk": "[3.3.4, )",
-          "Speckle.Sdk.Dependencies": "[3.3.4, )"
+          "Speckle.Objects": "[3.3.5, )",
+          "Speckle.Sdk": "[3.3.5, )",
+          "Speckle.Sdk.Dependencies": "[3.3.5, )"
         }
       },
       "speckle.connectors.logging": {
@@ -301,9 +301,9 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "0iGDakpkQIApAD3RCS8D0e5oM6yvvklDQFAEU30IvcQ+wpiEMqKJ2vidWG2vOrHMVPyiN7O457TXB41AhEWNlg=="
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "RukqLb0lVNgtmhKPeZJCncibnyutQ6Dr6+UQCa4PjWinIXpSm3A3ywK9ISkU+5StW1QoejiR7kc9a6qmiLys6w=="
       }
     }
   }

--- a/Sdk/Speckle.Connectors.Common.Tests/packages.lock.json
+++ b/Sdk/Speckle.Connectors.Common.Tests/packages.lock.json
@@ -313,9 +313,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.3.4, )",
-          "Speckle.Sdk": "[3.3.4, )",
-          "Speckle.Sdk.Dependencies": "[3.3.4, )"
+          "Speckle.Objects": "[3.3.5, )",
+          "Speckle.Sdk": "[3.3.5, )",
+          "Speckle.Sdk.Dependencies": "[3.3.5, )"
         }
       },
       "speckle.connectors.logging": {
@@ -327,7 +327,7 @@
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Moq": "[4.20.70, )",
           "NUnit": "[4.1.0, )",
-          "Speckle.Sdk": "[3.3.4, )"
+          "Speckle.Sdk": "[3.3.5, )"
         }
       },
       "Microsoft.Extensions.Logging": {
@@ -371,18 +371,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "MaZQFVtKGpntTwKL8go5zKIzjDJfXQQVpKXEvBPT/7SZISkpLTgmetizcQHZ1DGrA+Tps14dYFEWp7Ai+zCCCA==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "VPbYI8TyPDlKlNUHPLPAL1HveN9649LKVxw8opgGypoqq0MC5I7WxQjDcuB8xKnQ1PCSO8suu4hEJgdyPcEvWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.3.4"
+          "Speckle.Sdk": "3.3.5"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "I7HzhT3PaE+Gd+T2LgqL5kqvc+SPJYnRofJhCv8smsUjADEonxUf+dAEV3AHM31CWGZT6SNe876+drXm60fUDg==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "7r8CmugwinniEF6v0N0bWuC+xpJaRfa/EnEjzj8NLpFG1b3uAjOxteGlQgR+evVacxTCEsuNkio7Mdv97odgpg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -391,14 +391,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.3.4"
+          "Speckle.Sdk.Dependencies": "3.3.5"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "0iGDakpkQIApAD3RCS8D0e5oM6yvvklDQFAEU30IvcQ+wpiEMqKJ2vidWG2vOrHMVPyiN7O457TXB41AhEWNlg=="
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "RukqLb0lVNgtmhKPeZJCncibnyutQ6Dr6+UQCa4PjWinIXpSm3A3ywK9ISkU+5StW1QoejiR7kc9a6qmiLys6w=="
       }
     }
   }

--- a/Sdk/Speckle.Connectors.Common/packages.lock.json
+++ b/Sdk/Speckle.Connectors.Common/packages.lock.json
@@ -44,18 +44,18 @@
       },
       "Speckle.Objects": {
         "type": "Direct",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "MaZQFVtKGpntTwKL8go5zKIzjDJfXQQVpKXEvBPT/7SZISkpLTgmetizcQHZ1DGrA+Tps14dYFEWp7Ai+zCCCA==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "VPbYI8TyPDlKlNUHPLPAL1HveN9649LKVxw8opgGypoqq0MC5I7WxQjDcuB8xKnQ1PCSO8suu4hEJgdyPcEvWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.3.4"
+          "Speckle.Sdk": "3.3.5"
         }
       },
       "Speckle.Sdk": {
         "type": "Direct",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "I7HzhT3PaE+Gd+T2LgqL5kqvc+SPJYnRofJhCv8smsUjADEonxUf+dAEV3AHM31CWGZT6SNe876+drXm60fUDg==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "7r8CmugwinniEF6v0N0bWuC+xpJaRfa/EnEjzj8NLpFG1b3uAjOxteGlQgR+evVacxTCEsuNkio7Mdv97odgpg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -65,14 +65,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.3.4"
+          "Speckle.Sdk.Dependencies": "3.3.5"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Direct",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "0iGDakpkQIApAD3RCS8D0e5oM6yvvklDQFAEU30IvcQ+wpiEMqKJ2vidWG2vOrHMVPyiN7O457TXB41AhEWNlg=="
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "RukqLb0lVNgtmhKPeZJCncibnyutQ6Dr6+UQCa4PjWinIXpSm3A3ywK9ISkU+5StW1QoejiR7kc9a6qmiLys6w=="
       },
       "GraphQL.Client": {
         "type": "Transitive",
@@ -360,18 +360,18 @@
       },
       "Speckle.Objects": {
         "type": "Direct",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "MaZQFVtKGpntTwKL8go5zKIzjDJfXQQVpKXEvBPT/7SZISkpLTgmetizcQHZ1DGrA+Tps14dYFEWp7Ai+zCCCA==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "VPbYI8TyPDlKlNUHPLPAL1HveN9649LKVxw8opgGypoqq0MC5I7WxQjDcuB8xKnQ1PCSO8suu4hEJgdyPcEvWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.3.4"
+          "Speckle.Sdk": "3.3.5"
         }
       },
       "Speckle.Sdk": {
         "type": "Direct",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "I7HzhT3PaE+Gd+T2LgqL5kqvc+SPJYnRofJhCv8smsUjADEonxUf+dAEV3AHM31CWGZT6SNe876+drXm60fUDg==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "7r8CmugwinniEF6v0N0bWuC+xpJaRfa/EnEjzj8NLpFG1b3uAjOxteGlQgR+evVacxTCEsuNkio7Mdv97odgpg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -381,14 +381,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.3.4"
+          "Speckle.Sdk.Dependencies": "3.3.5"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Direct",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "0iGDakpkQIApAD3RCS8D0e5oM6yvvklDQFAEU30IvcQ+wpiEMqKJ2vidWG2vOrHMVPyiN7O457TXB41AhEWNlg=="
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "RukqLb0lVNgtmhKPeZJCncibnyutQ6Dr6+UQCa4PjWinIXpSm3A3ywK9ISkU+5StW1QoejiR7kc9a6qmiLys6w=="
       },
       "GraphQL.Client": {
         "type": "Transitive",
@@ -637,18 +637,18 @@
       },
       "Speckle.Objects": {
         "type": "Direct",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "MaZQFVtKGpntTwKL8go5zKIzjDJfXQQVpKXEvBPT/7SZISkpLTgmetizcQHZ1DGrA+Tps14dYFEWp7Ai+zCCCA==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "VPbYI8TyPDlKlNUHPLPAL1HveN9649LKVxw8opgGypoqq0MC5I7WxQjDcuB8xKnQ1PCSO8suu4hEJgdyPcEvWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.3.4"
+          "Speckle.Sdk": "3.3.5"
         }
       },
       "Speckle.Sdk": {
         "type": "Direct",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "I7HzhT3PaE+Gd+T2LgqL5kqvc+SPJYnRofJhCv8smsUjADEonxUf+dAEV3AHM31CWGZT6SNe876+drXm60fUDg==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "7r8CmugwinniEF6v0N0bWuC+xpJaRfa/EnEjzj8NLpFG1b3uAjOxteGlQgR+evVacxTCEsuNkio7Mdv97odgpg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -657,14 +657,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.3.4"
+          "Speckle.Sdk.Dependencies": "3.3.5"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Direct",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "0iGDakpkQIApAD3RCS8D0e5oM6yvvklDQFAEU30IvcQ+wpiEMqKJ2vidWG2vOrHMVPyiN7O457TXB41AhEWNlg=="
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "RukqLb0lVNgtmhKPeZJCncibnyutQ6Dr6+UQCa4PjWinIXpSm3A3ywK9ISkU+5StW1QoejiR7kc9a6qmiLys6w=="
       },
       "GraphQL.Client": {
         "type": "Transitive",

--- a/Sdk/Speckle.Converters.Common.Tests/packages.lock.json
+++ b/Sdk/Speckle.Converters.Common.Tests/packages.lock.json
@@ -327,7 +327,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.3.4, )"
+          "Speckle.Objects": "[3.3.5, )"
         }
       },
       "speckle.testing": {
@@ -336,7 +336,7 @@
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Moq": "[4.20.70, )",
           "NUnit": "[4.1.0, )",
-          "Speckle.Sdk": "[3.3.4, )"
+          "Speckle.Sdk": "[3.3.5, )"
         }
       },
       "Microsoft.Extensions.Logging": {
@@ -365,18 +365,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "MaZQFVtKGpntTwKL8go5zKIzjDJfXQQVpKXEvBPT/7SZISkpLTgmetizcQHZ1DGrA+Tps14dYFEWp7Ai+zCCCA==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "VPbYI8TyPDlKlNUHPLPAL1HveN9649LKVxw8opgGypoqq0MC5I7WxQjDcuB8xKnQ1PCSO8suu4hEJgdyPcEvWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.3.4"
+          "Speckle.Sdk": "3.3.5"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "I7HzhT3PaE+Gd+T2LgqL5kqvc+SPJYnRofJhCv8smsUjADEonxUf+dAEV3AHM31CWGZT6SNe876+drXm60fUDg==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "7r8CmugwinniEF6v0N0bWuC+xpJaRfa/EnEjzj8NLpFG1b3uAjOxteGlQgR+evVacxTCEsuNkio7Mdv97odgpg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -385,14 +385,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.3.4"
+          "Speckle.Sdk.Dependencies": "3.3.5"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "0iGDakpkQIApAD3RCS8D0e5oM6yvvklDQFAEU30IvcQ+wpiEMqKJ2vidWG2vOrHMVPyiN7O457TXB41AhEWNlg=="
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "RukqLb0lVNgtmhKPeZJCncibnyutQ6Dr6+UQCa4PjWinIXpSm3A3ywK9ISkU+5StW1QoejiR7kc9a6qmiLys6w=="
       }
     }
   }

--- a/Sdk/Speckle.Converters.Common/packages.lock.json
+++ b/Sdk/Speckle.Converters.Common/packages.lock.json
@@ -41,11 +41,11 @@
       },
       "Speckle.Objects": {
         "type": "Direct",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "MaZQFVtKGpntTwKL8go5zKIzjDJfXQQVpKXEvBPT/7SZISkpLTgmetizcQHZ1DGrA+Tps14dYFEWp7Ai+zCCCA==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "VPbYI8TyPDlKlNUHPLPAL1HveN9649LKVxw8opgGypoqq0MC5I7WxQjDcuB8xKnQ1PCSO8suu4hEJgdyPcEvWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.3.4"
+          "Speckle.Sdk": "3.3.5"
         }
       },
       "GraphQL.Client": {
@@ -283,9 +283,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "I7HzhT3PaE+Gd+T2LgqL5kqvc+SPJYnRofJhCv8smsUjADEonxUf+dAEV3AHM31CWGZT6SNe876+drXm60fUDg==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "7r8CmugwinniEF6v0N0bWuC+xpJaRfa/EnEjzj8NLpFG1b3uAjOxteGlQgR+evVacxTCEsuNkio7Mdv97odgpg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -295,14 +295,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.3.4"
+          "Speckle.Sdk.Dependencies": "3.3.5"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "0iGDakpkQIApAD3RCS8D0e5oM6yvvklDQFAEU30IvcQ+wpiEMqKJ2vidWG2vOrHMVPyiN7O457TXB41AhEWNlg=="
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "RukqLb0lVNgtmhKPeZJCncibnyutQ6Dr6+UQCa4PjWinIXpSm3A3ywK9ISkU+5StW1QoejiR7kc9a6qmiLys6w=="
       }
     },
     "net6.0": {
@@ -345,11 +345,11 @@
       },
       "Speckle.Objects": {
         "type": "Direct",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "MaZQFVtKGpntTwKL8go5zKIzjDJfXQQVpKXEvBPT/7SZISkpLTgmetizcQHZ1DGrA+Tps14dYFEWp7Ai+zCCCA==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "VPbYI8TyPDlKlNUHPLPAL1HveN9649LKVxw8opgGypoqq0MC5I7WxQjDcuB8xKnQ1PCSO8suu4hEJgdyPcEvWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.3.4"
+          "Speckle.Sdk": "3.3.5"
         }
       },
       "GraphQL.Client": {
@@ -548,9 +548,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "I7HzhT3PaE+Gd+T2LgqL5kqvc+SPJYnRofJhCv8smsUjADEonxUf+dAEV3AHM31CWGZT6SNe876+drXm60fUDg==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "7r8CmugwinniEF6v0N0bWuC+xpJaRfa/EnEjzj8NLpFG1b3uAjOxteGlQgR+evVacxTCEsuNkio7Mdv97odgpg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -560,14 +560,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.3.4"
+          "Speckle.Sdk.Dependencies": "3.3.5"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "0iGDakpkQIApAD3RCS8D0e5oM6yvvklDQFAEU30IvcQ+wpiEMqKJ2vidWG2vOrHMVPyiN7O457TXB41AhEWNlg=="
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "RukqLb0lVNgtmhKPeZJCncibnyutQ6Dr6+UQCa4PjWinIXpSm3A3ywK9ISkU+5StW1QoejiR7kc9a6qmiLys6w=="
       }
     },
     "net8.0": {
@@ -610,11 +610,11 @@
       },
       "Speckle.Objects": {
         "type": "Direct",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "MaZQFVtKGpntTwKL8go5zKIzjDJfXQQVpKXEvBPT/7SZISkpLTgmetizcQHZ1DGrA+Tps14dYFEWp7Ai+zCCCA==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "VPbYI8TyPDlKlNUHPLPAL1HveN9649LKVxw8opgGypoqq0MC5I7WxQjDcuB8xKnQ1PCSO8suu4hEJgdyPcEvWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.3.4"
+          "Speckle.Sdk": "3.3.5"
         }
       },
       "GraphQL.Client": {
@@ -808,9 +808,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "I7HzhT3PaE+Gd+T2LgqL5kqvc+SPJYnRofJhCv8smsUjADEonxUf+dAEV3AHM31CWGZT6SNe876+drXm60fUDg==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "7r8CmugwinniEF6v0N0bWuC+xpJaRfa/EnEjzj8NLpFG1b3uAjOxteGlQgR+evVacxTCEsuNkio7Mdv97odgpg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -819,14 +819,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.3.4"
+          "Speckle.Sdk.Dependencies": "3.3.5"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "0iGDakpkQIApAD3RCS8D0e5oM6yvvklDQFAEU30IvcQ+wpiEMqKJ2vidWG2vOrHMVPyiN7O457TXB41AhEWNlg=="
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "RukqLb0lVNgtmhKPeZJCncibnyutQ6Dr6+UQCa4PjWinIXpSm3A3ywK9ISkU+5StW1QoejiR7kc9a6qmiLys6w=="
       }
     }
   }

--- a/Sdk/Speckle.Testing/packages.lock.json
+++ b/Sdk/Speckle.Testing/packages.lock.json
@@ -59,9 +59,9 @@
       },
       "Speckle.Sdk": {
         "type": "Direct",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "I7HzhT3PaE+Gd+T2LgqL5kqvc+SPJYnRofJhCv8smsUjADEonxUf+dAEV3AHM31CWGZT6SNe876+drXm60fUDg==",
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "7r8CmugwinniEF6v0N0bWuC+xpJaRfa/EnEjzj8NLpFG1b3uAjOxteGlQgR+evVacxTCEsuNkio7Mdv97odgpg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -70,7 +70,7 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.3.4"
+          "Speckle.Sdk.Dependencies": "3.3.5"
         }
       },
       "Castle.Core": {
@@ -283,9 +283,9 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.3.4, )",
-        "resolved": "3.3.4",
-        "contentHash": "0iGDakpkQIApAD3RCS8D0e5oM6yvvklDQFAEU30IvcQ+wpiEMqKJ2vidWG2vOrHMVPyiN7O457TXB41AhEWNlg=="
+        "requested": "[3.3.5, )",
+        "resolved": "3.3.5",
+        "contentHash": "RukqLb0lVNgtmhKPeZJCncibnyutQ6Dr6+UQCa4PjWinIXpSm3A3ywK9ISkU+5StW1QoejiR7kc9a6qmiLys6w=="
       }
     }
   }


### PR DESCRIPTION
Bump SDK to [3.3.5](https://github.com/specklesystems/speckle-sharp-sdk/releases/tag/3.3.5)