### PR TITLE
refactor(grasshopper): make `SpeckleBlockInstanceWrapper` inherit from `SpeckleObjectWrapper`

### DIFF
--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Collections/ExpandCollection.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Collections/ExpandCollection.cs
@@ -71,19 +71,7 @@ public class ExpandCollection : GH_Component, IGH_VariableParameterComponent
       };
 
       // Create appropriate Goo types for each object (downside of the inheritance refactor)
-      List<IGH_Goo> atomicObjectGoos = new();
-
-      foreach (var obj in objects)
-      {
-        if (obj is SpeckleBlockInstanceWrapper instanceWrapper)
-        {
-          atomicObjectGoos.Add(new SpeckleBlockInstanceWrapperGoo(instanceWrapper));
-        }
-        else if (obj is SpeckleObjectWrapper objWrapper)
-        {
-          atomicObjectGoos.Add(new SpeckleObjectWrapperGoo(objWrapper));
-        }
-      }
+      List<IGH_Goo> atomicObjectGoos = objects.Select(obj => obj.CreateGoo()).ToList();
 
       outputParams.Add(new OutputParamWrapper(param, atomicObjectGoos, null));
     }
@@ -125,19 +113,10 @@ public class ExpandCollection : GH_Component, IGH_VariableParameterComponent
       else
       {
         // Create appropriate Goo types for child objects
-        // feels like we're working around a design decision here
-        List<IGH_Goo> childObjectGoos = new();
-        foreach (var obj in childWrapper.Elements.OfType<SpeckleObjectWrapper>())
-        {
-          if (obj is SpeckleBlockInstanceWrapper instanceWrapper)
-          {
-            childObjectGoos.Add(new SpeckleBlockInstanceWrapperGoo(instanceWrapper));
-          }
-          else
-          {
-            childObjectGoos.Add(new SpeckleObjectWrapperGoo(obj));
-          }
-        }
+        List<IGH_Goo> childObjectGoos = childWrapper
+          .Elements.OfType<SpeckleObjectWrapper>()
+          .Select(obj => obj.CreateGoo())
+          .ToList();
         outputValue = childObjectGoos;
       }
 

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Collections/ExpandCollection.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Collections/ExpandCollection.cs
@@ -2,6 +2,7 @@ using System.Collections;
 using System.Runtime.InteropServices;
 using Grasshopper.Kernel;
 using Grasshopper.Kernel.Parameters;
+using Grasshopper.Kernel.Types;
 using Speckle.Connectors.GrasshopperShared.HostApp;
 using Speckle.Connectors.GrasshopperShared.Parameters;
 using Speckle.Connectors.GrasshopperShared.Properties;
@@ -51,15 +52,8 @@ public class ExpandCollection : GH_Component, IGH_VariableParameterComponent
     Name = wrapper.Name;
     NickName = wrapper.Name;
 
-    var objects = wrapper
-      .Elements.Where(el => el is not SpeckleCollectionWrapper)
-      .OfType<SpeckleObjectWrapper>()
-      .Select(o => new SpeckleObjectWrapperGoo(o))
-      .ToList();
-    var collections = wrapper
-      .Elements.Where(el => el is SpeckleCollectionWrapper)
-      .OfType<SpeckleCollectionWrapper>()
-      .ToList();
+    var objects = wrapper.Elements.OfType<SpeckleObjectWrapper>().ToList();
+    var collections = wrapper.Elements.OfType<SpeckleCollectionWrapper>().ToList();
 
     var outputParams = new List<OutputParamWrapper>();
     if (objects.Count != 0)
@@ -72,6 +66,20 @@ public class ExpandCollection : GH_Component, IGH_VariableParameterComponent
           "Some collections may contain a mix of objects and other collections. Here we output the atomic objects from within this collection.",
         Access = GH_ParamAccess.list
       };
