### PR TITLE
feat(grasshopper): deconstruct and create empty props

### DIFF
--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Dev/DeconstructSpeckleParam.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Dev/DeconstructSpeckleParam.cs
@@ -31,7 +31,7 @@ public class DeconstructSpeckleParam : GH_Component, IGH_VariableParameterCompon
     pManager.AddGenericParameter(
       "Speckle Param",
       "SP",
-      "Speckle param to deconstruct. Expects Collections, Objects, or Materials",
+      "Speckle param to deconstruct. Expects Collections, Objects, Materials, or Properties",
       GH_ParamAccess.item
     );
   }
@@ -60,6 +60,14 @@ public class DeconstructSpeckleParam : GH_Component, IGH_VariableParameterCompon
       case SpeckleMaterialWrapperGoo matGoo:
         Name = string.IsNullOrEmpty(matGoo.Value.Name) ? matGoo.Value.Material.speckle_type : matGoo.Value.Name;
         outputParams = CreateOutputParamsFromBase(matGoo.Value.Base);
+        break;
+      case SpecklePropertyGroupGoo propGoo:
+        Name = $"properties ({propGoo.Value.Count})";
+        outputParams = new();
+        foreach (var key in propGoo.Value.Keys)
+        {
+          outputParams.Add(CreateOutputParamByKeyValue(key, propGoo.Value[key].Value, GH_ParamAccess.item));
+        }
         break;
       default:
         return;

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Objects/CreateSpeckleProperties.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Objects/CreateSpeckleProperties.cs
@@ -27,7 +27,11 @@ public class CreateSpeckleProperties : GH_Component, IGH_VariableParameterCompon
 
   private readonly DebounceDispatcher _debounceDispatcher = new();
 
-  protected override void RegisterInputParams(GH_InputParamManager pManager) { }
+  protected override void RegisterInputParams(GH_InputParamManager pManager)
+  {
+    var p = CreateParameter(GH_ParameterSide.Input, 0);
+    pManager.AddParameter(p);
+  }
 
   protected override void RegisterOutputParams(GH_OutputParamManager pManager)
   {

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Objects/CreateSpeckleProperties.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Objects/CreateSpeckleProperties.cs
@@ -23,13 +23,11 @@ public class CreateSpeckleProperties : GH_Component, IGH_VariableParameterCompon
 
   protected override Bitmap Icon => Resources.speckle_properties_create;
 
+  public bool CreateEmptyProperties { get; set; }
+
   private readonly DebounceDispatcher _debounceDispatcher = new();
 
-  protected override void RegisterInputParams(GH_InputParamManager pManager)
-  {
-    var p = CreateParameter(GH_ParameterSide.Input, 0);
-    pManager.AddParameter(p);
-  }
+  protected override void RegisterInputParams(GH_InputParamManager pManager) { }
 
   protected override void RegisterOutputParams(GH_OutputParamManager pManager)
   {
@@ -39,7 +37,6 @@ public class CreateSpeckleProperties : GH_Component, IGH_VariableParameterCompon
   protected override void SolveInstance(IGH_DataAccess da)
   {
     // Create a data tree to store output
-
     Dictionary<string, object?> properties = new();
 
     // Check for structure of all inputs to see matching branches
@@ -60,8 +57,18 @@ public class CreateSpeckleProperties : GH_Component, IGH_VariableParameterCompon
     {
       object? value = null;
       var success = da.GetData(i, ref value);
+      if (!success)
+      {
+        AddRuntimeMessage(
+          GH_RuntimeMessageLevel.Warning,
+          $"Parameter {Params.Input[i].NickName} does not have any values."
+        );
+
+        return;
+      }
+
       var actualValue = value?.GetType().GetProperty("Value").GetValue(value); // note: unsure if reflection here hurts our performance
-      if (!success || value == null || actualValue == null)
+      if (value == null || actualValue == null)
       {
         AddRuntimeMessage(
           GH_RuntimeMessageLevel.Warning,
@@ -80,7 +87,7 @@ public class CreateSpeckleProperties : GH_Component, IGH_VariableParameterCompon
 
   public bool CanInsertParameter(GH_ParameterSide side, int index)
   {
-    return side == GH_ParameterSide.Input;
+    return side == GH_ParameterSide.Input && !CreateEmptyProperties;
   }
 
   public bool CanRemoveParameter(GH_ParameterSide side, int index)
@@ -136,5 +143,35 @@ public class CreateSpeckleProperties : GH_Component, IGH_VariableParameterCompon
           break;
       }
     };
+  }
+
+  public override void AppendAdditionalMenuItems(ToolStripDropDown menu)
+  {
+    base.AppendAdditionalMenuItems(menu);
+
+    Menu_AppendSeparator(menu);
+    ToolStripMenuItem emptyPropsMenuItem = Menu_AppendItem(
+      menu,
+      "Create empty Properties",
+      (s, e) =>
+      {
+        CreateEmptyProperties = !CreateEmptyProperties;
+        if (CreateEmptyProperties)
+        {
+          Params.Input.Clear();
+          ClearData();
+        }
+        else if (Params.Input.Count == 0)
+        {
+          var p = CreateParameter(GH_ParameterSide.Input, 0);
+          Params.RegisterInputParam(p);
+        }
+        ExpireSolution(true);
+      },
+      true,
+      CreateEmptyProperties
+    );
+    emptyPropsMenuItem.ToolTipText =
+      "Toggle creating empty Properties. If set, the output Properties will be empty. Use for removing properties from objects.";
   }
 }


### PR DESCRIPTION

<!---

Provide a short summary in the Title above. Use the following template:

category(project): summary

Categories:

* feat: (new feature for the user, not a new feature for build script)
* fix: (bug fix for the user, not a fix to a build script)
* docs: (changes to the documentation)
* style: (formatting, missing semi colons, etc; no production code change)
* refactor: (refactoring production code, eg. renaming a variable)
* test: (adding missing tests, refactoring tests; no production code change)
* chore: (updating grunt tasks etc; no production code change)

Example:

feat(revit): added category filter to send

-->

## Description

Adds an option to handle Speckle Properties as an input for `Deconstruct`, which exposes all dictionary entries
Adds a right-click menu item to `Create Properties` node to allow users to create empty properties
## User Value

Better property UX, to retrieve values quickly


## Changes:

-Deconstruct node
-create properties node

## To-do before merge:

## Screenshots:

![{7A8704E8-1B40-48DC-BA1E-9E94E493E2D1}](https://github.com/user-attachments/assets/218dafd9-fe90-4e9d-b306-982439c10dc8)


## Validation of changes:

Simple testing of both nodes.
Haven't tested file save behavior.
Undo currently does not undo "create empty Properties" actions.

## Checklist:

<!---

This checklist is a useful reminder of related tasks to uphold our repo quality. Amend this list as needed for the pr.

-->
- [ ] I have updated or added relevant documentation.

