### PR TITLE
fix: passes correct arguments to ui on send results

### DIFF
--- a/Connectors/Autocad/Speckle.Connectors.AutocadShared/Bindings/AutocadSendBaseBinding.cs
+++ b/Connectors/Autocad/Speckle.Connectors.AutocadShared/Bindings/AutocadSendBaseBinding.cs
@@ -188,7 +188,7 @@ public abstract class AutocadSendBaseBinding : ISendBinding
           cancellationItem.Token
         );
 
-      await Commands.SetModelSendResult(modelCardId, sendResult.RootObjId, sendResult.ConversionResults);
+      await Commands.SetModelSendResult(modelCardId, sendResult.VersionId, sendResult.ConversionResults);
     }
     catch (OperationCanceledException)
     {

--- a/Connectors/CSi/Speckle.Connectors.CSiShared/Bindings/CsiSharedSendBinding.cs
+++ b/Connectors/CSi/Speckle.Connectors.CSiShared/Bindings/CsiSharedSendBinding.cs
@@ -106,7 +106,7 @@ public sealed class CsiSharedSendBinding : ISendBinding
           cancellationItem.Token
         );
 
-      await Commands.SetModelSendResult(modelCardId, sendResult.RootObjId, sendResult.ConversionResults);
+      await Commands.SetModelSendResult(modelCardId, sendResult.VersionId, sendResult.ConversionResults);
     }
     catch (OperationCanceledException)
     {

--- a/Connectors/Navisworks/Speckle.Connectors.NavisworksShared/Bindings/NavisworksSendBinding.cs
+++ b/Connectors/Navisworks/Speckle.Connectors.NavisworksShared/Bindings/NavisworksSendBinding.cs
@@ -122,7 +122,7 @@ public class NavisworksSendBinding : ISendBinding
         cancellationItem.Token
       );
 
-      await Commands.SetModelSendResult(modelCardId, sendResult.RootObjId, sendResult.ConversionResults);
+      await Commands.SetModelSendResult(modelCardId, sendResult.VersionId, sendResult.ConversionResults);
     }
     catch (OperationCanceledException)
     {

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Bindings/RevitSendBinding.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Bindings/RevitSendBinding.cs
@@ -164,7 +164,7 @@ internal sealed class RevitSendBinding : RevitBaseBinding, ISendBinding
           cancellationItem.Token
         );
 
-      await Commands.SetModelSendResult(modelCardId, sendResult.RootObjId, sendResult.ConversionResults);
+      await Commands.SetModelSendResult(modelCardId, sendResult.VersionId, sendResult.ConversionResults);
     }
     catch (OperationCanceledException)
     {

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/Bindings/RhinoSendBinding.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/Bindings/RhinoSendBinding.cs
@@ -321,7 +321,7 @@ public sealed class RhinoSendBinding : ISendBinding
           cancellationItem.Token
         );
 
-      await Commands.SetModelSendResult(modelCardId, sendResult.RootObjId, sendResult.ConversionResults);
+      await Commands.SetModelSendResult(modelCardId, sendResult.VersionId, sendResult.ConversionResults);
     }
     catch (OperationCanceledException)
     {

--- a/Connectors/Tekla/Speckle.Connector.TeklaShared/Bindings/TeklaSendBinding.cs
+++ b/Connectors/Tekla/Speckle.Connector.TeklaShared/Bindings/TeklaSendBinding.cs
@@ -149,7 +149,7 @@ public sealed class TeklaSendBinding : ISendBinding
           cancellationItem.Token
         );
 
-      await Commands.SetModelSendResult(modelCardId, sendResult.RootObjId, sendResult.ConversionResults);
+      await Commands.SetModelSendResult(modelCardId, sendResult.VersionId, sendResult.ConversionResults);
     }
     catch (OperationCanceledException)
     {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/2980f635-ed10-4fbe-9e96-3da46f963c01)

It would be great if we can release again after this merge, as it's blocking [CNX-598: Version message](https://linear.app/speckle/issue/CNX-598/version-message)