### PR TITLE
feat(logging): Track a static session id

### DIFF
--- a/Sdk/Speckle.Connectors.Logging/Consts.cs
+++ b/Sdk/Speckle.Connectors.Logging/Consts.cs
@@ -9,6 +9,7 @@ public static class Consts
   public const string OS_NAME = "os.name";
   public const string OS_TYPE = "os.type";
   public const string OS_SLUG = "os.slug";
+  public const string RUNTIME_SESSION_ID = "runtime.session_id";
   public const string RUNTIME_NAME = "runtime.name";
   public const string USER_ID = "user.id";
   public const string TRACING_SOURCE = "speckle";

--- a/Sdk/Speckle.Connectors.Logging/Internal/ResourceCreator.cs
+++ b/Sdk/Speckle.Connectors.Logging/Internal/ResourceCreator.cs
@@ -5,6 +5,8 @@ namespace Speckle.Connectors.Logging.Internal;
 
 internal static class ResourceCreator
 {
+  private static readonly string s_sessionId = Guid.NewGuid().ToString();
+
   internal static ResourceBuilder Create(string applicationAndVersion, string slug, string connectorVersion) =>
     ResourceBuilder
       .CreateEmpty()
@@ -17,7 +19,8 @@ internal static class ResourceCreator
           new(Consts.OS_NAME, Environment.OSVersion.ToString()),
           new(Consts.OS_TYPE, RuntimeInformation.ProcessArchitecture.ToString()),
           new(Consts.OS_SLUG, DetermineHostOsSlug()),
-          new(Consts.RUNTIME_NAME, RuntimeInformation.FrameworkDescription)
+          new(Consts.RUNTIME_NAME, RuntimeInformation.FrameworkDescription),
+          new(Consts.RUNTIME_SESSION_ID, s_sessionId)
         }
       );
 


### PR DESCRIPTION
Many logs in seq lack a user correlating ID, this is because only some functions that log actually know what `Account` is in use.

I have a quick and dirty solution that will help us correlate logs. A static session id that is consistent across all logs from a user's session...

It's not perfect, but is
 - Completely anonymous, no user data involved.
 - Would give us a more accurate way to determine which logs correlate to other related logs in seq