### PR TITLE
fix(grasshopper): receive pipeline polish

### DIFF
--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Receive/ReceiveAsyncComponent.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Receive/ReceiveAsyncComponent.cs
@@ -442,9 +442,13 @@ public sealed class ReceiveComponentWorker : WorkerInstance<ReceiveAsyncComponen
       materialUnpacker
     );
 
+    var definitionObjectIds = unpackedRoot.DefinitionProxies.GetDefinitionObjectIds();
+
     foreach (var atomicContext in atomicObjects)
     {
-      mapHandler.ConvertAtomicObject(atomicContext);
+      var objId = atomicContext.Current.applicationId;
+      bool isDefinitionObject = objId != null && definitionObjectIds.Contains(objId);
+      mapHandler.ConvertAtomicObject(atomicContext, isDefinitionObject);
     }
 
     // process block instances using converted atomic objects

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Receive/ReceiveAsyncComponent.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Receive/ReceiveAsyncComponent.cs
@@ -442,11 +442,13 @@ public sealed class ReceiveComponentWorker : WorkerInstance<ReceiveAsyncComponen
       materialUnpacker
     );
 
+    // objects used in definitions need to be added to ConvertedObjectsMap but not directly to collection
+    // this flattened list allows us to create the bool flag needed by the ConvertAtomicObject method
     var definitionObjectIds = unpackedRoot.DefinitionProxies.GetDefinitionObjectIds();
 
     foreach (var atomicContext in atomicObjects)
     {
-      var objId = atomicContext.Current.applicationId;
+      var objId = atomicContext.Current.applicationId ?? atomicContext.Current.id;
       bool isDefinitionObject = objId != null && definitionObjectIds.Contains(objId);
       mapHandler.ConvertAtomicObject(atomicContext, isDefinitionObject);
     }

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Receive/ReceiveAsyncComponent.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Receive/ReceiveAsyncComponent.cs
@@ -454,7 +454,6 @@ public sealed class ReceiveComponentWorker : WorkerInstance<ReceiveAsyncComponen
     }
 
     // process block instances using converted atomic objects
-    // NOTE: Objects of block definitions appear both as standalone objects and within block definitions when baked.
     // block processing needs converted objects, but object filtering needs block definitions.
     mapHandler.ConvertBlockInstances(blockInstances, unpackedRoot.DefinitionProxies);
 

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Receive/ReceiveComponent.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Receive/ReceiveComponent.cs
@@ -182,9 +182,13 @@ public class ReceiveComponent : SpeckleTaskCapableComponent<ReceiveComponentInpu
       materialUnpacker
     );
 
+    var definitionObjectIds = unpackedRoot.DefinitionProxies.GetDefinitionObjectIds();
+
     foreach (var atomicContext in atomicObjects)
     {
-      mapHandler.ConvertAtomicObject(atomicContext);
+      var objId = atomicContext.Current.applicationId;
+      bool isDefinitionObject = objId != null && definitionObjectIds.Contains(objId);
+      mapHandler.ConvertAtomicObject(atomicContext, isDefinitionObject);
     }
 
     // process block instances using converted atomic objects

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Receive/ReceiveComponent.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Receive/ReceiveComponent.cs
@@ -182,11 +182,13 @@ public class ReceiveComponent : SpeckleTaskCapableComponent<ReceiveComponentInpu
       materialUnpacker
     );
 
+    // objects used in definitions need to be added to ConvertedObjectsMap but not directly to collection
+    // this flattened list allows us to create the bool flag needed by the ConvertAtomicObject method
     var definitionObjectIds = unpackedRoot.DefinitionProxies.GetDefinitionObjectIds();
 
     foreach (var atomicContext in atomicObjects)
     {
-      var objId = atomicContext.Current.applicationId;
+      var objId = atomicContext.Current.applicationId ?? atomicContext.Current.id;
       bool isDefinitionObject = objId != null && definitionObjectIds.Contains(objId);
       mapHandler.ConvertAtomicObject(atomicContext, isDefinitionObject);
     }

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Receive/ReceiveComponent.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Receive/ReceiveComponent.cs
@@ -194,7 +194,6 @@ public class ReceiveComponent : SpeckleTaskCapableComponent<ReceiveComponentInpu
     }
 
     // process block instances using converted atomic objects
