### PR TITLE
feat(grasshopper): implement `DataObject` casting with property sync

### DIFF
--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/Wrappers/SpeckleDataObjectWrapper.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/Wrappers/SpeckleDataObjectWrapper.cs
@@ -1,5 +1,4 @@
 ﻿using Grasshopper.Kernel.Types;
-using Rhino.Geometry;
 using Speckle.Sdk.Models;
 using DataObject = Speckle.Objects.Data.DataObject;
 
@@ -13,7 +12,7 @@ public class SpeckleDataObjectWrapper : SpeckleWrapper, ISpeckleCollectionObject
   /// <summary>
   /// The wrapped DataObject.
   /// </summary>
-  public DataObject DataObject { get; set; } // Public for consistency with existing wrappers, but would private be better to force things through Base that validates?
+  public DataObject DataObject { get; set; }
 
   /// <summary>
   /// Validated gateway to the typed property (validates and delegates to DataObject).
@@ -32,12 +31,16 @@ public class SpeckleDataObjectWrapper : SpeckleWrapper, ISpeckleCollectionObject
   }
 
   /// <summary>
-  /// Converted geometries from DataObject.displayValue.
+  /// Contains a list of <see cref="SpeckleGeometryWrapper"/>.
   /// </summary>
-  public List<GeometryBase> Geometries { get; set; } = [];
+  /// <remarks>
+  /// A list of the wrappers as opposed to the geometry bases allows us to hold on to the color and material information.
+  /// However, this does make syncing of name, props etc. more challenging.
+  /// </remarks>
+  public List<SpeckleGeometryWrapper> Geometries { get; set; } = [];
 
   /// <summary>
-  /// Structured properties from the DataObject.
+  /// Properties on the wrapper and wrapped Base (DataObject) are kept in sync here.
   /// </summary>
   public SpecklePropertyGroupGoo Properties { get; set; } = new();
 
@@ -60,7 +63,7 @@ public class SpeckleDataObjectWrapper : SpeckleWrapper, ISpeckleCollectionObject
     new()
     {
       Base = DataObject.ShallowCopy(),
-      Geometries = new List<GeometryBase>(Geometries),
+      Geometries = [.. Geometries],
       Properties = Properties,
       ApplicationId = ApplicationId,
       Name = Name

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/Wrappers/SpeckleDataObjectWrapperGoo.ModelObjects.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/Wrappers/SpeckleDataObjectWrapperGoo.ModelObjects.cs
@@ -1,0 +1,58 @@
+#if RHINO8_OR_GREATER
+using Grasshopper.Kernel;
+using Grasshopper.Kernel.Types;
+using Grasshopper.Rhinoceros.Model;
+using Rhino.DocObjects;
+
+namespace Speckle.Connectors.GrasshopperShared.Parameters;
+
+/// <summary>
+/// Rhino 8+ ModelObject casting support for SpeckleDataObjectWrapperGoo.
+/// </summary>
+public partial class SpeckleDataObjectWrapperGoo : GH_Goo<SpeckleDataObjectWrapper>, IGH_PreviewData
+{
+  /// <summary>
+  /// Handles casting from Rhino 8+ ModelObjects to DataObject.
+  /// </summary>
+  private bool CastFromModelObject(object source)
+  {
+    switch (source)
+    {
+      case ModelObject modelObject:
+        var geometryWrapperGoo = new SpeckleGeometryWrapperGoo(modelObject);
+        if (geometryWrapperGoo.IsValid)
+        {
+          return CastFromSpeckleGeometryWrapper(geometryWrapperGoo.Value);
+        }
+        return false;
+
+      case RhinoObject rhinoObject: // can this happen? I'm inclined to say no, but who knows with gh
+        return CastFromModelObject((ModelObject)rhinoObject);
+
+      default:
+        return false;
+    }
+  }
+
+  /// <summary>
+  /// Handles casting from DataObject to Rhino 8+ ModelObjects.
+  /// </summary>
+  /// <remarks>
+  /// Only works if DataObject has exactly one geometry
+  /// </remarks>
+  private bool CastToModelObject<T>(ref T target)
+  {
+    if (Value.Geometries.Count != 1)
+    {
+      return false;
+    }
+
+    // extract first (and only) geometry and delegate to SpeckleGeometryWrapperGoo
+    var firstGeometry = Value.Geometries[0];
+    var geometryGoo = new SpeckleGeometryWrapperGoo(firstGeometry);
+
+    // using existing ModelObject casting logic from SpeckleGeometryWrapperGoo
+    return geometryGoo.CastTo(ref target);
+  }
+}
+#endif

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/Wrappers/SpeckleDataObjectWrapperGoo.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/Wrappers/SpeckleDataObjectWrapperGoo.cs
@@ -25,7 +25,16 @@ public partial class SpeckleDataObjectWrapperGoo : GH_Goo<SpeckleDataObjectWrapp
   /// <remarks>Should only be used for casting!</remarks>
   public SpeckleDataObjectWrapperGoo()
   {
-    Value = new() { Base = new(), Geometries = [] };
+    Value = new()
+    {
+      Base = new DataObject
+      {
+        name = "",
+        displayValue = [],
+        properties = new Dictionary<string, object?>()
+      },
+      Geometries = []
+    };
   }
 
   public override bool IsValid => Value?.DataObject is not null && Value.ApplicationId is not null;

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/Wrappers/SpeckleDataObjectWrapperGoo.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/Wrappers/SpeckleDataObjectWrapperGoo.cs
@@ -97,8 +97,8 @@ public class SpeckleDataObjectWrapperGoo : GH_Goo<SpeckleDataObjectWrapper>, IGH
           applicationId = geometryWrapper.ApplicationId
         };
 
