### PR TITLE
fix(grasshopper): url resource set bug on async receive

### DIFF
--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Collections/ExpandCollection.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Collections/ExpandCollection.cs
@@ -78,11 +78,12 @@ public class ExpandCollection : GH_Component, IGH_VariableParameterComponent
 
     foreach (SpeckleCollectionWrapper childWrapper in collections)
     {
-      // skip empty
+      /* POC: we shouldn't skip empty, people would probably expect to see what they see in browser.
       if (childWrapper.Elements.Count == 0)
       {
         continue;
       }
+      */
 
       var hasInnerCollections = childWrapper.Elements.Any(el => el is SpeckleCollectionWrapper);
       var topology = childWrapper.Topology; // Note: this is a reminder for the future

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Receive/ReceiveAsyncComponent.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Receive/ReceiveAsyncComponent.cs
@@ -258,7 +258,7 @@ public class ReceiveAsyncComponent : GH_AsyncComponent
         AutoReceive = false;
         LastInfoMessage = "";
         ResetApiClient(dataInput);
-        return;
+        break;
       case SpeckleUrlModelResource:
         InputType = "Model";
         // handled in do work


### PR DESCRIPTION
Fixes a small bug where we were returning early before setting the UrlModelResource in the async receive node.
Also includes a small change to allow expand collection to parse empty subcollections, since this will probably be expected to match the viewer experience.

![{86D1BE59-A544-4D53-87AD-E3A6694E2992}](https://github.com/user-attachments/assets/d9de3ad1-1a54-464b-bd27-b945e939a1ce)