+
+      List<IGH_Goo> atomicObjectGoos = new();
+
+      foreach (var obj in objects)
+      {
+        if (obj is SpeckleBlockInstanceWrapper instanceWrapper)
+        {
+          atomicObjectGoos.Add(new SpeckleBlockInstanceWrapperGoo(instanceWrapper));
+        }
+        else if (obj is SpeckleObjectWrapper objWrapper)
+        {
+          atomicObjectGoos.Add(new SpeckleObjectWrapperGoo(objWrapper));
+        }
+      }
 
       outputParams.Add(new OutputParamWrapper(param, objects, null));
     }

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Dev/DeconstructSpeckleParam.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Dev/DeconstructSpeckleParam.cs
@@ -47,9 +47,21 @@ public class DeconstructSpeckleParam : GH_Component, IGH_VariableParameterCompon
 
     switch (data)
     {
-      case SpeckleWrapper wrapper:
-        Name = string.IsNullOrEmpty(wrapper.Name) ? wrapper.Base.speckle_type : wrapper.Name;
-        outputParams = CreateOutputParamsFromBase(wrapper.Base);
+      case SpeckleObjectWrapperGoo objectGoo when objectGoo.Value != null:
+        Name = string.IsNullOrEmpty(objectGoo.Value.Name) ? objectGoo.Value.Base.speckle_type : objectGoo.Value.Name;
+        outputParams = CreateOutputParamsFromBase(objectGoo.Value.Base);
+        break;
+
+      case SpeckleBlockInstanceWrapperGoo blockInstanceGoo when blockInstanceGoo.Value != null:
+        Name = string.IsNullOrEmpty(blockInstanceGoo.Value.Name)
+          ? blockInstanceGoo.Value.Base.speckle_type
+          : blockInstanceGoo.Value.Name;
+        outputParams = CreateOutputParamsFromBase(blockInstanceGoo.Value.Base);
+        break;
+
+      case SpeckleBlockDefinitionWrapperGoo blockDef:
+        Name = string.IsNullOrEmpty(blockDef.Value.Name) ? blockDef.Value.Base.speckle_type : blockDef.Value.Name;
+        outputParams = CreateOutputParamsFromBase(blockDef.Value.Base);
         break;
 
       case SpecklePropertyGroupGoo propGoo:

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Dev/DeconstructSpeckleParam.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Dev/DeconstructSpeckleParam.cs
@@ -211,8 +211,7 @@ public class DeconstructSpeckleParam : GH_Component, IGH_VariableParameterCompon
             GeometryBase = g,
             Name = b["name"] as string ?? "",
             Color = null,
-            Material = null,
-            WrapperGuid = null
+            Material = null
           };
 
         convertedWrappers.Add(new(convertedWrapper));
@@ -231,8 +230,7 @@ public class DeconstructSpeckleParam : GH_Component, IGH_VariableParameterCompon
           GeometryBase = null,
           Name = @base[Constants.NAME_PROP] as string ?? "",
           Color = null,
