### PR TITLE
fix(rhino): replacing invalid chars in block definition names

### DIFF
--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/HostApp/RhinoInstanceBaker.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/HostApp/RhinoInstanceBaker.cs
@@ -21,21 +21,18 @@ public class RhinoInstanceBaker : IInstanceBaker<IReadOnlyCollection<string>>
   private readonly RhinoMaterialBaker _materialBaker;
   private readonly RhinoLayerBaker _layerBaker;
   private readonly RhinoColorBaker _colorBaker;
-  private readonly RhinoUtils _utils;
   private readonly ILogger<RhinoInstanceBaker> _logger;
 
   public RhinoInstanceBaker(
     RhinoLayerBaker layerBaker,
     RhinoMaterialBaker rhinoMaterialBaker,
     RhinoColorBaker colorBaker,
-    RhinoUtils utils,
     ILogger<RhinoInstanceBaker> logger
   )
   {
     _layerBaker = layerBaker;
     _materialBaker = rhinoMaterialBaker;
     _colorBaker = colorBaker;
-    _utils = utils;
     _logger = logger;
   }
 
@@ -98,7 +95,7 @@ public class RhinoInstanceBaker : IInstanceBaker<IReadOnlyCollection<string>>
           var defName = $"{definitionProxy.name}-({definitionProxy.applicationId})-{baseLayerName}";
           // we cannot place Block Definitions if we have "/" or "\" in the name
           // https://linear.app/speckle/issue/CNX-2051/cant-create-instances-of-blocks-if-originating-from-speckle-sub-model
-          defName = _utils.CleanBlockDefinitionName(defName);
+          defName = RhinoUtils.CleanBlockDefinitionName(defName);
           var defIndex = doc.InstanceDefinitions.Add(
             defName,
             "No description", // POC: perhaps bring it along from source? We'd need to look at ACAD first

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/HostApp/RhinoLayerBaker.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/HostApp/RhinoLayerBaker.cs
@@ -17,7 +17,6 @@ public class RhinoLayerBaker : TraversalContextUnpacker
   private readonly RhinoMaterialBaker _materialBaker;
   private readonly RhinoColorBaker _colorBaker;
   private readonly Dictionary<string, int> _hostLayerCache = new();
-  private readonly RhinoUtils _utils;
 
   private static readonly string s_pathSeparator =
 #if RHINO8_OR_GREATER
@@ -26,11 +25,10 @@ public class RhinoLayerBaker : TraversalContextUnpacker
   Layer.PathSeparator;
 #endif
 
-  public RhinoLayerBaker(RhinoMaterialBaker materialBaker, RhinoColorBaker colorBaker, RhinoUtils utils)
+  public RhinoLayerBaker(RhinoMaterialBaker materialBaker, RhinoColorBaker colorBaker)
   {
     _materialBaker = materialBaker;
     _colorBaker = colorBaker;
-    _utils = utils;
   }
 
   /// <summary>
@@ -83,7 +81,7 @@ public class RhinoLayerBaker : TraversalContextUnpacker
   public int GetLayerIndex(Collection[] collectionPath, string baseLayerName)
   {
     var layerPath = collectionPath
-      .Select(o => string.IsNullOrWhiteSpace(o.name) ? "unnamed" : _utils.CleanLayerName(o.name))
+      .Select(o => string.IsNullOrWhiteSpace(o.name) ? "unnamed" : RhinoUtils.CleanLayerName(o.name))
       .Prepend(baseLayerName);
 
     var layerFullName = string.Join(s_pathSeparator, layerPath);
@@ -111,7 +109,7 @@ public class RhinoLayerBaker : TraversalContextUnpacker
     {
       currentLayerName +=
         s_pathSeparator
-        + (string.IsNullOrWhiteSpace(collection.name) ? "unnamed" : _utils.CleanLayerName(collection.name));
+        + (string.IsNullOrWhiteSpace(collection.name) ? "unnamed" : RhinoUtils.CleanLayerName(collection.name));
 
       if (_hostLayerCache.TryGetValue(currentLayerName, out int value))
       {
@@ -119,7 +117,7 @@ public class RhinoLayerBaker : TraversalContextUnpacker
         continue;
       }
 
-      var cleanNewLayerName = _utils.CleanLayerName(collection.name);
+      var cleanNewLayerName = RhinoUtils.CleanLayerName(collection.name);
       Layer newLayer = new() { Name = cleanNewLayerName, ParentLayerId = previousLayer?.Id ?? Guid.Empty };
 
       // set material

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/HostApp/RhinoUtils.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/HostApp/RhinoUtils.cs
@@ -1,19 +1,21 @@
 namespace Speckle.Connectors.Rhino.HostApp;
 
-public class RhinoUtils
+public static class RhinoUtils
 {
-  public string CleanBlockDefinitionName(string str)
+  public static string CleanBlockDefinitionName(string str)
   {
     return ReplaceChars(str, @"\/", "_");
   }
 
-  public string CleanLayerName(string str)
+  // Cleans up layer names to be "rhino" proof. Note this can be improved, as "()[] and {}" are illegal only at the start.
+  // https://docs.mcneel.com/rhino/6/help/en-us/index.htm#information/namingconventions.htm?Highlight=naming
+  public static string CleanLayerName(string str)
   {
     str = ReplaceChars(str, @"[](){}", "");
     return ReplaceChars(str, @":;", "-");
   }
 
-  private string ReplaceChars(string str, string invalidChars, string replaceString)
+  private static string ReplaceChars(string str, string invalidChars, string replaceString)
   {
     foreach (char c in invalidChars)
     {

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/Registration/ServiceRegistration.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/Registration/ServiceRegistration.cs
@@ -87,9 +87,6 @@ public static class ServiceRegistration
 
     serviceCollection.AddScoped<PropertiesExtractor>();
 
-    // Register utils
-    serviceCollection.AddScoped<RhinoUtils>();
-
     // operation progress manager
     serviceCollection.AddSingleton<IOperationProgressManager, OperationProgressManager>();
   }


### PR DESCRIPTION
- replacing invalid chars ("/" and "\\") in block definition names with ("-") on receive