### PR TITLE
feat(Navisworks): CNX-2009 - Adds saved views filter to Navisworks send operations

### DIFF
--- a/Connectors/Navisworks/Speckle.Connectors.NavisworksShared/Bindings/NavisworksSendBinding.cs
+++ b/Connectors/Navisworks/Speckle.Connectors.NavisworksShared/Bindings/NavisworksSendBinding.cs
@@ -66,7 +66,8 @@ public class NavisworksSendBinding : ISendBinding
   public List<ISendFilter> GetSendFilters() =>
     [
       new NavisworksSelectionFilter() { IsDefault = true },
-      new NavisworksSavedSetsFilter(new ElementSelectionService())
+      new NavisworksSavedSetsFilter(new ElementSelectionService()),
+      new NavisworksSavedViewsFilter(new ElementSelectionService())
     ];
 
   public List<ICardSetting> GetSendSettings() =>

--- a/Connectors/Navisworks/Speckle.Connectors.NavisworksShared/DependencyInjection/NavisworksConnectorServiceRegistration.cs
+++ b/Connectors/Navisworks/Speckle.Connectors.NavisworksShared/DependencyInjection/NavisworksConnectorServiceRegistration.cs
@@ -68,6 +68,7 @@ public static class NavisworksConnectorServiceRegistration
     // register filters
     serviceCollection.AddScoped<ISendFilter, NavisworksSelectionFilter>();
     serviceCollection.AddScoped<ISendFilter, NavisworksSavedSetsFilter>();
+    serviceCollection.AddScoped<ISendFilter, NavisworksSavedViewsFilter>();
     serviceCollection.AddScoped<IElementSelectionService, ElementSelectionService>();
   }
 }

--- a/Connectors/Navisworks/Speckle.Connectors.NavisworksShared/Operations/Send/Filters/NavisworksSavedSetsFilter.cs
+++ b/Connectors/Navisworks/Speckle.Connectors.NavisworksShared/Operations/Send/Filters/NavisworksSavedSetsFilter.cs
@@ -2,7 +2,6 @@
 using Speckle.Connectors.DUI.Exceptions;
 using Speckle.Connectors.DUI.Models.Card.SendFilter;
 using Speckle.Connectors.DUI.Utils;
-using Speckle.Converter.Navisworks.Constants;
 
 namespace Speckle.Connector.Navisworks.Operations.Send.Filters;
 
@@ -85,12 +84,14 @@ public class NavisworksSavedSetsFilter : DiscriminatedObject, ISendFilterSelect
   {
     List<NAV.SelectionSet> savedSetRecords = [];
 
-    CollectSavedSets(NavisworksApp.ActiveDocument.SelectionSets.RootItem, savedSetRecords);
+    var root = NavisworksApp.ActiveDocument.SelectionSets.RootItem;
+
+    CollectSavedSets(root, savedSetRecords);
 
     Items = savedSetRecords
       .Select(setRecord =>
       {
-        string hierarchicalName = BuildHierarchicalName(setRecord);
+        string hierarchicalName = SavedItemHelpers.BuildHierarchicalName(setRecord, root);
         return new SendFilterSelectItem(setRecord.Guid.ToString(), hierarchicalName);
       })
       .ToList();
@@ -103,7 +104,7 @@ public class NavisworksSavedSetsFilter : DiscriminatedObject, ISendFilterSelect
       return;
     }
 
-    foreach (NAV.SavedItem item in ((NAV.FolderItem)parentItem).Children)
+    foreach (NAV.SavedItem item in ((NAV.GroupItem)parentItem).Children)
     {
       if (item.IsGroup)
       {
@@ -114,19 +115,5 @@ public class NavisworksSavedSetsFilter : DiscriminatedObject, ISendFilterSelect
         collectedSets.Add((NAV.SelectionSet)item);
       }
     }
-  }
-
-  private static string BuildHierarchicalName(NAV.SavedItem item)
-  {
-    var pathParts = new List<string> { item.DisplayName };
-
-    var current = item.Parent;
-    while (current != null && current != NavisworksApp.ActiveDocument.SelectionSets.RootItem)
-    {
-      pathParts.Insert(0, current.DisplayName);
-      current = current.Parent;
-    }
-
-    return string.Join(PathConstants.SET_SEPARATOR, pathParts);
   }
 }

