### PR TITLE
(fix) Rhino: add more null protection

### DIFF
--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/Extensions/AttributeExtensions.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/Extensions/AttributeExtensions.cs
@@ -19,8 +19,8 @@ public static class SpeckleAttributeExtensions
     ObjectAttributes atts = new() { Name = name };
     Dictionary<string, string> userStrings = new();
     Dictionary<string, object?> properties = @base is DataObject dataObj
-      ? dataObj.properties
-      : @base["properties"] as Dictionary<string, object?> ?? new();
+      ? dataObj.properties ?? []
+      : @base["properties"] as Dictionary<string, object?> ?? [];
     FlattenDictionaryToUserStrings(properties, userStrings, "");
     foreach (var kvp in userStrings)
     {
@@ -40,7 +40,7 @@ public static class SpeckleAttributeExtensions
   private static void FlattenDictionaryToUserStrings(
     Dictionary<string, object?> dict,
     Dictionary<string, string> flattenedDict,
-    string keyPrefix = ""
+    string keyPrefix
   )
   {
     foreach (var kvp in dict)


### PR DESCRIPTION
Trying to avoid these null issues as properties could be null
![image](https://github.com/user-attachments/assets/452ada61-73bb-4e40-9a75-787cf62fe3db)
