### PR TITLE
feat(grasshopper): add direct casting from speckle object to geometry types

### DIFF
--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/SpeckleObjectWrapper.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/SpeckleObjectWrapper.cs
@@ -285,12 +285,28 @@ public partial class SpeckleObjectWrapperGoo : GH_Goo<SpeckleObjectWrapper>, IGH
   {
     var type = typeof(T);
 
-    if (type == typeof(IGH_GeometricGoo))
+    if (Value.GeometryBase == null)
     {
-      target = (T)(object)GH_Convert.ToGeometricGoo(Value.GeometryBase);
-      return true;
+      return CastToModelObject(ref target);
     }
 
+    switch (type)
+    {
+      case Type t when t == typeof(GH_Brep):
+        Brep? brep = null;
+        if (GH_Convert.ToBrep(Value.GeometryBase, ref brep, GH_Conversion.Both))
+        {
+          target = (T)(object)new GH_Brep(brep);
+          return true;
+        }
+        break;
+
+      case Type t when t == typeof(IGH_GeometricGoo):
+        target = (T)GH_Convert.ToGeometricGoo(Value.GeometryBase);
+        return true;
+    }
+
+    // fallback to existing model object casting
     return CastToModelObject(ref target);
   }
 

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/SpeckleObjectWrapper.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/SpeckleObjectWrapper.cs
@@ -283,31 +283,134 @@ public partial class SpeckleObjectWrapperGoo : GH_Goo<SpeckleObjectWrapper>, IGH
 
   public override bool CastTo<T>(ref T target)
   {
-    var type = typeof(T);
-
     if (Value.GeometryBase == null)
     {
       return CastToModelObject(ref target);
     }
 
-    switch (type)
-    {
-      case Type t when t == typeof(GH_Brep):
-        Brep? brep = null;
-        if (GH_Convert.ToBrep(Value.GeometryBase, ref brep, GH_Conversion.Both))
-        {
-          target = (T)(object)new GH_Brep(brep);
-          return true;
-        }
-        break;
+    var targetType = typeof(T);
 
-      case Type t when t == typeof(IGH_GeometricGoo):
+    switch (targetType)
+    {
+      case var _ when targetType == typeof(GH_Point):
+        return TryCastToPoint(ref target);
+
+      case var _ when targetType == typeof(GH_Curve):
+        return TryCastToCurve(ref target);
+
+      case var _ when targetType == typeof(GH_Line):
+        return TryCastToLine(ref target);
+
+      case var _ when targetType == typeof(GH_Brep):
+        return TryCastToBrep(ref target);
+
+      case var _ when targetType == typeof(GH_Mesh):
+        return TryCastToMesh(ref target);
+
+      case var _ when targetType == typeof(GH_SubD):
+        return TryCastToSubD(ref target);
+
+      case var _ when targetType == typeof(GH_Surface):
+        return TryCastToSurface(ref target);
+
+      case var _ when targetType == typeof(GH_PointCloud):
+        return TryCastToPointcloud(ref target);
+
+      case var _ when targetType == typeof(IGH_GeometricGoo):
         target = (T)GH_Convert.ToGeometricGoo(Value.GeometryBase);
         return true;
-    }
 
-    // fallback to existing model object casting
-    return CastToModelObject(ref target);
+      default:
+        return CastToModelObject(ref target);
+    }
+  }
+
+  private bool TryCastToPointcloud<T>(ref T target)
+  {
+    PointCloud? pointCloud = null;
+    if (GH_Convert.ToPointCloud(Value.GeometryBase, ref pointCloud, GH_Conversion.Both))
+    {
+      target = (T)(object)new GH_PointCloud(pointCloud);
+      return true;
+    }
+    return false;
+  }
+
+  private bool TryCastToSurface<T>(ref T target)
+  {
+    Surface? surface = null;
+    if (GH_Convert.ToSurface(Value.GeometryBase, ref surface, GH_Conversion.Both))
+    {
+      target = (T)(object)new GH_Surface(surface);
+      return true;
+    }
+    return false;
+  }
+
+  private bool TryCastToSubD<T>(ref T target)
+  {
+    SubD? subd = null;
+    if (GH_Convert.ToSubD(Value.GeometryBase, ref subd, GH_Conversion.Both))
+    {
+      target = (T)(object)new GH_SubD(subd);
+      return true;
+    }
+    return false;
+  }
+
+  private bool TryCastToMesh<T>(ref T target)
+  {
+    Mesh? mesh = null;
+    if (GH_Convert.ToMesh(Value.GeometryBase, ref mesh, GH_Conversion.Both))
+    {
+      target = (T)(object)new GH_Mesh(mesh);
+      return true;
+    }
+    return false;
+  }
+
+  private bool TryCastToBrep<T>(ref T target)
+  {
+    Brep? brep = null;
+    if (GH_Convert.ToBrep(Value.GeometryBase, ref brep, GH_Conversion.Both))
+    {
+      target = (T)(object)new GH_Brep(brep);
+      return true;
+    }
+    return false;
+  }
+
+  private bool TryCastToLine<T>(ref T target)
+  {
+    Line line = new();
+    if (GH_Convert.ToLine(Value.GeometryBase, ref line, GH_Conversion.Both))
+    {
+      target = (T)(object)new GH_Line(line);
+      return true;
+    }
+    return false;
+  }
+
+  private bool TryCastToCurve<T>(ref T target)
+  {
+    Curve? curve = null;
+    if (GH_Convert.ToCurve(Value.GeometryBase, ref curve, GH_Conversion.Both))
+    {
+      target = (T)(object)new GH_Curve(curve);
+      return true;
+    }
+    return false;
+  }
+
+  private bool TryCastToPoint<T>(ref T target)
+  {
+    Point3d point = new();
+    if (GH_Convert.ToPoint3d(Value.GeometryBase, ref point, GH_Conversion.Both))
+    {
+      target = (T)(object)new GH_Point(point);
+      return true;
+    }
+    return false;
   }
 
   public void DrawViewportWires(GH_PreviewWireArgs args)


### PR DESCRIPTION
## Description

Adds direct casting from speckle objects to other native gh geometry types. Namely:

- `Point`
- `Curve`
- `Line`
- `Brep`
- `Mesh`
- `SubD`
- `Surface`
- `Pointcloud`

Fixes [CNX-1741](https://linear.app/speckle/issue/CNX-1741/add-direct-casting-from-speckle-object-to-geometry-types).

## User Value

Direct casting (stems for a user request). 

## Changes:

`SpeckleObjectWrapper.cs` has the `CastTo` method extended with another conditional. This is the `TryUnifiedCast` which essentially tries to "wrap" all type conversion logic in to a condensed method. But, native gh conversions can become quite verbose. This was seen as the best solution considering the strict typing requirements.

## Validation of changes:

Note that mixed geometry will light up red if we directly pipe into a native specific component (e.g. `Curve` or `Brep`) as opposed to the generic `Geometry` component. This, however, mimics native behaviour and the conversions still do take place. Users just need to filter out the nulls.

![image](https://github.com/user-attachments/assets/860bbe3f-9a02-40bc-8f52-19c2cd56474e)

## Checklist:

- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] I have added appropriate tests.
- [x] I have updated or added relevant documentation.

