### PR TITLE
feat(grasshopper): add preview support for `DataObject`

### DIFF
--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/Wrappers/SpeckleDataObjectWrapper.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/Wrappers/SpeckleDataObjectWrapper.cs
@@ -1,4 +1,6 @@
-﻿using Grasshopper.Kernel.Types;
+﻿using Grasshopper.Kernel;
+using Grasshopper.Kernel.Types;
+using Rhino.Display;
 using Speckle.Sdk.Models;
 using DataObject = Speckle.Objects.Data.DataObject;
 
@@ -101,9 +103,28 @@ public class SpeckleDataObjectWrapper : SpeckleWrapper, ISpeckleCollectionObject
   public override string ToString() =>
     $"Speckle Data Object : {(string.IsNullOrWhiteSpace(Name) ? Base.speckle_type : Name)}";
 
-  // TODO: CNX-2094
-  // public virtual void DrawPreview()
-  // public void DrawPreviewRaw()
+  /// <summary>
+  /// Draws preview for all geometries contained in this data object.
+  /// </summary>
+  public virtual void DrawPreview(IGH_PreviewArgs args, bool isSelected = false)
+  {
+    // iterate through all geometries and delegate to their existing preview logic
+    foreach (var geometry in Geometries)
+    {
+      geometry.DrawPreview(args, isSelected);
+    }
+  }
+
+  /// <summary>
+  /// Draws raw preview for all geometries using a specific material.
+  /// </summary>
+  public void DrawPreviewRaw(DisplayPipeline display, DisplayMaterial material)
+  {
+    foreach (var geometry in Geometries)
+    {
+      geometry.DrawPreviewRaw(display, material);
+    }
+  }
 
   // TODO: CNX-2095
   // public virtual void Bake()

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/Wrappers/SpeckleDataObjectWrapperGoo.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/Wrappers/SpeckleDataObjectWrapperGoo.cs
@@ -127,14 +127,37 @@ public partial class SpeckleDataObjectWrapperGoo : GH_Goo<SpeckleDataObjectWrapp
   private bool CastToModelObject<T>(ref T _) => false;
 #endif
 
-  // TODO: CNX-2094
-  public void DrawViewportWires(GH_PreviewWireArgs args) => throw new NotImplementedException();
+  public void DrawViewportWires(GH_PreviewWireArgs args)
+  {
+    // TODO?
+  }
 
-  // TODO: CNX-2094
-  public void DrawViewportMeshes(GH_PreviewMeshArgs args) => throw new NotImplementedException();
+  /// <summary>
+  /// Draws viewport meshes/surfaces for the data object.
+  /// </summary>
+  public void DrawViewportMeshes(GH_PreviewMeshArgs args) => Value.DrawPreviewRaw(args.Pipeline, args.Material);
 
-  // TODO: CNX-2094
-  public BoundingBox ClippingBox { get; }
+  /// <summary>
+  /// Calculates the bounding box for all geometries in this data object.
+  /// </summary>
+  public BoundingBox ClippingBox
+  {
+    get
+    {
+      var clippingBox = new BoundingBox();
+
+      foreach (var geometry in Value.Geometries)
+      {
+        if (geometry.GeometryBase != null)
+        {
+          var box = geometry.GeometryBase.GetBoundingBox(false);
+          clippingBox.Union(box);
+        }
+      }
+
+      return clippingBox;
+    }
+  }
 
   /// <summary>
   /// Creates a single-element DataObject from <see cref="SpeckleGeometryWrapper"/> (one geometry → one display value).

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/Wrappers/SpeckleDataObjectWrapperParam.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/Wrappers/SpeckleDataObjectWrapperParam.cs
@@ -40,16 +40,55 @@ public class SpeckleDataObjectParam : GH_Param<SpeckleDataObjectWrapperGoo>, IGH
   // TODO: CNX-2095
   void IGH_BakeAwareObject.BakeGeometry(RhinoDoc doc, ObjectAttributes att, List<Guid> objIds) { }
 
-  // TODO: CNX-2094
-  public void DrawViewportWires(IGH_PreviewArgs args) => throw new NotImplementedException();
+  /// <summary>
+  /// Draws viewport wires for all data objects in this parameter.
+  /// </summary>
+  public void DrawViewportWires(IGH_PreviewArgs args)
+  {
+    // Following the pattern - most wire drawing is handled in DrawViewportMeshes
+    // Keep this minimal like other parameter types
+  }
 
-  // TODO: CNX-2094
-  public void DrawViewportMeshes(IGH_PreviewArgs args) => throw new NotImplementedException();
+  /// <summary>
+  /// Draws viewport meshes for all data objects in this parameter.
+  /// </summary>
+  public void DrawViewportMeshes(IGH_PreviewArgs args)
+  {
+    var isSelected = args.Document.SelectedObjects().Contains(this) || OwnerSelected();
+
+    foreach (var item in VolatileData.AllData(true))
+    {
+      if (item is SpeckleDataObjectWrapperGoo goo)
+      {
+        goo.Value.DrawPreview(args, isSelected);
+      }
+    }
+  }
 
   public bool Hidden { get; set; }
 
   public bool IsPreviewCapable => !VolatileData.IsEmpty;
 
-  // TODO: CNX-2094
-  public BoundingBox ClippingBox { get; }
+  /// <summary>
+  /// Calculates the clipping box for all data objects in this parameter.
+  /// </summary>
+  public BoundingBox ClippingBox
+  {
+    get
+    {
+      var clippingBox = new BoundingBox();
+
+      foreach (var item in VolatileData.AllData(true))
+      {
+        if (item is SpeckleDataObjectWrapperGoo goo)
+        {
+          clippingBox.Union(goo.ClippingBox);
+        }
+      }
+
+      return clippingBox;
+    }
+  }
+
+  private bool OwnerSelected() => Attributes?.Parent?.Selected ?? false;
 }


### PR DESCRIPTION
## Description
Adds preview for `SpeckleDataObjectWrapper`. Data objects can now be visualized in the viewport like other Speckle object types.

Relates to [CNX-2094](https://linear.app/speckle/issue/CNX-2094/add-previewing)

## User Value
Users can now see visual previews of `DataObjects`.

## Changes:
- Added `DrawPreview()` and `DrawPreviewRaw()` methods to `SpeckleDataObjectWrapper`
- Implemented `DrawViewportMeshes()` and bounding box calculation in `SpeckleDataObjectWrapperGoo` 
- Implemented preview methods in `SpeckleDataObjectParam` following existing patterns
- Preview logic delegates to existing `SpeckleGeometryWrapper.DrawPreview()` methods

## Validation of changes:

![preview](https://github.com/user-attachments/assets/be15abbf-f6b2-4be8-bba4-31103a9e0435)

## Checklist:
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] I have added appropriate tests.
- [x] I have updated or added relevant documentation.

