### PR TITLE
fix(revit): prevent Panel removal when hosted by CurtainSystem for proper send

### DIFF
--- a/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/ElementUnpacker.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/ElementUnpacker.cs
@@ -134,7 +134,11 @@ public class ElementUnpacker
     }
     elements.RemoveAll(element =>
       (element is Mullion { Host: not null } m && ids.Contains(m.Host.Id))
-      || (element is Panel { Host: not null } p && ids.Contains(p.Host.Id))
+      || (
+        element is Panel { Host: not null } p
+        && ids.Contains(p.Host.Id)
+        && doc.GetElement(p.Host.Id) is not CurtainSystem
+      )
       || (
         element is FamilyInstance { Host: not null } f
         && doc.GetElement(f.Host.Id) is Wall { CurtainGrid: not null }

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/ElementUnpacker.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/ElementUnpacker.cs
@@ -137,7 +137,7 @@ public class ElementUnpacker
       || (
         element is Panel { Host: not null } p
         && ids.Contains(p.Host.Id)
-        && doc.GetElement(p.Host.Id) is not CurtainSystem
+        && doc.GetElement(p.Host.Id) is not CurtainSystem // don't remove panels when host is CurtainSystem [CNX-1884](https://linear.app/speckle/issue/CNX-1884/revit-curtain-system-not-sending-properly)
       )
       || (
         element is FamilyInstance { Host: not null } f


### PR DESCRIPTION
## Description
Fixed an issue where `Panel` hosted by `CurtainSystem` were being incorrectly removed during element unpacking, resutlting in curtain systems not sending properly. I don't think this was ever working?

The problem occurred in `PackCurtainWallElementsAndStackedWalls` where the `RemoveAll` logic was removing all Panels whose host IDs existed in the collection, **without** considering the host type. This caused conflicts between Curtain Panels (which contain geometry we want) and `CurtainSystem` (which are "empty" containers - `solid.Faces.Size == 0`).

Fixes [CNX-1884](https://linear.app/speckle/issue/CNX-1884/revit-curtain-system-not-sending-properly).

## User Value
What you see is what you get 😎 

## Changes:

(**DISCLAIMER**: horrible fix, I know! but is there a better way?? 💩)

- Modified `PackCurtainWallElementsAndStackedWalls` method to preserve `Panel` when their host is a `CurtainSystem`
- Added host type check `doc.GetElement(p.Host.Id) is not CurtainSystem` to `Panel` removal condition

## To-Do Before Merge
- [] Did break anything related to `PackCurtainWallElementsAndStackedWalls` original intent @didimitrie ?? Validation screenshot below.

## Validation of changes:

Test model [here](https://app.speckle.systems/projects/03074a2834/models/d0d1479e9d). 
- Curtain systems now fixed
- No changes to curtain wall or stacked walls

<img width="1280" alt="image" src="https://github.com/user-attachments/assets/865f7c32-1dde-41d4-9c3d-4d0270b57cb2" />

## Checklist:

- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] I have added appropriate tests.
- [x] I have updated or added relevant documentation.

