### PR TITLE
hotfix(grasshopper): avoids account exception on constructor of speckle operation wizard

### DIFF
--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Wizard/SpeckleOperationWizard.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Wizard/SpeckleOperationWizard.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
 using Microsoft.Extensions.DependencyInjection;
 using Speckle.Connectors.Common.Operations;
 using Speckle.Connectors.GrasshopperShared.HostApp;
@@ -49,7 +49,7 @@ public class SpeckleOperationWizard
 
     var userSelectedAccountId = _accountService.GetUserSelectedAccountId();
     Accounts = _accountManager.GetAccounts().ToList();
-    SelectedAccount = userSelectedAccountId == null ? null : _accountManager.GetAccount(userSelectedAccountId);
+    SelectedAccount = Accounts.FirstOrDefault(a => a.id == userSelectedAccountId);
 
     WorkspaceMenuHandler = new WorkspaceMenuHandler(FetchWorkspaces, CreateNewWorkspace);
     ProjectMenuHandler = new ProjectMenuHandler(FetchProjects);


### PR DESCRIPTION
Unhandled exceptions in the constructor of components will prevent them from loading.
The URL component was failing to load with an unhandled SpeckleAccountManagerException, probably caused by a stored account ID that has been deleted

https://speckle.community/t/speckle-model-link-component-missing-in-v-3-3-0/18378/11