### PR TITLE
fix (civil3d) extract properties from c3d block references

### DIFF
--- a/Converters/Autocad/Speckle.Converters.AutocadShared/ServiceRegistration.cs
+++ b/Converters/Autocad/Speckle.Converters.AutocadShared/ServiceRegistration.cs
@@ -27,6 +27,7 @@ public static class ServiceRegistration
 
     // add other classes
     // serviceCollection.AddScoped<PropertiesExtractor>(); // NOTE: commented out until we can test in acad
+    serviceCollection.AddScoped<IPropertiesExtractor, PropertiesExtractor>();
     serviceCollection.AddScoped<ExtensionDictionaryExtractor>();
   }
 }

--- a/Converters/Autocad/Speckle.Converters.AutocadShared/Speckle.Converters.AutocadShared.projitems
+++ b/Converters/Autocad/Speckle.Converters.AutocadShared/Speckle.Converters.AutocadShared.projitems
@@ -55,6 +55,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)ToSpeckle\Geometry\Solid3dToSpeckleConverter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ToSpeckle\Geometry\DBTextToSpeckleConverter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ToSpeckle\Properties\ExtensionDictionaryExtractor.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)tospeckle\properties\IPropertiesExtractor.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ToSpeckle\Properties\PropertiesExtractor.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ToSpeckle\Raw\BrepToSpeckleRawConverter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ToSpeckle\Raw\CircularArc2dToSpeckleRawConverter.cs" />

--- a/Converters/Autocad/Speckle.Converters.AutocadShared/ToSpeckle/Properties/IPropertiesExtractor.cs
+++ b/Converters/Autocad/Speckle.Converters.AutocadShared/ToSpeckle/Properties/IPropertiesExtractor.cs
@@ -1,0 +1,6 @@
+namespace Speckle.Converters.AutocadShared.ToSpeckle;
+
+public interface IPropertiesExtractor
+{
+  Dictionary<string, object?> GetProperties(ADB.Entity entity);
+}

--- a/Converters/Autocad/Speckle.Converters.AutocadShared/ToSpeckle/Properties/PropertiesExtractor.cs
+++ b/Converters/Autocad/Speckle.Converters.AutocadShared/ToSpeckle/Properties/PropertiesExtractor.cs
@@ -3,7 +3,7 @@ namespace Speckle.Converters.AutocadShared.ToSpeckle;
 /// <summary>
 /// Extracts properties for autocad entities. NOTE: currently not in use in acad
 /// </summary>
-public class PropertiesExtractor
+public class PropertiesExtractor : IPropertiesExtractor
 {
   private readonly ExtensionDictionaryExtractor _extensionDictionaryExtractor;
 

--- a/Converters/Civil3d/Speckle.Converters.Civil3dShared/ServiceRegistration.cs
+++ b/Converters/Civil3d/Speckle.Converters.Civil3dShared/ServiceRegistration.cs
@@ -37,6 +37,7 @@ public static class ServiceRegistration
     // add other classes
     serviceCollection.AddScoped<Speckle.Converters.Civil3dShared.ToSpeckle.PropertiesExtractor>(); // for civil
     // serviceCollection.AddScoped<Speckle.Converters.AutocadShared.ToSpeckle.PropertiesExtractor>(); // for autocad // NOTE: we can't test for acad, so we're kicking this out from acad
+    serviceCollection.AddScoped<Speckle.Converters.AutocadShared.ToSpeckle.IPropertiesExtractor, PropertiesExtractor>();
     serviceCollection.AddScoped<PartDataExtractor>();
     serviceCollection.AddScoped<DisplayValueExtractor>();
     serviceCollection.AddScoped<BaseCurveExtractor>();

--- a/Converters/Civil3d/Speckle.Converters.Civil3dShared/ToSpeckle/Properties/PropertiesExtractor.cs
+++ b/Converters/Civil3d/Speckle.Converters.Civil3dShared/ToSpeckle/Properties/PropertiesExtractor.cs
@@ -3,7 +3,7 @@ namespace Speckle.Converters.Civil3dShared.ToSpeckle;
 /// <summary>
 /// Extracts properties for the CivilObject class.
 /// </summary>
-public class PropertiesExtractor
+public class PropertiesExtractor : Speckle.Converters.AutocadShared.ToSpeckle.IPropertiesExtractor
 {
   private readonly ClassPropertiesExtractor _classPropertiesExtractor;
   private readonly PartDataExtractor _partDataExtractor;


### PR DESCRIPTION
extract properties from c3d block references:

- added IPropertiesExtractor interface to Autocad Converter
- added property extraction to AutocadInstanceUnpacker
- injecting the right property extractor for each hostapp (autocad/civil) in the ServiceRegistration.cs