-    // NOTE: Objects of block definitions appear both as standalone objects and within block definitions when baked.
     // block processing needs converted objects, but object filtering needs block definitions.
     mapHandler.ConvertBlockInstances(blockInstances, unpackedRoot.DefinitionProxies);
 

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/HostApp/Helpers.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/HostApp/Helpers.cs
@@ -215,12 +215,13 @@ public static class GrasshopperHelpers
     }
     return topology;
   }
-  
+
   /// <summary>
   /// Gets all object IDs that are contained within block definitions.
   /// </summary>
   public static HashSet<string> GetDefinitionObjectIds(
-    this IReadOnlyCollection<InstanceDefinitionProxy>? definitionProxies)
+    this IReadOnlyCollection<InstanceDefinitionProxy>? definitionProxies
+  )
   {
     if (definitionProxies == null)
     {

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/HostApp/Helpers.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/HostApp/Helpers.cs
@@ -9,6 +9,7 @@ using Speckle.DoubleNumerics;
 using Speckle.Sdk;
 using Speckle.Sdk.Common;
 using Speckle.Sdk.Common.Exceptions;
+using Speckle.Sdk.Models.Instances;
 
 namespace Speckle.Connectors.GrasshopperShared.HostApp;
 
@@ -213,5 +214,24 @@ public static class GrasshopperHelpers
       topology += myPath.ToString(false) + "-" + param.VolatileData.get_Branch(myPath).Count + " ";
     }
     return topology;
+  }
+  
+  /// <summary>
+  /// Gets all object IDs that are contained within block definitions.
+  /// </summary>
+  public static HashSet<string> GetDefinitionObjectIds(
+    this IReadOnlyCollection<InstanceDefinitionProxy>? definitionProxies)
+  {
+    if (definitionProxies == null)
+    {
+      return [];
+    }
+
+    // Flatten nested collections: definitionProxies -> objects -> individual objectIds
+    return definitionProxies
+      .Where(proxy => proxy?.objects != null)
+      .SelectMany(proxy => proxy.objects) // proxy.objects is List<string> of object IDs
+      .Where(id => !string.IsNullOrWhiteSpace(id))
+      .ToHashSet();
   }
 }

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Operations/Receive/GrasshopperCollectionRebuilder.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Operations/Receive/GrasshopperCollectionRebuilder.cs
@@ -31,21 +31,6 @@ internal sealed class GrasshopperCollectionRebuilder
     GrasshopperMaterialUnpacker materialUnpacker
   )
   {
-    // add the object color and material
-    speckleGrasshopperObjectWrapper.Color = colorUnpacker.Cache.TryGetValue(
-      speckleGrasshopperObjectWrapper.Base.applicationId ?? "",
-      out var cachedColor
-    )
-      ? cachedColor
-      : null;
-
-    speckleGrasshopperObjectWrapper.Material = materialUnpacker.Cache.TryGetValue(
-      speckleGrasshopperObjectWrapper.Base.applicationId ?? "",
-      out var cachedMaterial
-    )
-      ? cachedMaterial
-      : null;
-
     var collWrapper = GetOrCreateSpeckleCollectionFromPath(collectionPath, colorUnpacker, materialUnpacker);
     collWrapper.Elements.Add(speckleGrasshopperObjectWrapper);
   }

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Operations/Receive/LocalToGlobalMapHandler.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Operations/Receive/LocalToGlobalMapHandler.cs
@@ -40,11 +40,12 @@ internal sealed class LocalToGlobalMapHandler
   }
 
   /// <summary>
-  /// Converts atomic object.
+  /// Converts atomic object from TraversalContext to SpeckleObjectWrapper.
   /// </summary>
