### PR TITLE
fix(grasshopper): assigns geometries the mat and color of the dataobject

### DIFF
--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Operations/Receive/LocalToGlobalMapHandler.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Operations/Receive/LocalToGlobalMapHandler.cs
@@ -71,6 +71,21 @@ internal sealed class LocalToGlobalMapHandler
 
       if (obj is Speckle.Objects.Data.DataObject dataObject)
       {
+        // get color and mat on dataobject first
+        Color? dataObjColor = _colorUnpacker.Cache.TryGetValue(
+          dataObject.applicationId ?? "",
+          out var cachedDataObjColor
+        )
+          ? cachedDataObjColor
+          : null;
+
+        SpeckleMaterialWrapper? dataObjMat = _materialUnpacker.Cache.TryGetValue(
+          dataObject.applicationId ?? "",
+          out var cachedDataObjMaterial
+        )
+          ? cachedDataObjMaterial
+          : null;
+
         // get geometries
         List<SpeckleGeometryWrapper> geometries = new();
         foreach ((object convertedObj, Base original) in converted)
@@ -84,10 +99,10 @@ internal sealed class LocalToGlobalMapHandler
                 GeometryBase = geometryBase,
                 Color = _colorUnpacker.Cache.TryGetValue(original.applicationId ?? "", out var cachedObjColor)
                   ? cachedObjColor
-                  : null,
+                  : dataObjColor,
                 Material = _materialUnpacker.Cache.TryGetValue(original.applicationId ?? "", out var cachedObjMaterial)
                   ? cachedObjMaterial
-                  : null,
+                  : dataObjMat,
               };
 
             geometries.Add(wrapper);


### PR DESCRIPTION
<!---

Provide a short summary in the Title above. Use the following template:

category(project): summary

Categories:

* feat: (new feature for the user, not a new feature for build script)
* fix: (bug fix for the user, not a fix to a build script)
* docs: (changes to the documentation)
* style: (formatting, missing semi colons, etc; no production code change)
* refactor: (refactoring production code, eg. renaming a variable)
* test: (adding missing tests, refactoring tests; no production code change)
* chore: (updating grunt tasks etc; no production code change)

Example:

feat(revit): added category filter to send

-->

## Description

Some connectors like navisworks attaches the rendermaterial/color to the dataobject, *not* the displayvalue geo of the dataobject (as in revit).

This fix now passes the dataobject mat and color to the displayvalue geos on load, if the geos do not have a mat or color already.

## User Value

no more missing colors and materials when loading navis models

## Changes:

<!---

- Item 1
- Item 2

-->

## To-do before merge:

<!---

(Optional -- remove this section if not needed)

Include any notes about things that need to happen before this PR is merged, e.g.:

- [ ] Change the base branch

- [ ] Ensure PR #56 is merged

-->

## Screenshots:
before:
<img width="1827" height="311" alt="image" src="https://github.com/user-attachments/assets/2c2025e1-0fa8-4312-a205-94beaa17a792" />

 after:
<img width="1530" height="672" alt="image" src="https://github.com/user-attachments/assets/872be152-9677-4f86-ac64-d973ffb95335" />


## Validation of changes:

<!---

Describe what tests have been added or amended, and why these demonstrate it works and will prevent this feature being accidentally broken by future changes.

-->

## Checklist:

<!---

This checklist is a useful reminder of related tasks to uphold our repo quality. Amend this list as needed for the pr.

-->
- [ ] My commits are related to the pull request and do not amend unrelated code or documentation.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.

