### PR TITLE
feat (Grasshopper) dev enable account auth by dev token

### DIFF
--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Dev/TokenUrlComponent.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Dev/TokenUrlComponent.cs
@@ -1,0 +1,57 @@
+using System.Runtime.InteropServices;
+using Grasshopper.Kernel;
+using Speckle.Connectors.GrasshopperShared.HostApp;
+using Speckle.Connectors.GrasshopperShared.Parameters;
+using Speckle.Connectors.GrasshopperShared.Properties;
+
+namespace Speckle.Connectors.GrasshopperShared.Components.Dev;
+
+[Guid("18152AE4-4BE7-46F0-9826-09061897A5CC")]
+public class TokenUrlComponent : GH_Component
+{
+  public TokenUrlComponent()
+    : base(
+      "Speckle Model URL",
+      "URL",
+      "Create a Speckle model link using URL and developer token",
+      ComponentCategories.PRIMARY_RIBBON,
+      ComponentCategories.DEVELOPER
+    ) { }
+
+  public override Guid ComponentGuid => GetType().GUID;
+  protected override Bitmap Icon => Resources.speckle_inputs_model;
+
+  protected override void RegisterInputParams(GH_InputParamManager pManager)
+  {
+    pManager.AddTextParameter("Speckle Url", "Url", "Speckle URL", GH_ParamAccess.item);
+    pManager.AddTextParameter("Speckle Token", "Token", "Speckle Authorization Token", GH_ParamAccess.item);
+  }
+
+  protected override void RegisterOutputParams(GH_OutputParamManager pManager)
+  {
+    pManager.AddParameter(new SpeckleUrlModelResourceParam());
+  }
+
+  protected override void SolveInstance(IGH_DataAccess da)
+  {
+    // get inputs
+    string urlInput = "";
+    if (!da.GetData(0, ref urlInput))
+    {
+      AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, $"Speckle Url is missing");
+      return;
+    }
+
+    string tokenInput = "";
+    if (!da.GetData(0, ref tokenInput))
+    {
+      AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, $"Speckle token is missing");
+      return;
+    }
+
+    // do work here
+
+    // output url resource
+    da.SetData(0, new SpeckleUrlModelVersionResource());
+  }
+}

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Dev/TokenUrlComponent.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Dev/TokenUrlComponent.cs
@@ -69,8 +69,8 @@ public class TokenUrlComponent : GH_Component
       da.AbortComponentSolution();
     }
   }
-  
-    public (SpeckleUrlModelResource resource, bool hasPermission) SolveInstanceWithUrAndToken(
+
+  public (SpeckleUrlModelResource resource, bool hasPermission) SolveInstanceWithUrAndToken(
     string input,
     string token,
     bool isSender
@@ -97,7 +97,9 @@ public class TokenUrlComponent : GH_Component
     if (account != null)
     {
       scope.Get<IAccountService>().SetUserSelectedAccountId(account.id);
-    } else {
+    }
+    else
+    {
       throw new SpeckleException("No account found for server URL");
     }
 
@@ -109,8 +111,7 @@ public class TokenUrlComponent : GH_Component
     {
       var workspace = client.Workspace.Get(project.workspaceId).Result;
     }
-    
-  
+
     switch (resource)
     {
       case SpeckleUrlLatestModelVersionResource latestVersionResource:
@@ -127,8 +128,6 @@ public class TokenUrlComponent : GH_Component
         throw new SpeckleException("Unknown Speckle resource type");
     }
 
-
     return (resource, isSender ? projectPermissions.canPublish.authorized : projectPermissions.canLoad.authorized);
   }
-    
 }

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Receive/GrasshopperReceiveInfo.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Receive/GrasshopperReceiveInfo.cs
@@ -1,16 +1,15 @@
 using Speckle.Connectors.Common.Operations;
