### PR TITLE
fix(revit): walls sweeps published duplicated

### DIFF
--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/Filters/RevitViewsFilter.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/Filters/RevitViewsFilter.cs
@@ -77,7 +77,7 @@ public class RevitViewsFilter : DiscriminatedObject, ISendFilter, IRevitSendFilt
     }
     using var viewCollector = new FilteredElementCollector(_doc, view.Id);
     var elementsInView = viewCollector.ToElements();
-    var objectIds = elementsInView.Select(e => e.UniqueId).ToList();
+    var objectIds = elementsInView.Where(e => e.Category?.Parent == null).Select(e => e.UniqueId).ToList();
     SelectedObjectIds = objectIds;
     return objectIds;
   }

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/Filters/RevitViewsFilter.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/Filters/RevitViewsFilter.cs
@@ -77,6 +77,11 @@ public class RevitViewsFilter : DiscriminatedObject, ISendFilter, IRevitSendFilt
     }
     using var viewCollector = new FilteredElementCollector(_doc, view.Id);
     var elementsInView = viewCollector.ToElements();
+
+    // NOTE: FilteredElementCollector() grabs OST_Cornices, which are part of Wall definitions as ADDITIONAL elements
+    // on this return. displayValue for Wall already includes this, therefore we end up with duplicate elements on wall sweeps
+    // related to [CNX-1482](https://linear.app/speckle/issue/CNX-1482/wall-sweeps-published-duplicated)
+    // therefore, LINQ expression excludes elements which are subcategory. this problem is localised to sending via views
     var objectIds = elementsInView.Where(e => e.Category?.Parent == null).Select(e => e.UniqueId).ToList();
     SelectedObjectIds = objectIds;
     return objectIds;

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/Filters/RevitViewsFilter.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/Filters/RevitViewsFilter.cs
@@ -72,17 +72,17 @@ public class RevitViewsFilter : DiscriminatedObject, ISendFilter, IRevitSendFilt
 
     if (view is null)
     {
-      //this used to throw an exception but we don't want to fail loudly if the view is not found
+      //this used to throw an exception, but we don't want to fail loudly if the view is not found
       return [];
     }
     using var viewCollector = new FilteredElementCollector(_doc, view.Id);
     var elementsInView = viewCollector.ToElements();
 
-    // NOTE: FilteredElementCollector() grabs OST_Cornices, which are part of Wall definitions as ADDITIONAL elements
-    // on this return. displayValue for Wall already includes this, therefore we end up with duplicate elements on wall sweeps
+    // NOTE: FilteredElementCollector() includes sweeps and reveals from a wall family's definition and includes them as additional objects
+    // on this return. displayValue for Wall already includes these, therefore we end up with duplicate elements on wall sweeps
     // related to [CNX-1482](https://linear.app/speckle/issue/CNX-1482/wall-sweeps-published-duplicated)
-    // therefore, LINQ expression excludes elements which are subcategory. this problem is localised to sending via views
-    var objectIds = elementsInView.Where(e => e.Category?.Parent == null).Select(e => e.UniqueId).ToList();
+    // i (björn) noticed that all these elements have an empty string as Name parameter, hence below exclusion. tested as much as possible, seems like legit fix
+    var objectIds = elementsInView.Where(e => !string.IsNullOrEmpty(e.Name)).Select(e => e.UniqueId).ToList();
     SelectedObjectIds = objectIds;
     return objectIds;
   }


### PR DESCRIPTION
## Description

Wall sweeps from walls are published multiple times. Fixes [CNX-1482](https://linear.app/speckle/issue/CNX-1482/wall-sweeps-published-duplicated).

## User Value

Accurate object quantification.

## Changes:

- Excluded elements `""` as their `Name` parameter
- Initial thought of excluding `SubCategory` as discussed in this ticket was discarded, as we were losing objects such as lintels

## To-do before merge:

Validate that we aren't excluding other objects due to this "fix".

## Screenshots:

- We isolate one wall sweep and send via view
<img width="1280" alt="image" src="https://github.com/user-attachments/assets/9eaf37b7-592f-4e9a-9b8e-9c9b4443abec" />

- The `FilteredElementCollector()` returns the `Wall` with two additional objects (`WallSweep`).
<img width="640" alt="image" src="https://github.com/user-attachments/assets/850d7912-2472-46a5-b8fd-8f1964c6bc49" />

- These come from the wall assembly and have an empty string as their  `Name` 
<img width="1280" alt="image" src="https://github.com/user-attachments/assets/0201b231-720a-4f1a-8c35-42bf6aa6f0fe" />

- This is essential, as other `WallSweep` (e.g. Lintels) have a `Name`.

## Validation of changes:

What the video is showing:
- **First send** - current behaviour. One wall being sent, but the `FilteredElementCollector()` returns 38 objects (5 would be expected, 1 wall + 4 "standard elements"). Hiding the main wall in the viewer illustrates the problem
- **Second send** - we apply the filter `.Where(e => !string.IsNullOrEmpty(e.Name))` and see that a wall send only has the wall with no duplicate elements.
- Sending the whole model to make sure we're not filtering out other things eroneously. Lintels was, for example, problematic.

https://github.com/user-attachments/assets/114cbf8b-03db-46e3-a8e5-bb13b7afe41a

Testing other models, where I don't expect anything to be filtered out:
- `rst_basic_sample_project` - `elementsInView: Count = 884`, `objectIds: Count = 884`  ✅
- `rac_basic_sample_project` - `elementsInView: Count = 533`, `objectIds: Count = 533`  ✅
- `Snowdon Towers Sample Structural` - `elementsInView: Count = 1500`, `objectIds: Count = 1500`  ✅

## Checklist:

- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] I have added appropriate tests.
- [x] I have updated or added relevant documentation.

