### PR TITLE
feat(grasshopper): Create DataObject wrapper, goo, and param classes

### DIFF
--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/Wrappers/SpeckleDataObjectWrapper.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/Wrappers/SpeckleDataObjectWrapper.cs
@@ -1,0 +1,68 @@
+﻿using Grasshopper.Kernel.Types;
+using Rhino.Geometry;
+using Speckle.Sdk.Models;
+using DataObject = Speckle.Objects.Data.DataObject;
+
+namespace Speckle.Connectors.GrasshopperShared.Parameters;
+
+/// <summary>
+/// Wrapper around a data object and its converted speckle equivalent.
+/// </summary>
+public class SpeckleDataObjectWrapper : SpeckleWrapper, ISpeckleCollectionObject
+{
+  /// <summary>
+  /// The wrapped DataObject.
+  /// </summary>
+  public DataObject DataObject { get; set; } // Public for consistency with existing wrappers, but would private be better to force things through Base that validates?
+
+  /// <summary>
+  /// Validated gateway to the typed property (validates and delegates to DataObject).
+  /// </summary>
+  public override required Base Base
+  {
+    get => DataObject;
+    set
+    {
+      if (value is not DataObject dataObject)
+      {
+        throw new ArgumentException("Cannot create data object wrapper from a non-DataObject Base");
+      }
+      DataObject = dataObject;
+    }
+  }
+
+  /// <summary>
+  /// Converted geometries from DataObject.displayValue.
+  /// </summary>
+  public List<GeometryBase> Geometries { get; set; } = [];
+
+  /// <summary>
+  /// Structured properties from the DataObject.
+  /// </summary>
+  public SpecklePropertyGroupGoo Properties { get; set; } = new();
+
+  public override IGH_Goo CreateGoo() => new SpeckleDataObjectWrapperGoo(this);
+
+  public override string ToString() =>
+    $"Speckle Data Object : {(string.IsNullOrWhiteSpace(Name) ? Base.speckle_type : Name)}";
+
+  // TODO: CNX-2094
+  // public virtual void DrawPreview()
+  // public void DrawPreviewRaw()
+
+  // TODO: CNX-2095
+  // public virtual void Bake()
+
+  /// <summary>
+  /// Creates a deep copy of this wrapper.
+  /// </summary>
+  public SpeckleDataObjectWrapper DeepCopy() =>
+    new()
+    {
+      Base = DataObject.ShallowCopy(),
+      Geometries = new List<GeometryBase>(Geometries),
+      Properties = Properties,
+      ApplicationId = ApplicationId,
+      Name = Name
+    };
+}

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/Wrappers/SpeckleDataObjectWrapperGoo.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/Wrappers/SpeckleDataObjectWrapperGoo.cs
@@ -1,0 +1,66 @@
+﻿using Grasshopper.Kernel;
+using Grasshopper.Kernel.Types;
+using Rhino.Geometry;
+
+namespace Speckle.Connectors.GrasshopperShared.Parameters;
+
+/// <summary>
+/// Goo wrapper for SpeckleDataObjectWrapper.
+/// </summary>
+public class SpeckleDataObjectWrapperGoo : GH_Goo<SpeckleDataObjectWrapper>, IGH_PreviewData
+{
+  /// <summary>
+  /// Creates goo with a DataObject wrapper.
+  /// </summary>
+  public SpeckleDataObjectWrapperGoo(SpeckleDataObjectWrapper value)
+  {
+    Value = value;
+  }
+
+  // TODO: Do we need a parameterless constructor like other wrappers? Will see when we get to casting. Most probably :(
+
+  public override bool IsValid => Value?.DataObject is not null && Value.ApplicationId is not null;
+  public override string TypeName => "Speckle Data Object";
+  public override string TypeDescription => "Represents a Speckle data object";
+
+  public override IGH_Goo Duplicate() => new SpeckleDataObjectWrapperGoo(Value.DeepCopy());
+
+  public override string ToString() =>
+    $"Speckle Data Object : {(string.IsNullOrWhiteSpace(Value.Name) ? Value.Base.speckle_type : Value.Name)}";
+
+  /// <summary>
+  /// Handles casting from other types to DataObject wrapper.
+  /// </summary>
+  public override bool CastFrom(object source)
+  {
+    switch (source)
+    {
+      case SpeckleDataObjectWrapper wrapper:
+        Value = wrapper;
+        return true;
+      case SpeckleDataObjectWrapperGoo wrapperGoo:
+        Value = wrapperGoo.Value;
+        return true;
+
+      // TODO: CNX-2092: Castings form part of this scope
+    }
+
+    return false;
+  }
+
+  /// <summary>
+  /// Handles casting to other types from DataObject wrapper.
+  /// </summary>
+  public override bool CastTo<T>(ref T target) =>
+    // TODO: CNX-2092: Castings form part of this scope
+    false;
+
+  // TODO: CNX-2094
+  public void DrawViewportWires(GH_PreviewWireArgs args) => throw new NotImplementedException();
+
+  // TODO: CNX-2094
+  public void DrawViewportMeshes(GH_PreviewMeshArgs args) => throw new NotImplementedException();
+
+  // TODO: CNX-2094
+  public BoundingBox ClippingBox { get; }
+}

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/Wrappers/SpeckleDataObjectWrapperParam.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/Wrappers/SpeckleDataObjectWrapperParam.cs
@@ -1,0 +1,55 @@
+﻿using Grasshopper.Kernel;
+using Rhino;
+using Rhino.DocObjects;
+using Rhino.Geometry;
+using Speckle.Connectors.GrasshopperShared.Components;
+using Speckle.Connectors.GrasshopperShared.Properties;
+
+namespace Speckle.Connectors.GrasshopperShared.Parameters;
+
+public class SpeckleDataObjectParam : GH_Param<SpeckleDataObjectWrapperGoo>, IGH_BakeAwareObject, IGH_PreviewObject
+{
+  public SpeckleDataObjectParam()
+    : this(GH_ParamAccess.item) { }
+
+  public SpeckleDataObjectParam(IGH_InstanceDescription tag)
+    : base(tag) { }
+
+  public SpeckleDataObjectParam(IGH_InstanceDescription tag, GH_ParamAccess access)
+    : base(tag, access) { }
+
+  public SpeckleDataObjectParam(GH_ParamAccess access)
+    : base(
+      "Speckle Data Object",
+      "SDO",
+      "A Speckle data object with structured properties and display geometries",
+      ComponentCategories.PRIMARY_RIBBON,
+      ComponentCategories.PARAMETERS,
+      access
+    ) { }
+
+  public override Guid ComponentGuid => new("47B930F9-587B-4A88-8CEB-19986E60BA61");
+  protected override Bitmap Icon => Resources.speckle_param_object; // TODO: DataObject icon
+  public override GH_Exposure Exposure => GH_Exposure.primary;
+
+  bool IGH_BakeAwareObject.IsBakeCapable => !VolatileData.IsEmpty;
+
+  // TODO: CNX-2095
+  void IGH_BakeAwareObject.BakeGeometry(RhinoDoc doc, List<Guid> objIds) { }
+
+  // TODO: CNX-2095
+  void IGH_BakeAwareObject.BakeGeometry(RhinoDoc doc, ObjectAttributes att, List<Guid> objIds) { }
+
+  // TODO: CNX-2094
+  public void DrawViewportWires(IGH_PreviewArgs args) => throw new NotImplementedException();
+
+  // TODO: CNX-2094
+  public void DrawViewportMeshes(IGH_PreviewArgs args) => throw new NotImplementedException();
+
+  public bool Hidden { get; set; }
+
+  public bool IsPreviewCapable => !VolatileData.IsEmpty;
+
+  // TODO: CNX-2094
+  public BoundingBox ClippingBox { get; }
+}

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Speckle.Connectors.GrasshopperShared.projitems
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Speckle.Connectors.GrasshopperShared.projitems
@@ -74,6 +74,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)Parameters\SpeckleVariableParam.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Parameters\Wrappers\SpeckleCollectionWrapperGoo.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Parameters\Wrappers\SpeckleCollectionWrapperParam.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Parameters\Wrappers\SpeckleDataObjectWrapper.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Parameters\Wrappers\SpeckleDataObjectWrapperGoo.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Parameters\Wrappers\SpeckleDataObjectWrapperParam.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Parameters\Wrappers\SpeckleMaterialWrapperGoo.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Parameters\Wrappers\SpeckleMaterialWrapperParam.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Parameters\Wrappers\SpeckleObjectWrapperParam.cs" />


### PR DESCRIPTION
## Description
Created classes needed for DataObject support:
- `SpeckleDataObjectWrapper` - wraps `DataObject` and implements ICollectionObject
- `SpeckleDataObjectWrapperGoo`
- `SpeckleDataObjectParam`

Fixes [CNX-2090](https://linear.app/speckle/issue/CNX-2090/create-dataobject-wrapper-goo-and-param).

## User Value
Nothing immediate. Foundational work for `DataObejct` support.

## Changes:
- Added `SpeckleDataObjectWrapper` inheriting from `SpeckleWrapper` and implementing `ICollectionObject`
- Added `SpeckleDataObjectWrapperGoo` inheriting from `GH_Goo<SpeckleDataObjectWrapper>`
- Added `SpeckleDataObjectParam` inheriting from `GH_Param<SpeckleDataObjectWrapperGoo>`
- Added TODO comments for future ticket implementations (casting, previewing, baking, loading/publishing, passthrough)

## Checklist:
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [ ] I have added appropriate tests.
- [x] I have updated or added relevant documentation.

