### PR TITLE
feat(grasshopper): adds dataobject passthrough node

### DIFF
--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Objects/SpeckleDataObjectPassthrough.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Objects/SpeckleDataObjectPassthrough.cs
@@ -1,0 +1,176 @@
+using System.Runtime.InteropServices;
+using Grasshopper.Kernel;
+using Speckle.Connectors.GrasshopperShared.HostApp;
+using Speckle.Connectors.GrasshopperShared.Parameters;
+using Speckle.Connectors.GrasshopperShared.Properties;
+
+namespace Speckle.Connectors.GrasshopperShared.Components.Objects;
+
+[Guid("5CE8AA40-7706-4893-853D-4C77604548FA")]
+public class SpeckleDataObjectPassthrough : GH_Component
+{
+  public SpeckleDataObjectPassthrough()
+    : base(
+      "Speckle Data Object",
+      "SDO",
+      "Create or modify a Speckle Data Object",
+      ComponentCategories.PRIMARY_RIBBON,
+      ComponentCategories.OBJECTS
+    ) { }
+
+  public override Guid ComponentGuid => GetType().GUID;
+  protected override Bitmap Icon => Resources.speckle_objects_object;
+  public override GH_Exposure Exposure => GH_Exposure.primary;
+
+  protected override void RegisterInputParams(GH_InputParamManager pManager)
+  {
+    int objIndex = pManager.AddParameter(
+      new SpeckleDataObjectParam(),
+      "Speckle Data Object",
+      "SDO",
+      "Input Speckle DataObject. Model Objects are also accepted.",
+      GH_ParamAccess.item
+    );
+    Params.Input[objIndex].Optional = true;
+
+    int geoIndex = pManager.AddParameter(
+      new SpeckleGeometryWrapperParam(),
+      "Geometries",
+      "G",
+      "Geometries of the Speckle Data Object. Speckle Geometry and Grasshopper geometry are accepted.",
+      GH_ParamAccess.list
+    );
+    Params.Input[geoIndex].Optional = true;
+
+    int nameIndex = pManager.AddTextParameter("Name", "N", "Name of the Speckle Data Object", GH_ParamAccess.item);
+    Params.Input[nameIndex].Optional = true;
+
+    int propIndex = pManager.AddParameter(
+      new SpecklePropertyGroupParam(),
+      "Properties",
+      "P",
+      "The properties of the Speckle Data Object. Speckle Properties and User Content are accepted.",
+      GH_ParamAccess.item
+    );
+    Params.Input[propIndex].Optional = true;
+  }
+
+  protected override void RegisterOutputParams(GH_OutputParamManager pManager)
+  {
+    pManager.AddParameter(
+      new SpeckleDataObjectParam(),
+      "Speckle Data Object",
+      "SDO",
+      "Speckle Data Object",
+      GH_ParamAccess.item
+    );
+
+    pManager.AddParameter(
+      new SpeckleGeometryWrapperParam(),
+      "Geometries",
+      "G",
+      "Geometries of the Speckle Data Object.",
+      GH_ParamAccess.list
+    );
+
+    pManager.AddTextParameter("Name", "N", "Name of the Speckle Data Object", GH_ParamAccess.item);
+
+    pManager.AddParameter(
+      new SpecklePropertyGroupParam(),
+      "Properties",
+      "P",
+      "The properties of the Speckle Data Object",
+      GH_ParamAccess.item
+    );
+
+    pManager.AddTextParameter(
+      "Path",
+      "p",
+      $"The Collection Path of the Speckle Geometry, delimited with `{Constants.LAYER_PATH_DELIMITER}`",
+      GH_ParamAccess.item
+    );
+  }
+
+  protected override void SolveInstance(IGH_DataAccess da)
+  {
+    // process the object
+    // deep copy so we don't mutate the object
+    SpeckleDataObjectWrapperGoo inputObject = new();
+    SpeckleDataObjectWrapper? result = null;
+    if (da.GetData(0, ref inputObject))
+    {
+      result = inputObject.Value.DeepCopy();
+    }
+
+    List<SpeckleGeometryWrapperGoo> inputGeometry = new();
+    if (!da.GetDataList(1, inputGeometry) && result == null)
+    {
+      AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, $"Pass in a Speckle DataObject or Geometries.");
+      return;
+    }
+
+    foreach (var inputGeo in inputGeometry)
+    {
+      if (inputGeo.Value is SpeckleBlockInstanceWrapper)
+      {
+        AddRuntimeMessage(GH_RuntimeMessageLevel.Error, $"DataObjects cannot contain Block Instances.");
+        return;
+      }
+    }
+
+    string? inputName = null;
+    da.GetData(2, ref inputName);
+
+    SpecklePropertyGroupGoo? inputProperties = null;
+    da.GetData(3, ref inputProperties);
+
+    // process geometry
+    if (result == null)
+    {
+      result = new SpeckleDataObjectWrapperGoo().Value;
+    }
+
+    if (inputGeometry.Count > 0)
+    {
+      result.Geometries.Clear();
+      foreach (var inputGeo in inputGeometry)
+      {
+        // deep copy so we don't mutate the input geo which may be speckle geometry
+        SpeckleGeometryWrapper mutatingGeo = inputGeo.Value.DeepCopy();
+
+        // assign fields before adding, otherwise they will be out of sync with wrapper
+        mutatingGeo.Base[Constants.NAME_PROP] = result.Name;
+        mutatingGeo.Properties = result.Properties;
+        mutatingGeo.Parent = result.Parent;
+        mutatingGeo.Path = result.Path;
+
+        result.Geometries.Add(mutatingGeo);
+      }
+    }
+
+    // process name
+    if (inputName != null)
+    {
+      result!.Name = inputName;
+    }
+
+    // process properties
+    if (inputProperties != null)
+    {
+      result!.Properties = inputProperties;
+    }
+
+    // get the path
+    string path =
+      result!.Path.Count > 1
+        ? string.Join(Constants.LAYER_PATH_DELIMITER, result!.Path)
+        : result!.Path.FirstOrDefault();
+
+    // set all the data
+    da.SetData(0, result.CreateGoo());
+    da.SetDataList(1, result.Geometries);
+    da.SetData(2, result.Name);
+    da.SetData(3, result.Properties);
+    da.SetData(4, path);
+  }
+}

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/Wrappers/SpeckleDataObjectWrapperGoo.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/Wrappers/SpeckleDataObjectWrapperGoo.cs
@@ -1,4 +1,4 @@
-﻿using Grasshopper.Kernel;
+using Grasshopper.Kernel;
 using Grasshopper.Kernel.Types;
 using Rhino.Geometry;
 using Speckle.Sdk.Models;