-          Material = null,
-          WrapperGuid = null,
+          Material = null
         };
       return new() { new SpeckleObjectWrapperGoo(convertedWrapper) };
     }

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Objects/CreateSpeckleBlockInstance.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Objects/CreateSpeckleBlockInstance.cs
@@ -122,7 +122,7 @@ public class CreateSpeckleBlockInstance : GH_Component
 
     if (inputInstance?.Value != null)
     {
-      result = inputInstance.Value.DeepCopy();
+      result = (SpeckleBlockInstanceWrapper)inputInstance.Value.DeepCopy();
     }
     else
     {

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Objects/CreateSpeckleBlockInstance.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Objects/CreateSpeckleBlockInstance.cs
@@ -1,9 +1,12 @@
 using System.Runtime.InteropServices;
 using Grasshopper.Kernel;
 using Grasshopper.Kernel.Types;
+using Rhino;
 using Rhino.Geometry;
+using Speckle.Connectors.GrasshopperShared.HostApp;
 using Speckle.Connectors.GrasshopperShared.Parameters;
 using Speckle.Connectors.GrasshopperShared.Properties;
+using Speckle.Sdk.Models.Instances;
 
 namespace Speckle.Connectors.GrasshopperShared.Components.Objects;
 
@@ -126,7 +129,24 @@ public class CreateSpeckleBlockInstance : GH_Component
     }
     else
     {
-      result = new SpeckleBlockInstanceWrapper { Name = "Block Instance", ApplicationId = Guid.NewGuid().ToString() };
+      // TODO: this is gross. we need a better factory pattern. below is repeated twice in SpeckleBlockInstanceWrapper.cs
+      var units = RhinoDoc.ActiveDoc?.ModelUnitSystem.ToSpeckleString() ?? "none";
+      var newAppId = Guid.NewGuid().ToString();
+
+      result = new SpeckleBlockInstanceWrapper
+      {
+        Base = new InstanceProxy
+        {
+          definitionId = "placeholder",
+          maxDepth = 1,
+          transform = GrasshopperHelpers.TransformToMatrix(Transform.Identity, units),
+          units = units,
+          applicationId = newAppId
+        },
+        GeometryBase = null,
+        Name = "Block Instance",
+        ApplicationId = newAppId
+      };
       mutated = true;
     }
 

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Objects/CreateSpeckleObject.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Objects/CreateSpeckleObject.cs
@@ -210,7 +210,7 @@ public class CreateSpeckleObject : GH_Component
       {
         AddRuntimeMessage(
           GH_RuntimeMessageLevel.Warning,
-          $"Material input is not valid. Only Display Materials, Baked Model Materials, and Speckle Materials are accepted."
+          "Material input is not valid. Only Display Materials, Baked Model Materials, and Speckle Materials are accepted."
         );
         return;
       }

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Objects/GetCollectionObjects.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Objects/GetCollectionObjects.cs
@@ -102,7 +102,7 @@ public class GetCollectionObjects : GH_Component
 
   private IEnumerable<SpeckleObjectWrapper> GetAllObjectsFromCollection(SpeckleCollectionWrapper collectionWrapper)
   {
-    foreach (SpeckleWrapper element in collectionWrapper.Elements)
+    foreach (SpeckleWrapper element in collectionWrapper.Elements.Cast<SpeckleWrapper>())
     {
       switch (element)
       {

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Objects/GetCollectionObjects.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Objects/GetCollectionObjects.cs
@@ -102,7 +102,7 @@ public class GetCollectionObjects : GH_Component
 
   private IEnumerable<SpeckleObjectWrapper> GetAllObjectsFromCollection(SpeckleCollectionWrapper collectionWrapper)
   {
-    foreach (SpeckleWrapper element in collectionWrapper.Elements.Cast<SpeckleWrapper>())
+    foreach (ISpeckleCollectionObject element in collectionWrapper.Elements)
     {
       switch (element)
       {
@@ -112,6 +112,8 @@ public class GetCollectionObjects : GH_Component
             yield return item;
           }
           break;
+
+        // This includes SpeckleBlockInstanceWrapper since it inherits from SpeckleObjectWrapper
         case SpeckleObjectWrapper objectWrapper:
           yield return objectWrapper;
           break;

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/HostApp/Helpers.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/HostApp/Helpers.cs
@@ -3,7 +3,6 @@ using Grasshopper.Kernel;
 using Grasshopper.Kernel.Data;
 using Grasshopper.Kernel.Types;
 using Rhino;
-using Rhino.DocObjects;
 using Rhino.Geometry;
 using Speckle.Connectors.GrasshopperShared.Parameters;
 using Speckle.DoubleNumerics;
@@ -212,45 +211,5 @@ public static class GrasshopperHelpers
       topology += myPath.ToString(false) + "-" + param.VolatileData.get_Branch(myPath).Count + " ";
     }
     return topology;
-  }
-}
-
-public static class BakingHelpers
-{
-  public static ObjectAttributes CreateObjectAttributes(
-    string name,
-    Color? color = null,
-    SpeckleMaterialWrapper? material = null,
-    SpecklePropertyGroupGoo? properties = null,
-    int layerIndex = -1
-  )
-  {
-    var attributes = new ObjectAttributes { Name = name };
-
-    if (layerIndex >= 0)
-    {
-      attributes.LayerIndex = layerIndex;
-    }
-
-    if (color is Color validColor)
-    {
-      attributes.ObjectColor = validColor;
-      attributes.ColorSource = ObjectColorSource.ColorFromObject;
-    }
-
-    if (material is SpeckleMaterialWrapper materialWrapper)
-    {
-      int matIndex = materialWrapper.Bake(RhinoDoc.ActiveDoc, materialWrapper.Name);
-      if (matIndex >= 0)
-      {
-        attributes.MaterialIndex = matIndex;
-        attributes.MaterialSource = ObjectMaterialSource.MaterialFromObject;
-      }
-    }
-
-    // add props
-    properties?.AssignToObjectAttributes(attributes);
-
-    return attributes;
   }
 }

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Operations/Receive/LocalToGlobalMapHandler.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Operations/Receive/LocalToGlobalMapHandler.cs
@@ -104,7 +104,6 @@ internal sealed class LocalToGlobalMapHandler
           Name = name,
           Color = null,
           Material = null,
-          WrapperGuid = map.AtomicObject.applicationId,
           ApplicationId = original.applicationId ?? Guid.NewGuid().ToString() // create if none
         };
 

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Operations/Send/GrasshopperSendOperation.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Operations/Send/GrasshopperSendOperation.cs
@@ -66,53 +66,57 @@ public class GrasshopperRootObjectBuilder : IRootObjectBuilder<SpeckleCollection
 
     // iterate through this wrapper's elements to unwrap children
     // HashSet<string> collObjectIds = new();
-    foreach (SpeckleWrapper wrapperElement in wrapper.Elements.Cast<SpeckleWrapper>())
+    foreach (ISpeckleCollectionObject element in wrapper.Elements)
     {
-      if (wrapperElement is SpeckleCollectionWrapper collWrapper)
+      switch (element)
       {
-        // create an application id for this collection if none exists. This will be used for color and render material proxies
-        collWrapper.ApplicationId ??= collWrapper.GetSpeckleApplicationId();
+        case SpeckleCollectionWrapper collWrapper:
+          // create an application id for this collection if none exists. This will be used for color and render material proxies
+          collWrapper.ApplicationId ??= collWrapper.GetSpeckleApplicationId();
 
-        // add to collection and continue unwrap
-        currentColl.elements.Add(collWrapper.Collection);
-        Unwrap(collWrapper, colorPacker, materialPacker, blockPacker);
-      }
-      // NOTE: order is super important since SpeckleBlockInstanceWrapper inherits from SpeckleObjectWrapper
-      // this is fragile and not nice.
-      else if (wrapperElement is SpeckleBlockInstanceWrapper bi)
-      {
-        // process block instances - they get added to collection as DataObject
-        Base blockInstanceBase = ConvertWrapperToBase(bi);
-        currentColl.elements.Add(blockInstanceBase);
+          // add to collection and continue unwrap
+          currentColl.elements.Add(collWrapper.Collection);
+          Unwrap(collWrapper, colorPacker, materialPacker, blockPacker);
+          break;
 
-        // process block for definition collection and get defining objects
-        var definitionObjects = blockPacker.ProcessInstance(bi);
+        // NOTE: order is super important since SpeckleBlockInstanceWrapper inherits from SpeckleObjectWrapper
+        // this is fragile and not nice.
+        case SpeckleBlockInstanceWrapper bi:
+          // process block instances - they get added to collection as DataObject
+          Base blockInstanceBase = ConvertWrapperToBase(bi);
+          currentColl.elements.Add(blockInstanceBase);
 
-        if (definitionObjects != null)
-        {
-          foreach (var definitionObject in definitionObjects)
+          // process block for definition collection and get defining objects
+          var definitionObjects = blockPacker.ProcessInstance(bi);
+
+          if (definitionObjects != null)
           {
-            Base defObjectBase = ConvertWrapperToBase(definitionObject);
+            foreach (var definitionObject in definitionObjects)
+            {
+              Base defObjectBase = ConvertWrapperToBase(definitionObject);
 
-            // just add to current collection
-            // TODO: where on collection?
-            currentColl.elements.Add(defObjectBase);
+              // just add to current collection
+              // TODO: where on collection?
+              currentColl.elements.Add(defObjectBase);
 
-            colorPacker.ProcessColor(definitionObject.ApplicationId, definitionObject.Color);
-            materialPacker.ProcessMaterial(definitionObject.ApplicationId, definitionObject.Material);
+              colorPacker.ProcessColor(definitionObject.ApplicationId, definitionObject.Color);
+              materialPacker.ProcessMaterial(definitionObject.ApplicationId, definitionObject.Material);
+            }
           }
-        }
-      }
-      else if (wrapperElement is SpeckleObjectWrapper so)
-      {
-        // process the object first. This may result in application id mutations, so this must be done before processing color and materials.
-        //ProcessObjectWrapper(so, ref collObjectIds);
-        Base objectBase = ConvertWrapperToBase(so);
-        currentColl.elements.Add(objectBase);
 
-        // unpack color and render material
-        colorPacker.ProcessColor(so.ApplicationId, so.Color);
-        materialPacker.ProcessMaterial(so.ApplicationId, so.Material);
+          break;
+
+        case SpeckleObjectWrapper so:
+          // process the object first. This may result in application id mutations, so this must be done before processing color and materials.
+          //ProcessObjectWrapper(so, ref collObjectIds);
+          Base objectBase = ConvertWrapperToBase(so);
+          currentColl.elements.Add(objectBase);
+
+          // unpack color and render material
+          colorPacker.ProcessColor(so.ApplicationId, so.Color);
+          materialPacker.ProcessMaterial(so.ApplicationId, so.Material);
+
+          break;
       }
     }
 

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/Interfaces.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/Interfaces.cs
@@ -6,3 +6,10 @@ namespace Speckle.Connectors.GrasshopperShared.Parameters;
   Justification = "Needed to identify acceptable values of properties without multiple inheritance"
 )]
 public interface ISpecklePropertyGoo { }
