### PR TITLE
feat(grasshopper): add baking support for `SpeckleDataObjectWrapper`

### DIFF
--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/Wrappers/SpeckleDataObjectWrapperParam.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/Wrappers/SpeckleDataObjectWrapperParam.cs
@@ -34,11 +34,29 @@ public class SpeckleDataObjectParam : GH_Param<SpeckleDataObjectWrapperGoo>, IGH
 
   bool IGH_BakeAwareObject.IsBakeCapable => !VolatileData.IsEmpty;
 
-  // TODO: CNX-2095
-  void IGH_BakeAwareObject.BakeGeometry(RhinoDoc doc, List<Guid> objIds) { }
+  void IGH_BakeAwareObject.BakeGeometry(RhinoDoc doc, List<Guid> objIds)
+  {
+    foreach (var item in VolatileData.AllData(true))
+    {
+      if (item is SpeckleDataObjectWrapperGoo goo)
+      {
+        goo.Value.Bake(doc, objIds);
+      }
+    }
+  }
 
-  // TODO: CNX-2095
-  void IGH_BakeAwareObject.BakeGeometry(RhinoDoc doc, ObjectAttributes att, List<Guid> objIds) { }
+  void IGH_BakeAwareObject.BakeGeometry(RhinoDoc doc, ObjectAttributes att, List<Guid> objIds)
+  {
+    foreach (var item in VolatileData.AllData(true))
+    {
+      if (item is SpeckleDataObjectWrapperGoo goo)
+      {
+        int layerIndex = goo.Value.Path.Count == 0 ? att.LayerIndex : -1;
+        bool layerCreated = goo.Value.Path.Count == 0;
+        goo.Value.Bake(doc, objIds, layerIndex, layerCreated);
+      }
+    }
+  }
 
   /// <summary>
   /// Draws viewport wires for all data objects in this parameter.


### PR DESCRIPTION
## Description
Implements baking functionality for `SpeckleDataObjectWrapper`. `DataObjects` now bake as Rhino groups.

Related to [CNX-2095](https://linear.app/speckle/issue/CNX-2095/add-baking).

## User Value
Users can now bake `DataObjects` from Grasshopper components.

## Changes:
- Added `Bake()` method to `SpeckleDataObjectWrapper` with group creation logic
- Added `CreateGroupName()` private method following `RhinoGroupBaker` pattern
- Implemented `BakeGeometry()` methods in `SpeckleDataObjectWrapperParam`

## Screenshots & Validation of changes:

** still testing

## Checklist:
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [ ] I have added appropriate tests.
- [x] I have updated or added relevant documentation.

