### PR TITLE
Feat(gh): Add optional version message for senders

### DIFF
--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Send/SendAsyncComponent.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Send/SendAsyncComponent.cs
@@ -25,9 +25,6 @@ namespace Speckle.Connectors.GrasshopperShared.Components.Operations.Send;
 [Guid("52481972-7867-404F-8D9F-E1481183F355")]
 public class SendAsyncComponent : GH_AsyncComponent<SendAsyncComponent>
 {
-  public GhContextMenuButton ProjectContextMenuButton { get; set; }
-  public GhContextMenuButton ModelContextMenuButton { get; set; }
-
   public SendAsyncComponent()
     : base(
       "Publish",
@@ -57,6 +54,8 @@ public class SendAsyncComponent : GH_AsyncComponent<SendAsyncComponent>
   public SpeckleUrlModelResource? OutputParam { get; set; }
   public bool HasMultipleInputs { get; set; }
 
+  public string? VersionMessage { get; private set; }
+
   protected override void RegisterInputParams(GH_InputParamManager pManager)
   {
     pManager.AddParameter(new SpeckleUrlModelResourceParam());
@@ -67,6 +66,8 @@ public class SendAsyncComponent : GH_AsyncComponent<SendAsyncComponent>
       "The collection model object to send",
       GH_ParamAccess.item
     );
+    pManager.AddTextParameter("Version Message", "versionMessage", "The version message", GH_ParamAccess.item);
+    pManager[2].Optional = true;
   }
 
   protected override void RegisterOutputParams(GH_OutputParamManager pManager)
@@ -275,6 +276,10 @@ public class SendAsyncComponent : GH_AsyncComponent<SendAsyncComponent>
       return;
     }
     RootCollectionWrapper = rootCollectionWrapper;
+
+    string? versionMessage = null;
+    da.GetData(2, ref versionMessage);
+    VersionMessage = versionMessage;
   }
 }
 
@@ -402,7 +407,13 @@ public class SendComponentWorker : WorkerInstance<SendAsyncComponent>
     using var scope = PriorityLoader.CreateScopeForActiveDocument();
     var sendOperation = scope.ServiceProvider.GetRequiredService<SendOperation<SpeckleCollectionWrapperGoo>>();
     SendOperationResult? result = await sendOperation
-      .Execute(new List<SpeckleCollectionWrapperGoo>() { rootCollectionWrapper }, sendInfo, progress, CancellationToken)
+      .Execute(
+        new List<SpeckleCollectionWrapperGoo>() { rootCollectionWrapper },
+        sendInfo,
+        progress,
+        CancellationToken,
+        Parent.VersionMessage
+      )
       .ConfigureAwait(false);
 
     // TODO: If we have NodeRun events later, better to have `ComponentTracker` to use across components

--- a/DUI3/Speckle.Connectors.DUI.Tests/SendOperationManagerTests.cs
+++ b/DUI3/Speckle.Connectors.DUI.Tests/SendOperationManagerTests.cs
@@ -81,7 +81,7 @@ public class SendOperationManagerTests : MoqTest
 
     var sendOperationMock = Create<ISendOperation<string>>();
     sendOperationMock
-      .Setup(x => x.Execute(objects, It.IsAny<SendInfo>(), progressHandler.Object, It.IsAny<CancellationToken>()))
+      .Setup(x => x.Execute(objects, It.IsAny<SendInfo>(), progressHandler.Object, It.IsAny<CancellationToken>(), null))
       .ReturnsAsync(
         new SendOperationResult("rootObjId", versionId, new Dictionary<Id, ObjectReference>(), sendResults)
       );

--- a/Sdk/Speckle.Connectors.Common.Tests/Operations/SendOperationTests.cs
+++ b/Sdk/Speckle.Connectors.Common.Tests/Operations/SendOperationTests.cs
@@ -124,7 +124,9 @@ public class SendOperationTests : MoqTest
     sendConversionCache.Setup(x => x.StoreSendResult(projectId, refs));
     sendProgress.Setup(x => x.Begin());
 
-    sendOperationVersionRecorder.Setup(x => x.RecordVersion(rootId, sendInfo, account, ct)).ReturnsAsync("version");
+    sendOperationVersionRecorder
+      .Setup(x => x.RecordVersion(rootId, sendInfo, account, ct, null))
+      .ReturnsAsync("version");
 
     var sp = services.BuildServiceProvider();
 

--- a/Sdk/Speckle.Connectors.Common/Operations/SendOperationVersionRecorder.cs
+++ b/Sdk/Speckle.Connectors.Common/Operations/SendOperationVersionRecorder.cs
@@ -8,7 +8,13 @@ namespace Speckle.Connectors.Common.Operations;
 [GenerateAutoInterface]
 public class SendOperationVersionRecorder(IClientFactory clientFactory) : ISendOperationVersionRecorder
 {
-  public async Task<string> RecordVersion(string rootId, SendInfo sendInfo, Account account, CancellationToken ct)
+  public async Task<string> RecordVersion(
+    string rootId,
+    SendInfo sendInfo,
+    Account account,
+    CancellationToken ct,
+    string? versionMessage = null
+  )
   {
     using var apiClient = clientFactory.Create(account);
     var x = await apiClient
@@ -17,7 +23,8 @@ public class SendOperationVersionRecorder(IClientFactory clientFactory) : ISendO
           rootId,
           sendInfo.ModelId,
           sendInfo.ProjectId,
-          sourceApplication: sendInfo.SourceApplication
+          sourceApplication: sendInfo.SourceApplication,
+          message: versionMessage
         ),
         ct
       )


### PR DESCRIPTION
### In canvas

<img width="886" height="751" alt="image" src="https://github.com/user-attachments/assets/ac60a89d-8c62-4475-8a48-2702958fa231" />

### In web

<img width="478" height="420" alt="image" src="https://github.com/user-attachments/assets/b74fc914-7b17-4d72-8e36-5dd95552bd97" />

### Input is optional, so component does not scream if no input provided

<img width="957" height="500" alt="image" src="https://github.com/user-attachments/assets/fb0cc994-a8ca-4299-a009-1b862103c9bc" />

### And resulting as before when input is empty

<img width="521" height="213" alt="image" src="https://github.com/user-attachments/assets/42464c2e-de1d-4050-a18a-0c1b6947cb86" />