+
+[System.Diagnostics.CodeAnalysis.SuppressMessage(
+  "Design",
+  "CA1040:Avoid empty interfaces",
+  Justification = "Needed to identify acceptable values of objects in collections"
+)]
+public interface ISpeckleCollectionObject { }

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/SpeckleBlockDefinitionWrapper.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/SpeckleBlockDefinitionWrapper.cs
@@ -5,7 +5,6 @@ using Rhino.Display;
 using Rhino.DocObjects;
 using Rhino.Geometry;
 using Speckle.Connectors.GrasshopperShared.Components;
-using Speckle.Connectors.GrasshopperShared.HostApp;
 using Speckle.Connectors.GrasshopperShared.Properties;
 using Speckle.Sdk.Models;
 using Speckle.Sdk.Models.Instances;
@@ -46,9 +45,7 @@ public class SpeckleBlockDefinitionWrapper : SpeckleWrapper
 
   private static void ValidateObjects(List<SpeckleObjectWrapper> objects)
   {
-    var invalidObjects = objects
-      .Where(o => o.GetType() != typeof(SpeckleObjectWrapper) && o.GetType() != typeof(SpeckleBlockInstanceWrapper))
-      .ToList(); // Materialize the enumerable once
+    var invalidObjects = objects.Where(o => o.GetType() != typeof(SpeckleObjectWrapper)).ToList();
 
     if (invalidObjects.Count > 0)
     {
@@ -101,7 +98,7 @@ public class SpeckleBlockDefinitionWrapper : SpeckleWrapper
       if (obj.GeometryBase != null)
       {
         geometries.Add(obj.GeometryBase);
-        attributes.Add(BakingHelpers.CreateObjectAttributes(obj.Name, obj.Color, obj.Material, obj.Properties));
+        attributes.Add(obj.CreateObjectAttributes(bakeMaterial: true));
       }
     }
 

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/SpeckleBlockInstanceWrapper.ModelObjects.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/SpeckleBlockInstanceWrapper.ModelObjects.cs
@@ -80,7 +80,8 @@ public partial class SpeckleBlockInstanceWrapperGoo
         applicationId = Guid.NewGuid().ToString()
       },
       Transform = Transform.Identity,