--- a/Connectors/Navisworks/Speckle.Connectors.NavisworksShared/Operations/Send/Filters/NavisworksSavedViewsFilter.cs
+++ b/Connectors/Navisworks/Speckle.Connectors.NavisworksShared/Operations/Send/Filters/NavisworksSavedViewsFilter.cs
@@ -1,0 +1,173 @@
+﻿using Speckle.Connector.Navisworks.Services;
+using Speckle.Connectors.DUI.Exceptions;
+using Speckle.Connectors.DUI.Models.Card.SendFilter;
+using Speckle.Connectors.DUI.Utils;
+
+namespace Speckle.Connector.Navisworks.Operations.Send.Filters;
+
+public class NavisworksSavedViewsFilter : DiscriminatedObject, ISendFilterSelect
+{
+  private readonly IElementSelectionService _selectionService;
+
+  public NavisworksSavedViewsFilter(IElementSelectionService selectionService)
+  {
+    _selectionService = selectionService;
+
+    Items = [];
+    SelectedItems = [];
+
+    GetSavedViews();
+  }
+
+  public string Id { get; set; } = "navisworksSavedViews";
+
+  public string Name { get; set; } = "Saved Views";
+
+  public string Type { get; set; } = "Select";
+
+  public string? Summary { get; set; }
+
+  public bool IsDefault { get; set; }
+
+  public List<string> SelectedObjectIds { get; set; } = [];
+
+  public Dictionary<string, string>? IdMap { get; set; }
+
+  public bool IsMultiSelectable { get; set; }
+
+  public List<SendFilterSelectItem> SelectedItems { get; set; }
+
+  public List<SendFilterSelectItem> Items { get; set; }
+
+  public List<string> RefreshObjectIds()
+  {
+    List<string> objectIds = [];
+
+    if (SelectedItems.Count == 0)
+    {
+      return objectIds;
+    }
+
+    var savedViews = NavisworksApp.ActiveDocument.SavedViewpoints;
+
+    foreach (var savedViewItem in SelectedItems.Select(item => ResolveSavedView(item.Id)))
+    {
+      // Get the visible elements in the saved view.
+      objectIds.AddRange(ResolvedSavedViewObjects(savedViewItem));
+    }
+
+    return objectIds;
+  }
+
+  private static NAV.SavedViewpoint ResolveSavedView(string savedViewReference)
+  {
+    if (Guid.TryParse(savedViewReference, out var guid))
+    {
+      // Even though we may have already got a match, that could be to a generic Guid from earlier versions of Navisworks
+      if (savedViewReference != Guid.Empty.ToString())
+      {
+        return (NAV.SavedViewpoint)NavisworksApp.ActiveDocument.SavedViewpoints.ResolveGuid(guid);
+      }
+    }
+
+    var savedRef = new NAV.SavedItemReference("LcOpSavedViewsElement", savedViewReference);
+
+    var resolvedReference = NavisworksApp.ActiveDocument.ResolveReference(savedRef) as NAV.SavedViewpoint;
+
+    return resolvedReference
+      ?? throw new SpeckleSendFilterException($"Saved view with reference {savedViewReference} not found.");
+  }
+
+  private IEnumerable<string> ResolvedSavedViewObjects(NAV.SavedViewpoint savedView)
+  {
+    var objectIds = new List<string>();
+
+    // THIS IS COMMENTED OUT AS IT IS LEGACY DEFENSIVE BEHAVIOUR - DISCUSSION REQUIRED
+    // if (!savedView.ContainsVisibilityOverrides)
+    // {
+    //   // We check this again as the view settings may have changed in the saved card.
+    //   // If the saved view does not contain visibility overrides, this is effectively everything in the model.
+    //   // This will need to be the documented behaviour.
+    //   throw new SpeckleSendFilterException(
+    //     "Saved view does not contain visibility overrides. This would effectively publish everything in the model."
+    //   );
+    // }
+
+    NavisworksApp.ActiveDocument.SavedViewpoints.CurrentSavedViewpoint = savedView;
+    var models = NavisworksApp.ActiveDocument.Models;
+    NavisworksApp.ActiveDocument.CurrentSelection.Clear();
+
+    foreach (var model in models)
+    {
+      var rootItem = model.RootItem;
+
+      if (!_selectionService.IsVisible(rootItem))
+      {
+        // If the root item is hidden, we skip it and its descendants.
+        continue;
+      }
+
+      objectIds.AddRange(
+        rootItem.Descendants.Where(_selectionService.IsVisible).Select(_selectionService.GetModelItemPath).ToList()
+      );
+    }
+
+    return objectIds;
+  }
+
+  /// <summary>
+  /// Since it is called from constructor, it is re-called whenever UI calls SendBinding.GetSendFilters() on SendFilter dialog.
+  /// Do not change the behavior/scope of this class on send binding unless make sure the behavior is same. Otherwise, we might not be able to update list of saved sets.
+  /// </summary>
+  private void GetSavedViews()
+  {
+    List<NAV.SavedViewpoint> savedViewRecords = [];
+
+    var root = NavisworksApp.ActiveDocument.SavedViewpoints.RootItem;
+
+    CollectSavedViews(root, savedViewRecords);
+
+    Items = savedViewRecords
+      .Select(viewRecord =>
+      {
+        var reference = NavisworksApp.ActiveDocument.SavedViewpoints.CreateReference(viewRecord);
+
+        // If the guid is effectively empty, we can use the saved view's name as a fallback
+        var selectItemId =
+          viewRecord.Guid.ToString() == Guid.Empty.ToString() ? reference.SavedItemId : viewRecord.Guid.ToString();
+        string hierarchicalName = SavedItemHelpers.BuildHierarchicalName(viewRecord, root);
+
+        return new SendFilterSelectItem(selectItemId, hierarchicalName);
+      })
+      .ToList();
+  }
+
+  private static void CollectSavedViews(NAV.SavedItem parentItem, List<NAV.SavedViewpoint> collectedSets)
+  {
+    if (!parentItem.IsGroup)
+    {
+      return;
+    }
+
+    foreach (NAV.SavedItem item in ((NAV.GroupItem)parentItem).Children)
+    {
+      switch (item.IsGroup)
+      {
+        // THIS IS COMMENTED OUT AS IT IS LEGACY DEFENSIVE BEHAVIOUR - DISCUSSION REQUIRED
+        // case false when item is NAV.SavedViewpoint { ContainsVisibilityOverrides: false }:
+        //   // If the saved view does not contain visibility overrides, this is effectively everything in the model.
+        //   // This will need to be the documented behaviour.
+        //   break;
+        case false:
+          collectedSets.Add((NAV.SavedViewpoint)item);
+          break;
+        default: // handles item.IsGroup == true
+          if (((NAV.GroupItem)item).Children.Count > 0) // Don't add empty groups
+          {
+            CollectSavedViews(item, collectedSets);
+          }
+          break;
+      }
+    }
+  }
+}

