### PR TITLE
fix(Navisworks): include GUIDs and other non-dictionary properties in flat hierarchy

### DIFF
--- a/Converters/Navisworks/Speckle.Converters.NavisworksShared/DataHandlers/HierarchicalPropertyHandler.cs
+++ b/Converters/Navisworks/Speckle.Converters.NavisworksShared/DataHandlers/HierarchicalPropertyHandler.cs
@@ -62,6 +62,10 @@ public class HierarchicalPropertyHandler(
   )
   {
     var categoryDictionaries = ProcessPropertySets(item);
+    if (categoryDictionaries.Count == 0)
+    {
+      return;
+    }
 
     foreach (var kvp in categoryDictionaries)
     {
@@ -108,7 +112,7 @@ public class HierarchicalPropertyHandler(
   {
     List<string> blessedNamesForProps = [];
 
-    List<string> bannedNamesForProps =
+    HashSet<string> bannedNamesForProps =
     [
       "ClassName",
       "ClassDisplayName",

--- a/Converters/Navisworks/Speckle.Converters.NavisworksShared/DataHandlers/HierarchicalPropertyHandler.cs
+++ b/Converters/Navisworks/Speckle.Converters.NavisworksShared/DataHandlers/HierarchicalPropertyHandler.cs
@@ -77,14 +77,12 @@ public class HierarchicalPropertyHandler(
 
       if (kvp.Value is not Dictionary<string, object?> properties)
       {
-        // Get or create the pseudoClassProperties category
         if (!propertyCollection.TryGetValue(PseudoClassPropertiesKey, out var pseudoProperties))
         {
           pseudoProperties = [];
           propertyCollection.Add(PseudoClassPropertiesKey, pseudoProperties);
         }
 
-        // Add this non-dictionary value to pseudoClassProperties
         if (!pseudoProperties.TryGetValue(kvp.Key, out var valueSet))
         {
           valueSet = [];
@@ -128,10 +126,8 @@ public class HierarchicalPropertyHandler(
       return;
     }
 
-    // Add each pseudo class property to the main dictionary
     foreach (var prop in pseudoProps.Where(prop => !bannedNamesForProps.Contains(prop.Key)))
     {
-      // if prop value is null, skip it
       if (prop.Value == null)
       {
         continue;
@@ -140,7 +136,6 @@ public class HierarchicalPropertyHandler(
       propertyDict[prop.Key] = prop.Value;
     }
 
-    // Remove the pseudoClassProperties container
     propertyDict.Remove(PseudoClassPropertiesKey);
   }
 

--- a/Converters/Navisworks/Speckle.Converters.NavisworksShared/DataHandlers/HierarchicalPropertyHandler.cs
+++ b/Converters/Navisworks/Speckle.Converters.NavisworksShared/DataHandlers/HierarchicalPropertyHandler.cs
@@ -164,7 +164,7 @@ public class HierarchicalPropertyHandler(
       {
         if ((kvS.Value).Count != 1)
         {
-          // continue;
+          continue;
         }
 
         categoryDict[kvS.Key] = kvS.Value.First();

--- a/Converters/Navisworks/Speckle.Converters.NavisworksShared/DataHandlers/HierarchicalPropertyHandler.cs
+++ b/Converters/Navisworks/Speckle.Converters.NavisworksShared/DataHandlers/HierarchicalPropertyHandler.cs
@@ -110,9 +110,7 @@ public class HierarchicalPropertyHandler(
 
   private void FlattenPseudoClassProperties(Dictionary<string, object?> propertyDict)
   {
-    List<string> blessedNamesForProps = [];
-
-    HashSet<string> bannedNamesForProps =
+    string[] bannedNamesForProps =
     [
       "ClassName",
       "ClassDisplayName",
@@ -131,11 +129,7 @@ public class HierarchicalPropertyHandler(
     }
 
     // Add each pseudo class property to the main dictionary
-    foreach (
-      var prop in pseudoProps
-        .Where(prop => blessedNamesForProps.Count <= 0 || blessedNamesForProps.Contains(prop.Key))
-        .Where(prop => !bannedNamesForProps.Contains(prop.Key))
-    )
+    foreach (var prop in pseudoProps.Where(prop => !bannedNamesForProps.Contains(prop.Key)))
     {
       // if prop value is null, skip it
       if (prop.Value == null)


### PR DESCRIPTION
Handles properties that are not dictionaries by adding them to a temporary "pseudo class properties" category' and flattens those properties into the main dictionary for easier access.

Also filters specific property names like "ClassName" and "DisplayName".

Source with GUID on ancestor node:
<img width="1069" height="577" alt="Screenshot 2025-07-22 234854" src="https://github.com/user-attachments/assets/ee8f8d24-cfa2-49c6-81d9-22b96ce44ddd" />

Prior State of flattened and merged leaf node as Speckle Object:
<img width="1232" height="787" alt="Screenshot 2025-07-22 234830" src="https://github.com/user-attachments/assets/544fc4eb-d1d8-4d09-a06b-629c60e37898" />

Resolved class properties as result of changes:
<img width="1229" height="811" alt="Screenshot 2025-07-22 234759" src="https://github.com/user-attachments/assets/39722c97-8335-429e-ba1c-ad1ffbe90346" />



