### PR TITLE
refactor(autocad): refactors hatch and region conversion and fixes some bugs

### DIFF
--- a/Converters/Autocad/Speckle.Converters.AutocadShared/ToSpeckle/Geometry/HatchToSpeckleConverter.cs
+++ b/Converters/Autocad/Speckle.Converters.AutocadShared/ToSpeckle/Geometry/HatchToSpeckleConverter.cs
@@ -18,16 +18,15 @@ public class HatchToSpeckleConverter : IToSpeckleTopLevelConverter, ITypedConver
   public Base Convert(object target) => Convert((ADB.Hatch)target);
 
   /// <summary>
-  /// Converting AutoCAD Hatch to Speckle Region. This method first converts Hatch to AutoCAD Region, and then uses RegionToSpeckle converter.
-  /// This is done because AutoCAD Region class allows to directly extract Brep representation (and convert it to display Mesh),
-  /// get distinct Outer and Inner loops, and filter out Hatches that consist of multiple disconnected parts (which our Region class is not designed for).
+  /// Converting AutoCAD Hatch to Speckle Region.
+  /// This method first converts Hatch to AutoCAD Region, and then uses RegionToSpeckle converter.
+  /// AutoCAD Region is a much simpler class than Hatch, and converting to region allows us to handle a bunch of unsupported conditions in Hatches.
   /// </summary>
   /// <param name="target">AutoCAD Hatch object</param>
   /// <returns>Speckle Region with property 'hasHatchPattern' as 'true'</returns>
   public SOG.Region Convert(ADB.Hatch target)
   {
     ADB.Region? regionToConvert = null;
-
     for (int i = 0; i < target.NumberOfLoops; i++)
     {
       // Convert HatchLoop into DBObjectCollection for the subsequent construction of the Region (.CreateFromCurves())
@@ -45,6 +44,7 @@ public class HatchToSpeckleConverter : IToSpeckleTopLevelConverter, ITypedConver
             $"Hatch conversion failed {target}: unexpected number of regions generated from 1 hatch loop"
           );
         }
+
         ADB.Region loopRegion = (ADB.Region)regionCollection[0];
 
         // Assign first loop as the main Region, other Regions will be subtracted from it
@@ -58,6 +58,7 @@ public class HatchToSpeckleConverter : IToSpeckleTopLevelConverter, ITypedConver
           {
             throw new ConversionException($"Hatch conversion failed: {target}");
           }
+
           // subtract region from Boundary region
           double areaBefore = regionToConvert.Area;
           regionToConvert.BooleanOperation(ADB.BooleanOperationType.BoolSubtract, loopRegion);
@@ -76,6 +77,10 @@ public class HatchToSpeckleConverter : IToSpeckleTopLevelConverter, ITypedConver
       throw new ConversionException($"Hatch conversion failed: {target}");
     }
 
+    // move this region to the target elevation
+    // POC: I've tried passing this elevation to ConvertHatchLoopToCurveEntityList() for direct assignment when converting 2d to 3d points, but this results in non-planarity in splines for some reason.
+    regionToConvert.TransformBy(AG.Matrix3d.Displacement(new AG.Vector3d(0, 0, target.Elevation)));
+
     // convert and store Regions
     SOG.Region convertedRegion = _regionConverter.Convert(regionToConvert);
     convertedRegion.hasHatchPattern = true;
@@ -84,125 +89,104 @@ public class HatchToSpeckleConverter : IToSpeckleTopLevelConverter, ITypedConver
   }
 
   /// <summary>
