### PR TITLE
feat(grasshopper): automatically adds new param for create collection and properties

### DIFF
--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Collections/CreateCollection.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Collections/CreateCollection.cs
@@ -69,7 +69,7 @@ public class CreateCollection : GH_Component, IGH_VariableParameterComponent
 
       if (inputCollections.Count != 0 && inputNonCollections.Count != 0)
       {
-        // TODO: error out! we want to disallow setting objects and collections in the same parent collection
+        // error out! we want to disallow setting objects and collections in the same parent collection
         AddRuntimeMessage(
           GH_RuntimeMessageLevel.Error,
           $"Parameter {inputParam.NickName} should not contain both objects and collections."
@@ -154,13 +154,14 @@ public class CreateCollection : GH_Component, IGH_VariableParameterComponent
 
   public IGH_Param CreateParameter(GH_ParameterSide side, int index)
   {
-    var myParam = new Param_GenericObject
-    {
-      Name = $"Sub-Collection {Params.Input.Count + 1}",
-      MutableNickName = true,
-      Optional = true,
-      Access = GH_ParamAccess.tree // always tree
-    };
+    Param_GenericObject myParam =
+      new()
+      {
+        Name = $"Sub-Collection {Params.Input.Count + 1}",
+        MutableNickName = true,
+        Optional = true,
+        Access = GH_ParamAccess.tree // always tree
+      };
 
     myParam.NickName = myParam.Name;
     myParam.Optional = true;
@@ -170,11 +171,6 @@ public class CreateCollection : GH_Component, IGH_VariableParameterComponent
   public bool DestroyParameter(GH_ParameterSide side, int index)
   {
     return side == GH_ParameterSide.Input;
-  }
-
-  public void VariableParameterMaintenance()
-  {
-    // TODO?
   }
 
   public override void AddedToDocument(GH_Document document)
@@ -198,7 +194,21 @@ public class CreateCollection : GH_Component, IGH_VariableParameterComponent
           args.Parameter.Name = args.Parameter.NickName;
           ExpireSolution(true);
           break;
+        case GH_ObjectEventType.Sources:
+          // if this event is a source change, and param is the last input, then add a new param automatically
+          if (args.Parameter.SourceCount > 0 && args.ParameterIndex == Params.Input.Count - 1)
+          {
+            IGH_Param param = CreateParameter(GH_ParameterSide.Input, Params.Input.Count);
+            Params.RegisterInputParam(param);
+            Params.OnParametersChanged();
+          }
+          break;
       }
     };
+  }
+
+  public void VariableParameterMaintenance()
+  {
+    //todo
   }
 }


### PR DESCRIPTION
<!---

Provide a short summary in the Title above. Use the following template:

category(project): summary

Categories:

* feat: (new feature for the user, not a new feature for build script)
* fix: (bug fix for the user, not a fix to a build script)
* docs: (changes to the documentation)
* style: (formatting, missing semi colons, etc; no production code change)
* refactor: (refactoring production code, eg. renaming a variable)
* test: (adding missing tests, refactoring tests; no production code change)
* chore: (updating grunt tasks etc; no production code change)

Example:

feat(revit): added category filter to send

-->

## Description
Mimicking the behavior of Grasshopper's native `Merge` component, this pr automatically adds a new input param if a source has been added to the last param on the components:
- Create Collection
- Create Properties
Expected behavior: New input should be created only on the addition of a source to the last input param. If any source is disconnected, this component shouldn't change inputs. Check native gh merge component for same behavior

Note:
- Also fixed an issue with the Create Properties component, to allow for empty props to be created. Previous node also was allowing some inputs like point, when we do not support any non-string/bool/number inputs.
<!---

Describe your changes, and why you're making them.

Link related github issues here ->
Fixes #85, Fixes #22, Connects #123

-->

## User Value

Easier UX when creating many inputs for props or collections

## Changes:

- Create Properties
- Create Collection

## To-do before merge:

- [ ] Check for same behavior as merge node

## Screenshots:

![{FBD5D75D-1827-4D26-A5B8-A6B61E669678}](https://github.com/user-attachments/assets/7fa29c42-8231-4ba7-9026-b5e73a74cdc0)

## Validation of changes:

Simple testing of adding sources, removing sources, and adding and deleting params