-  /// <remarks>
-  /// Definition objects are converted and added to ConvertedObjectsMap but not to collection hierarchy.
-  /// </remarks>
+  /// <param name="isDefinitionObject">
+  /// If true, object is added to ConvertedObjectsMap but excluded from collection hierarchy
+  /// to prevent duplication (definition objects appear both standalone and within block definitions).
+  /// </param>
   public void ConvertAtomicObject(TraversalContext atomicContext, bool isDefinitionObject = false)
   {
     var obj = atomicContext.Current;
@@ -66,7 +67,7 @@ internal sealed class LocalToGlobalMapHandler
 
       var path = _traversalContextUnpacker.GetCollectionPath(atomicContext).ToList();
       SpeckleCollectionWrapper? objectCollection = null;
-      
+
       if (!isDefinitionObject)
       {
         objectCollection = CollectionRebuilder.GetOrCreateSpeckleCollectionFromPath(
@@ -119,7 +120,7 @@ internal sealed class LocalToGlobalMapHandler
 
         // Always add to ConvertedObjectsMap (regardless of definition or atomic objects). Blocks need for unpacking
         ConvertedObjectsMap[objId] = wrapper;
-        
+
         // Only add atomic objects to collection hierarchy if it's not a definition object
         if (!isDefinitionObject && objectCollection != null)
         {

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Operations/Send/GrasshopperBlockPacker.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Operations/Send/GrasshopperBlockPacker.cs
@@ -74,6 +74,8 @@ internal sealed class GrasshopperBlockPacker
 
     // Process objects recursively
     var objectsToAdd = new List<SpeckleObjectWrapper>();
+    var currentObjectIds = new List<string>(); // Track current object IDs for proxy update
+
     foreach (var obj in definition.Objects)
     {
       if (obj.ApplicationId == null) // we should be loud about this. If gone through all casting etc. this should be complete!
@@ -84,6 +86,7 @@ internal sealed class GrasshopperBlockPacker
       }
 
       objectsToAdd.Add(obj);
+      currentObjectIds.Add(obj.ApplicationId); // Collect current ID
       _instanceObjectsManager.AddAtomicObject(obj.ApplicationId, obj);
 
       if (obj is SpeckleBlockInstanceWrapper nestedInstance)
@@ -97,6 +100,7 @@ internal sealed class GrasshopperBlockPacker
     }
 
     // Add definition to InstanceObjectsManager
+    definition.InstanceDefinitionProxy.objects = currentObjectIds;
     definition.InstanceDefinitionProxy.maxDepth = depth;
     _instanceObjectsManager.AddDefinitionProxy(definitionId, definition.InstanceDefinitionProxy);
     InstanceDefinitionProxies[definitionId] = definition.InstanceDefinitionProxy;

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Operations/Send/GrasshopperSendOperation.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Operations/Send/GrasshopperSendOperation.cs
@@ -93,6 +93,7 @@ public class GrasshopperRootObjectBuilder : IRootObjectBuilder<SpeckleCollection
         case SpeckleObjectWrapper so: // handles both SpeckleObjectWrapper and SpeckleBlockInstanceWrapper (inheritance)
           // convert wrapper to base and add to collection - common for all object wrappers
           Base objectBase = ConvertWrapperToBase(so);
+          string applicationId = objectBase.applicationId!;
           currentColl.elements.Add(objectBase);
 
           // do block instance specific stuff (if this object wrapper is actually a block instance)
@@ -102,8 +103,8 @@ public class GrasshopperRootObjectBuilder : IRootObjectBuilder<SpeckleCollection
           }
 
           // process color and material for all object wrappers (including block instances)
-          colorPacker.ProcessColor(so.ApplicationId, so.Color);
-          materialPacker.ProcessMaterial(so.ApplicationId, so.Material);
+          colorPacker.ProcessColor(applicationId, so.Color);
+          materialPacker.ProcessMaterial(applicationId, so.Material);
           break;
       }
     }
