### PR TITLE
feat(grasshopper): add `CastToModelObject` support for `SpecklePropertyGroupGoo`

### DIFF
--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/SpecklePropertyGroupGoo.ModelObjects.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/SpecklePropertyGroupGoo.ModelObjects.cs
@@ -2,6 +2,9 @@
 using Grasshopper.Rhinoceros;
 using Grasshopper.Kernel.Types;
 using Grasshopper.Rhinoceros.Model;
+using Grasshopper.Rhinoceros.Params;
+using Rhino;
+using Rhino.DocObjects;
 
 namespace Speckle.Connectors.GrasshopperShared.Parameters;
 
@@ -33,6 +36,41 @@ public partial class SpecklePropertyGroupGoo : GH_Goo<Dictionary<string, Speckle
       default:
         return false;
     }
+  }
+
+  private bool CastToModelObject<T>(ref T target)
+  {
+    var type = typeof(T);
+
+    if (type == typeof(IGH_ModelContentData))
+    {
+      var attributes = new ObjectAttributes();
+      foreach (var entry in Value)
+      {
+        string stringValue = entry.Value.Value?.ToString() ?? "";
+        attributes.SetUserString(entry.Key, stringValue);
+      }
+
+      var modelObject = new ModelObject(RhinoDoc.ActiveDoc, attributes);
+      target = (T)(object)modelObject;
+      return true;
+    }
+
+    if (type == typeof(ModelUserText))
+    {
+      var keyValuePairs = new List<KeyValuePair<string, string>>();
+      foreach (var entry in Value)
+      {
+        string stringValue = entry.Value.Value?.ToString() ?? "";
+        keyValuePairs.Add(new KeyValuePair<string, string>(entry.Key, stringValue));
+      }
+
+      var modelUserText = new ModelUserText(keyValuePairs);
+      target = (T)(object)modelUserText;
+      return true;
+    }
+
+    return false;
   }
 }
 #endif

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/SpecklePropertyGroupGoo.ModelObjects.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/SpecklePropertyGroupGoo.ModelObjects.cs
@@ -42,6 +42,7 @@ public partial class SpecklePropertyGroupGoo : GH_Goo<Dictionary<string, Speckle
   {
     var type = typeof(T);
 
+    // grasshopper interface types
     if (type == typeof(IGH_ModelContentData))
     {
       var attributes = new ObjectAttributes();
@@ -56,6 +57,9 @@ public partial class SpecklePropertyGroupGoo : GH_Goo<Dictionary<string, Speckle
       return true;
     }
 
+    // raw rhino types (for direct casting scenarios) <- could we remove?? 🧐
+    // for model content we would only ever hit IGH_ModelContentData
+    // added ModelUserText as this is the pattern oberved in the rest of codebase.
     if (type == typeof(ModelUserText))
     {
       var keyValuePairs = new List<KeyValuePair<string, string>>();

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/SpecklePropertyGroupGoo.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/SpecklePropertyGroupGoo.cs
@@ -73,12 +73,11 @@ public partial class SpecklePropertyGroupGoo : GH_Goo<Dictionary<string, Speckle
       {
         dictionary.Add(entry.Key, entry.Value.Value);
       }
-
       target = (T)(object)dictionary;
       return true;
     }
 
-    return false;
+    return CastToModelObject(ref target);
   }
 
   // Flattens a dictionary that may contain more dictionaries of the same type


### PR DESCRIPTION
# Description
Adds missing `CastToModelObject` method to `SpecklePropertyGroupGoo` to allow casting Speckle properties to **Rhino 8+** model content types. Allows direct piping to User Text components in gh.

## User Value
Users can now directly pipe Speckle Object properties to User Text components.

## Changes:
- Added `CastToModelObject<T>` method to `SpecklePropertyGroupGoo` 
- Supports casting to `IGH_ModelContentData` (creates `ModelObject` with user text)
- Supports casting to `ModelUserText` (direct conversion) _(<- not sure if needed though??)_

## Screenshots and Validation of changes:

<img width="1031" alt="image" src="https://github.com/user-attachments/assets/426ffd59-46ed-4545-8061-2a0eefa64d91" />

## Checklist:
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] I have added appropriate tests.
- [x] I have updated or added relevant documentation.

