### PR TITLE
feat(revit): set `DirectShape` name

### DIFF
--- a/Converters/Revit/Speckle.Converters.RevitShared/ToHost/Raw/LocalToGlobalToDirectShapeConverter.cs
+++ b/Converters/Revit/Speckle.Converters.RevitShared/ToHost/Raw/LocalToGlobalToDirectShapeConverter.cs
@@ -5,6 +5,7 @@ using Speckle.DoubleNumerics;
 using Speckle.Objects.Data;
 using Speckle.Sdk.Common;
 using Speckle.Sdk.Models;
+using Speckle.Sdk.Models.Extensions;
 
 namespace Speckle.Converters.RevitShared.ToSpeckle;
 
@@ -58,6 +59,15 @@ public class LocalToGlobalToDirectShapeConverter
 
     // 2 - init DirectShape
     var result = DB.DirectShape.CreateElement(_converterSettings.Current.Document, new DB.ElementId(dsCategory));
+
+    // NOTE: this should technically be in a property extraction class / helper method
+    // This change is localised to [CNX-1825](https://linear.app/speckle/issue/CNX-1825/set-directshape-name)
+    // TODO: Property extraction is a greater conversation which needs to be had: [CNX-1830](https://linear.app/speckle/issue/CNX-1830/data-exchange-investigations)
+    var name = target.atomicObject.TryGetName();
+    if (name is not null)
+    {
+      result.SetName(name);
+    }
 
     // If there is no transforms to be applied, use the simple way of creating direct shapes
     if (target.matrix.Count == 0)


### PR DESCRIPTION
## Description

Fixes [CNX-1825](https://linear.app/speckle/issue/CNX-1825/set-directshape-name).

## User Value

No immediate value as the `name` doesn't appear in the properties palette. This will be adressed in [CNX-1830](https://linear.app/speckle/issue/CNX-1830/data-exchange-investigations). In this PR, we at least set the name of the `DirectShape` which can be observed using `RevitLookup`.

## Changes:

`SetName` in `LocalToGlobalToDirectShapeConverter.cs`.

## Validation of changes:

### Before

![image](https://github.com/user-attachments/assets/17d13659-203b-4555-a163-9e649788e7f5)

### After

<img width="875" alt="image" src="https://github.com/user-attachments/assets/899e55d7-d0c9-46a9-823d-05de355fb375" />

## Checklist:

<!---

This checklist is a useful reminder of related tasks to uphold our repo quality. Amend this list as needed for the pr.

-->
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] I have added appropriate tests.
- [x] I have updated or added relevant documentation.