-      ApplicationId = Guid.NewGuid().ToString()
+      ApplicationId = Guid.NewGuid().ToString(),
+      GeometryBase = null
     };
     return true;
   }
@@ -182,7 +183,7 @@ public partial class SpeckleBlockInstanceWrapperGoo
 
     Value = new SpeckleBlockInstanceWrapper()
     {
-      InstanceProxy = new InstanceProxy()
+      Base = new InstanceProxy()
       {
         definitionId = definitionId.ToString(),
         maxDepth = 1,
@@ -192,7 +193,8 @@ public partial class SpeckleBlockInstanceWrapperGoo
       },
       Transform = instanceRef.Xform,
       ApplicationId = Guid.NewGuid().ToString(),
-      Definition = definition // May be null in pure Grasshopper workflows
+      Definition = definition, // May be null in pure Grasshopper workflows
+      GeometryBase = null
     };
     return true;
   }

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/SpeckleBlockInstanceWrapper.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/SpeckleBlockInstanceWrapper.cs
@@ -158,6 +158,8 @@ public class SpeckleBlockInstanceWrapper : SpeckleObjectWrapper, ISpeckleCollect
       Transform = _transform // block instance specific
     };
 
+  public override IGH_Goo CreateGoo() => new SpeckleBlockInstanceWrapperGoo(this);
+
   private void UpdateTransformFromProxy()
   {
     var units = _instanceProxy.units;

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/SpeckleBlockInstanceWrapper.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/SpeckleBlockInstanceWrapper.cs
@@ -145,7 +145,7 @@ public class SpeckleBlockInstanceWrapper : SpeckleObjectWrapper, ISpeckleCollect
     new SpeckleBlockInstanceWrapper // covariant return types to satisfy inheritance chain
     {
       Base = InstanceProxy.ShallowCopy(),
-      GeometryBase = null, // safe default. GeometryBase is null for instances?
+      GeometryBase = null, // We need this GeometryBase property on instances. It corresponds to an InstanceReferenceGeometry object that inherits from GeometryBase in rhinocommon
       Color = null, // TODO: commented out in props
       Material = null, // TODO: commented out in props
       WrapperGuid = WrapperGuid,

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/SpeckleCollectionWrapper.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/SpeckleCollectionWrapper.cs
@@ -21,7 +21,7 @@ namespace Speckle.Connectors.GrasshopperShared.Parameters;
 /// This is because changing the Name or ApplicationId will update Collection.
 /// </remarks>
 #pragma warning disable CA1711 // Identifiers should not have incorrect suffix
-public class SpeckleCollectionWrapper : SpeckleWrapper
+public class SpeckleCollectionWrapper : SpeckleWrapper, ISpeckleCollectionObject
 #pragma warning restore CA1711 // Identifiers should not have incorrect suffix
 {
   public override required Base Base
@@ -56,7 +56,7 @@ public class SpeckleCollectionWrapper : SpeckleWrapper
     }
   }
 
-  public List<SpeckleWrapper> Elements { get; set; } = new();
+  public List<ISpeckleCollectionObject> Elements { get; set; } = new();
 
   /// <summary>
   /// The Grasshopper Topology of this collection. This setter also sets the "topology" prop dynamically on <see cref="Collection"/>
@@ -99,10 +99,6 @@ public class SpeckleCollectionWrapper : SpeckleWrapper
           o.Path = newPath;
           o.Parent = this;
           break;
-        case SpeckleBlockInstanceWrapper bi:
-          bi.Path = newPath;
-          bi.Parent = this;
-          break;
         case SpeckleCollectionWrapper c:
           // don't forget to add the child collection name to the path
           var childPath = newPath.ToList();
@@ -129,7 +125,6 @@ public class SpeckleCollectionWrapper : SpeckleWrapper
           {
             SpeckleCollectionWrapper c => c.DeepCopy(),
             SpeckleObjectWrapper o => o.DeepCopy(),
-            SpeckleBlockInstanceWrapper bi => bi.DeepCopy(),
             _ => e
           }
         )