@@ -117,7 +117,7 @@ public partial class SpeckleDataObjectWrapperGoo : GH_Goo<SpeckleDataObjectWrapp
           return geometryGoo.CastTo(ref target);
         }
 
-        return false;
+        return CastToModelObject(ref target);
     }
   }
 

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/Wrappers/SpeckleGeometryWrapper.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/Wrappers/SpeckleGeometryWrapper.cs
@@ -40,7 +40,7 @@ public class SpeckleGeometryWrapper : SpeckleWrapper, ISpeckleCollectionObject
   public SpeckleMaterialWrapper? Material { get; set; }
 
   public override string ToString() =>
-    $"Speckle Object : {(string.IsNullOrWhiteSpace(Name) ? Base.speckle_type : Name)}";
+    $"Speckle Geometry : {(string.IsNullOrWhiteSpace(Name) ? Base.speckle_type : Name)}";
 
   public virtual void DrawPreview(IGH_PreviewArgs args, bool isSelected = false)
   {

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/Wrappers/SpeckleGeometryWrapperGoo.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/Wrappers/SpeckleGeometryWrapperGoo.cs
@@ -9,7 +9,7 @@ namespace Speckle.Connectors.GrasshopperShared.Parameters;
 public partial class SpeckleGeometryWrapperGoo : GH_Goo<SpeckleGeometryWrapper>, IGH_PreviewData
 {
   public override bool IsValid => Value.Base is not null && Value.ApplicationId is not null;
-  public override string TypeName => "Speckle Object";
+  public override string TypeName => "Speckle Geometry";
   public override string TypeDescription => "Represents a geometry object from Speckle";
 
   public SpeckleGeometryWrapperGoo(SpeckleGeometryWrapper value)
@@ -33,7 +33,7 @@ public partial class SpeckleGeometryWrapperGoo : GH_Goo<SpeckleGeometryWrapper>,
   public override IGH_Goo Duplicate() => new SpeckleGeometryWrapperGoo(Value.DeepCopy());
 
   public override string ToString() =>
-    $"Speckle Object : {(string.IsNullOrWhiteSpace(Value.Name) ? Value.Base.speckle_type : Value.Name)}";
+    $"Speckle Geometry : {(string.IsNullOrWhiteSpace(Value.Name) ? Value.Base.speckle_type : Value.Name)}";
 
   /// <summary>
   /// Casts from Speckle objects, geometry base, and model objects.

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/Wrappers/SpeckleGeometryWrapperParam.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/Wrappers/SpeckleGeometryWrapperParam.cs
@@ -20,9 +20,9 @@ public class SpeckleGeometryWrapperParam : GH_Param<SpeckleGeometryWrapperGoo>, 
 
   public SpeckleGeometryWrapperParam(GH_ParamAccess access)
     : base(
-      "Speckle Object",
-      "SO",
-      "Represents a Speckle object",
+      "Speckle Geometry",
+      "SG",
+      "Represents a Speckle Geometry",
       ComponentCategories.PRIMARY_RIBBON,
       ComponentCategories.PARAMETERS,
       access

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Speckle.Connectors.GrasshopperShared.projitems
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Speckle.Connectors.GrasshopperShared.projitems
@@ -20,6 +20,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Components\Objects\SpeckleBlockDefinitionPassthrough.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Components\Dev\TokenUrlComponent.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Components\IGH_StructureExtensions.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Components\Objects\SpeckleDataObjectPassthrough.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Components\Objects\SpeckleGeometryPassthrough.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Components\Objects\SpecklePropertiesPassthrough.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Components\Objects\QuerySpeckleObjects.cs" />


### PR DESCRIPTION
<!---

Provide a short summary in the Title above. Use the following template:

category(project): summary

Categories:

* feat: (new feature for the user, not a new feature for build script)
* fix: (bug fix for the user, not a fix to a build script)
* docs: (changes to the documentation)
* style: (formatting, missing semi colons, etc; no production code change)
* refactor: (refactoring production code, eg. renaming a variable)
* test: (adding missing tests, refactoring tests; no production code change)
* chore: (updating grunt tasks etc; no production code change)

Example:

feat(revit): added category filter to send

-->

## Description

Adds passthrough node for dataobjects
 Also fixes:
- deconstruct node to handle dataobjects
- some ToString naming of geometry objects
- removes `displayvalue` of dataobject on load, to prevent storing of redundant values

## User Value

<!---

Describe in 1 sentence the user value.

This can also be a link to the relevant thread in Speckle community, or a link to the Linear issue.
-->


## Changes:

<!---

- Item 1
- Item 2

-->

## To-do before merge:

<!---

(Optional -- remove this section if not needed)

Include any notes about things that need to happen before this PR is merged, e.g.:

- [ ] Change the base branch

- [ ] Ensure PR #56 is merged

-->

## Screenshots:

![image](https://github.com/user-attachments/assets/5af3ef89-77b2-4d04-97e3-0e82e6cbea07)


## Validation of changes:

<!---

Describe what tests have been added or amended, and why these demonstrate it works and will prevent this feature being accidentally broken by future changes.

-->

## Checklist:

<!---

This checklist is a useful reminder of related tasks to uphold our repo quality. Amend this list as needed for the pr.

-->
- [ ] My commits are related to the pull request and do not amend unrelated code or documentation.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.

