### PR TITLE
chore(grasshopper): rename to view created "model" online

### DIFF
--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Send/SendAsyncComponent.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Send/SendAsyncComponent.cs
@@ -118,7 +118,7 @@ public class SendAsyncComponent : GH_AsyncComponent
     {
       Menu_AppendSeparator(menu);
 
-      Menu_AppendItem(menu, $"View created version online ↗", (s, e) => Open(Url));
+      Menu_AppendItem(menu, $"View created model online ↗", (s, e) => Open(Url));
     }
 
     Menu_AppendSeparator(menu);
@@ -336,7 +336,7 @@ public class SendComponentWorker : WorkerInstance
       */
       Parent.AddRuntimeMessage(
         GH_RuntimeMessageLevel.Remark,
-        $"Successfully published to Speckle. Right-click to view online."
+        $"Successfully published to Speckle. Right-click on the component to view online."
       );
       Parent.AddRuntimeMessage(
         GH_RuntimeMessageLevel.Remark,

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Send/SendComponent.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Send/SendComponent.cs
@@ -119,7 +119,7 @@ public class SendComponent : SpeckleScopedTaskCapableComponent<SendComponentInpu
     {
       Menu_AppendSeparator(menu);
 
-      Menu_AppendItem(menu, $"View created version online ↗", (s, e) => Open(Url));
+      Menu_AppendItem(menu, $"View created model online ↗", (s, e) => Open(Url));
     }
 
     static void Open(string url)


### PR DESCRIPTION
## Description

Fixes [CNX-1722](https://linear.app/speckle/issue/CNX-1722/right-click-view-created-model-online)

## User Value

Consistent DUI3 naming.

## Changes:

- View created **version** online -> View created **model** online
- Updated description to "Successfully published to Speckle. Right-click **on the component** to view online.". Simply saying right-click is misleading, I though by right-clicking on that dialog, it would take me to the model.

## Validation of changes:

### Before

<img width="392" alt="Screenshot 2025-05-30 085040" src="https://github.com/user-attachments/assets/0a93bfab-8939-4a6f-b1a9-71c61907c14e" />

### After

<img width="386" alt="image" src="https://github.com/user-attachments/assets/3ba5b955-91ea-42a2-aff2-28e126e915dd" />

<img width="647" alt="image" src="https://github.com/user-attachments/assets/cf5c28b6-ed25-4a92-9567-34e4c8e5d468" />

## Checklist:

- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.