-      // create wrapper
-      // NOTE: Name, ApplicationId and Properties kept in sync with wrapped DataObject through getters and setters
+      // create wrapper - Name, ApplicationId and Properties kept in sync with wrapped DataObject through getters/setters
+      // geometry will inherit DataObject properties through the syncing (hopefully)
       Value = new SpeckleDataObjectWrapper { Base = dataObject, Geometries = [geometryWrapper] };
 
       return true;

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/Wrappers/SpeckleGeometryWrapperGoo.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/Wrappers/SpeckleGeometryWrapperGoo.cs
@@ -54,6 +54,10 @@ public partial class SpeckleGeometryWrapperGoo : GH_Goo<SpeckleGeometryWrapper>,
       case SpeckleBlockInstanceWrapperGoo instanceWrapperGoo:
         Value = instanceWrapperGoo.Value;
         return true;
+      case SpeckleDataObjectWrapperGoo dataObjectGoo:
+        return CastFromDataObject(dataObjectGoo.Value);
+      case SpeckleDataObjectWrapper dataObjectWrapper:
+        return CastFromDataObject(dataObjectWrapper);
       case IGH_GeometricGoo geometricGoo:
         GeometryBase gb = geometricGoo.ToGeometryBase();
         Base converted = SpeckleConversionContext.ConvertToSpeckle(gb);
@@ -209,6 +213,23 @@ public partial class SpeckleGeometryWrapperGoo : GH_Goo<SpeckleGeometryWrapper>,
       return true;
     }
     return false;
+  }
+
+  /// <summary>
+  /// Handles casting from DataObject to SpeckleGeometryWrapper.
+  /// Only works if DataObject has exactly one geometry.
+  /// </summary>
+  private bool CastFromDataObject(SpeckleDataObjectWrapper dataObjectWrapper)
+  {
+    // Apply single-geometry constraint
+    if (dataObjectWrapper.Geometries.Count != 1)
+    {
+      return false;
+    }
+
+    // Extract the single geometry
+    Value = dataObjectWrapper.Geometries[0];
+    return true;
   }
 
   public void DrawViewportWires(GH_PreviewWireArgs args)

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/Wrappers/SpeckleWrapper.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/Wrappers/SpeckleWrapper.cs
@@ -12,7 +12,10 @@ public abstract class SpeckleWrapper
   /// <summary>
   /// The name of the object. When set, this will also update the "name" property of <see cref="Base"/>.
   /// </summary>
-  public string Name
+  /// <remarks>
+  /// Made virtual to allow DataObject to override with custom sync logic.
+  /// </remarks>
+  public virtual string Name
   {
     get => Base[Constants.NAME_PROP] as string ?? "";
     set => Base[Constants.NAME_PROP] = value;

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Speckle.Connectors.GrasshopperShared.projitems
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Speckle.Connectors.GrasshopperShared.projitems
@@ -74,6 +74,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Parameters\SpeckleVariableParam.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Parameters\Wrappers\SpeckleCollectionWrapperGoo.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Parameters\Wrappers\SpeckleCollectionWrapperParam.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Parameters\Wrappers\SpeckleDataObjectWrapperGoo.ModelObjects.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Parameters\Wrappers\SpeckleGeometryWrapper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Parameters\Wrappers\SpeckleGeometryWrapperGoo.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Parameters\Wrappers\SpeckleGeometryWrapperGoo.ModelObjects.cs" />


### PR DESCRIPTION
## Description

`DataObject` casting. Fixes [CNX-2092](https://linear.app/speckle/issue/CNX-2092/add-casting).

## User Value

Users can now cast geometry, Speckle objects, and ModelObjects to/from `DataObjects` with property preservation and syncing (hopefully).

## Changes:
- **CastFrom** in `SpeckleDataObjectWrapperGoo`:
  - `SpeckleGeometryWrapper` → DataObject (single-element DataObject creation)
  - `IGH_GeometricGoo` → DataObject (Grasshopper native geometry types)
  - `SpeckleDataObjectWrapper` → DataObject (self-casting)
  - Block instance rejection (by design - instances not allowed in DataObjects)
- **CastTo** in `SpeckleDataObjectWrapperGoo`:
  - DataObject → geometry types (only when exactly 1 geometry - single-geometry constraint)
  - DataObject → Base/DataObject types
  - Delegation to `SpeckleGeometryWrapperGoo` for geometric operations
- **Added Rhino 8+ ModelObject**:
  - Created `SpeckleDataObjectWrapperGoo.ModelObjects.cs` with ModelObject casting
- **Property syncs**:
  - Made `SpeckleWrapper.Name` virtual to allow `DataObject` custom sync logic
  - Implemented `SyncGeometriesToDataObject()` method for property propagation
  - `DataObject` as source of truth for properties and names
- **Added bidirectional casting**:
  - Extended `SpeckleGeometryWrapperGoo.CastFrom()` to handle DataObject → SpeckleObject conversion
  - Implemented `CastFromDataObject()` helper method with single-geometry constraint

## Screenshots & Validation of changes:

<img width="892" alt="image" src="https://github.com/user-attachments/assets/ca828e2c-1b62-48c2-86ad-3c86ab1901a7" />

## Checklist:
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] I have added appropriate tests.
- [x] I have updated or added relevant documentation.

