### PR TITLE
feat(grasshopper): add DataObject publishing support

### DIFF
--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Collections/CreateCollection.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Collections/CreateCollection.cs
@@ -158,8 +158,17 @@ public class CreateCollection : VariableParameterComponentBase
   {
     foreach (var obj in objects)
     {
-      // deep copy to avoid mutations
-      if (obj?.ToSpeckleGeometryWrapper() is SpeckleGeometryWrapper objWrapper)
+      // handle data objects directly (deep copy to avoid mutations)
+      // NOTE: DataObject first, since a DataObject with one geo is castable to speckle geometry
+      if (obj is SpeckleDataObjectWrapperGoo dataObjectWrapperGoo)
+      {
+        var dataObjectWrapper = dataObjectWrapperGoo.Value.DeepCopy();
+        dataObjectWrapper.Path = childPath;
+        dataObjectWrapper.Parent = parentCollection;
+        parentCollection.Elements.Add(dataObjectWrapper);
+      }
+      // handle geometry objects (deep copy to avoid mutations)
+      else if (obj?.ToSpeckleGeometryWrapper() is SpeckleGeometryWrapper objWrapper)
       {
         SpeckleGeometryWrapper wrapper = objWrapper.DeepCopy();
         wrapper.Path = childPath;

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Objects/PropertyGroupPathsSelector.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Objects/PropertyGroupPathsSelector.cs
@@ -29,8 +29,15 @@ public class PropertyGroupPathsSelector : ValueSet<IGH_Goo>
   {
     var objectPropertyGroups = VolatileData
       .AllData(true)
-      .OfType<SpeckleGeometryWrapperGoo>()
-      .Select(goo => goo.Value.Properties)
+      .Where(goo => goo is SpeckleGeometryWrapperGoo or SpeckleDataObjectWrapperGoo)
+      .Select(goo =>
+        goo switch
+        {
+          SpeckleGeometryWrapperGoo geometryGoo => geometryGoo.Value.Properties,
+          SpeckleDataObjectWrapperGoo dataGoo => dataGoo.Value.Properties,
+          _ => throw new InvalidOperationException("Unexpected goo type")
+        }
+      )
       .ToList();
 
 #if RHINO8_OR_GREATER

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Operations/Send/GrasshopperSendOperation.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Operations/Send/GrasshopperSendOperation.cs
@@ -5,6 +5,7 @@ using Speckle.Connectors.GrasshopperShared.HostApp;
 using Speckle.Connectors.GrasshopperShared.Parameters;
 using Speckle.Sdk.Models;
 using Speckle.Sdk.Models.Collections;
+using DataObject = Speckle.Objects.Data.DataObject;
 
 namespace Speckle.Connectors.GrasshopperShared.Operations.Send;
 
@@ -92,7 +93,7 @@ public class GrasshopperRootObjectBuilder : IRootObjectBuilder<SpeckleCollection
 
         case SpeckleGeometryWrapper so: // handles both SpeckleObjectWrapper and SpeckleBlockInstanceWrapper (inheritance)
           // convert wrapper to base and add to collection - common for all object wrappers
-          Base objectBase = Unwrap(so);
+          Base objectBase = UnwrapGeometry(so);
           string applicationId = objectBase.applicationId!;
           currentColl.elements.Add(objectBase);
 
@@ -105,6 +106,14 @@ public class GrasshopperRootObjectBuilder : IRootObjectBuilder<SpeckleCollection
           // process color and material for all object wrappers (including block instances)
           colorPacker.ProcessColor(applicationId, so.Color);
           materialPacker.ProcessMaterial(applicationId, so.Material);
+          break;
+
+        case SpeckleDataObjectWrapper dataObjectWrapper:
+          // convert wrapper to DataObject and add to collection
+          // UnwrapDataObject will unwrap underlying geometry and handle color and material
+          // arguably doing too much, but I'm apprehensive looping twice without good reason
+          DataObject dataObject = UnwrapDataObject(dataObjectWrapper, colorPacker, materialPacker);
+          currentColl.elements.Add(dataObject);
           break;
       }
     }
@@ -130,7 +139,7 @@ public class GrasshopperRootObjectBuilder : IRootObjectBuilder<SpeckleCollection
   /// <remarks>
   /// POC: if we move properties assignment to auto set the wrapped base, we can get rid of this entirely!
   /// </remarks>
-  private Base Unwrap(SpeckleGeometryWrapper wrapper)
+  private Base UnwrapGeometry(SpeckleGeometryWrapper wrapper)
   {
     Dictionary<string, object?> props = [];
     Base baseObject = wrapper.Base;
@@ -164,7 +173,7 @@ public class GrasshopperRootObjectBuilder : IRootObjectBuilder<SpeckleCollection
     {
       foreach (var definitionObject in definitionObjects)
       {
-        Base defObjectBase = Unwrap(definitionObject);
+        Base defObjectBase = UnwrapGeometry(definitionObject);
         string applicationId = defObjectBase.applicationId!;
 
         // just add to current collection for now
@@ -174,6 +183,47 @@ public class GrasshopperRootObjectBuilder : IRootObjectBuilder<SpeckleCollection
         materialPacker.ProcessMaterial(applicationId, definitionObject.Material);
       }
     }
+  }
+
+  /// <summary>
+  /// Converts a <see cref="SpeckleDataObjectWrapper"/> to underlying DataObject with properly configured displayValue.
+  /// Processes colors and materials for each individual geometry during conversion.
+  /// </summary>
+  private DataObject UnwrapDataObject(
+    SpeckleDataObjectWrapper wrapper,
+    GrasshopperColorPacker colorPacker,
+    GrasshopperMaterialPacker materialPacker
+  )
+  {
+    DataObject dataObject = wrapper.DataObject;
+
+    // Convert geometries back to Base objects for displayValue
+    var displayValue = new List<Base>();
+    foreach (var geometryWrapper in wrapper.Geometries)
+    {
+      Base geometryBase = UnwrapGeometry(geometryWrapper);
+      displayValue.Add(geometryBase);
+
+      // process color and material for each geometry while we're iterating
+      // this could be in the switch statements (like SpeckleGeometryWrapper) but then we're unnecessarily looping twice
+      if (geometryWrapper.ApplicationId != null)
+      {
+        colorPacker.ProcessColor(geometryWrapper.ApplicationId, geometryWrapper.Color);
+        materialPacker.ProcessMaterial(geometryWrapper.ApplicationId, geometryWrapper.Material);
+      }
+    }
+
+    // Update the DataObject's displayValue
+    dataObject.displayValue = displayValue;
+
+    // Ensure properties are set from wrapper
+    Dictionary<string, object?> props = [];
+    if (wrapper.Properties.CastTo(ref props))
+    {
+      dataObject.properties = props;
+    }
+
+    return dataObject;
   }
 
   /*


### PR DESCRIPTION
## Description
- Adds support for publishing `DataObject` 
- Also updates `CreateCollection` and `PropertySelector` components to handle `DataObject`
- Related to [CNX-2097](https://linear.app/speckle/issue/CNX-2097/publishing-data-objects)

## User Value
Users can now publish `DataObject`s

## Changes:
- Add `DataObject` case to send operation unwrap logic
- Implement `UnwrapDataObject` method with color/material processing per geometry
- Rename `Unwrap(SpeckleGeometryWrapper)` → `UnwrapGeometry()` for clarity
- Update `CreateCollection` to handle `DataObject`s directly
- Add `DataObject` support to `PropertySelector` component

## To-do before merge:
- [ ] Update `GetObjectProperties` component to explicitly accept `DataObjects`. Not sure how this works? Change `AddParameter` to `AddGenericParameter`?

## Screenshots & Validation of changes:
- Load model with `DataObject` and immediately publish

<img width="1128" alt="Screenshot 2025-07-10 043325" src="https://github.com/user-attachments/assets/857e0eab-3ad1-424d-9c66-5ba766cd0be1" />

- "Missing" `DataObject` happens before publish. To investigate.

<img width="628" alt="image" src="https://github.com/user-attachments/assets/f7e4b3ca-956c-4b51-9e13-cd6e5db6f45a" />

## Checklist:
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] I have added appropriate tests.
- [x] I have updated or added relevant documentation.