@@ -171,13 +172,13 @@ public class GrasshopperRootObjectBuilder : IRootObjectBuilder<SpeckleCollection
       foreach (var definitionObject in definitionObjects)
       {
         Base defObjectBase = ConvertWrapperToBase(definitionObject);
+        string applicationId = defObjectBase.applicationId!;
 
-        // just add to current collection
-        // TODO: where on collection?
+        // just add to current collection for now
         currentColl.elements.Add(defObjectBase);
 
-        colorPacker.ProcessColor(definitionObject.ApplicationId, definitionObject.Color);
-        materialPacker.ProcessMaterial(definitionObject.ApplicationId, definitionObject.Material);
+        colorPacker.ProcessColor(applicationId, definitionObject.Color);
+        materialPacker.ProcessMaterial(applicationId, definitionObject.Material);
       }
     }
   }


### PR DESCRIPTION
## Description
These mainly had to do with the receive pipeline. Definition objects were being processed twice - once as regular atomic objects (added to main collection) and once as part of block definitions, causing duplication conflicts during send operations. Definition objects must be converted (for `ConvertedObjectsMap`) but excluded from the main collection hierarchy.

Related to:
- [CNX-2071](https://linear.app/speckle/issue/CNX-2071/type-filters-all-work-as-expected)
- [CNX-2072](https://linear.app/speckle/issue/CNX-2072/sending-objects-file)

## User Value
Users can now successfully load Rhino models with blocks through Grasshopper, republish them immediately, and see correct colors and full visibility in the Speckle viewer.

## Changes:
- **Fixed definition object duplication**: Added `isDefinitionObject` parameter to `ConvertAtomicObject()` to prevent definition objects from being added to collection hierarchy while preserving them in `ConvertedObjectsMap` for block construction
- **Implemented `GetDefinitionObjectIds()` extension method**: extracts all object IDs belonging to block definitions
- **Fixed color overwriting bug**: Removed redundant color/material assignments from `AppendSpeckleGrasshopperObject()` that were overwriting correctly-assigned colors during receive

## Screenshots & Validation of changes:

### Testing Scenarios:

1. Load & Publish
    1. Publish objects model from Rhino
    2. Load in gh
    3. Bake to Rhino
    4. Query loaded model and check totals per object
    5. Immediately publish back
    6. Visually inspect the two
    7. Inspect viewer for material and color overwrites

2. GH Blocks Publish
    1. Create blocks in GH using components
    2. Publish and visually inspect
    3. Inspect viewer for material and color overwrites
    5. Try load published model in Rhino and make sure block definitions etc. ok

### Before

#### Query Problems
- Block objects are included "double" and as normal objects too
- Rhino objects model has 153 objects - 27 text and dimension = 126
- But we get more (includes the objects that define blocks)

<img width="960" alt="image" src="https://github.com/user-attachments/assets/b485f449-8946-426d-97ab-fe78f4b98cea" />

#### Viewer Problems

<img width="1917" alt="Screenshot 2025-06-27 180208" src="https://github.com/user-attachments/assets/64093284-c3e4-4a00-b7b1-bbb2423f98c7" />

#### Baking Problems
- Load and then bake is "correct" on a visual side and that all objects (including instances) are present
- But the objects of the instances are also included:

<img width="960" alt="image" src="https://github.com/user-attachments/assets/94ea399f-7e40-43c8-9df8-5ad94cc58817" />

### After

#### Query Fix
- 126 objects + 11 block instances = 137 objects! 🎉 
<img width="960" alt="image" src="https://github.com/user-attachments/assets/4d85cb59-cfe5-4a78-86b6-1153dd8d83d9" />

#### Happy Viewer

<img width="960" alt="image" src="https://github.com/user-attachments/assets/9ecdb2bb-e1b5-4f70-a52c-8d2935cb1969" />

## Checklist:
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] I have added appropriate tests.
- [x] I have updated or added relevant documentation.