--- a/Connectors/Navisworks/Speckle.Connectors.NavisworksShared/Operations/Send/Filters/SavedItemHelpers.cs
+++ b/Connectors/Navisworks/Speckle.Connectors.NavisworksShared/Operations/Send/Filters/SavedItemHelpers.cs
@@ -1,0 +1,20 @@
+﻿using Speckle.Converter.Navisworks.Constants;
+
+namespace Speckle.Connector.Navisworks.Operations.Send.Filters;
+
+public static class SavedItemHelpers
+{
+  internal static string BuildHierarchicalName(NAV.SavedItem item, NAV.FolderItem? root)
+  {
+    var pathParts = new List<string> { item.DisplayName };
+
+    var current = item.Parent;
+    while (current != null && current != root)
+    {
+      pathParts.Insert(0, current.DisplayName);
+      current = current.Parent;
+    }
+
+    return string.Join(PathConstants.SET_SEPARATOR, pathParts);
+  }
+}

--- a/Connectors/Navisworks/Speckle.Connectors.NavisworksShared/Speckle.Connectors.NavisworksShared.projitems
+++ b/Connectors/Navisworks/Speckle.Connectors.NavisworksShared/Speckle.Connectors.NavisworksShared.projitems
@@ -20,6 +20,8 @@
     <Compile Include="$(MSBuildThisFileDirectory)HostApp\NavisworksDocumentModelStore.cs"/>
     <Compile Include="$(MSBuildThisFileDirectory)HostApp\NavisworksIdleManager.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HostApp\NavisworksMaterialUnpacker.cs"/>
+    <Compile Include="$(MSBuildThisFileDirectory)Operations\Send\Filters\NavisworksSavedViewsFilter.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Operations\Send\Filters\SavedItemHelpers.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Operations\Send\GeometryNodeMerger.cs"/>
     <Compile Include="$(MSBuildThisFileDirectory)Operations\Send\NavisworksHierarchyBuilder.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Operations\Send\NavisworksRootObjectBuilder.cs"/>


### PR DESCRIPTION
Introduces a new filter for selecting saved views during send operations in the Navisworks connector, enabling users to send only visible elements from saved views. Working with saved views to curate data exchanges is the second most common interaction users perform with Navisworks after Saved Sets, which is already implemented.

![image](https://github.com/user-attachments/assets/3a73a25c-809f-466c-8674-5f6333d98dfc)

It doesn't, at this time, add the selected viewpoint to Canonical views. I don't think other connectors do either??

![image](https://github.com/user-attachments/assets/dc6d8877-c2cc-4d48-9796-ddbe86b8ec9b)

Only a single saved view can be selected. The `>` separated view names represent the group hierarchy of saved viewpoints.

Additional changes (DRY):
Enhances the build process of hierarchical names for saved items by refactoring code into a reusable helper function, improving maintainability and consistency across filters.