+using Speckle.Sdk.Credentials;
 
 namespace Speckle.Connectors.GrasshopperShared.Components.Operations.Receive;
 
 public record GrasshopperReceiveInfo(
-  string AccountId,
-  Uri ServerUrl,
+  Account Account,
   string? WorkspaceId,
   string ProjectId,
   string ProjectName,
   string ModelId,
   string ModelName,
   string SelectedVersionId,
-  string SourceApplication,
   string? SelectedVersionUserId
-) : ReceiveInfo(AccountId, ServerUrl, ProjectId, ProjectName, ModelId, ModelName, SelectedVersionId, SourceApplication);
+) : ReceiveInfo(Account, ProjectId, ProjectName, ModelId, ModelName, SelectedVersionId);

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Receive/GrasshopperReceiveInfo.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Receive/GrasshopperReceiveInfo.cs
@@ -11,5 +11,6 @@ public record GrasshopperReceiveInfo(
   string ModelId,
   string ModelName,
   string SelectedVersionId,
+  string SourceApplication,
   string? SelectedVersionUserId
-) : ReceiveInfo(Account, ProjectId, ProjectName, ModelId, ModelName, SelectedVersionId);
+) : ReceiveInfo(Account, ProjectId, ProjectName, ModelId, ModelName, SelectedVersionId, SourceApplication);

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Receive/ReceiveAsyncComponent.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Receive/ReceiveAsyncComponent.cs
@@ -279,7 +279,7 @@ public class ReceiveAsyncComponent : GH_AsyncComponent<ReceiveAsyncComponent>
     try
     {
       using var scope = PriorityLoader.CreateScopeForActiveDocument();
-      Account? account = 
+      Account? account =
         urlResource.Account.AccountId != null
           ? scope.Get<IAccountManager>().GetAccount(urlResource.Account.AccountId)
           : scope.Get<IAccountService>().GetAccountWithServerUrlFallback("", new Uri(urlResource.Account.Server)); // fallback the account that matches with URL if any
@@ -458,7 +458,7 @@ public sealed class ReceiveComponentWorker : WorkerInstance<ReceiveAsyncComponen
     var customProperties = new Dictionary<string, object>()
     {
       { "isAsync", true },
-      { "sourceHostApp", scope.Get<ISpeckleApplication>().Slug},
+      { "sourceHostApp", scope.Get<ISpeckleApplication>().Slug },
       { "auto", Parent.AutoReceive }
     };
     if (receiveInfo.WorkspaceId != null)

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Receive/ReceiveAsyncComponent.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Receive/ReceiveAsyncComponent.cs
@@ -5,7 +5,6 @@ using Grasshopper.Kernel;
 using Grasshopper.Kernel.Attributes;
 using GrasshopperAsyncComponent;
 using Rhino;
-using Speckle.Connectors.Common;
 using Speckle.Connectors.Common.Analytics;
 using Speckle.Connectors.Common.Instances;
 using Speckle.Connectors.Common.Operations;
@@ -280,10 +279,10 @@ public class ReceiveAsyncComponent : GH_AsyncComponent<ReceiveAsyncComponent>
     try
     {
       using var scope = PriorityLoader.CreateScopeForActiveDocument();
-      Account? account =
-        urlResource.AccountId != null
-          ? scope.Get<IAccountManager>().GetAccount(urlResource.AccountId)
-          : scope.Get<IAccountService>().GetAccountWithServerUrlFallback("", new Uri(urlResource.Server)); // fallback the account that matches with URL if any
+      Account? account = 
+        urlResource.Account.AccountId != null
+          ? scope.Get<IAccountManager>().GetAccount(urlResource.Account.AccountId)
+          : scope.Get<IAccountService>().GetAccountWithServerUrlFallback("", new Uri(urlResource.Account.Server)); // fallback the account that matches with URL if any
 
       if (account is null)
       {
@@ -373,7 +372,9 @@ public sealed class ReceiveComponentWorker : WorkerInstance<ReceiveAsyncComponen
     }
   }
 
+#pragma warning disable CA1506
   private async Task Receive(Action<string, double> reportProgress)
+#pragma warning restore CA1506
   {
     if (UrlModelResource is null)
     {
@@ -457,7 +458,7 @@ public sealed class ReceiveComponentWorker : WorkerInstance<ReceiveAsyncComponen
     var customProperties = new Dictionary<string, object>()
     {
       { "isAsync", true },
-      { "sourceHostApp", HostApplications.GetSlugFromHostAppNameAndVersion(receiveInfo.SourceApplication) },
+      { "sourceHostApp", scope.Get<ISpeckleApplication>().Slug},
       { "auto", Parent.AutoReceive }
     };
     if (receiveInfo.WorkspaceId != null)

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Receive/ReceiveAsyncComponent.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Receive/ReceiveAsyncComponent.cs
@@ -5,6 +5,7 @@ using Grasshopper.Kernel;
 using Grasshopper.Kernel.Attributes;
 using GrasshopperAsyncComponent;
 using Rhino;
+using Speckle.Connectors.Common;
 using Speckle.Connectors.Common.Analytics;
 using Speckle.Connectors.Common.Instances;
 using Speckle.Connectors.Common.Operations;
@@ -458,7 +459,7 @@ public sealed class ReceiveComponentWorker : WorkerInstance<ReceiveAsyncComponen
     var customProperties = new Dictionary<string, object>()
     {
       { "isAsync", true },
-      { "sourceHostApp", scope.Get<ISpeckleApplication>().Slug },
+      { "sourceHostApp", HostApplications.GetSlugFromHostAppNameAndVersion(receiveInfo.SourceApplication) },
       { "auto", Parent.AutoReceive }
     };
     if (receiveInfo.WorkspaceId != null)

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Receive/ReceiveComponent.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Receive/ReceiveComponent.cs
@@ -1,5 +1,6 @@
 using Grasshopper.Kernel;
 using Microsoft.Extensions.DependencyInjection;
+using Speckle.Connectors.Common;
 using Speckle.Connectors.Common.Analytics;
 using Speckle.Connectors.Common.Instances;
 using Speckle.Connectors.Common.Operations;
@@ -143,7 +144,7 @@ public class ReceiveComponent : SpeckleTaskCapableComponent<ReceiveComponentInpu
     var customProperties = new Dictionary<string, object>()
     {
       { "isAsync", false },
-      { "sourceHostApp", scope.Get<ISpeckleApplication>().Slug }
+      { "sourceHostApp", HostApplications.GetSlugFromHostAppNameAndVersion(receiveInfo.SourceApplication) }
     };
     if (receiveInfo.WorkspaceId != null)
     {

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Receive/ReceiveComponent.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Receive/ReceiveComponent.cs
@@ -143,7 +143,7 @@ public class ReceiveComponent : SpeckleTaskCapableComponent<ReceiveComponentInpu
     var customProperties = new Dictionary<string, object>()
     {
       { "isAsync", false },
-      { "sourceHostApp", scope.Get<ISpeckleApplication>().Slug}
+      { "sourceHostApp", scope.Get<ISpeckleApplication>().Slug }
     };
     if (receiveInfo.WorkspaceId != null)
     {

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Send/GrasshopperSendInfo.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Send/GrasshopperSendInfo.cs
@@ -1,12 +1,11 @@
 using Speckle.Connectors.Common.Operations;
+using Speckle.Sdk.Credentials;
 
 namespace Speckle.Connectors.GrasshopperShared.Components.Operations.Send;
 
 public record GrasshopperSendInfo(
-  string AccountId,
-  Uri ServerUrl,
+  Account Account,
   string? WorkspaceId,
   string ProjectId,
-  string ModelId,
-  string SourceApplication
-) : SendInfo(AccountId, ServerUrl, ProjectId, ModelId, SourceApplication);
+  string ModelId
+) : SendInfo(Account, ProjectId, ModelId);

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Send/GrasshopperSendInfo.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Send/GrasshopperSendInfo.cs
@@ -3,5 +3,10 @@ using Speckle.Sdk.Credentials;
 
 namespace Speckle.Connectors.GrasshopperShared.Components.Operations.Send;
 
-public record GrasshopperSendInfo(Account Account, string? WorkspaceId, string ProjectId, string ModelId)
-  : SendInfo(Account, ProjectId, ModelId);
+public record GrasshopperSendInfo(
+  Account Account,
+  string? WorkspaceId,
+  string ProjectId,
+  string ModelId,
+  string SourceApplication
+) : SendInfo(Account, ProjectId, ModelId, SourceApplication);

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Send/GrasshopperSendInfo.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Send/GrasshopperSendInfo.cs
@@ -3,9 +3,5 @@ using Speckle.Sdk.Credentials;
 
 namespace Speckle.Connectors.GrasshopperShared.Components.Operations.Send;
 
-public record GrasshopperSendInfo(
-  Account Account,
-  string? WorkspaceId,
-  string ProjectId,
-  string ModelId
-) : SendInfo(Account, ProjectId, ModelId);
+public record GrasshopperSendInfo(Account Account, string? WorkspaceId, string ProjectId, string ModelId)
+  : SendInfo(Account, ProjectId, ModelId);

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Send/SendAsyncComponent.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Send/SendAsyncComponent.cs
@@ -261,9 +261,9 @@ public class SendAsyncComponent : GH_AsyncComponent<SendAsyncComponent>
     try
     {
       Account? account =
-        dataInput.AccountId != null
-          ? accountManager.GetAccount(dataInput.AccountId)
-          : accountService.GetAccountWithServerUrlFallback("", new Uri(dataInput.Server)); // fallback the account that matches with URL if any
+        dataInput.Account.AccountId != null
+          ? accountManager.GetAccount(dataInput.Account.AccountId)
+          : accountService.GetAccountWithServerUrlFallback("", new Uri(dataInput.Account.Server)); // fallback the account that matches with URL if any
       if (account is null)
       {
         throw new SpeckleAccountManagerException($"No default account was found");
@@ -429,16 +429,16 @@ public class SendComponentWorker : WorkerInstance<SendAsyncComponent>
       .ConfigureAwait(false);
 
     SpeckleUrlModelVersionResource createdVersion =
-      new(
-        sendInfo.AccountId,
-        sendInfo.ServerUrl.ToString(),
+      new(new(
+        sendInfo.Account.id, null,
+        sendInfo.Account.serverInfo.url),
         sendInfo.WorkspaceId,
         sendInfo.ProjectId,
         sendInfo.ModelId,
         result.VersionId
       );
     OutputParam = createdVersion;
-    Parent.Url = $"{createdVersion.Server}projects/{sendInfo.ProjectId}/models/{sendInfo.ModelId}";
+    Parent.Url = $"{createdVersion.Account.Server}projects/{sendInfo.ProjectId}/models/{sendInfo.ModelId}";
   }
 }
 

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Send/SendAsyncComponent.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Send/SendAsyncComponent.cs
@@ -429,9 +429,8 @@ public class SendComponentWorker : WorkerInstance<SendAsyncComponent>
       .ConfigureAwait(false);
 
     SpeckleUrlModelVersionResource createdVersion =
-      new(new(
-        sendInfo.Account.id, null,
-        sendInfo.Account.serverInfo.url),
+      new(
+        new(sendInfo.Account.id, null, sendInfo.Account.serverInfo.url),
         sendInfo.WorkspaceId,
         sendInfo.ProjectId,
         sendInfo.ModelId,

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Send/SendComponent.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Send/SendComponent.cs
@@ -192,10 +192,8 @@ public class SendComponent : SpeckleTaskCapableComponent<SendComponentInput, Sen
     await mixpanel.TrackEvent(MixPanelEvents.Send, account, customProperties);
 
     SpeckleUrlLatestModelVersionResource createdVersionResource =
-      new(new(
-        sendInfo.Account.id,
-        null,
-        sendInfo.Account.serverInfo.url),
+      new(
+        new(sendInfo.Account.id, null, sendInfo.Account.serverInfo.url),
         sendInfo.WorkspaceId,
         sendInfo.ProjectId,
         sendInfo.ModelId

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Send/SendComponent.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Send/SendComponent.cs
@@ -160,16 +160,10 @@ public class SendComponent : SpeckleTaskCapableComponent<SendComponentInput, Sen
     }
 
     using var scope = PriorityLoader.CreateScopeForActiveDocument();
-    var accountService = scope.ServiceProvider.GetRequiredService<IAccountService>();
-    var accountManager = scope.ServiceProvider.GetRequiredService<IAccountManager>();
     var clientFactory = scope.ServiceProvider.GetRequiredService<IClientFactory>();
     var sendOperation = scope.ServiceProvider.GetRequiredService<SendOperation<SpeckleCollectionWrapperGoo>>();
 
-    Account? account =
-      input.Resource.AccountId != null
-        ? accountManager.GetAccount(input.Resource.AccountId)
-        : accountService.GetAccountWithServerUrlFallback("", new Uri(input.Resource.Server)); // fallback the account that matches with URL if any
-
+    Account? account = input.Resource.Account.GetAccount(scope);
     if (account is null)
     {
       throw new SpeckleAccountManagerException($"No default account was found");
@@ -198,15 +192,15 @@ public class SendComponent : SpeckleTaskCapableComponent<SendComponentInput, Sen
     await mixpanel.TrackEvent(MixPanelEvents.Send, account, customProperties);
 
     SpeckleUrlLatestModelVersionResource createdVersionResource =
-      new(
-        sendInfo.AccountId,
-        sendInfo.ServerUrl.ToString(),
+      new(new(
+        sendInfo.Account.id,
+        null,
+        sendInfo.Account.serverInfo.url),
         sendInfo.WorkspaceId,
         sendInfo.ProjectId,
         sendInfo.ModelId
       );
-    Url = $"{createdVersionResource.Server}projects/{sendInfo.ProjectId}/models/{sendInfo.ModelId}";
-
+    Url = $"{sendInfo.Account.serverInfo.url}projects/{sendInfo.ProjectId}/models/{sendInfo.ModelId}";
     return new SendComponentOutput(createdVersionResource);
   }
 }

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/SpeckleSelectModelComponent.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/SpeckleSelectModelComponent.cs
@@ -99,13 +99,13 @@ public class SpeckleSelectModelComponent : GH_Component
         try
         {
           // NOTE: once we split the logic in Sender and Receiver components, we need to set flag correctly
-          var (resource, hasPermission) = SpeckleOperationWizard.SolveInstanceWithUrlInput(urlInput, true);
+          var (resource, hasPermission) = SpeckleOperationWizard.SolveInstanceWithUrlInput(urlInput, true, null);
           if (!hasPermission)
           {
             AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "You do not have enough permission for this project.");
           }
           _storedUserId = SpeckleOperationWizard.SelectedAccount?.id;
-          _storedServer = resource.Server;
+          _storedServer = resource.Account.Server;
           da.SetData(0, resource);
         }
         catch (SpeckleException e)
@@ -257,8 +257,11 @@ public class SpeckleSelectModelComponent : GH_Component
         da.SetData(
           0,
           new SpeckleUrlLatestModelVersionResource(
+            new AccountResource(
             SpeckleOperationWizard.SelectedAccount.id,
-            SpeckleOperationWizard.SelectedAccount.serverInfo.url,
+            null,
+            SpeckleOperationWizard.SelectedAccount.serverInfo.url
+            ),
             SpeckleOperationWizard.SelectedWorkspace?.id,
             SpeckleOperationWizard.SelectedProject.id,
             SpeckleOperationWizard.SelectedModel.id
@@ -271,8 +274,11 @@ public class SpeckleSelectModelComponent : GH_Component
       da.SetData(
         0,
         new SpeckleUrlModelVersionResource(
-          SpeckleOperationWizard.SelectedAccount.id,
-          SpeckleOperationWizard.SelectedAccount.serverInfo.url,
+          new AccountResource(
+            SpeckleOperationWizard.SelectedAccount.id,
+            null,
+            SpeckleOperationWizard.SelectedAccount.serverInfo.url
+          ),
           SpeckleOperationWizard.SelectedWorkspace?.id,
           SpeckleOperationWizard.SelectedProject.id,
           SpeckleOperationWizard.SelectedModel.id,

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/SpeckleSelectModelComponent.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/SpeckleSelectModelComponent.cs
@@ -258,9 +258,9 @@ public class SpeckleSelectModelComponent : GH_Component
           0,
           new SpeckleUrlLatestModelVersionResource(
             new AccountResource(
-            SpeckleOperationWizard.SelectedAccount.id,
-            null,
-            SpeckleOperationWizard.SelectedAccount.serverInfo.url
+              SpeckleOperationWizard.SelectedAccount.id,
+              null,
+              SpeckleOperationWizard.SelectedAccount.serverInfo.url
             ),
             SpeckleOperationWizard.SelectedWorkspace?.id,
             SpeckleOperationWizard.SelectedProject.id,

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Wizard/SpeckleOperationWizard.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Wizard/SpeckleOperationWizard.cs
@@ -65,13 +65,17 @@ public class SpeckleOperationWizard
     ModelMenuHandler.ModelSelected += OnModelSelected;
   }
 
-  public (SpeckleUrlModelResource resource, bool hasPermission) SolveInstanceWithUrlInput(string input, bool isSender, string? token)
+  public (SpeckleUrlModelResource resource, bool hasPermission) SolveInstanceWithUrlInput(
+    string input,
+    bool isSender,
+    string? token
+  )
   {
     // When input is provided, lock interaction of buttons so only text is shown (no context menu)
     // Should perform validation, fill in all internal data of the component (project, model, version, account)
     // Should notify user if any of this goes wrong.
 
-    var resources = SpeckleResourceBuilder.FromUrlString(input,token);
+    var resources = SpeckleResourceBuilder.FromUrlString(input, token);
     if (resources.Length == 0)
     {
       throw new SpeckleException($"Input url string was empty");

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Wizard/SpeckleOperationWizard.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Wizard/SpeckleOperationWizard.cs
@@ -65,13 +65,13 @@ public class SpeckleOperationWizard
     ModelMenuHandler.ModelSelected += OnModelSelected;
   }
 
-  public (SpeckleUrlModelResource resource, bool hasPermission) SolveInstanceWithUrlInput(string input, bool isSender)
+  public (SpeckleUrlModelResource resource, bool hasPermission) SolveInstanceWithUrlInput(string input, bool isSender, string? token)
   {
     // When input is provided, lock interaction of buttons so only text is shown (no context menu)
     // Should perform validation, fill in all internal data of the component (project, model, version, account)
     // Should notify user if any of this goes wrong.
 
-    var resources = SpeckleResourceBuilder.FromUrlString(input);
+    var resources = SpeckleResourceBuilder.FromUrlString(input,token);
     if (resources.Length == 0)
     {
       throw new SpeckleException($"Input url string was empty");
@@ -83,8 +83,8 @@ public class SpeckleOperationWizard
     }
 
     var resource = resources.First();
-
-    var account = _accountService.GetAccountWithServerUrlFallback(string.Empty, new Uri(resource.Server));
+    using var scope = PriorityLoader.CreateScopeForActiveDocument();
+    var account = resource.Account.GetAccount(scope);
     SetAccount(account, false);
 
     if (SelectedAccount == null)

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/HostApp/SpeckleResource.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/HostApp/SpeckleResource.cs
@@ -63,12 +63,7 @@ public record SpeckleUrlLatestModelVersionResource(
     await client.Project.Get(ProjectId, cancellationToken).ConfigureAwait(false);
     await client.Model.Get(ModelId, ProjectId, cancellationToken).ConfigureAwait(false);
 
-    return new GrasshopperSendInfo(
-      client.Account,
-      WorkspaceId,
-      ProjectId,
-      ModelId
-    );
+    return new GrasshopperSendInfo(client.Account, WorkspaceId, ProjectId, ModelId);
   }
 }
 
@@ -112,12 +107,7 @@ public record SpeckleUrlModelVersionResource(
     await client.Project.Get(ProjectId, cancellationToken).ConfigureAwait(false);
     await client.Model.Get(ModelId, ProjectId, cancellationToken).ConfigureAwait(false);
 
-    return new GrasshopperSendInfo(
-      client.Account,
-      WorkspaceId,
-      ProjectId,
-      ModelId
-    );
+    return new GrasshopperSendInfo(client.Account, WorkspaceId, ProjectId, ModelId);
   }
 }
 
@@ -138,7 +128,6 @@ public record SpeckleUrlModelObjectResource(
     CancellationToken cancellationToken = default
   ) => throw new NotImplementedException("Object Resources are not supported yet");
 }
-
 
 public record AccountResource(string? AccountId, string? Token, string Server)
 {

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/HostApp/SpeckleResource.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/HostApp/SpeckleResource.cs
@@ -5,6 +5,7 @@ using Speckle.Connectors.GrasshopperShared.Components.Operations.Send;
 using Speckle.Connectors.GrasshopperShared.Registration;
 using Speckle.Sdk.Api;
 using Speckle.Sdk.Api.GraphQL.Models;
+using Speckle.Sdk.Common;
 using Speckle.Sdk.Credentials;
 using Version = Speckle.Sdk.Api.GraphQL.Models.Version;
 
@@ -48,6 +49,7 @@ public record SpeckleUrlLatestModelVersionResource(
       ModelId,
       model.name,
       version.id,
+      version.sourceApplication.NotNull(),
       version.authorUser?.id
     );
 
@@ -63,7 +65,13 @@ public record SpeckleUrlLatestModelVersionResource(
     await client.Project.Get(ProjectId, cancellationToken).ConfigureAwait(false);
     await client.Model.Get(ModelId, ProjectId, cancellationToken).ConfigureAwait(false);
 
-    return new GrasshopperSendInfo(client.Account, WorkspaceId, ProjectId, ModelId);
+    return new GrasshopperSendInfo(
+      client.Account,
+      WorkspaceId,
+      ProjectId,
+      ModelId,
+      "Grasshopper8" // TODO: Grab from the right place!
+    );
   }
 }
 
@@ -92,6 +100,7 @@ public record SpeckleUrlModelVersionResource(
       ModelId,
       model.name,
       VersionId,
+      version.sourceApplication.NotNull(),
       version.authorUser?.id
     );
 
@@ -107,7 +116,13 @@ public record SpeckleUrlModelVersionResource(
     await client.Project.Get(ProjectId, cancellationToken).ConfigureAwait(false);
     await client.Model.Get(ModelId, ProjectId, cancellationToken).ConfigureAwait(false);
 
-    return new GrasshopperSendInfo(client.Account, WorkspaceId, ProjectId, ModelId);
+    return new GrasshopperSendInfo(
+      client.Account,
+      WorkspaceId,
+      ProjectId,
+      ModelId,
+      "Grasshopper8" // TODO: Grab from the right place!
+    );
   }
 }
 

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/HostApp/SpeckleResource.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/HostApp/SpeckleResource.cs
@@ -1,15 +1,18 @@
+using Microsoft.Extensions.DependencyInjection;
+using Speckle.Connectors.Common.Operations;
 using Speckle.Connectors.GrasshopperShared.Components.Operations.Receive;
 using Speckle.Connectors.GrasshopperShared.Components.Operations.Send;
+using Speckle.Connectors.GrasshopperShared.Registration;
 using Speckle.Sdk.Api;
 using Speckle.Sdk.Api.GraphQL.Models;
-using Speckle.Sdk.Common;
+using Speckle.Sdk.Credentials;
 using Version = Speckle.Sdk.Api.GraphQL.Models.Version;
 
 namespace Speckle.Connectors.GrasshopperShared.HostApp;
 
 // noting that if the user inputs a model url string, this will not contain account info
 // (and that's why the accountID is nullable in the record resource)
-public abstract record SpeckleUrlModelResource(string? AccountId, string Server, string? WorkspaceId, string ProjectId)
+public abstract record SpeckleUrlModelResource(AccountResource Account, string? WorkspaceId, string ProjectId)
 {
   public abstract Task<GrasshopperReceiveInfo> GetReceiveInfo(
     IClient client,
@@ -20,12 +23,11 @@ public abstract record SpeckleUrlModelResource(string? AccountId, string Server,
 }
 
 public record SpeckleUrlLatestModelVersionResource(
-  string? AccountId,
-  string Server,
+  AccountResource Account,
   string? WorkspaceId,
   string ProjectId,
   string ModelId
-) : SpeckleUrlModelResource(AccountId, Server, WorkspaceId, ProjectId)
+) : SpeckleUrlModelResource(Account, WorkspaceId, ProjectId)
 {
   public override async Task<GrasshopperReceiveInfo> GetReceiveInfo(
     IClient client,
@@ -39,15 +41,13 @@ public record SpeckleUrlLatestModelVersionResource(
     Version version = model.versions.items[0];
 
     var info = new GrasshopperReceiveInfo(
-      client.Account.id,
-      new Uri(Server),
+      client.Account,
       project.workspaceId,
       ProjectId,
       project.name,
       ModelId,
       model.name,
       version.id,
-      version.sourceApplication.NotNull(),
       version.authorUser?.id
     );
 
@@ -64,24 +64,21 @@ public record SpeckleUrlLatestModelVersionResource(
     await client.Model.Get(ModelId, ProjectId, cancellationToken).ConfigureAwait(false);
 
     return new GrasshopperSendInfo(
-      client.Account.id,
-      new Uri(Server),
+      client.Account,
       WorkspaceId,
       ProjectId,
-      ModelId,
-      "Grasshopper8" // TODO: Grab from the right place!
+      ModelId
     );
   }
 }
 
 public record SpeckleUrlModelVersionResource(
-  string? AccountId,
-  string Server,
+  AccountResource Account,
   string? WorkspaceId,
   string ProjectId,
   string ModelId,
   string VersionId
-) : SpeckleUrlModelResource(AccountId, Server, WorkspaceId, ProjectId)
+) : SpeckleUrlModelResource(Account, WorkspaceId, ProjectId)
 {
   public override async Task<GrasshopperReceiveInfo> GetReceiveInfo(
     IClient client,
@@ -93,15 +90,13 @@ public record SpeckleUrlModelVersionResource(
     Version version = await client.Version.Get(VersionId, ProjectId, cancellationToken).ConfigureAwait(false);
 
     var info = new GrasshopperReceiveInfo(
-      client.Account.id,
-      new Uri(Server),
+      client.Account,
       project.workspaceId,
       ProjectId,
       project.name,
       ModelId,
       model.name,
       VersionId,
-      version.sourceApplication.NotNull(),
       version.authorUser?.id
     );
 
@@ -118,23 +113,20 @@ public record SpeckleUrlModelVersionResource(
     await client.Model.Get(ModelId, ProjectId, cancellationToken).ConfigureAwait(false);
 
     return new GrasshopperSendInfo(
-      client.Account.id,
-      new Uri(Server),
+      client.Account,
       WorkspaceId,
       ProjectId,
-      ModelId,
-      "Grasshopper8" // TODO: Grab from the right place!
+      ModelId
     );
   }
 }
 
 public record SpeckleUrlModelObjectResource(
-  string? AccountId,
-  string Server,
+  AccountResource Account,
   string? WorkspaceId,
   string ProjectId,
   string ObjectId
-) : SpeckleUrlModelResource(AccountId, Server, WorkspaceId, ProjectId)
+) : SpeckleUrlModelResource(Account, WorkspaceId, ProjectId)
 {
   public override Task<GrasshopperReceiveInfo> GetReceiveInfo(
     IClient client,
@@ -145,4 +137,19 @@ public record SpeckleUrlModelObjectResource(
     IClient client,
     CancellationToken cancellationToken = default
   ) => throw new NotImplementedException("Object Resources are not supported yet");
+}
+
+
+public record AccountResource(string? AccountId, string? Token, string Server)
+{
+  public Account? GetAccount(IServiceScope scope)
+  {
+    if (Token is not null)
+    {
+      return scope.Get<IAccountFactory>().CreateAccount(new Uri(Server), Token).GetAwaiter().GetResult();
+    }
+    return AccountId != null
+      ? scope.Get<IAccountManager>().GetAccount(AccountId)
+      : scope.Get<IAccountService>().GetAccountWithServerUrlFallback("", new Uri(Server)); // fallback the account that matches with URL if a
+  }
 }

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/HostApp/SpeckleResourceBuilder.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/HostApp/SpeckleResourceBuilder.cs
@@ -13,16 +13,16 @@ public record SpeckleResourceBuilder
       @"/projects/(?<projectId>[\w\d]+)(?:/models/(?<model>[\w\d]+(?:@[\w\d]+)?)(?:,(?<additionalModels>[\w\d]+(?:@[\w\d]+)?))*)?"
     );
 
-  public static SpeckleUrlModelResource[] FromUrlString(string speckleModel)
+  public static SpeckleUrlModelResource[] FromUrlString(string speckleModel, string? token)
   {
     var uri = new Uri(speckleModel);
     var serverUrl = uri.GetLeftPart(UriPartial.Authority);
     var match = s_fe2UrlRegex.Match(speckleModel);
-    var result = ParseFe2RegexMatch(serverUrl, match);
+    var result = ParseFe2RegexMatch(serverUrl, match, token);
     return result;
   }
 
-  private static SpeckleUrlModelResource[] ParseFe2RegexMatch(string serverUrl, Match match)
+  private static SpeckleUrlModelResource[] ParseFe2RegexMatch(string serverUrl, Match match, string? token)
   {
     var projectId = match.Groups["projectId"];
     var model = match.Groups["model"];
@@ -48,7 +48,7 @@ public record SpeckleResourceBuilder
       throw new NotSupportedException("Federation model urls are not supported");
     }
 
-    var modelRes = GetUrlModelResource(null, serverUrl, null, projectId.Value, model.Value);
+    var modelRes = GetUrlModelResource(null, token, serverUrl, null, projectId.Value, model.Value);
 
     var result = new List<SpeckleUrlModelResource> { modelRes };
 
@@ -56,7 +56,7 @@ public record SpeckleResourceBuilder
     {
       foreach (Capture additionalModelsCapture in additionalModels.Captures)
       {
-        var extraModel = GetUrlModelResource(null, serverUrl, null, projectId.Value, additionalModelsCapture.Value);
+        var extraModel = GetUrlModelResource(null, token ,serverUrl, null, projectId.Value, additionalModelsCapture.Value);
         result.Add(extraModel);
       }
     }
@@ -66,6 +66,7 @@ public record SpeckleResourceBuilder
 
   private static SpeckleUrlModelResource GetUrlModelResource(
     string? accountId,
+    string? token,
     string serverUrl,
     string? workspaceId,
     string projectId,
@@ -74,15 +75,15 @@ public record SpeckleResourceBuilder
   {
     if (modelValue.Length == 32)
     {
-      return new SpeckleUrlModelObjectResource(accountId, serverUrl, workspaceId, projectId, modelValue); // Model value is an ObjectID
+      return new SpeckleUrlModelObjectResource(new(accountId, token, serverUrl), workspaceId, projectId, modelValue); // Model value is an ObjectID
     }
 
     if (!modelValue.Contains('@'))
     {
-      return new SpeckleUrlLatestModelVersionResource(accountId, serverUrl, workspaceId, projectId, modelValue); // Model has no version attached
+      return new SpeckleUrlLatestModelVersionResource(new(accountId, token, serverUrl), workspaceId, projectId, modelValue); // Model has no version attached
     }
 
     var res = modelValue.Split('@');
-    return new SpeckleUrlModelVersionResource(accountId, serverUrl, workspaceId, projectId, res[0], res[1]);
+    return new SpeckleUrlModelVersionResource(new(accountId, token, serverUrl), workspaceId, projectId, res[0], res[1]);
   }
 }

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/HostApp/SpeckleResourceBuilder.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/HostApp/SpeckleResourceBuilder.cs
@@ -56,7 +56,14 @@ public record SpeckleResourceBuilder
     {
       foreach (Capture additionalModelsCapture in additionalModels.Captures)
       {
-        var extraModel = GetUrlModelResource(null, token ,serverUrl, null, projectId.Value, additionalModelsCapture.Value);
+        var extraModel = GetUrlModelResource(
+          null,
+          token,
+          serverUrl,
+          null,
+          projectId.Value,
+          additionalModelsCapture.Value
+        );
         result.Add(extraModel);
       }
     }
@@ -80,7 +87,12 @@ public record SpeckleResourceBuilder
 
     if (!modelValue.Contains('@'))
     {
-      return new SpeckleUrlLatestModelVersionResource(new(accountId, token, serverUrl), workspaceId, projectId, modelValue); // Model has no version attached
+      return new SpeckleUrlLatestModelVersionResource(
+        new(accountId, token, serverUrl),
+        workspaceId,
+        projectId,
+        modelValue
+      ); // Model has no version attached
     }
 
     var res = modelValue.Split('@');

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Speckle.Connectors.GrasshopperShared.projitems
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Speckle.Connectors.GrasshopperShared.projitems
@@ -16,6 +16,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Components\Collections\CollectionPathsSelector.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Components\Collections\CreateCollection.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Components\Collections\ExpandCollection.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Components\Dev\TokenUrlComponent.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Components\IGH_StructureExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Components\Objects\QuerySpeckleObjects.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Components\Objects\FilterSpeckleObjects.cs" />
@@ -87,9 +88,6 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="$(MSBuildThisFileDirectory)Resources\speckle_deconstruct.png" />
-  </ItemGroup>
-  <ItemGroup>
-    <Folder Include="$(MSBuildThisFileDirectory)Components\Dev\" />
   </ItemGroup>
   <ItemGroup>
     <None Include="$(MSBuildThisFileDirectory)Resources\speckle_objects_object.png" />

--- a/DUI3/Speckle.Connectors.DUI/Bindings/ReceiveOperationManager.cs
+++ b/DUI3/Speckle.Connectors.DUI/Bindings/ReceiveOperationManager.cs
@@ -18,8 +18,8 @@ public sealed class ReceiveOperationManager(
   IServiceScope serviceScope,
   ICancellationManager cancellationManager,
   IDocumentModelStore store,
-  ISpeckleApplication speckleApplication,
   IOperationProgressManager operationProgressManager,
+  IAccountService accountService,
   ILogger<ReceiveOperationManager> logger
 ) : IReceiveOperationManager
 {
@@ -49,7 +49,7 @@ public sealed class ReceiveOperationManager(
       var ro = serviceScope.ServiceProvider.GetRequiredService<IReceiveOperation>();
       var conversionResults = await processor(
         modelCard.ModelName,
-        () => ro.Execute(modelCard.GetReceiveInfo(speckleApplication.Slug), progress, cancellationItem.Token)
+        () => ro.Execute(modelCard.GetReceiveInfo(accountService), progress, cancellationItem.Token)
       );
 
       if (conversionResults is null)

--- a/DUI3/Speckle.Connectors.DUI/Bindings/ReceiveOperationManagerFactory.cs
+++ b/DUI3/Speckle.Connectors.DUI/Bindings/ReceiveOperationManagerFactory.cs
@@ -1,9 +1,9 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Speckle.Connectors.Common.Cancellation;
+using Speckle.Connectors.Common.Operations;
 using Speckle.Connectors.DUI.Models;
-using Speckle.InterfaceGenerator;
-using Speckle.Sdk;
+using Speckle.InterfaceGenerator; 
 
 namespace Speckle.Connectors.DUI.Bindings;
 
@@ -13,7 +13,7 @@ public class ReceiveOperationManagerFactory(
   IOperationProgressManager operationProgressManager,
   DocumentModelStore store,
   ICancellationManager cancellationManager,
-  ISpeckleApplication speckleApplication,
+  IAccountService accountService,
   ILoggerFactory loggerFactory
 ) : IReceiveOperationManagerFactory
 {
@@ -24,8 +24,7 @@ public class ReceiveOperationManagerFactory(
 #pragma warning restore CA2000
       cancellationManager,
       store,
-      speckleApplication,
-      operationProgressManager,
+      operationProgressManager,accountService,
       loggerFactory.CreateLogger<ReceiveOperationManager>()
     );
 }

--- a/DUI3/Speckle.Connectors.DUI/Bindings/ReceiveOperationManagerFactory.cs
+++ b/DUI3/Speckle.Connectors.DUI/Bindings/ReceiveOperationManagerFactory.cs
@@ -3,7 +3,7 @@ using Microsoft.Extensions.Logging;
 using Speckle.Connectors.Common.Cancellation;
 using Speckle.Connectors.Common.Operations;
 using Speckle.Connectors.DUI.Models;
-using Speckle.InterfaceGenerator; 
+using Speckle.InterfaceGenerator;
 
 namespace Speckle.Connectors.DUI.Bindings;
 
@@ -24,7 +24,8 @@ public class ReceiveOperationManagerFactory(
 #pragma warning restore CA2000
       cancellationManager,
       store,
-      operationProgressManager,accountService,
+      operationProgressManager,
+      accountService,
       loggerFactory.CreateLogger<ReceiveOperationManager>()
     );
 }

--- a/DUI3/Speckle.Connectors.DUI/Bindings/SendOperationManager.cs
+++ b/DUI3/Speckle.Connectors.DUI/Bindings/SendOperationManager.cs
@@ -20,8 +20,8 @@ public sealed class SendOperationManager(
   IOperationProgressManager operationProgressManager,
   DocumentModelStore store,
   ICancellationManager cancellationManager,
-  ISpeckleApplication speckleApplication,
   ISdkActivityFactory activityFactory,
+  IAccountService accountService,
   ILogger<SendOperationManager> logger
 ) : ISendOperationManager
 {
@@ -79,7 +79,7 @@ public sealed class SendOperationManager(
         throw new SpeckleSendFilterException("No objects were found to convert. Please update your publish filter!");
       }
 
-      var sendInfo = modelCard.GetSendInfo(speckleApplication.ApplicationAndVersion);
+      var sendInfo = modelCard.GetSendInfo(accountService);
 
       var sendResult = await serviceScope
         .ServiceProvider.GetRequiredService<ISendOperation<T>>()

--- a/DUI3/Speckle.Connectors.DUI/Bindings/SendOperationManagerFactory.cs
+++ b/DUI3/Speckle.Connectors.DUI/Bindings/SendOperationManagerFactory.cs
@@ -27,7 +27,8 @@ public class SendOperationManagerFactory(
       operationProgressManager,
       store,
       cancellationManager,
-      activityFactory,accountService,
+      activityFactory,
+      accountService,
       loggerFactory.CreateLogger<SendOperationManager>()
     );
 }

--- a/DUI3/Speckle.Connectors.DUI/Bindings/SendOperationManagerFactory.cs
+++ b/DUI3/Speckle.Connectors.DUI/Bindings/SendOperationManagerFactory.cs
@@ -1,9 +1,9 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Speckle.Connectors.Common.Cancellation;
+using Speckle.Connectors.Common.Operations;
 using Speckle.Connectors.DUI.Models;
 using Speckle.InterfaceGenerator;
-using Speckle.Sdk;
 using Speckle.Sdk.Logging;
 
 namespace Speckle.Connectors.DUI.Bindings;
@@ -14,8 +14,8 @@ public class SendOperationManagerFactory(
   IOperationProgressManager operationProgressManager,
   DocumentModelStore store,
   ICancellationManager cancellationManager,
-  ISpeckleApplication speckleApplication,
   ISdkActivityFactory activityFactory,
+  IAccountService accountService,
   ILoggerFactory loggerFactory
 ) : ISendOperationManagerFactory
 {
@@ -27,8 +27,7 @@ public class SendOperationManagerFactory(
       operationProgressManager,
       store,
       cancellationManager,
-      speckleApplication,
-      activityFactory,
+      activityFactory,accountService,
       loggerFactory.CreateLogger<SendOperationManager>()
     );
 }

--- a/DUI3/Speckle.Connectors.DUI/Models/Card/ReceiverModelCard.cs
+++ b/DUI3/Speckle.Connectors.DUI/Models/Card/ReceiverModelCard.cs
@@ -16,15 +16,16 @@ public class ReceiverModelCard : ModelCard
   public bool HasDismissedUpdateWarning { get; set; }
   public List<string>? BakedObjectIds { get; set; }
 
-  public ReceiveInfo GetReceiveInfo(string sourceApplication) =>
-    new(
-      AccountId.NotNull(),
-      new Uri(ServerUrl.NotNull()),
+  public ReceiveInfo GetReceiveInfo(IAccountService accountService)
+  {
+    var account = accountService.GetAccountWithServerUrlFallback(AccountId.NotNull(), new Uri(ServerUrl.NotNull()));
+    return new(
+      account,
       ProjectId.NotNull(),
       ProjectName.NotNull(),
       ModelId.NotNull(),
       ModelName.NotNull(),
-      SelectedVersionId.NotNull(),
-      sourceApplication
+      SelectedVersionId.NotNull()
     );
+  }
 }

--- a/DUI3/Speckle.Connectors.DUI/Models/Card/SenderModelCard.cs
+++ b/DUI3/Speckle.Connectors.DUI/Models/Card/SenderModelCard.cs
@@ -11,6 +11,9 @@ public class SenderModelCard : ModelCard
   // [JsonIgnore]
   // public HashSet<string> ChangedObjectIds { get; set; } = new();
 
-  public SendInfo GetSendInfo(string hostApplication) =>
-    new(AccountId.NotNull(), new Uri(ServerUrl.NotNull()), ProjectId.NotNull(), ModelId.NotNull(), hostApplication);
+  public SendInfo GetSendInfo(IAccountService accountService)
+  {
+    var account = accountService.GetAccountWithServerUrlFallback(AccountId.NotNull(), new Uri(ServerUrl.NotNull()));
+    return new(account, ProjectId.NotNull(), ModelId.NotNull());
+  }
 }

--- a/Sdk/Speckle.Connectors.Common/Operations/ReceiveInfo.cs
+++ b/Sdk/Speckle.Connectors.Common/Operations/ReceiveInfo.cs
@@ -1,12 +1,12 @@
-﻿namespace Speckle.Connectors.Common.Operations;
+﻿using Speckle.Sdk.Credentials;
+
+namespace Speckle.Connectors.Common.Operations;
 
 public record ReceiveInfo(
-  string AccountId,
-  Uri ServerUrl,
+  Account Account,
   string ProjectId,
   string ProjectName,
   string ModelId,
   string ModelName,
-  string SelectedVersionId,
-  string SourceApplication
+  string SelectedVersionId
 );

--- a/Sdk/Speckle.Connectors.Common/Operations/ReceiveInfo.cs
+++ b/Sdk/Speckle.Connectors.Common/Operations/ReceiveInfo.cs
@@ -8,5 +8,6 @@ public record ReceiveInfo(
   string ProjectName,
   string ModelId,
   string ModelName,
-  string SelectedVersionId
+  string SelectedVersionId,
+  string SourceAppilcation
 );

--- a/Sdk/Speckle.Connectors.Common/Operations/ReceiveOperation.cs
+++ b/Sdk/Speckle.Connectors.Common/Operations/ReceiveOperation.cs
@@ -14,11 +14,11 @@ namespace Speckle.Connectors.Common.Operations;
 [GenerateAutoInterface]
 public sealed class ReceiveOperation(
   IHostObjectBuilder hostObjectBuilder,
-  IAccountService accountService,
   IReceiveProgress receiveProgress,
   ISdkActivityFactory activityFactory,
   IOperations operations,
   IReceiveVersionRetriever receiveVersionRetriever,
+  ISpeckleApplication application,
   IThreadContext threadContext
 ) : IReceiveOperation
 {
@@ -32,7 +32,7 @@ public sealed class ReceiveOperation(
     cancellationToken.ThrowIfCancellationRequested();
     execute?.SetTag("receiveInfo", receiveInfo);
     // 2 - Check account exist
-    Account account = accountService.GetAccountWithServerUrlFallback(receiveInfo.AccountId, receiveInfo.ServerUrl);
+    Account account = receiveInfo.Account;
     using var userScope = ActivityScope.SetTag(Consts.USER_ID, account.GetHashedEmail());
     var version = await receiveVersionRetriever.GetVersion(account, receiveInfo, cancellationToken);
 
@@ -90,11 +90,11 @@ public sealed class ReceiveOperation(
   {
     using var conversionActivity = activityFactory.Start("ReceiveOperation.ConvertObjects");
     conversionActivity?.SetTag("smellsLikeV2Data", commitObject.SmellsLikeV2Data());
-    conversionActivity?.SetTag("receiveInfo.serverUrl", receiveInfo.ServerUrl);
+    conversionActivity?.SetTag("receiveInfo.serverUrl", receiveInfo.Account.serverInfo.url);
     conversionActivity?.SetTag("receiveInfo.projectId", receiveInfo.ProjectId);
     conversionActivity?.SetTag("receiveInfo.modelId", receiveInfo.ModelId);
     conversionActivity?.SetTag("receiveInfo.selectedVersionId", receiveInfo.SelectedVersionId);
-    conversionActivity?.SetTag("receiveInfo.sourceApplication", receiveInfo.SourceApplication);
+    conversionActivity?.SetTag("receiveInfo.sourceApplication", application.Slug);
 
     try
     {

--- a/Sdk/Speckle.Connectors.Common/Operations/ReceiveOperation.cs
+++ b/Sdk/Speckle.Connectors.Common/Operations/ReceiveOperation.cs
@@ -18,7 +18,6 @@ public sealed class ReceiveOperation(
   ISdkActivityFactory activityFactory,
   IOperations operations,
   IReceiveVersionRetriever receiveVersionRetriever,
-  ISpeckleApplication application,
   IThreadContext threadContext
 ) : IReceiveOperation
 {
@@ -94,7 +93,7 @@ public sealed class ReceiveOperation(
     conversionActivity?.SetTag("receiveInfo.projectId", receiveInfo.ProjectId);
     conversionActivity?.SetTag("receiveInfo.modelId", receiveInfo.ModelId);
     conversionActivity?.SetTag("receiveInfo.selectedVersionId", receiveInfo.SelectedVersionId);
-    conversionActivity?.SetTag("receiveInfo.sourceApplication", application.Slug);
+    conversionActivity?.SetTag("receiveInfo.sourceApplication", receiveInfo.SourceAppilcation);
 
     try
     {

--- a/Sdk/Speckle.Connectors.Common/Operations/ReceiveVersionRetriever.cs
+++ b/Sdk/Speckle.Connectors.Common/Operations/ReceiveVersionRetriever.cs
@@ -6,7 +6,8 @@ using Speckle.Sdk.Credentials;
 namespace Speckle.Connectors.Common.Operations;
 
 [GenerateAutoInterface]
-public class ReceiveVersionRetriever(IClientFactory clientFactory, ISpeckleApplication application) : IReceiveVersionRetriever
+public class ReceiveVersionRetriever(IClientFactory clientFactory, ISpeckleApplication application)
+  : IReceiveVersionRetriever
 {
   public async Task<Speckle.Sdk.Api.GraphQL.Models.Version> GetVersion(
     Account account,
@@ -29,9 +30,6 @@ public class ReceiveVersionRetriever(IClientFactory clientFactory, ISpeckleAppli
   {
     using var apiClient = clientFactory.Create(account);
 
-    await apiClient.Version.Received(
-      new(version.id, receiveInfo.ProjectId, application.Slug),
-      cancellationToken
-    );
+    await apiClient.Version.Received(new(version.id, receiveInfo.ProjectId, application.Slug), cancellationToken);
   }
 }

--- a/Sdk/Speckle.Connectors.Common/Operations/ReceiveVersionRetriever.cs
+++ b/Sdk/Speckle.Connectors.Common/Operations/ReceiveVersionRetriever.cs
@@ -1,11 +1,12 @@
 ﻿using Speckle.InterfaceGenerator;
+using Speckle.Sdk;
 using Speckle.Sdk.Api;
 using Speckle.Sdk.Credentials;
 
 namespace Speckle.Connectors.Common.Operations;
 
 [GenerateAutoInterface]
-public class ReceiveVersionRetriever(IClientFactory clientFactory) : IReceiveVersionRetriever
+public class ReceiveVersionRetriever(IClientFactory clientFactory, ISpeckleApplication application) : IReceiveVersionRetriever
 {
   public async Task<Speckle.Sdk.Api.GraphQL.Models.Version> GetVersion(
     Account account,
@@ -29,7 +30,7 @@ public class ReceiveVersionRetriever(IClientFactory clientFactory) : IReceiveVer
     using var apiClient = clientFactory.Create(account);
 
     await apiClient.Version.Received(
-      new(version.id, receiveInfo.ProjectId, receiveInfo.SourceApplication),
+      new(version.id, receiveInfo.ProjectId, application.Slug),
       cancellationToken
     );
   }

--- a/Sdk/Speckle.Connectors.Common/Operations/ReceiveVersionRetriever.cs
+++ b/Sdk/Speckle.Connectors.Common/Operations/ReceiveVersionRetriever.cs
@@ -1,13 +1,11 @@
 ﻿using Speckle.InterfaceGenerator;
-using Speckle.Sdk;
 using Speckle.Sdk.Api;
 using Speckle.Sdk.Credentials;
 
 namespace Speckle.Connectors.Common.Operations;
 
 [GenerateAutoInterface]
-public class ReceiveVersionRetriever(IClientFactory clientFactory, ISpeckleApplication application)
-  : IReceiveVersionRetriever
+public class ReceiveVersionRetriever(IClientFactory clientFactory) : IReceiveVersionRetriever
 {
   public async Task<Speckle.Sdk.Api.GraphQL.Models.Version> GetVersion(
     Account account,
@@ -30,6 +28,9 @@ public class ReceiveVersionRetriever(IClientFactory clientFactory, ISpeckleAppli
   {
     using var apiClient = clientFactory.Create(account);
 
-    await apiClient.Version.Received(new(version.id, receiveInfo.ProjectId, application.Slug), cancellationToken);
+    await apiClient.Version.Received(
+      new(version.id, receiveInfo.ProjectId, receiveInfo.SourceAppilcation),
+      cancellationToken
+    );
   }
 }

--- a/Sdk/Speckle.Connectors.Common/Operations/SendInfo.cs
+++ b/Sdk/Speckle.Connectors.Common/Operations/SendInfo.cs
@@ -2,4 +2,4 @@
 
 namespace Speckle.Connectors.Common.Operations;
 
-public record SendInfo(Account Account,string ProjectId, string ModelId);
+public record SendInfo(Account Account, string ProjectId, string ModelId);

--- a/Sdk/Speckle.Connectors.Common/Operations/SendInfo.cs
+++ b/Sdk/Speckle.Connectors.Common/Operations/SendInfo.cs
@@ -1,3 +1,5 @@
-﻿namespace Speckle.Connectors.Common.Operations;
+﻿using Speckle.Sdk.Credentials;
 
-public record SendInfo(string AccountId, Uri ServerUrl, string ProjectId, string ModelId, string SourceApplication);
+namespace Speckle.Connectors.Common.Operations;
+
+public record SendInfo(Account Account,string ProjectId, string ModelId);

--- a/Sdk/Speckle.Connectors.Common/Operations/SendInfo.cs
+++ b/Sdk/Speckle.Connectors.Common/Operations/SendInfo.cs
@@ -2,4 +2,4 @@
 
 namespace Speckle.Connectors.Common.Operations;
 
-public record SendInfo(Account Account, string ProjectId, string ModelId);
+public record SendInfo(Account Account, string ProjectId, string ModelId, string SourceApplication);

--- a/Sdk/Speckle.Connectors.Common/Operations/SendOperation.cs
+++ b/Sdk/Speckle.Connectors.Common/Operations/SendOperation.cs
@@ -17,7 +17,6 @@ namespace Speckle.Connectors.Common.Operations;
 public sealed class SendOperation<T>(
   IRootObjectBuilder<T> rootObjectBuilder,
   ISendConversionCache sendConversionCache,
-  IAccountService accountService,
   ISendProgress sendProgress,
   IOperations operations,
   ISendOperationVersionRecorder sendOperationVersionRecorder,
@@ -61,13 +60,13 @@ public sealed class SendOperation<T>(
 
     onOperationProgressed.Report(new("Uploading...", null));
 
-    Account account = accountService.GetAccountWithServerUrlFallback(sendInfo.AccountId, sendInfo.ServerUrl);
+    Account account = sendInfo.Account;
     using var userScope = ActivityScope.SetTag(Consts.USER_ID, account.GetHashedEmail());
     using var activity = activityFactory.Start("SendOperation");
 
     sendProgress.Begin();
     var sendResult = await operations.Send2(
-      sendInfo.ServerUrl,
+      new(sendInfo.Account.serverInfo.url),
       sendInfo.ProjectId,
       account.token,
       commitObject,

--- a/Sdk/Speckle.Connectors.Common/Operations/SendOperationVersionRecorder.cs
+++ b/Sdk/Speckle.Connectors.Common/Operations/SendOperationVersionRecorder.cs
@@ -1,5 +1,4 @@
 ﻿using Speckle.InterfaceGenerator;
-using Speckle.Sdk;
 using Speckle.Sdk.Api;
 using Speckle.Sdk.Api.GraphQL.Inputs;
 using Speckle.Sdk.Credentials;
@@ -7,8 +6,7 @@ using Speckle.Sdk.Credentials;
 namespace Speckle.Connectors.Common.Operations;
 
 [GenerateAutoInterface]
-public class SendOperationVersionRecorder(IClientFactory clientFactory, ISpeckleApplication application)
-  : ISendOperationVersionRecorder
+public class SendOperationVersionRecorder(IClientFactory clientFactory) : ISendOperationVersionRecorder
 {
   public async Task<string> RecordVersion(string rootId, SendInfo sendInfo, Account account, CancellationToken ct)
   {
@@ -19,7 +17,7 @@ public class SendOperationVersionRecorder(IClientFactory clientFactory, ISpeckle
           rootId,
           sendInfo.ModelId,
           sendInfo.ProjectId,
-          sourceApplication: application.ApplicationAndVersion
+          sourceApplication: sendInfo.SourceApplication
         ),
         ct
       )

--- a/Sdk/Speckle.Connectors.Common/Operations/SendOperationVersionRecorder.cs
+++ b/Sdk/Speckle.Connectors.Common/Operations/SendOperationVersionRecorder.cs
@@ -1,4 +1,5 @@
 ﻿using Speckle.InterfaceGenerator;
+using Speckle.Sdk;
 using Speckle.Sdk.Api;
 using Speckle.Sdk.Api.GraphQL.Inputs;
 using Speckle.Sdk.Credentials;
@@ -6,7 +7,7 @@ using Speckle.Sdk.Credentials;
 namespace Speckle.Connectors.Common.Operations;
 
 [GenerateAutoInterface]
-public class SendOperationVersionRecorder(IClientFactory clientFactory) : ISendOperationVersionRecorder
+public class SendOperationVersionRecorder(IClientFactory clientFactory, ISpeckleApplication application) : ISendOperationVersionRecorder
 {
   public async Task<string> RecordVersion(string rootId, SendInfo sendInfo, Account account, CancellationToken ct)
   {
@@ -17,7 +18,7 @@ public class SendOperationVersionRecorder(IClientFactory clientFactory) : ISendO
           rootId,
           sendInfo.ModelId,
           sendInfo.ProjectId,
-          sourceApplication: sendInfo.SourceApplication
+          sourceApplication: application.ApplicationAndVersion
         ),
         ct
       )

--- a/Sdk/Speckle.Connectors.Common/Operations/SendOperationVersionRecorder.cs
+++ b/Sdk/Speckle.Connectors.Common/Operations/SendOperationVersionRecorder.cs
@@ -7,7 +7,8 @@ using Speckle.Sdk.Credentials;
 namespace Speckle.Connectors.Common.Operations;
 
 [GenerateAutoInterface]
-public class SendOperationVersionRecorder(IClientFactory clientFactory, ISpeckleApplication application) : ISendOperationVersionRecorder
+public class SendOperationVersionRecorder(IClientFactory clientFactory, ISpeckleApplication application)
+  : ISendOperationVersionRecorder
 {
   public async Task<string> RecordVersion(string rootId, SendInfo sendInfo, Account account, CancellationToken ct)
   {


### PR DESCRIPTION
replaces https://github.com/specklesystems/speckle-sharp-connectors/pull/920
Slight refactor to use Account object sooner.
Grasshopper now a new component just for  URL with Token
