### PR TITLE
fix (grasshopper): `InheritNames` to resolve and reflect on `OutputParams`

### DIFF
--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/SpeckleVariableParam.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/SpeckleVariableParam.cs
@@ -112,6 +112,12 @@ public class SpeckleVariableParam : Param_GenericObject
 
         // Tell the parent component its layout needs to be recalculated
         Attributes.Parent?.ExpireLayout();
+
+        // Expire solution when name changes to refresh downstream components
+        if (AlwaysInheritNames)
+        {
+          ExpireSolution(true);
+        }
       }
       finally
       {
@@ -167,6 +173,12 @@ public class SpeckleVariableParam : Param_GenericObject
         if (AlwaysInheritNames && !_isUpdatingName) // Double-check in case it changed
         {
           TryInheritName();
+
+          // downstream components to be refreshed when source names change
+          if (OnPingDocument() != null)
+          {
+            OnPingDocument().ScheduleSolution(5, _ => ExpireSolution(true));
+          }
         }
       });
     }

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/SpeckleVariableParam.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/SpeckleVariableParam.cs
@@ -175,10 +175,7 @@ public class SpeckleVariableParam : Param_GenericObject
           TryInheritName();
 
           // downstream components to be refreshed when source names change
-          if (OnPingDocument() != null)
-          {
-            OnPingDocument().ScheduleSolution(5, _ => ExpireSolution(true));
-          }
+          OnPingDocument()?.ScheduleSolution(5, _ => ExpireSolution(true));
         }
       });
     }


### PR DESCRIPTION
## Description

- Downstream components not updating when property names change with "Always inherit names" enabled
- When `AlwaysInheritNames` is on and a source params name changes, the param correctly inherits new name but it doesn't trigger necessary events to refresh downstream components
- Fixes [CNX-1998](https://linear.app/speckle/issue/CNX-1998/fix-inheritnames-to-resolve-and-reflect-on-outputparams)

## User Value

Current and correct names on all referencing components.

## Changes:

Expiring solution on name changes.

## Validation of changes:

### Before

https://github.com/user-attachments/assets/0098a39b-3916-44d6-98d4-21d93cff2377

### After

https://github.com/user-attachments/assets/d20a551e-c8cc-42d7-9282-61b39409c7c8


## Checklist:

- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] I have added appropriate tests.
- [x] I have updated or added relevant documentation.