-  /// Converting AutoCAD HatchLoop into a list of AutoCAD Curves, so they can be used to construct an AutoCAD Region.
-  /// The major task is to convert all the 2d component parts (vertices or curves) into 3d Database Entities.
+  /// Converts Hatchloops to database-resident curve entities.
+  /// Curve entities are required by the Region create method.
   /// </summary>
   private List<ADB.Curve> ConvertHatchLoopToCurveEntityList(ADB.HatchLoop loop)
   {
     List<ADB.Curve> curveList = new();
 
-    // disposable object, wrapping into "using"
-    using (AG.Point3dCollection pts = new())
+    // 1 - handle the case of a polyline first
+    if (loop.IsPolyline)
     {
-      if (loop.IsPolyline)
+      // create a polyline from the loop.Polyline BulgeVertexCollection
+      ADB.Polyline polyline = new() { Closed = true };
+
+      for (int i = 0; i < loop.Polyline.Count; i++)
       {
-        // loop.Polyline doesn't actually return a Polyline, but a 'BulgeVertexCollection'. We need to construct a Polyline from it
-        ADB.Polyline polyline = new() { Closed = true };
+        var vertex = loop.Polyline[i];
 
-        // keep track of the number of vertices added to 'polyline', because to add new points we need to insert them via specific index (in method .AddVertexAt())
-        for (int i = 0; i < loop.Polyline.Count; i++)
+        // check if this is the last point, the closed property is already set and duplicated endpoints will result in an invalid polyline
+        if (i == loop.Polyline.Count - 1 && vertex.Vertex.GetDistanceTo(loop.Polyline[0].Vertex) < 0.001)
         {
-          ADB.BulgeVertex bVertex = loop.Polyline[i];
-          AG.Point3d point3d = new(bVertex.Vertex.X, bVertex.Vertex.Y, 0);
-
-          // add point only if it doesn't overlap with the first one ('closed' property is already set). Otherwise, polyline will be invalid.
-          if (pts.Count == 0 || pts[0].DistanceTo(point3d) > 0.001)
-          {
-            pts.Add(new AG.Point3d(bVertex.Vertex.X, bVertex.Vertex.Y, 0));
-            polyline.AddVertexAt(i, bVertex.Vertex, bVertex.Bulge, 0, 0);
-          }
+          continue;
         }
 
-        // if only 2 points, that's a circle
-        if (loop.Polyline.Count == 2)
-        {
-          AG.Point3d centerPt = new(pts[0].X + (pts[1].X - pts[0].X) / 2, pts[0].Y + (pts[1].Y - pts[0].Y) / 2, 0);
-          curveList.Add(new ADB.Circle(centerPt, AG.Vector3d.ZAxis, pts[0].DistanceTo(pts[1]) / 2));
-          return curveList;
-        }
-
-        curveList.Add(polyline);
-        return curveList;
+        polyline.AddVertexAt(i, vertex.Vertex, vertex.Bulge, 0, 0);
       }
+
+      curveList.Add(polyline);
+      return curveList;
     }
 
-    // if .Polyline is null, read from .Curves
+    // 2 - if the loop is not a polyline, handle the loop curves
+    // Notes: empirically, it seems that whenever the curve count is 1, it is a closed curve type like circle, ellipse, etc
+    // and when the curve count is > 1, they are line segments that will comprise of a closed area
+    // We'll process curves accordingly
     if (loop.Curves.Count == 0)
     {
       throw new ConversionException($"Hatch loop doesn't contain any segments.");
     }
 
-    if (loop.Curves.Count > 1) // handle the multi-segment case only with Line segments (not able to produce a Hatch Loop with multiple segments of other types)
+    foreach (AG.Curve2d curve in loop.Curves)
     {
-      foreach (AG.Curve2d curve2d in loop.Curves)
+      ADB.Curve? curveEntity = null;
+      switch (curve)
       {
-        if (curve2d is not AG.LineSegment2d l)
-        {
-          throw new ConversionException($"Hatch segments of type {curve2d.GetType()} are not supported");
-        }
-
-        ADB.Line line =
-          new(new AG.Point3d(l.StartPoint.X, l.StartPoint.Y, 0), new AG.Point3d(l.EndPoint.X, l.EndPoint.Y, 0));
-        curveList.Add(line);
-      }
-      return curveList;
-    }
-
-    var segment = loop.Curves[0]; // if .Curve has only 1 segments, it can be a closed Circle, Ellipse or Nurb
-    switch (segment)
-    {
-      case AG.CircularArc2d arc:
-        if (Math.Abs(arc.EndAngle - arc.StartAngle) - 2 * Math.PI > 0.0001) // check if it's not a circle
-        {
-          throw new ConversionException($"Multiple hatch segments of type {segment.GetType()} are not supported");
-        }
-
-        curveList.Add(new ADB.Circle(new(arc.Center.X, arc.Center.Y, 0), AG.Vector3d.ZAxis, arc.Radius));
-        return curveList;
-
-      case AG.EllipticalArc2d ellipse:
-        if (Math.Abs(ellipse.EndAngle - ellipse.StartAngle) - 2 * Math.PI > 0.0001) // check if it's not an ellipse
-        {
-          throw new ConversionException($"Multiple hatch segments of type {segment.GetType()} are not supported");
-        }
-        curveList.Add(
-          new ADB.Ellipse(
-            new(ellipse.Center.X, ellipse.Center.Y, 0),
-            AG.Vector3d.ZAxis,
-            new AG.Vector3d(ellipse.MajorAxis.X, ellipse.MajorAxis.Y, 0),
-            ellipse.MinorRadius / ellipse.MajorRadius,
-            ellipse.StartAngle,
-            ellipse.EndAngle
-          )
-        );
-        return curveList;
-
-      case AG.NurbCurve2d nurb:
-        using (AG.Point3dCollection ptsNurb = new())
-        {
-          AG.DoubleCollection knotsCollection = new();
-
-          nurb.Knots.Cast<double>().ToList().ForEach(x => knotsCollection.Add(x));
-          nurb.DefinitionData.ControlPoints.Cast<AG.Point2d>()
-            .ToList()
-            .ForEach(x => ptsNurb.Add(new AG.Point3d(x.X, x.Y, 0.0)));
-          curveList.Add(
-            new ADB.Spline(
-              nurb.Degree,
-              nurb.IsRational,
-              nurb.IsClosed(),
-              nurb.IsPeriodic(out _),
-              ptsNurb,
-              knotsCollection,
-              nurb.DefinitionData.Weights,
-              0,
-              0
-            )
+        case AG.LineSegment2d l:
+          curveEntity = new ADB.Line(
+            new AG.Point3d(l.StartPoint.X, l.StartPoint.Y, 0),
+            new AG.Point3d(l.EndPoint.X, l.EndPoint.Y, 0)
           );
-          return curveList;
-        }
-      default:
-        throw new ConversionException($"Multiple hatch segments of type {segment.GetType()} are not supported");
+          break;
+
+        case AG.CircularArc2d c:
+          AG.Point3d cCenter = new(c.Center.X, c.Center.Y, 0);
+          curveEntity =
+            c.EndPoint == c.StartPoint
+              ? new ADB.Circle(cCenter, AG.Vector3d.ZAxis, c.Radius)
+              : new ADB.Arc(cCenter, c.Radius, c.StartAngle, c.EndAngle);
+          break;
+
+        case AG.EllipticalArc2d e:
+          curveEntity = new ADB.Ellipse(
+            new AG.Point3d(e.Center.X, e.Center.Y, 0),
+            AG.Vector3d.ZAxis,
+            new AG.Vector3d(e.MajorAxis.X, e.MajorAxis.Y, 0),
+            e.MinorRadius / e.MajorRadius,
+            e.StartAngle,
+            e.EndAngle
+          );
+          break;
+
+        case AG.NurbCurve2d n: // need to convert to spline, ew
+          AG.Point3dCollection controlPoints = new();
+          AG.DoubleCollection knots = new();
+          n.Knots.Cast<double>().ToList().ForEach(x => knots.Add(x));
+          n.DefinitionData.ControlPoints.Cast<AG.Point2d>()
+            .ToList()
+            .ForEach(x => controlPoints.Add(new AG.Point3d(x.X, x.Y, 0)));
+
+          curveEntity = new ADB.Spline(
+            n.Degree,
+            n.IsRational,
+            n.IsClosed(),
+            n.IsPeriodic(out _),
+            controlPoints,
+            knots,
+            n.DefinitionData.Weights,
+            0,
+            0
+          );
+          break;
+
+        default:
+          throw new ConversionException($"Segments of type {curve.GetType()} are not supported");
+      }
+
+      curveList.Add(curveEntity);
     }
+
+    return curveList;
   }
 }

