### PR TITLE
hotfix(grasshopper): preserve appID on passthrough nodes

### DIFF
--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Objects/SpeckleBlockDefinitionPassthrough.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Objects/SpeckleBlockDefinitionPassthrough.cs
@@ -84,9 +84,6 @@ public class SpeckleBlockDefinitionPassthrough : GH_Component
       return;
     }
 
-    // keep track of mutation
-    bool mutated = false;
-
     // process the definition
     // deep copy so we don't mutate the object
     SpeckleBlockDefinitionWrapperGoo result = inputDefinition != null ? new(inputDefinition.Value.DeepCopy()) : new();
@@ -109,7 +106,6 @@ public class SpeckleBlockDefinitionPassthrough : GH_Component
 
       result.Value.Objects = processedObjects;
       result.Value.InstanceDefinitionProxy.objects = processedObjects.Select(o => o.ApplicationId!).ToList(); // TODO: this could also be set at the same time as `Objects` on the definition wrapper.
-      mutated = true;
     }
 
     // process name
@@ -122,13 +118,10 @@ public class SpeckleBlockDefinitionPassthrough : GH_Component
       }
 
       result.Value.Name = inputName;
-      mutated = true;
     }
 
-    // process application Id. Use a new appId if mutated, or if this is a new object
-    result.Value.ApplicationId = mutated
-      ? Guid.NewGuid().ToString()
-      : result.Value.ApplicationId ?? Guid.NewGuid().ToString();
+    // no need to process application Id.
+    // New definitions should have a new appID generated in the new() constructor, and we want to preserve old appID otherwise for changetracking.
 
     // set outputs
     da.SetData(0, result);

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Objects/SpeckleBlockInstancePassthrough.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Objects/SpeckleBlockInstancePassthrough.cs
@@ -151,12 +151,8 @@ public class SpeckleBlockInstancePassthrough : GH_Component
     SpeckleMaterialWrapperGoo? inputMaterial = null;
     da.GetData(6, ref inputMaterial);
 
-    // keep track of mutation
-    // poc: we should not mark mutations on color or material, as this shouldn't affect the appId of the object, and will allow original display values to stay intact on send.
-    bool mutated = false;
-
     // process the instance
-    // deep copy so we don't mutate the object
+    // deep copy so we don't mutate the incoming object
     SpeckleBlockInstanceWrapperGoo result =
       inputInstance != null ? new((SpeckleBlockInstanceWrapper)inputInstance.Value.DeepCopy()) : new();
 
@@ -164,7 +160,6 @@ public class SpeckleBlockInstancePassthrough : GH_Component
     if (inputDefinition != null)
     {
       result.Value.Definition = inputDefinition.Value;
-      mutated = true;
     }
 
     // Process transform
@@ -174,7 +169,6 @@ public class SpeckleBlockInstancePassthrough : GH_Component
       if (extractedTransform.HasValue)
       {
         result.Value.Transform = extractedTransform.Value;
-        mutated = true;
       }
       else
       {
@@ -190,14 +184,12 @@ public class SpeckleBlockInstancePassthrough : GH_Component
     if (inputName != null)
     {
       result.Value.Name = inputName;
-      mutated = true;
     }
 
     // Process properties
     if (inputProperties != null)
     {
       result.Value.Properties = inputProperties;
-      mutated = true;
     }
 
     // process color (no mutation)
@@ -212,10 +204,8 @@ public class SpeckleBlockInstancePassthrough : GH_Component
       result.Value.Material = inputMaterial.Value;
     }
 
-    // Generate new ApplicationId if mutated
-    result.Value.ApplicationId = mutated
-      ? Guid.NewGuid().ToString()
-      : result.Value.ApplicationId ?? Guid.NewGuid().ToString();
+    // no need to process application id.
+    // new appids are generated if this is a new object, otherwise the input object appID should be preserved for change tracking.
 
     // Set outputs
     da.SetData(0, result);

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Objects/SpeckleObjectPassthrough.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Objects/SpeckleObjectPassthrough.cs
@@ -155,10 +155,6 @@ public class SpeckleObjectPassthrough : GH_Component
     SpeckleMaterialWrapperGoo? inputMaterial = null;
     da.GetData(5, ref inputMaterial);
 
-    // keep track of mutation
-    // poc: we should not mark mutations on color or material, as this shouldn't affect the appId of the object, and will allow original display values to stay intact on send.
-    bool mutated = false;
-
     // process geometry
     // deep copy so we don't mutate the input geo which may be speckle objects
     if (inputGeometry != null)
@@ -189,8 +185,6 @@ public class SpeckleObjectPassthrough : GH_Component
           result.Base = mutatingGeo.Base;
           result.GeometryBase = mutatingGeo.GeometryBase;
         }
-
-        mutated = true;
       }
       else
       {
@@ -206,14 +200,12 @@ public class SpeckleObjectPassthrough : GH_Component
     if (inputName != null)
     {
       result!.Name = inputName;
-      mutated = true;
     }
 
     // process properties
     if (inputProperties != null)
     {
       result!.Properties = inputProperties;
-      mutated = true;
     }
 
     // process color (no mutation)
@@ -228,8 +220,8 @@ public class SpeckleObjectPassthrough : GH_Component
       result!.Material = inputMaterial.Value;
     }
 
-    // process application Id. Use a new appId if mutated, or if this is a new object
-    result!.ApplicationId = mutated ? Guid.NewGuid().ToString() : result!.ApplicationId ?? Guid.NewGuid().ToString();
+    // no need to process application Id.
+    // New definitions should have a new appID generated in the new() constructor, and we want to preserve old appID otherwise for changetracking.
 
     // get the path
     string path =


### PR DESCRIPTION
<!---

Provide a short summary in the Title above. Use the following template:

category(project): summary

Categories:

* feat: (new feature for the user, not a new feature for build script)
* fix: (bug fix for the user, not a fix to a build script)
* docs: (changes to the documentation)
* style: (formatting, missing semi colons, etc; no production code change)
* refactor: (refactoring production code, eg. renaming a variable)
* test: (adding missing tests, refactoring tests; no production code change)
* chore: (updating grunt tasks etc; no production code change)

Example:

feat(revit): added category filter to send

-->

## Description

No longer assigns a new appID on passthrough nodes when an input object is mutated.
Requested from community: https://speckle.community/t/no-unique-application-id-when-sending-speckle-blocks-through-grasshopper/18501/6

## User Value

Allows users working with model objects in Grasshopper to get more reliable change tracking

## Changes:

- speckle object passthrough
- speckle instance passthrough
- speckle definition passthrough

## To-do before merge:


## Screenshots:
Before:
![image](https://github.com/user-attachments/assets/54a68586-f1e0-4a52-8810-8817c4ef5c2f)

After:
![image](https://github.com/user-attachments/assets/c336706c-c3a9-40f4-a8c1-b697b1258d73)

## Validation of changes:

<!---

Describe what tests have been added or amended, and why these demonstrate it works and will prevent this feature being accidentally broken by future changes.

-->

## Checklist:

<!---

This checklist is a useful reminder of related tasks to uphold our repo quality. Amend this list as needed for the pr.

-->
- [ ] My commits are related to the pull request and do not amend unrelated code or documentation.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.

