### PR TITLE
Fix DI usage for MixPanelManager

### DIFF
--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Receive/ReceiveAsyncComponent.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Receive/ReceiveAsyncComponent.cs
@@ -6,6 +6,7 @@ using Grasshopper.Kernel.Attributes;
 using GrasshopperAsyncComponent;
 using Microsoft.Extensions.DependencyInjection;
 using Rhino;
+using Speckle.Connectors.Common;
 using Speckle.Connectors.Common.Analytics;
 using Speckle.Connectors.Common.Instances;
 using Speckle.Connectors.Common.Operations;
@@ -49,14 +50,13 @@ public class ReceiveAsyncComponent : GH_AsyncComponent
 
   // DI props
   public IClient ApiClient { get; private set; }
-  public IMixPanelManager MixPanelManager { get; private set; }
+  public MixPanelManager MixPanelManager { get; private set; }
   public GrasshopperReceiveOperation ReceiveOperation { get; private set; }
   public RootObjectUnpacker RootObjectUnpacker { get; private set; }
   public static IServiceScope? Scope { get; private set; }
   public AccountService AccountService { get; private set; }
   public AccountManager AccountManager { get; private set; }
   public IClientFactory ClientFactory { get; private set; }
-  public ISpeckleApplication SpeckleApplication { get; private set; }
 
   protected override void RegisterInputParams(GH_InputParamManager pManager)
   {
@@ -82,12 +82,11 @@ public class ReceiveAsyncComponent : GH_AsyncComponent
     Scope = PriorityLoader.Container.CreateScope();
     ReceiveOperation = Scope.ServiceProvider.GetRequiredService<GrasshopperReceiveOperation>();
 
-    MixPanelManager = Scope.ServiceProvider.GetRequiredService<IMixPanelManager>();
+    MixPanelManager = Scope.ServiceProvider.GetRequiredService<MixPanelManager>();
     RootObjectUnpacker = Scope.ServiceProvider.GetService<RootObjectUnpacker>();
     AccountService = Scope.ServiceProvider.GetRequiredService<AccountService>();
     AccountManager = Scope.ServiceProvider.GetRequiredService<AccountManager>();
     ClientFactory = Scope.ServiceProvider.GetRequiredService<IClientFactory>();
-    SpeckleApplication = Scope.ServiceProvider.GetRequiredService<ISpeckleApplication>();
 
     // We need to call this always in here to be able to react and set events :/
     ParseInput(da);
@@ -455,7 +454,7 @@ public class ReceiveComponentWorker : WorkerInstance
         var customProperties = new Dictionary<string, object>()
         {
           { "isAsync", true },
-          { "sourceHostApp", receiveComponent.SpeckleApplication.Slug },
+          { "sourceHostApp", HostApplications.GetSlugFromHostAppNameAndVersion(receiveInfo.SourceApplication) },
           { "auto", receiveComponent.AutoReceive }
         };
         if (receiveInfo.WorkspaceId != null)

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Receive/ReceiveAsyncComponent.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Receive/ReceiveAsyncComponent.cs
@@ -50,7 +50,7 @@ public class ReceiveAsyncComponent : GH_AsyncComponent
 
   // DI props
   public IClient ApiClient { get; private set; }
-  public MixPanelManager MixPanelManager { get; private set; }
+  public IMixPanelManager MixPanelManager { get; private set; }
   public GrasshopperReceiveOperation ReceiveOperation { get; private set; }
   public RootObjectUnpacker RootObjectUnpacker { get; private set; }
   public static IServiceScope? Scope { get; private set; }
@@ -82,7 +82,7 @@ public class ReceiveAsyncComponent : GH_AsyncComponent
     Scope = PriorityLoader.Container.CreateScope();
     ReceiveOperation = Scope.ServiceProvider.GetRequiredService<GrasshopperReceiveOperation>();
 
-    MixPanelManager = Scope.ServiceProvider.GetRequiredService<MixPanelManager>();
+    MixPanelManager = Scope.ServiceProvider.GetRequiredService<IMixPanelManager>();
     RootObjectUnpacker = Scope.ServiceProvider.GetService<RootObjectUnpacker>();
     AccountService = Scope.ServiceProvider.GetRequiredService<AccountService>();
     AccountManager = Scope.ServiceProvider.GetRequiredService<AccountManager>();

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Receive/ReceiveAsyncComponent.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Receive/ReceiveAsyncComponent.cs
@@ -6,7 +6,6 @@ using Grasshopper.Kernel.Attributes;
 using GrasshopperAsyncComponent;
 using Microsoft.Extensions.DependencyInjection;
 using Rhino;
-using Speckle.Connectors.Common;
 using Speckle.Connectors.Common.Analytics;
 using Speckle.Connectors.Common.Instances;
 using Speckle.Connectors.Common.Operations;
@@ -50,13 +49,14 @@ public class ReceiveAsyncComponent : GH_AsyncComponent
 
   // DI props
   public IClient ApiClient { get; private set; }
-  public MixPanelManager MixPanelManager { get; private set; }
+  public IMixPanelManager MixPanelManager { get; private set; }
   public GrasshopperReceiveOperation ReceiveOperation { get; private set; }
   public RootObjectUnpacker RootObjectUnpacker { get; private set; }
   public static IServiceScope? Scope { get; private set; }
   public AccountService AccountService { get; private set; }
   public AccountManager AccountManager { get; private set; }
   public IClientFactory ClientFactory { get; private set; }
+  public ISpeckleApplication SpeckleApplication { get; private set; }
 
   protected override void RegisterInputParams(GH_InputParamManager pManager)
   {
@@ -82,11 +82,12 @@ public class ReceiveAsyncComponent : GH_AsyncComponent
     Scope = PriorityLoader.Container.CreateScope();
     ReceiveOperation = Scope.ServiceProvider.GetRequiredService<GrasshopperReceiveOperation>();
 
-    MixPanelManager = Scope.ServiceProvider.GetRequiredService<MixPanelManager>();
+    MixPanelManager = Scope.ServiceProvider.GetRequiredService<IMixPanelManager>();
     RootObjectUnpacker = Scope.ServiceProvider.GetService<RootObjectUnpacker>();
     AccountService = Scope.ServiceProvider.GetRequiredService<AccountService>();
     AccountManager = Scope.ServiceProvider.GetRequiredService<AccountManager>();
     ClientFactory = Scope.ServiceProvider.GetRequiredService<IClientFactory>();
+    SpeckleApplication = Scope.ServiceProvider.GetRequiredService<ISpeckleApplication>();
 
     // We need to call this always in here to be able to react and set events :/
     ParseInput(da);
@@ -454,7 +455,7 @@ public class ReceiveComponentWorker : WorkerInstance
         var customProperties = new Dictionary<string, object>()
         {
           { "isAsync", true },
-          { "sourceHostApp", HostApplications.GetSlugFromHostAppNameAndVersion(receiveInfo.SourceApplication) },
+          { "sourceHostApp", receiveComponent.SpeckleApplication.Slug },
           { "auto", receiveComponent.AutoReceive }
         };
         if (receiveInfo.WorkspaceId != null)

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Receive/ReceiveComponent.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Receive/ReceiveComponent.cs
@@ -37,7 +37,7 @@ public class ReceiveComponentOutput
 
 public class ReceiveComponent : SpeckleScopedTaskCapableComponent<ReceiveComponentInput, ReceiveComponentOutput>
 {
-  private readonly MixPanelManager _mixpanel;
+  private readonly IMixPanelManager _mixpanel;
 
   public ReceiveComponent()
     : base(
@@ -48,7 +48,7 @@ public class ReceiveComponent : SpeckleScopedTaskCapableComponent<ReceiveCompone
       ComponentCategories.DEVELOPER
     )
   {
-    _mixpanel = PriorityLoader.Container.GetRequiredService<MixPanelManager>();
+    _mixpanel = PriorityLoader.Container.GetRequiredService<IMixPanelManager>();
   }
 
   public override Guid ComponentGuid => new("74954F59-B1B7-41FD-97DE-4C6B005F2801");

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Receive/ReceiveComponent.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Receive/ReceiveComponent.cs
@@ -1,5 +1,6 @@
 using Grasshopper.Kernel;
 using Microsoft.Extensions.DependencyInjection;
+using Speckle.Connectors.Common;
 using Speckle.Connectors.Common.Analytics;
 using Speckle.Connectors.Common.Instances;
 using Speckle.Connectors.Common.Operations;
@@ -36,8 +37,7 @@ public class ReceiveComponentOutput
 
 public class ReceiveComponent : SpeckleScopedTaskCapableComponent<ReceiveComponentInput, ReceiveComponentOutput>
 {
-  private readonly IMixPanelManager _mixpanel;
-  private readonly ISpeckleApplication _application;
+  private readonly MixPanelManager _mixpanel;
 
   public ReceiveComponent()
     : base(
@@ -48,8 +48,7 @@ public class ReceiveComponent : SpeckleScopedTaskCapableComponent<ReceiveCompone
       ComponentCategories.DEVELOPER
     )
   {
-    _mixpanel = PriorityLoader.Container.GetRequiredService<IMixPanelManager>();
-    _application = PriorityLoader.Container.GetRequiredService<ISpeckleApplication>();
+    _mixpanel = PriorityLoader.Container.GetRequiredService<MixPanelManager>();
   }
 
   public override Guid ComponentGuid => new("74954F59-B1B7-41FD-97DE-4C6B005F2801");
@@ -145,7 +144,7 @@ public class ReceiveComponent : SpeckleScopedTaskCapableComponent<ReceiveCompone
     var customProperties = new Dictionary<string, object>()
     {
       { "isAsync", false },
-      { "sourceHostApp", _application.Slug }
+      { "sourceHostApp", HostApplications.GetSlugFromHostAppNameAndVersion(receiveInfo.SourceApplication) }
     };
     if (receiveInfo.WorkspaceId != null)
     {

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Receive/ReceiveComponent.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Receive/ReceiveComponent.cs
@@ -1,6 +1,5 @@
 using Grasshopper.Kernel;
 using Microsoft.Extensions.DependencyInjection;
-using Speckle.Connectors.Common;
 using Speckle.Connectors.Common.Analytics;
 using Speckle.Connectors.Common.Instances;
 using Speckle.Connectors.Common.Operations;
@@ -37,7 +36,8 @@ public class ReceiveComponentOutput
 
 public class ReceiveComponent : SpeckleScopedTaskCapableComponent<ReceiveComponentInput, ReceiveComponentOutput>
 {
-  private readonly MixPanelManager _mixpanel;
+  private readonly IMixPanelManager _mixpanel;
+  private readonly ISpeckleApplication _application;
 
   public ReceiveComponent()
     : base(
@@ -48,7 +48,8 @@ public class ReceiveComponent : SpeckleScopedTaskCapableComponent<ReceiveCompone
       ComponentCategories.DEVELOPER
     )
   {
-    _mixpanel = PriorityLoader.Container.GetRequiredService<MixPanelManager>();
+    _mixpanel = PriorityLoader.Container.GetRequiredService<IMixPanelManager>();
+    _application = PriorityLoader.Container.GetRequiredService<ISpeckleApplication>();
   }
 
   public override Guid ComponentGuid => new("74954F59-B1B7-41FD-97DE-4C6B005F2801");
@@ -144,7 +145,7 @@ public class ReceiveComponent : SpeckleScopedTaskCapableComponent<ReceiveCompone
     var customProperties = new Dictionary<string, object>()
     {
       { "isAsync", false },
-      { "sourceHostApp", HostApplications.GetSlugFromHostAppNameAndVersion(receiveInfo.SourceApplication) }
+      { "sourceHostApp", _application.Slug }
     };
     if (receiveInfo.WorkspaceId != null)
     {

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Send/SendAsyncComponent.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Send/SendAsyncComponent.cs
@@ -57,7 +57,7 @@ public class SendAsyncComponent : GH_AsyncComponent
   public double OverallProgress { get; set; }
   public string? Url { get; set; }
   public IClient ApiClient { get; set; }
-  public MixPanelManager MixPanelManager { get; set; }
+  public IMixPanelManager MixPanelManager { get; set; }
   public HostApp.SpeckleUrlModelResource? UrlModelResource { get; set; }
   public SpeckleCollectionWrapperGoo? RootCollectionWrapper { get; set; }
 
@@ -143,7 +143,7 @@ public class SendAsyncComponent : GH_AsyncComponent
     Scope = PriorityLoader.Container.CreateScope();
     SendOperation = Scope.ServiceProvider.GetRequiredService<SendOperation<SpeckleCollectionWrapperGoo>>();
 
-    MixPanelManager = Scope.ServiceProvider.GetRequiredService<MixPanelManager>();
+    MixPanelManager = Scope.ServiceProvider.GetRequiredService<IMixPanelManager>();
     var accountService = Scope.ServiceProvider.GetRequiredService<AccountService>();
     var accountManager = Scope.ServiceProvider.GetRequiredService<AccountManager>();
     var clientFactory = Scope.ServiceProvider.GetRequiredService<IClientFactory>();

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Send/SendComponent.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Send/SendComponent.cs
@@ -36,7 +36,7 @@ public class SendComponentOutput(SpeckleUrlModelResource? resource)
 
 public class SendComponent : SpeckleScopedTaskCapableComponent<SendComponentInput, SendComponentOutput>
 {
-  private readonly MixPanelManager _mixpanel;
+  private readonly IMixPanelManager _mixpanel;
 
   public SendComponent()
     : base(
@@ -47,7 +47,7 @@ public class SendComponent : SpeckleScopedTaskCapableComponent<SendComponentInpu
       ComponentCategories.DEVELOPER
     )
   {
-    _mixpanel = PriorityLoader.Container.GetRequiredService<MixPanelManager>();
+    _mixpanel = PriorityLoader.Container.GetRequiredService<IMixPanelManager>();
   }
 
   public override Guid ComponentGuid => new("0CF0D173-BDF0-4AC2-9157-02822B90E9FB");

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Registration/PriorityLoader.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Registration/PriorityLoader.cs
@@ -1,7 +1,6 @@
 using Grasshopper.Kernel;
 using Microsoft.Extensions.DependencyInjection;
 using Speckle.Connectors.Common;
-using Speckle.Connectors.Common.Analytics;
 using Speckle.Connectors.Common.Builders;
 using Speckle.Connectors.Common.Operations;
 using Speckle.Connectors.Common.Operations.Receive;
@@ -33,7 +32,6 @@ public class PriorityLoader : GH_AssemblyPriority
       // receive
       services.AddTransient<GrasshopperReceiveOperation>();
       services.AddTransient<AccountService>();
-      services.AddSingleton<MixPanelManager>();
       services.AddSingleton(DefaultTraversal.CreateTraversalFunc());
       services.AddScoped<RootObjectUnpacker>();
       services.AddTransient<TraversalContextUnpacker>();

--- a/Sdk/Speckle.Connectors.Common/HostApplications.cs
+++ b/Sdk/Speckle.Connectors.Common/HostApplications.cs
@@ -1,4 +1,5 @@
-﻿using Speckle.Sdk;
+﻿using System.Text.RegularExpressions;
+using Speckle.Sdk;
 
 namespace Speckle.Connectors.Common;
 
@@ -39,4 +40,65 @@ public static class HostApplications
     Navisworks = new("Navisworks", "navisworks"),
     AdvanceSteel = new("Advance Steel", "advancesteel"),
     Other = new("Other", "other");
+
+  /// <summary>
+  /// Gets a slug from a host application name and version.
+  /// </summary>
+  /// <param name="appName">Application name with its version, e.g., "Rhino 7", "Revit 2024".</param>
+  /// <returns>Slug string.</returns>
+  public static string GetSlugFromHostAppNameAndVersion(string appName)
+  {
+    if (string.IsNullOrWhiteSpace(appName))
+    {
+      return "other";
+    }
+
+    // Remove whitespace and convert to lowercase
+    appName = Regex.Replace(appName.ToLowerInvariant(), @"\s+", "");
+
+    var keywords = new List<string>
+    {
+      "dynamo",
+      "revit",
+      "autocad",
+      "civil",
+      "rhino",
+      "grasshopper",
+      "unity",
+      "gsa",
+      "microstation",
+      "openroads",
+      "openrail",
+      "openbuildings",
+      "etabs",
+      "sap",
+      "csibridge",
+      "safe",
+      "teklastructures",
+      "dxf",
+      "excel",
+      "unreal",
+      "powerbi",
+      "blender",
+      "qgis",
+      "arcgis",
+      "sketchup",
+      "archicad",
+      "topsolid",
+      "python",
+      "net",
+      "navisworks",
+      "advancesteel"
+    };
+
+    foreach (var keyword in keywords)
+    {
+      if (appName.Contains(keyword))
+      {
+        return keyword;
+      }
+    }
+
+    return appName;
+  }
 }

--- a/Sdk/Speckle.Connectors.Common/HostApplications.cs
+++ b/Sdk/Speckle.Connectors.Common/HostApplications.cs
@@ -1,5 +1,4 @@
-﻿using System.Text.RegularExpressions;
-using Speckle.Sdk;
+﻿using Speckle.Sdk;
 
 namespace Speckle.Connectors.Common;
 
@@ -40,65 +39,4 @@ public static class HostApplications
     Navisworks = new("Navisworks", "navisworks"),
     AdvanceSteel = new("Advance Steel", "advancesteel"),
     Other = new("Other", "other");
-
-  /// <summary>
-  /// Gets a slug from a host application name and version.
-  /// </summary>
-  /// <param name="appName">Application name with its version, e.g., "Rhino 7", "Revit 2024".</param>
-  /// <returns>Slug string.</returns>
-  public static string GetSlugFromHostAppNameAndVersion(string appName)
-  {
-    if (string.IsNullOrWhiteSpace(appName))
-    {
-      return "other";
-    }
-
-    // Remove whitespace and convert to lowercase
-    appName = Regex.Replace(appName.ToLowerInvariant(), @"\s+", "");
-
-    var keywords = new List<string>
-    {
-      "dynamo",
-      "revit",
-      "autocad",
-      "civil",
-      "rhino",
-      "grasshopper",
-      "unity",
-      "gsa",
-      "microstation",
-      "openroads",
-      "openrail",
-      "openbuildings",
-      "etabs",
-      "sap",
-      "csibridge",
-      "safe",
-      "teklastructures",
-      "dxf",
-      "excel",
-      "unreal",
-      "powerbi",
-      "blender",
-      "qgis",
-      "arcgis",
-      "sketchup",
-      "archicad",
-      "topsolid",
-      "python",
-      "net",
-      "navisworks",
-      "advancesteel"
-    };
-
-    foreach (var keyword in keywords)
-    {
-      if (appName.Contains(keyword))
-      {
-        return keyword;
-      }
-    }
-
-    return appName;
-  }
 }


### PR DESCRIPTION
Don't parse slug, just grab it directly.
Use DI interfaces for future testability as they exist already.

Relates to: https://github.com/specklesystems/speckle-sharp-connectors/pull/834