### PR TITLE
Rethrow raw operation exceptions that are probably CancelledTaskExceptions

### DIFF
--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Plugin/RevitThreadContext.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Plugin/RevitThreadContext.cs
@@ -38,6 +38,10 @@ public class RevitThreadContext : ThreadContext
         return default;
       }
     });
+    if (ex is OperationCanceledException operation)
+    {
+      throw operation;
+    }
     if (ex is not null)
     {
       throw new SpeckleRevitTaskException(ex);
@@ -61,6 +65,10 @@ public class RevitThreadContext : ThreadContext
         return default;
       }
     });
+    if (ex is OperationCanceledException operation)
+    {
+      throw operation;
+    }
     if (ex is not null)
     {
       throw new SpeckleRevitTaskException(ex);
@@ -104,6 +112,11 @@ public class RevitThreadContext : ThreadContext
         ex = e;
       }
     });
+
+    if (ex is OperationCanceledException operation)
+    {
+      throw operation;
+    }
     if (ex is not null)
     {
       throw new SpeckleRevitTaskException(ex);


### PR DESCRIPTION
This should stop Revit from barking as we don't wrap them
<img width="1182" height="458" alt="image" src="https://github.com/user-attachments/assets/2321ab98-2896-404f-9d1c-fb2ae4bfad64" />