@@ -173,13 +168,6 @@ public class SpeckleCollectionWrapper : SpeckleWrapper
       else if (obj is SpeckleCollectionWrapper c)
       {
         c.Bake(doc, obj_ids, bakeObjects, currentLayerIndex);
-      }
-      else if (obj is SpeckleBlockInstanceWrapper bi)
-      {
-        if (bakeObjects)
-        {
-          bi.Bake(doc, obj_ids, currentLayerIndex);
-        }
       }
     }
 

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/SpeckleObjectWrapper.ModelObjects.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/SpeckleObjectWrapper.ModelObjects.cs
@@ -63,8 +63,7 @@ public partial class SpeckleObjectWrapperGoo : GH_Goo<SpeckleObjectWrapper>, IGH
               Name = modelObject.Name.ToString(),
               Color = color,
               Material = materialWrapper.Value,
-              Properties = propertyGroup,
-              WrapperGuid = null // keep this null, processed on send
+              Properties = propertyGroup
             };
 
           Value = so;

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/SpeckleObjectWrapper.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/SpeckleObjectWrapper.cs
@@ -214,6 +214,8 @@ public class SpeckleObjectWrapper : SpeckleWrapper, ISpeckleCollectionObject
     return attributes;
   }
 
+  public virtual IGH_Goo CreateGoo() => new SpeckleObjectWrapperGoo(this);
+
   protected virtual void AddPropertiesToAttributes(ObjectAttributes attributes) =>
     Properties?.AssignToObjectAttributes(attributes);
 

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/SpeckleObjectWrapper.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/SpeckleObjectWrapper.cs
@@ -16,7 +16,7 @@ namespace Speckle.Connectors.GrasshopperShared.Parameters;
 /// </summary>
 public class SpeckleObjectWrapper : SpeckleWrapper, ISpeckleCollectionObject
 {
-  public override Base Base { get; set; }
+  public override required Base Base { get; set; }
 
   /// <summary>
   /// The GeometryBase corresponding to the <see cref="SpeckleWrapper.Base"/>
@@ -25,7 +25,7 @@ public class SpeckleObjectWrapper : SpeckleWrapper, ISpeckleCollectionObject
   /// POC: how will we send intervals and other gh native objects? do we? maybe not for now?
   /// Objects using fallback conversion (eg DataObjects) will create one wrapper per geometry in the display value.
   /// </remarks>
-  public GeometryBase? GeometryBase { get; set; }
+  public required GeometryBase? GeometryBase { get; set; }
 
   // The list of layer/collection names that forms the full path to this object
   public List<string> Path { get; set; } = new();
@@ -41,12 +41,6 @@ public class SpeckleObjectWrapper : SpeckleWrapper, ISpeckleCollectionObject
   /// The material of the <see cref="Base"/>
   /// </summary>
   public SpeckleMaterialWrapper? Material { get; set; }
-
-  /// <summary>
-  /// Represents the guid of this <see cref="SpeckleObjectWrapper"/>
-  /// </summary>
-  /// <remarks>This property will usually be assigned in create components, or in publish components, and may differ from <see cref="Base.applicationId"/></remarks>
-  public string? WrapperGuid { get; set; }
 
   public override string ToString() => $"Speckle Wrapper [{GeometryBase?.GetType().Name}]";
 
@@ -190,7 +184,6 @@ public class SpeckleObjectWrapper : SpeckleWrapper, ISpeckleCollectionObject
       GeometryBase = GeometryBase?.Duplicate(),
       Color = Color,
       Material = Material,
-      WrapperGuid = WrapperGuid,
       ApplicationId = ApplicationId,
       Parent = Parent,
       Properties = Properties,
@@ -291,7 +284,6 @@ public partial class SpeckleObjectWrapperGoo : GH_Goo<SpeckleObjectWrapper>, IGH
           Name = "",
           Color = null,
           Material = null,
-          WrapperGuid = null,
           ApplicationId = Guid.NewGuid().ToString()
         };
         return true;
