### PR TITLE
This should stop derived expected exceptions from being logged as errors to seq.  More detail on revit exceptions in the message

### DIFF
--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Plugin/SpeckleRevitTaskException.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Plugin/SpeckleRevitTaskException.cs
@@ -7,7 +7,7 @@ using Speckle.Sdk.Common;
 namespace Speckle.Connectors.Revit.Plugin;
 
 #pragma warning disable CA1032
-public class SpeckleRevitTaskException(Exception exception) : SpeckleException("Revit operation failed", exception)
+public class SpeckleRevitTaskException(Exception exception) : SpeckleException("Revit operation failed: " + exception.Message, exception)
 #pragma warning restore CA1032
 {
   public static async Task ProcessException<T>(

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Plugin/SpeckleRevitTaskException.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Plugin/SpeckleRevitTaskException.cs
@@ -7,7 +7,8 @@ using Speckle.Sdk.Common;
 namespace Speckle.Connectors.Revit.Plugin;
 
 #pragma warning disable CA1032
-public class SpeckleRevitTaskException(Exception exception) : SpeckleException("Revit operation failed: " + exception.Message, exception)
+public class SpeckleRevitTaskException(Exception exception)
+  : SpeckleException("Revit operation failed: " + exception.Message, exception)
 #pragma warning restore CA1032
 {
   public static async Task ProcessException<T>(

--- a/DUI3/Speckle.Connectors.DUI/Logging/BindingErrorLogging.cs
+++ b/DUI3/Speckle.Connectors.DUI/Logging/BindingErrorLogging.cs
@@ -13,12 +13,11 @@ public static class HandledModelCardErrors
 {
   public static void LogModelCardHandledError<T>(this ILogger<T> logger, Exception ex)
   {
-    LogLevel level = ex switch
+    var level = LogLevel.Error;
+    if (ex is SpeckleException)
     {
-      SpeckleException => LogLevel.Warning,
-      _ => LogLevel.Error
-    };
-
+      level = LogLevel.Warning;
+    }
     logger.Log(level, ex, "{bindingType} operation was not successful", typeof(T));
   }
 }


### PR DESCRIPTION
Send errors were getting logged as errors because the pattern matching didn't use derived classes as well.  Change the code to not do it for derived errors.  Revit Exceptions have detail in the messages now.

![image](https://github.com/user-attachments/assets/1ccac16b-b8be-4e54-a44f-b6ca8e9d4f23)
