### PR TITLE
feat(civil 3d): adds pressure pipe base curve, display value, and partdata

### DIFF
--- a/Converters/Civil3d/Speckle.Converters.Civil3dShared/Helpers/BaseCurveExtractor.cs
+++ b/Converters/Civil3d/Speckle.Converters.Civil3dShared/Helpers/BaseCurveExtractor.cs
@@ -44,9 +44,14 @@ public sealed class BaseCurveExtractor
     switch (entity)
     {
       // rant: if this is a pipe, the BaseCurve prop is fake news && will return a DB.line with start and endpoints set to [0,0,0] & [0,0,1]
+      // pressurepipes also tend to have null basecurves
       // do not use basecurve for pipes 😡
       case CDB.Pipe pipe:
         return GetPipeBaseCurves(pipe);
+#if CIVIL3D2024_OR_GREATER
+      case CDB.PressurePipe pressurePipe:
+        return GetPipeBaseCurves(pressurePipe);
+#endif
 
       case CDB.Alignment alignment:
         return GetAlignmentBaseCurves(alignment);
@@ -76,6 +81,15 @@ public sealed class BaseCurveExtractor
         return new() { _lineConverter.Convert(new AG.LineSegment3d(pipe.StartPoint, pipe.EndPoint)) };
     }
   }
+
+#if CIVIL3D2024_OR_GREATER
+  private List<Speckle.Objects.ICurve> GetPipeBaseCurves(CDB.PressurePipe pipe)
+  {
+    return pipe.IsCurve
+      ? new() { _arcConverter.Convert(pipe.CurveGeometry.GetArc2d()) }
+      : new() { _lineConverter.Convert(new AG.LineSegment3d(pipe.StartPoint, pipe.EndPoint)) };
+  }
+#endif
 
   private List<Speckle.Objects.ICurve> GetAlignmentBaseCurves(CDB.Alignment alignment)
   {

--- a/Converters/Civil3d/Speckle.Converters.Civil3dShared/Helpers/DisplayValueExtractor.cs
+++ b/Converters/Civil3d/Speckle.Converters.Civil3dShared/Helpers/DisplayValueExtractor.cs
@@ -53,6 +53,11 @@ public sealed class DisplayValueExtractor
         SOG.Mesh partMesh = _solidConverter.Convert(part.Solid3dBody);
         yield return partMesh;
         break;
+      // pressure pipe networks: https://help.autodesk.com/view/CIV3D/2025/ENU/?guid=f1361ca3-4195-3b06-8a66-ecd31f5208b0
+      case CDB.PressurePart pressurePart:
+        SOG.Mesh pressurePartMesh = _solidConverter.Convert(pressurePart.Get3dBody());
+        yield return pressurePartMesh;
+        break;
 
       // surfaces: https://help.autodesk.com/view/CIV3D/2025/ENU/?guid=d741aa49-e7da-9513-6b0b-226ebe3fa43f
       // POC: volume surfaces not supported

--- a/Converters/Civil3d/Speckle.Converters.Civil3dShared/ToSpeckle/Properties/PartDataExtractor.cs
+++ b/Converters/Civil3d/Speckle.Converters.Civil3dShared/ToSpeckle/Properties/PartDataExtractor.cs
@@ -16,12 +16,31 @@ public class PartDataExtractor
   /// <returns></returns>
   public Dictionary<string, object?>? GetPartData(CDB.Entity entity)
   {
-    if (entity is CDB.Part part)
+    return entity switch
     {
-      return ParsePartData(part.PartData);
+      CDB.Part part => ParsePartData(part.PartData),
+      CDB.PressurePart pressurePart => ParsePartData(pressurePart.PartData),
+      _ => null
+    };
+  }
+
+  private Dictionary<string, object?> ParsePartData(CDB.PressureNetworkPartData partData)
+  {
+    var result = new Dictionary<string, object?>();
+    foreach (CDB.PressurePartProperty prop in partData)
+    {
+      if (!prop.HasValue)
+      {
+        continue; // don't send null props
+      }
+
+      if (!result.ContainsKey(prop.DisplayName))
+      {
+        result.Add(prop.DisplayName, prop.Value);
+      }
     }
 
-    return null;
+    return result;
   }
 
   private Dictionary<string, object?> ParsePartData(CDB.PartDataRecord partData)


### PR DESCRIPTION
<!---

Provide a short summary in the Title above. Use the following template:

category(project): summary

Categories:

* feat: (new feature for the user, not a new feature for build script)
* fix: (bug fix for the user, not a fix to a build script)
* docs: (changes to the documentation)
* style: (formatting, missing semi colons, etc; no production code change)
* refactor: (refactoring production code, eg. renaming a variable)
* test: (adding missing tests, refactoring tests; no production code change)
* chore: (updating grunt tasks etc; no production code change)

Example:

feat(revit): added category filter to send

-->

## Description

Adds pressure pipe base curve, displayvalue, and partdata.
This was necessary to handle separately because they do not inherit from `Part` as with regular pipes, they inherit from `PressurePart` and therefore need their own case in the basecurveextractor, displayvalueextractor and propertiesextractor

- Note: for basecurve extraction, these methods are only available in Civil3d 2024+
## User Value

Now you get your pressure pipes with mesh and props.
Community post: https://speckle.community/t/civil-3d-pressure-pipes-not-exported/17841

## Changes:

civil converter

## Screenshots:

- After: https://latest.speckle.systems/projects/3f895e614f/models/1737754fb4

## Validation of changes:

Sent test file