@@ -451,6 +443,7 @@ public partial class SpeckleObjectWrapperGoo : GH_Goo<SpeckleObjectWrapper>, IGH
     Value = value;
   }
 
+  // NOTE: parameterless constructor should only be used for casting
   public SpeckleObjectWrapperGoo()
   {
     Value = new()
@@ -459,7 +452,6 @@ public partial class SpeckleObjectWrapperGoo : GH_Goo<SpeckleObjectWrapper>, IGH
       GeometryBase = null,
       Color = null,
       Material = null,
-      WrapperGuid = null,
     };
   }
 }


### PR DESCRIPTION
## Description
Refactored inheritance hierarchy to make `SpeckleBlockInstanceWrapper` inherit from `SpeckleObjectWrapper` instead of directly from `SpeckleWrapper`. This removes the need for the `BakingHelpers` static class and simplifies (hopefully) the logic in the collections, validations etc.

## User Value
Fun time in gh.

## Changes:
- Changed `SpeckleBlockInstanceWrapper` to inherit from `SpeckleObjectWrapper`
- Before and after sketched out [here](https://excalidraw.com/#json=w--IltBklb_l_esrtXYtD,Pb2JBi8PwoTBFjaI5uUuew)
- Added `CreateObjectAttributes()` method to `SpeckleObjectWrapper` with virtual material handling
- Removed `BakingHelpers.CreateObjectAttributes()` static method
- Updated all `Bake()` methods to use the new approach
- Made `Bake()` and `DeepCopy()` methods virtual in `SpeckleObjectWrapper` with proper overrides in `SpeckleBlockInstanceWrapper`
- Removed `required` keyword from nullable properties to fix object initialization issues
- Updated type checking order in `GrasshopperSendOperation.Unwrap()` to check derived types before base types

## To-do before merge:

- [x] Discuss current implementation and inheritance strategy. Seems to be a constant tradeoff. What's the best approach (cc: @adamhathcock)

## Validation of changes:
No breaking changes from previous working branch prs.

## Checklist:
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.

