### PR TITLE
Fix(build): Fix Deep Clean

### DIFF
--- a/Build/Program.cs
+++ b/Build/Program.cs
@@ -28,14 +28,7 @@ if (args.Length > 1)
   args = new[] { arguments.First() };
   //arguments = arguments.Skip(1).ToList();
 }*/
-void Build(string solution, string configuration)
-{
-  Console.WriteLine();
-  Console.WriteLine();
-  Console.WriteLine($"Building solution '{solution}' as '{configuration}'");
-  Console.WriteLine();
-  Run("dotnet", $"build \".\\{solution}\" --configuration {configuration} --no-restore");
-}
+
 void Restore(string solution)
 {
   Console.WriteLine();
@@ -72,7 +65,6 @@ void CleanSolution(string solution, string configuration)
   DeleteDirectories("**/obj");
   DeleteFiles("**/*.lock.json");
   Restore(solution);
-  Build(solution, configuration);
 }
 
 Target(


### PR DESCRIPTION
@adamhathcock It seems that deep-clean has not been working for a while.

```
C:\Program Files\dotnet\sdk\8.0.409\Microsoft.Common.CurrentVersion.targets(5321,5): error MSB3027:
  Could not copy "C:\Speckle Repos\speckle-sharp-connectors\Build\obj\Debug\net8.0\apphost.exe" to "bin\Debug\net8.0\Build.exe".
  Exceeded retry count of 10.
  Failed.
  The file is locked by: "build (25904)" [C:\Speckle Repos\speckle-sharp-connectors\Build\Build.csproj]

C:\Program Files\dotnet\sdk\8.0.409\Microsoft.Common.CurrentVersion.targets(5321,5): error MSB3021:
  Unable to copy file "C:\Speckle Repos\speckle-sharp-connectors\Build\obj\Debug\net8.0\apphost.exe" to "bin\Debug\net8.0\Build.exe".
  The process cannot access the file 'C:\Speckle Repos\speckle-sharp-connectors\Build\bin\Debug\net8.0\Build.exe' because it is being used by another process. [C:\Speckle Repos\speckle-sharp-connectors\Build\Build.csproj]

```

I've investigated, and it looks like `deep-clean` attempts to build the entire solution. But because we are running `Build.csproj` which is in the solution, some of the files are locked by the build process. Thus the build process cannot rebuild it's self, and the whole deep-clean fails.

---

In this PR, I've made deep-clean just clean files + restore. It doesn't attempt to build. I figured this is more useful that the current state.