### PR TITLE
chore(grasshopper): various touchups

### DIFF
--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/ComponentUtils.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/ComponentUtils.cs
@@ -7,7 +7,7 @@ public static class ComponentCategories
   public const string PRIMARY_RIBBON = "Speckle";
 
   // categories
-  public const string OPERATIONS = "    Publish & Load";
+  public const string OPERATIONS = "    Models";
   public const string OBJECTS = "   Objects";
   public const string COLLECTIONS = "  Collections";
   public const string PARAMETERS = " Params";

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/ComponentUtils.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/ComponentUtils.cs
@@ -3,8 +3,11 @@ namespace Speckle.Connectors.GrasshopperShared.Components;
 // NOTE: The number of spaces determines the order in which they display in the ribbon (nice hack)
 public static class ComponentCategories
 {
+  // ribbon
   public const string PRIMARY_RIBBON = "Speckle";
-  public const string OPERATIONS = "    Ops";
+
+  // categories
+  public const string OPERATIONS = "    Publish & Load";
   public const string OBJECTS = "   Objects";
   public const string COLLECTIONS = "  Collections";
   public const string PARAMETERS = " Params";

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Objects/CreateSpeckleProperties.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Objects/CreateSpeckleProperties.cs
@@ -17,6 +17,7 @@ public class CreateSpeckleProperties : VariableParameterComponentBase
 
   public override Guid ComponentGuid => GetType().GUID;
   protected override Bitmap Icon => Resources.speckle_properties_create;
+  public override GH_Exposure Exposure => GH_Exposure.secondary;
 
   public CreateSpeckleProperties()
     : base(

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Objects/FilterSpeckleObjects.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Objects/FilterSpeckleObjects.cs
@@ -14,7 +14,7 @@ public class FilterSpeckleObjects : GH_Component
 {
   public override Guid ComponentGuid => GetType().GUID;
   protected override Bitmap Icon => Resources.speckle_objects_filter;
-  public override GH_Exposure Exposure => GH_Exposure.primary | GH_Exposure.obscure;
+  public override GH_Exposure Exposure => GH_Exposure.primary;
 
   public FilterSpeckleObjects()
     : base(

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Objects/FilterSpeckleObjects.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Objects/FilterSpeckleObjects.cs
@@ -14,6 +14,7 @@ public class FilterSpeckleObjects : GH_Component
 {
   public override Guid ComponentGuid => GetType().GUID;
   protected override Bitmap Icon => Resources.speckle_objects_filter;
+  public override GH_Exposure Exposure => GH_Exposure.primary;
 
   public FilterSpeckleObjects()
     : base(

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Objects/FilterSpeckleObjects.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Objects/FilterSpeckleObjects.cs
@@ -14,7 +14,7 @@ public class FilterSpeckleObjects : GH_Component
 {
   public override Guid ComponentGuid => GetType().GUID;
   protected override Bitmap Icon => Resources.speckle_objects_filter;
-  public override GH_Exposure Exposure => GH_Exposure.primary;
+  public override GH_Exposure Exposure => GH_Exposure.primary | GH_Exposure.obscure;
 
   public FilterSpeckleObjects()
     : base(

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Objects/GetObjectProperties.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Objects/GetObjectProperties.cs
@@ -12,7 +12,7 @@ public class GetObjectProperties : GH_Component, IGH_VariableParameterComponent
   public override Guid ComponentGuid => GetType().GUID;
 
   protected override Bitmap Icon => Resources.speckle_properties_query;
-  public override GH_Exposure Exposure => GH_Exposure.secondary;
+  public override GH_Exposure Exposure => GH_Exposure.secondary | GH_Exposure.obscure;
 
   public GetObjectProperties()
     : base(

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Objects/GetObjectProperties.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Objects/GetObjectProperties.cs
@@ -12,6 +12,7 @@ public class GetObjectProperties : GH_Component, IGH_VariableParameterComponent
   public override Guid ComponentGuid => GetType().GUID;
 
   protected override Bitmap Icon => Resources.speckle_properties_query;
+  public override GH_Exposure Exposure => GH_Exposure.secondary;
 
   public GetObjectProperties()
     : base(

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Objects/GetObjectProperties.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Objects/GetObjectProperties.cs
@@ -12,7 +12,7 @@ public class GetObjectProperties : GH_Component, IGH_VariableParameterComponent
   public override Guid ComponentGuid => GetType().GUID;
 
   protected override Bitmap Icon => Resources.speckle_properties_query;
-  public override GH_Exposure Exposure => GH_Exposure.secondary | GH_Exposure.obscure;
+  public override GH_Exposure Exposure => GH_Exposure.secondary;
 
   public GetObjectProperties()
     : base(

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Objects/PropertyGroupPathsSelector.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Objects/PropertyGroupPathsSelector.cs
@@ -23,7 +23,7 @@ public class PropertyGroupPathsSelector : ValueSet<IGH_Goo>
 
   public override Guid ComponentGuid => new Guid("8882BE3A-81F1-4416-B420-58D69E4CC8F1");
   protected override Bitmap Icon => Resources.speckle_inputs_property;
-  public override GH_Exposure Exposure => GH_Exposure.secondary;
+  public override GH_Exposure Exposure => GH_Exposure.secondary | GH_Exposure.obscure;
 
   protected override void LoadVolatileData()
   {

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Objects/PropertyGroupPathsSelector.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Objects/PropertyGroupPathsSelector.cs
@@ -23,7 +23,7 @@ public class PropertyGroupPathsSelector : ValueSet<IGH_Goo>
 
   public override Guid ComponentGuid => new Guid("8882BE3A-81F1-4416-B420-58D69E4CC8F1");
   protected override Bitmap Icon => Resources.speckle_inputs_property;
-  public override GH_Exposure Exposure => GH_Exposure.secondary | GH_Exposure.obscure;
+  public override GH_Exposure Exposure => GH_Exposure.secondary;
 
   protected override void LoadVolatileData()
   {

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Objects/PropertyGroupPathsSelector.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Objects/PropertyGroupPathsSelector.cs
@@ -1,3 +1,4 @@
+using Grasshopper.Kernel;
 using Grasshopper.Kernel.Types;
 using Speckle.Connectors.Common.Extensions;
 using Speckle.Connectors.GrasshopperShared.Components.BaseComponents;
@@ -21,8 +22,8 @@ public class PropertyGroupPathsSelector : ValueSet<IGH_Goo>
     ) { }
 
   public override Guid ComponentGuid => new Guid("8882BE3A-81F1-4416-B420-58D69E4CC8F1");
-
   protected override Bitmap Icon => Resources.speckle_inputs_property;
+  public override GH_Exposure Exposure => GH_Exposure.secondary;
 
   protected override void LoadVolatileData()
   {

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Objects/QuerySpeckleObjects.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Objects/QuerySpeckleObjects.cs
@@ -16,6 +16,7 @@ public class QuerySpeckleObjects : GH_Component, IGH_VariableParameterComponent
 {
   public override Guid ComponentGuid => GetType().GUID;
   protected override Bitmap Icon => Resources.speckle_objects_query;
+  public override GH_Exposure Exposure => GH_Exposure.primary;
 
   public QuerySpeckleObjects()
     : base(

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Objects/SpeckleObjectPassthrough.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Objects/SpeckleObjectPassthrough.cs
@@ -22,6 +22,7 @@ public class SpeckleObjectPassthrough : GH_Component
 
   public override Guid ComponentGuid => GetType().GUID;
   protected override Bitmap Icon => Resources.speckle_objects_object;
+  public override GH_Exposure Exposure => GH_Exposure.primary;
 
   protected override void RegisterInputParams(GH_InputParamManager pManager)
   {

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Objects/SpecklePropertiesPassthrough.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Objects/SpecklePropertiesPassthrough.cs
@@ -14,6 +14,7 @@ public class SpecklePropertiesPassthrough : GH_Component
 {
   public override Guid ComponentGuid => GetType().GUID;
   protected override Bitmap Icon => Resources.speckle_properties_properties;
+  public override GH_Exposure Exposure => GH_Exposure.secondary;
 
   private enum PropertyMode
   {

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/SpeckleSelectModelComponent.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/SpeckleSelectModelComponent.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using GH_IO.Serialization;
 using Grasshopper.Kernel;
 using Speckle.Connectors.GrasshopperShared.Components.Operations.Wizard;
@@ -324,6 +325,30 @@ public class SpeckleSelectModelComponent : GH_Component
         SpeckleOperationWizard.SelectedAccount?.id != account.id,
         SpeckleOperationWizard.SelectedAccount?.id == account.id
       );
+    }
+
+    if (SpeckleOperationWizard.SelectedAccount != null && SpeckleOperationWizard.SelectedProject != null)
+    {
+      Menu_AppendSeparator(menu);
+      Menu_AppendItem(
+        menu,
+        $"View model online ↗",
+        (s, e) =>
+          Open(
+            SpeckleOperationWizard.SelectedAccount.serverInfo.url,
+            SpeckleOperationWizard.SelectedProject.id,
+            SpeckleOperationWizard.SelectedModel?.id,
+            SpeckleOperationWizard.SelectedVersion?.id
+          )
+      );
+    }
+
+    static void Open(string server, string projectId, string? modelId, string? versionId)
+    {
+      string url =
+        $"{server}/projects/{projectId}/models/{(modelId is null ? "" : modelId)}{(versionId is null ? "" : $"@{versionId}")}";
+      var psi = new ProcessStartInfo { FileName = url, UseShellExecute = true };
+      Process.Start(psi);
     }
   }
 

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/SpeckleCollectionWrapper.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/SpeckleCollectionWrapper.cs
@@ -290,6 +290,7 @@ public class SpeckleCollectionParam : GH_Param<SpeckleCollectionWrapperGoo>, IGH
 
   public override Guid ComponentGuid => new("6E871D5B-B221-4992-882A-EFE6796F3010");
   protected override Bitmap Icon => Resources.speckle_param_collection;
+  public override GH_Exposure Exposure => GH_Exposure.primary;
 
   bool IGH_BakeAwareObject.IsBakeCapable => // False if no data
     !VolatileData.IsEmpty;

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/SpeckleMaterialWrapper.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/SpeckleMaterialWrapper.cs
@@ -224,8 +224,8 @@ public class SpeckleMaterialParam : GH_Param<SpeckleMaterialWrapperGoo>, IGH_Bak
     ) { }
 
   public override Guid ComponentGuid => new("1A08CF79-2072-4B14-9430-E4465FF0C0FE");
-
   protected override Bitmap Icon => Resources.speckle_param_material;
+  public override GH_Exposure Exposure => GH_Exposure.secondary;
 
   bool IGH_BakeAwareObject.IsBakeCapable => // False if no data
     !VolatileData.IsEmpty;

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/SpeckleObjectWrapper.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/SpeckleObjectWrapper.cs
@@ -461,8 +461,8 @@ public class SpeckleObjectParam : GH_Param<SpeckleObjectWrapperGoo>, IGH_BakeAwa
     ) { }
 
   public override Guid ComponentGuid => new("22FD5510-D5D3-4101-8727-153FFD329E4F");
-
   protected override Bitmap Icon => Resources.speckle_param_object;
+  public override GH_Exposure Exposure => GH_Exposure.primary;
 
   public bool IsBakeCapable =>
     // False if no data

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/SpecklePropertyGroupGoo.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/SpecklePropertyGroupGoo.cs
@@ -207,6 +207,7 @@ public class SpecklePropertyGroupParam : GH_Param<SpecklePropertyGroupGoo>
 {
   public override Guid ComponentGuid => new("AF4757C3-BA33-4ACD-A92B-C80356043129");
   protected override Bitmap Icon => Resources.speckle_param_properties;
+  public override GH_Exposure Exposure => GH_Exposure.secondary;
 
   public SpecklePropertyGroupParam()
     : this(GH_ParamAccess.item) { }


### PR DESCRIPTION
<!---

Provide a short summary in the Title above. Use the following template:

category(project): summary

Categories:

* feat: (new feature for the user, not a new feature for build script)
* fix: (bug fix for the user, not a fix to a build script)
* docs: (changes to the documentation)
* style: (formatting, missing semi colons, etc; no production code change)
* refactor: (refactoring production code, eg. renaming a variable)
* test: (adding missing tests, refactoring tests; no production code change)
* chore: (updating grunt tasks etc; no production code change)

Example:

feat(revit): added category filter to send

-->

## Description

- Adds the option to open your current URL node in browser, for project, model, or version urls (supposed to help users create new models more easily and to know what they're receiving)
- Sorts components with dividers by adjusting exposure (UI is cleaner)

## User Value

see above


## Changes:

<!---

- Item 1
- Item 2

-->

## To-do before merge:

<!---

(Optional -- remove this section if not needed)

Include any notes about things that need to happen before this PR is merged, e.g.:

- [ ] Change the base branch

- [ ] Ensure PR #56 is merged

-->

## Screenshots:

Opening Urls:
![image](https://github.com/user-attachments/assets/2d788756-ca2a-43ff-8660-f2cc13a8e0a0)

Sorted components:
![image](https://github.com/user-attachments/assets/be68d9de-68da-4661-bb2e-1be311ffd8ec)


## Validation of changes:

<!---

Describe what tests have been added or amended, and why these demonstrate it works and will prevent this feature being accidentally broken by future changes.

-->

## Checklist:

<!---

This checklist is a useful reminder of related tasks to uphold our repo quality. Amend this list as needed for the pr.

-->
- [ ] My commits are related to the pull request and do not amend unrelated code or documentation.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.

