### PR TITLE
fix(revit): reverting setting render material appearance

### DIFF
--- a/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/RevitMaterialBaker.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/RevitMaterialBaker.cs
@@ -129,10 +129,6 @@ public class RevitMaterialBaker
         var newMaterialId = Material.Create(_converterSettings.Current.Document, matName);
         var revitMaterial = (Material)_converterSettings.Current.Document.GetElement(newMaterialId);
         revitMaterial.Color = new Color(diffuse.R, diffuse.G, diffuse.B);
-
-        // NOTE: UseRenderAppearanceForShading path of least resistance [CNX-1062](https://linear.app/speckle/issue/CNX-1062/set-material-appearance-in-addition-to-shading)
-        // appearance is based on assets and tricky
-        revitMaterial.UseRenderAppearanceForShading = true;
         revitMaterial.Transparency = (int)(transparency * 100);
         revitMaterial.Shininess = (int)(speckleRenderMaterial.metalness * 128);
         revitMaterial.Smoothness = (int)(smoothness * 128);


### PR DESCRIPTION
This isn't what was intended with [CNX-1062](https://linear.app/speckle/issue/CNX-1062/set-material-appearance-in-addition-to-shading)