--- a/Converters/Autocad/Speckle.Converters.AutocadShared/ToSpeckle/Raw/CircularArc2dToSpeckleRawConverter.cs
+++ b/Converters/Autocad/Speckle.Converters.AutocadShared/ToSpeckle/Raw/CircularArc2dToSpeckleRawConverter.cs
@@ -3,12 +3,12 @@ using Speckle.Converters.Common.Objects;
 
 namespace Speckle.Converters.Autocad.ToSpeckle.Raw;
 
-public class CircularArc2dToSpeckleConverter : ITypedConverter<AG.CircularArc2d, SOG.Arc>
+public class CircularArc2dToSpeckleRawConverter : ITypedConverter<AG.CircularArc2d, SOG.Arc>
 {
   private readonly ITypedConverter<AG.Plane, SOG.Plane> _planeConverter;
   private readonly IConverterSettingsStore<AutocadConversionSettings> _settingsStore;
 
-  public CircularArc2dToSpeckleConverter(
+  public CircularArc2dToSpeckleRawConverter(
     ITypedConverter<AG.Plane, SOG.Plane> planeConverter,
     IConverterSettingsStore<AutocadConversionSettings> settingsStore
   )

--- a/Converters/Autocad/Speckle.Converters.AutocadShared/ToSpeckle/Raw/CircularArc3dToSpeckleRawConverter.cs
+++ b/Converters/Autocad/Speckle.Converters.AutocadShared/ToSpeckle/Raw/CircularArc3dToSpeckleRawConverter.cs
@@ -3,13 +3,13 @@ using Speckle.Converters.Common.Objects;
 
 namespace Speckle.Converters.Autocad.ToSpeckle.Raw;
 
-public class CircularArc3dToSpeckleConverter : ITypedConverter<AG.CircularArc3d, SOG.Arc>
+public class CircularArc3dToSpeckleRawConverter : ITypedConverter<AG.CircularArc3d, SOG.Arc>
 {
   private readonly ITypedConverter<AG.Point3d, SOG.Point> _pointConverter;
   private readonly ITypedConverter<AG.Plane, SOG.Plane> _planeConverter;
   private readonly IConverterSettingsStore<AutocadConversionSettings> _settingsStore;
 
-  public CircularArc3dToSpeckleConverter(
+  public CircularArc3dToSpeckleRawConverter(
     ITypedConverter<AG.Point3d, SOG.Point> pointConverter,
     ITypedConverter<AG.Plane, SOG.Plane> planeConverter,
     IConverterSettingsStore<AutocadConversionSettings> settingsStore


### PR DESCRIPTION
Refactors the hatch and region converter to remove unecessary code, and to clean up logic.
Also fixes a big bug:
- previously, hatches were only being converted to the xy plane. now, hatches in other planes are converted properly


commit before pr: https://app.speckle.systems/projects/d58144b502/models/9bd1c080d8@f931cd971b
![{A8B17020-53C9-45C3-ABA1-B90338F3D984}](https://github.com/user-attachments/assets/11d42def-9a5b-46a5-bf32-75b542816d3c)

commit after pr: https://app.speckle.systems/projects/d58144b502/models/9bd1c080d8@002a94941d
![{49176F5C-E5AC-461E-A30A-32924C5493F0}](https://github.com/user-attachments/assets/b3d40d58-b38a-423c-8d85-e52f88ba8b6f)

