### PR TITLE
fix(grasshopper): url node button improvements

### DIFF
--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Wizard/ModelMenuHandler.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Wizard/ModelMenuHandler.cs
@@ -71,6 +71,7 @@ public class ModelMenuHandler
 
   private bool PopulateMenu(ToolStripDropDown menu)
   {
+    menu.LayoutStyle = ToolStripLayoutStyle.VerticalStackWithOverflow;
     _menu = menu;
     _searchItem = new SearchToolStripMenuItem(menu, Refetch);
 

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Wizard/ProjectMenuHandler.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Wizard/ProjectMenuHandler.cs
@@ -71,6 +71,7 @@ public class ProjectMenuHandler
 
   private bool PopulateMenu(ToolStripDropDown menu)
   {
+    menu.LayoutStyle = ToolStripLayoutStyle.VerticalStackWithOverflow;
     _menu = menu;
     _searchItem = new SearchToolStripMenuItem(menu, Refetch);
 

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Wizard/SearchToolStripMenuItem.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Wizard/SearchToolStripMenuItem.cs
@@ -16,6 +16,7 @@ public class SearchToolStripMenuItem
 
   public SearchToolStripMenuItem(ToolStripDropDown parent, Func<string, Task> onSearchTextChanged)
   {
+    parent.LayoutStyle = ToolStripLayoutStyle.VerticalStackWithOverflow;
     ParentDropDown = parent;
     ParentDropDown.Opacity = 0.95;
     ParentDropDown.TopLevel = true;
@@ -38,9 +39,11 @@ public class SearchToolStripMenuItem
   {
     var item = new ToolStripMenuItem(text)
     {
+      TextAlign = ContentAlignment.MiddleLeft,
       Checked = isChecked ?? false,
       Image = image,
-      ImageScaling = ToolStripItemImageScaling.SizeToFit
+      ImageScaling = ToolStripItemImageScaling.SizeToFit,
+      ImageAlign = ContentAlignment.MiddleLeft
     };
     item.Click += click;
     if (visible == false)
@@ -60,10 +63,10 @@ public class SearchToolStripMenuItem
   {
     var textBox = new TextBox
     {
-      BorderStyle = BorderStyle.None,
-      Width = 600,
-      Font = new Font("Segoe UI", 9),
       TextAlign = HorizontalAlignment.Left,
+      BorderStyle = BorderStyle.None,
+      Width = ParentDropDown.Width,
+      Font = new Font("Segoe UI", 9),
       Text = SEARCH_PLACEHOLDER_TEXT,
       BackColor = Color.White,
     };
@@ -105,10 +108,10 @@ public class SearchToolStripMenuItem
 
     SearchHost = new ToolStripControlHost(textBox)
     {
+      Alignment = ToolStripItemAlignment.Left,
+      ControlAlign = ContentAlignment.MiddleLeft,
       Name = SearchItemId,
-      AutoSize = false,
-      Size = new Size(170, 24),
-      Margin = new Padding(4),
+      Margin = new Padding(2),
       Padding = new Padding(2)
     };
 

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Wizard/SpeckleOperationWizard.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Wizard/SpeckleOperationWizard.cs
@@ -26,6 +26,7 @@ public class SpeckleOperationWizard
   public Project? SelectedProject { get; private set; }
   public Model? SelectedModel { get; private set; }
   public Version? SelectedVersion { get; private set; }
+  public bool IsLatestVersion { get; private set; }
 
   public WorkspaceMenuHandler WorkspaceMenuHandler { get; }
   public ProjectMenuHandler ProjectMenuHandler { get; }
@@ -116,7 +117,7 @@ public class SpeckleOperationWizard
 
         // TODO: this wont be the case when we have separation between send and receive components
         var v = client.Version.Get(versionResource.VersionId, versionResource.ProjectId).Result;
-        VersionMenuHandler?.RedrawMenuButton(v);
+        VersionMenuHandler?.RedrawMenuButton(v, false);
         break;
       case SpeckleUrlModelObjectResource:
         throw new SpeckleException("Object URLs are not supported");
@@ -238,7 +239,7 @@ public class SpeckleOperationWizard
     using IClient client = _clientFactory.Create(SelectedAccount);
     var version = client.Version.Get(versionId, SelectedProject.id).Result;
     SelectedVersion = version;
-    VersionMenuHandler?.RedrawMenuButton(SelectedVersion);
+    VersionMenuHandler?.RedrawMenuButton(SelectedVersion, IsLatestVersion);
   }
 
   /// <summary>
@@ -438,13 +439,14 @@ public class SpeckleOperationWizard
   private void OnModelSelected(object sender, ModelSelectedEventArgs e)
   {
     SelectedModel = e.SelectedModel;
-    ResetVersions();
+    ResetVersions(true);
     _refreshComponent.Invoke();
   }
 
   private void OnVersionSelected(object sender, VersionSelectedEventArgs e)
   {
     SelectedVersion = e.SelectedVersion;
+    IsLatestVersion = e.IsLatest;
     _refreshComponent.Invoke();
   }
 
@@ -469,10 +471,10 @@ public class SpeckleOperationWizard
     ResetVersions();
   }
 
-  private void ResetVersions()
+  private void ResetVersions(bool defaultToLatest = false)
   {
     SelectedVersion = null;
-    VersionMenuHandler?.Reset();
+    VersionMenuHandler?.Reset(defaultToLatest);
   }
 
   private Task CreateNewWorkspace()

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Wizard/WorkspaceMenuHandler.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Wizard/WorkspaceMenuHandler.cs
@@ -1,4 +1,4 @@
-﻿using System.Drawing.Drawing2D;
+using System.Drawing.Drawing2D;
 using Speckle.Sdk.Api.GraphQL.Models;
 
 namespace Speckle.Connectors.GrasshopperShared.Components.Operations.Wizard;
@@ -56,6 +56,7 @@ public class WorkspaceMenuHandler
 
   private bool PopulateMenu(ToolStripDropDown menu)
   {
+    menu.LayoutStyle = ToolStripLayoutStyle.VerticalStackWithOverflow;
     _menu = menu;
     _searchItem = new SearchToolStripMenuItem(menu, Refetch);
 


### PR DESCRIPTION

<!---

Provide a short summary in the Title above. Use the following template:

category(project): summary

Categories:

* feat: (new feature for the user, not a new feature for build script)
* fix: (bug fix for the user, not a fix to a build script)
* docs: (changes to the documentation)
* style: (formatting, missing semi colons, etc; no production code change)
* refactor: (refactoring production code, eg. renaming a variable)
* test: (adding missing tests, refactoring tests; no production code change)
* chore: (updating grunt tasks etc; no production code change)

Example:

feat(revit): added category filter to send

-->

## Description

Makes the following fixes to the url node:
- `Version` button now shows "Latest Version" by default after a model is selected, or if the "latest version" toolstip item is selected
- all toolstrips on buttons are now vertically formated, fixing a vertical divider issue

## User Value

prettier UI

## Changes:

- url node

## To-do before merge:

<!---

(Optional -- remove this section if not needed)

Include any notes about things that need to happen before this PR is merged, e.g.:

- [ ] Change the base branch

- [ ] Ensure PR #56 is merged

-->

## Screenshots:

Before:

After:
Toolstrip dividers are now horizontal instead of vertical
![image](https://github.com/user-attachments/assets/c4ef63e3-71df-4961-8d09-118955e91f5e)

Latest version is shown by default and when selected
![image](https://github.com/user-attachments/assets/6720b06c-f615-4501-b767-b0719d108c08)

## Validation of changes:

<!---

Describe what tests have been added or amended, and why these demonstrate it works and will prevent this feature being accidentally broken by future changes.

-->

## Checklist:

<!---

This checklist is a useful reminder of related tasks to uphold our repo quality. Amend this list as needed for the pr.

-->
- [ ] My commits are related to the pull request and do not amend unrelated code or documentation.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.

