### PR TITLE
Don't mark cancelled or conversion exceptions as errors

### DIFF
--- a/Sdk/Speckle.Connectors.Common.Tests/Operations/ReceiveConversionHandlerTests.cs
+++ b/Sdk/Speckle.Connectors.Common.Tests/Operations/ReceiveConversionHandlerTests.cs
@@ -38,7 +38,6 @@ public class ReceiveConversionHandlerTests
     Exception? result = handler.TryConvert(() => throw ex);
 
     result.Should().Be(ex);
-    activity.Verify(a => a.SetStatus(SdkActivityStatusCode.Error), Times.Once);
   }
 
   [Test]
@@ -50,7 +49,6 @@ public class ReceiveConversionHandlerTests
     var handler = new ReceiveConversionHandler(activityFactory.Object);
 
     Assert.Throws<OperationCanceledException>(() => handler.TryConvert(() => throw new OperationCanceledException()));
-    activity.Verify(a => a.SetStatus(SdkActivityStatusCode.Error), Times.Once);
   }
 
   [Test]

--- a/Sdk/Speckle.Connectors.Common/Operations/ReceiveConversionHandler.cs
+++ b/Sdk/Speckle.Connectors.Common/Operations/ReceiveConversionHandler.cs
@@ -20,13 +20,11 @@ public class ReceiveConversionHandler(ISdkActivityFactory activityFactory) : IRe
     catch (ConversionException ce)
     {
       //handle conversions but don't log to seq
-      convertActivity?.SetStatus(SdkActivityStatusCode.Error);
       return ce;
     }
     catch (OperationCanceledException)
     {
       //handle conversions but don't log to seq and also throw
-      convertActivity?.SetStatus(SdkActivityStatusCode.Error);
       throw;
     }
     catch (Exception ex) when (!ex.IsFatal())


### PR DESCRIPTION
These are expected but should up in Seq as errors even though the exceptions aren't logged.  This shouldn't happen.

![image](https://github.com/user-attachments/assets/96ceb715-6ebe-41fc-b98e-5b8c920d1a60)
