### PR TITLE
feat: add `RevitBuiltInCategoryStore` for Interop Lite mapper

### DIFF
--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/HostApp/RevitBuiltInCategoryStore.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/HostApp/RevitBuiltInCategoryStore.cs
@@ -1,0 +1,62 @@
+namespace Speckle.Connectors.Rhino.HostApp;
+
+/// <summary>
+/// Currently hardcoded Revit BuiltInCategories for the Interop Lite mapper.
+/// This provides a select list of commonly used categories for object mapping
+/// from Rhino to Revit.
+///
+/// NOTE: Currently located in Rhino codebase for Rhino-to-Revit POC use case.
+/// When we extend to other connectors implementing a RevitMapper interface,
+/// this should be moved to a shared location (e.g., Speckle.Connectors.Common
+/// or Speckle.Converters.RevitShared).
+/// </summary>
+public static class RevitBuiltInCategoryStore
+{
+  /// <summary>
+  /// Curated list of Revit BuiltInCategory enum names for the lite interop mapper.
+  /// These are the exact enum names as they appear in the Revit API.
+  /// </summary>
+  public static readonly List<string> Categories =
+  [
+    "OST_Ceilings",
+    "OST_Columns",
+    "OST_CurtainGrids",
+    "OST_CurtainGridsCurtaSystem",
+    "OST_CurtainGridsRoof",
+    "OST_CurtainGridsSystem",
+    "OST_CurtainGridsWall",
+    "OST_Curtain_Systems",
+    "OST_CurtainWallMullions",
+    "OST_CurtainWallPanels",
+    "OST_Floors",
+    "OST_Furniture",
+    "OST_FurnitureSystems",
+    "OST_Roofs",
+    "OST_StackedWalls",
+    "OST_Walls",
+    // STRUCTURAL
+    "OST_StructuralColumns",
+    "OST_StructuralFoundation",
+    "OST_StructuralFraming",
+    "OST_StructuralFramingSystem",
+    "OST_StructuralTruss",
+    // MISC
+    "OST_Levels",
+    "OST_Grids",
+    "OST_Rooms",
+    "OST_Areas",
+    // MEP
+    "OST_DuctCurves",
+    "OST_DuctSystem",
+    "OST_DuctFitting",
+    "OST_PipeCurves",
+    "OST_PipeCurvesCenterLine",
+    "OST_PipeSegments",
+    "OST_PipeFitting",
+    "OST_Conduit",
+    "OST_ConduitFitting",
+    "OST_Cable",
+    "OST_CableTray",
+    "OST_CableTrayFitting"
+  ];
+}

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/Speckle.Connectors.RhinoShared.projitems
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/Speckle.Connectors.RhinoShared.projitems
@@ -23,6 +23,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bindings\RhinoSelectionBinding.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\AttributeExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HostApp\Properties\PropertiesExtractor.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)HostApp\RevitBuiltInCategoryStore.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HostApp\RhinoIdleManager.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HostApp\RhinoUtils.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Operations\Send\Filters\RhinoSelectionFilter.cs" />


### PR DESCRIPTION
## Description
Related to [CNX-2182](https://linear.app/speckle/issue/CNX-2182/create-revitbuiltincategory-store).

## User Value
N/A

## Changes:
- Added `RevitBuiltInCategoryStore` static class

## Validation of changes:
- Static store contains exact Revit enum names verified against API documentation
- No external dependencies added to Rhino connector
- Simple list structure for easy maintenance and extension
- Clean separation - Rhino deals with strings, only Revit connector handles enums

## Checklist:
- [ ] My commits are related to the pull request and do not amend unrelated code or documentation.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.

