### PR TITLE
fix(grasshopper): update workspace type to match SDK `LimitedWorkspace` changes

### DIFF
--- a/Connectors/Autocad/Speckle.Connectors.Autocad2022/packages.lock.json
+++ b/Connectors/Autocad/Speckle.Connectors.Autocad2022/packages.lock.json
@@ -259,9 +259,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.4.6, )",
-          "Speckle.Sdk": "[3.4.6, )",
-          "Speckle.Sdk.Dependencies": "[3.4.8, )"
+          "Speckle.Objects": "[3.5.0, )",
+          "Speckle.Sdk": "[3.5.0, )",
+          "Speckle.Sdk.Dependencies": "[3.5.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -292,7 +292,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.4.6, )"
+          "Speckle.Objects": "[3.5.0, )"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -336,18 +336,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "JjCdW+gUWq7u1Tb5SlLaFCIYfmrMA9HbUzCdlSPDzyJkPuJFhwK3qKDwe4ggrAs7DuNuBhqL/VKCr/J29Wh2ng==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "k76bpvFvArisd0DbdtpLQbonkl57CYG3szD0sDw0fWZolh8nogw2hRrNL6U2KcrJqCvYVc+zGYSXTJfv9xgntA==",
         "dependencies": {
-          "Speckle.Sdk": "3.4.6"
+          "Speckle.Sdk": "3.5.0"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "YBa/RuwvBbymjWGv7sD2TwMSLhSjz3GYPOGVJtZzBZvev/zDQNZozvIlre+Lk7xpT2KPdH1FRfLkPWyW+qonMA==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "mOLFubk+co9rDtRLsB1wobvmkYaiEMvDV+3hRPlhnqe8WhV+vbBSjzj58EpKEprWXLwjyc0kVzsrvlM++PnL0g==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -357,14 +357,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.4.6"
+          "Speckle.Sdk.Dependencies": "3.5.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.4.8, )",
-        "resolved": "3.4.8",
-        "contentHash": "bNpJc2NBvjtJmdYS3xb6Fv4eqI/xZ2URXfWeXUFaWPMfC1QXLTjlK6iFriQk9ptLwr/dt4UPDPYYHOBynY1f2A=="
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "lPYk1E97tWJ5qO6B8F30VZ+vgOxMYQ5cspyUOALwWoyFloM1KZkvwyeBlm8FiQDx0su5KbTS4S10LQvnS2AqKg=="
       }
     }
   }

--- a/Connectors/Autocad/Speckle.Connectors.Autocad2023/packages.lock.json
+++ b/Connectors/Autocad/Speckle.Connectors.Autocad2023/packages.lock.json
@@ -259,9 +259,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.4.6, )",
-          "Speckle.Sdk": "[3.4.6, )",
-          "Speckle.Sdk.Dependencies": "[3.4.8, )"
+          "Speckle.Objects": "[3.5.0, )",
+          "Speckle.Sdk": "[3.5.0, )",
+          "Speckle.Sdk.Dependencies": "[3.5.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -292,7 +292,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.4.6, )"
+          "Speckle.Objects": "[3.5.0, )"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -336,18 +336,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "JjCdW+gUWq7u1Tb5SlLaFCIYfmrMA9HbUzCdlSPDzyJkPuJFhwK3qKDwe4ggrAs7DuNuBhqL/VKCr/J29Wh2ng==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "k76bpvFvArisd0DbdtpLQbonkl57CYG3szD0sDw0fWZolh8nogw2hRrNL6U2KcrJqCvYVc+zGYSXTJfv9xgntA==",
         "dependencies": {
-          "Speckle.Sdk": "3.4.6"
+          "Speckle.Sdk": "3.5.0"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "YBa/RuwvBbymjWGv7sD2TwMSLhSjz3GYPOGVJtZzBZvev/zDQNZozvIlre+Lk7xpT2KPdH1FRfLkPWyW+qonMA==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "mOLFubk+co9rDtRLsB1wobvmkYaiEMvDV+3hRPlhnqe8WhV+vbBSjzj58EpKEprWXLwjyc0kVzsrvlM++PnL0g==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -357,14 +357,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.4.6"
+          "Speckle.Sdk.Dependencies": "3.5.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.4.8, )",
-        "resolved": "3.4.8",
-        "contentHash": "bNpJc2NBvjtJmdYS3xb6Fv4eqI/xZ2URXfWeXUFaWPMfC1QXLTjlK6iFriQk9ptLwr/dt4UPDPYYHOBynY1f2A=="
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "lPYk1E97tWJ5qO6B8F30VZ+vgOxMYQ5cspyUOALwWoyFloM1KZkvwyeBlm8FiQDx0su5KbTS4S10LQvnS2AqKg=="
       }
     }
   }

--- a/Connectors/Autocad/Speckle.Connectors.Autocad2024/packages.lock.json
+++ b/Connectors/Autocad/Speckle.Connectors.Autocad2024/packages.lock.json
@@ -259,9 +259,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.4.6, )",
-          "Speckle.Sdk": "[3.4.6, )",
-          "Speckle.Sdk.Dependencies": "[3.4.8, )"
+          "Speckle.Objects": "[3.5.0, )",
+          "Speckle.Sdk": "[3.5.0, )",
+          "Speckle.Sdk.Dependencies": "[3.5.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -293,7 +293,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.4.6, )"
+          "Speckle.Objects": "[3.5.0, )"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -337,18 +337,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "JjCdW+gUWq7u1Tb5SlLaFCIYfmrMA9HbUzCdlSPDzyJkPuJFhwK3qKDwe4ggrAs7DuNuBhqL/VKCr/J29Wh2ng==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "k76bpvFvArisd0DbdtpLQbonkl57CYG3szD0sDw0fWZolh8nogw2hRrNL6U2KcrJqCvYVc+zGYSXTJfv9xgntA==",
         "dependencies": {
-          "Speckle.Sdk": "3.4.6"
+          "Speckle.Sdk": "3.5.0"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "YBa/RuwvBbymjWGv7sD2TwMSLhSjz3GYPOGVJtZzBZvev/zDQNZozvIlre+Lk7xpT2KPdH1FRfLkPWyW+qonMA==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "mOLFubk+co9rDtRLsB1wobvmkYaiEMvDV+3hRPlhnqe8WhV+vbBSjzj58EpKEprWXLwjyc0kVzsrvlM++PnL0g==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -358,14 +358,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.4.6"
+          "Speckle.Sdk.Dependencies": "3.5.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.4.8, )",
-        "resolved": "3.4.8",
-        "contentHash": "bNpJc2NBvjtJmdYS3xb6Fv4eqI/xZ2URXfWeXUFaWPMfC1QXLTjlK6iFriQk9ptLwr/dt4UPDPYYHOBynY1f2A=="
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "lPYk1E97tWJ5qO6B8F30VZ+vgOxMYQ5cspyUOALwWoyFloM1KZkvwyeBlm8FiQDx0su5KbTS4S10LQvnS2AqKg=="
       }
     }
   }

--- a/Connectors/Autocad/Speckle.Connectors.Autocad2025/packages.lock.json
+++ b/Connectors/Autocad/Speckle.Connectors.Autocad2025/packages.lock.json
@@ -210,9 +210,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.4.6, )",
-          "Speckle.Sdk": "[3.4.6, )",
-          "Speckle.Sdk.Dependencies": "[3.4.8, )"
+          "Speckle.Objects": "[3.5.0, )",
+          "Speckle.Sdk": "[3.5.0, )",
+          "Speckle.Sdk.Dependencies": "[3.5.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -244,7 +244,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.4.6, )"
+          "Speckle.Objects": "[3.5.0, )"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -288,18 +288,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "JjCdW+gUWq7u1Tb5SlLaFCIYfmrMA9HbUzCdlSPDzyJkPuJFhwK3qKDwe4ggrAs7DuNuBhqL/VKCr/J29Wh2ng==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "k76bpvFvArisd0DbdtpLQbonkl57CYG3szD0sDw0fWZolh8nogw2hRrNL6U2KcrJqCvYVc+zGYSXTJfv9xgntA==",
         "dependencies": {
-          "Speckle.Sdk": "3.4.6"
+          "Speckle.Sdk": "3.5.0"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "YBa/RuwvBbymjWGv7sD2TwMSLhSjz3GYPOGVJtZzBZvev/zDQNZozvIlre+Lk7xpT2KPdH1FRfLkPWyW+qonMA==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "mOLFubk+co9rDtRLsB1wobvmkYaiEMvDV+3hRPlhnqe8WhV+vbBSjzj58EpKEprWXLwjyc0kVzsrvlM++PnL0g==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -307,14 +307,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.4.6"
+          "Speckle.Sdk.Dependencies": "3.5.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.4.8, )",
-        "resolved": "3.4.8",
-        "contentHash": "bNpJc2NBvjtJmdYS3xb6Fv4eqI/xZ2URXfWeXUFaWPMfC1QXLTjlK6iFriQk9ptLwr/dt4UPDPYYHOBynY1f2A=="
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "lPYk1E97tWJ5qO6B8F30VZ+vgOxMYQ5cspyUOALwWoyFloM1KZkvwyeBlm8FiQDx0su5KbTS4S10LQvnS2AqKg=="
       }
     },
     "net8.0-windows7.0/win-x64": {

--- a/Connectors/Autocad/Speckle.Connectors.Autocad2026/packages.lock.json
+++ b/Connectors/Autocad/Speckle.Connectors.Autocad2026/packages.lock.json
@@ -210,9 +210,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.4.6, )",
-          "Speckle.Sdk": "[3.4.6, )",
-          "Speckle.Sdk.Dependencies": "[3.4.8, )"
+          "Speckle.Objects": "[3.5.0, )",
+          "Speckle.Sdk": "[3.5.0, )",
+          "Speckle.Sdk.Dependencies": "[3.5.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -244,7 +244,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.4.6, )"
+          "Speckle.Objects": "[3.5.0, )"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -288,18 +288,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "JjCdW+gUWq7u1Tb5SlLaFCIYfmrMA9HbUzCdlSPDzyJkPuJFhwK3qKDwe4ggrAs7DuNuBhqL/VKCr/J29Wh2ng==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "k76bpvFvArisd0DbdtpLQbonkl57CYG3szD0sDw0fWZolh8nogw2hRrNL6U2KcrJqCvYVc+zGYSXTJfv9xgntA==",
         "dependencies": {
-          "Speckle.Sdk": "3.4.6"
+          "Speckle.Sdk": "3.5.0"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "YBa/RuwvBbymjWGv7sD2TwMSLhSjz3GYPOGVJtZzBZvev/zDQNZozvIlre+Lk7xpT2KPdH1FRfLkPWyW+qonMA==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "mOLFubk+co9rDtRLsB1wobvmkYaiEMvDV+3hRPlhnqe8WhV+vbBSjzj58EpKEprWXLwjyc0kVzsrvlM++PnL0g==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -307,14 +307,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.4.6"
+          "Speckle.Sdk.Dependencies": "3.5.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.4.8, )",
-        "resolved": "3.4.8",
-        "contentHash": "bNpJc2NBvjtJmdYS3xb6Fv4eqI/xZ2URXfWeXUFaWPMfC1QXLTjlK6iFriQk9ptLwr/dt4UPDPYYHOBynY1f2A=="
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "lPYk1E97tWJ5qO6B8F30VZ+vgOxMYQ5cspyUOALwWoyFloM1KZkvwyeBlm8FiQDx0su5KbTS4S10LQvnS2AqKg=="
       }
     },
     "net8.0-windows7.0/win-x64": {

--- a/Connectors/Autocad/Speckle.Connectors.Civil3d2022/packages.lock.json
+++ b/Connectors/Autocad/Speckle.Connectors.Civil3d2022/packages.lock.json
@@ -268,9 +268,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.4.6, )",
-          "Speckle.Sdk": "[3.4.6, )",
-          "Speckle.Sdk.Dependencies": "[3.4.8, )"
+          "Speckle.Objects": "[3.5.0, )",
+          "Speckle.Sdk": "[3.5.0, )",
+          "Speckle.Sdk.Dependencies": "[3.5.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -302,7 +302,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.4.6, )"
+          "Speckle.Objects": "[3.5.0, )"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -346,18 +346,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "JjCdW+gUWq7u1Tb5SlLaFCIYfmrMA9HbUzCdlSPDzyJkPuJFhwK3qKDwe4ggrAs7DuNuBhqL/VKCr/J29Wh2ng==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "k76bpvFvArisd0DbdtpLQbonkl57CYG3szD0sDw0fWZolh8nogw2hRrNL6U2KcrJqCvYVc+zGYSXTJfv9xgntA==",
         "dependencies": {
-          "Speckle.Sdk": "3.4.6"
+          "Speckle.Sdk": "3.5.0"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "YBa/RuwvBbymjWGv7sD2TwMSLhSjz3GYPOGVJtZzBZvev/zDQNZozvIlre+Lk7xpT2KPdH1FRfLkPWyW+qonMA==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "mOLFubk+co9rDtRLsB1wobvmkYaiEMvDV+3hRPlhnqe8WhV+vbBSjzj58EpKEprWXLwjyc0kVzsrvlM++PnL0g==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -367,14 +367,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.4.6"
+          "Speckle.Sdk.Dependencies": "3.5.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.4.8, )",
-        "resolved": "3.4.8",
-        "contentHash": "bNpJc2NBvjtJmdYS3xb6Fv4eqI/xZ2URXfWeXUFaWPMfC1QXLTjlK6iFriQk9ptLwr/dt4UPDPYYHOBynY1f2A=="
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "lPYk1E97tWJ5qO6B8F30VZ+vgOxMYQ5cspyUOALwWoyFloM1KZkvwyeBlm8FiQDx0su5KbTS4S10LQvnS2AqKg=="
       }
     }
   }

--- a/Connectors/Autocad/Speckle.Connectors.Civil3d2023/packages.lock.json
+++ b/Connectors/Autocad/Speckle.Connectors.Civil3d2023/packages.lock.json
@@ -268,9 +268,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.4.6, )",
-          "Speckle.Sdk": "[3.4.6, )",
-          "Speckle.Sdk.Dependencies": "[3.4.8, )"
+          "Speckle.Objects": "[3.5.0, )",
+          "Speckle.Sdk": "[3.5.0, )",
+          "Speckle.Sdk.Dependencies": "[3.5.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -302,7 +302,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.4.6, )"
+          "Speckle.Objects": "[3.5.0, )"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -346,18 +346,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "JjCdW+gUWq7u1Tb5SlLaFCIYfmrMA9HbUzCdlSPDzyJkPuJFhwK3qKDwe4ggrAs7DuNuBhqL/VKCr/J29Wh2ng==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "k76bpvFvArisd0DbdtpLQbonkl57CYG3szD0sDw0fWZolh8nogw2hRrNL6U2KcrJqCvYVc+zGYSXTJfv9xgntA==",
         "dependencies": {
-          "Speckle.Sdk": "3.4.6"
+          "Speckle.Sdk": "3.5.0"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "YBa/RuwvBbymjWGv7sD2TwMSLhSjz3GYPOGVJtZzBZvev/zDQNZozvIlre+Lk7xpT2KPdH1FRfLkPWyW+qonMA==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "mOLFubk+co9rDtRLsB1wobvmkYaiEMvDV+3hRPlhnqe8WhV+vbBSjzj58EpKEprWXLwjyc0kVzsrvlM++PnL0g==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -367,14 +367,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.4.6"
+          "Speckle.Sdk.Dependencies": "3.5.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.4.8, )",
-        "resolved": "3.4.8",
-        "contentHash": "bNpJc2NBvjtJmdYS3xb6Fv4eqI/xZ2URXfWeXUFaWPMfC1QXLTjlK6iFriQk9ptLwr/dt4UPDPYYHOBynY1f2A=="
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "lPYk1E97tWJ5qO6B8F30VZ+vgOxMYQ5cspyUOALwWoyFloM1KZkvwyeBlm8FiQDx0su5KbTS4S10LQvnS2AqKg=="
       }
     }
   }

--- a/Connectors/Autocad/Speckle.Connectors.Civil3d2024/packages.lock.json
+++ b/Connectors/Autocad/Speckle.Connectors.Civil3d2024/packages.lock.json
@@ -268,9 +268,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.4.6, )",
-          "Speckle.Sdk": "[3.4.6, )",
-          "Speckle.Sdk.Dependencies": "[3.4.8, )"
+          "Speckle.Objects": "[3.5.0, )",
+          "Speckle.Sdk": "[3.5.0, )",
+          "Speckle.Sdk.Dependencies": "[3.5.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -302,7 +302,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.4.6, )"
+          "Speckle.Objects": "[3.5.0, )"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -346,18 +346,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "JjCdW+gUWq7u1Tb5SlLaFCIYfmrMA9HbUzCdlSPDzyJkPuJFhwK3qKDwe4ggrAs7DuNuBhqL/VKCr/J29Wh2ng==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "k76bpvFvArisd0DbdtpLQbonkl57CYG3szD0sDw0fWZolh8nogw2hRrNL6U2KcrJqCvYVc+zGYSXTJfv9xgntA==",
         "dependencies": {
-          "Speckle.Sdk": "3.4.6"
+          "Speckle.Sdk": "3.5.0"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "YBa/RuwvBbymjWGv7sD2TwMSLhSjz3GYPOGVJtZzBZvev/zDQNZozvIlre+Lk7xpT2KPdH1FRfLkPWyW+qonMA==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "mOLFubk+co9rDtRLsB1wobvmkYaiEMvDV+3hRPlhnqe8WhV+vbBSjzj58EpKEprWXLwjyc0kVzsrvlM++PnL0g==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -367,14 +367,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.4.6"
+          "Speckle.Sdk.Dependencies": "3.5.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.4.8, )",
-        "resolved": "3.4.8",
-        "contentHash": "bNpJc2NBvjtJmdYS3xb6Fv4eqI/xZ2URXfWeXUFaWPMfC1QXLTjlK6iFriQk9ptLwr/dt4UPDPYYHOBynY1f2A=="
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "lPYk1E97tWJ5qO6B8F30VZ+vgOxMYQ5cspyUOALwWoyFloM1KZkvwyeBlm8FiQDx0su5KbTS4S10LQvnS2AqKg=="
       }
     }
   }

--- a/Connectors/Autocad/Speckle.Connectors.Civil3d2025/packages.lock.json
+++ b/Connectors/Autocad/Speckle.Connectors.Civil3d2025/packages.lock.json
@@ -219,9 +219,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.4.6, )",
-          "Speckle.Sdk": "[3.4.6, )",
-          "Speckle.Sdk.Dependencies": "[3.4.8, )"
+          "Speckle.Objects": "[3.5.0, )",
+          "Speckle.Sdk": "[3.5.0, )",
+          "Speckle.Sdk.Dependencies": "[3.5.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -254,7 +254,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.4.6, )"
+          "Speckle.Objects": "[3.5.0, )"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -298,18 +298,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "JjCdW+gUWq7u1Tb5SlLaFCIYfmrMA9HbUzCdlSPDzyJkPuJFhwK3qKDwe4ggrAs7DuNuBhqL/VKCr/J29Wh2ng==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "k76bpvFvArisd0DbdtpLQbonkl57CYG3szD0sDw0fWZolh8nogw2hRrNL6U2KcrJqCvYVc+zGYSXTJfv9xgntA==",
         "dependencies": {
-          "Speckle.Sdk": "3.4.6"
+          "Speckle.Sdk": "3.5.0"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "YBa/RuwvBbymjWGv7sD2TwMSLhSjz3GYPOGVJtZzBZvev/zDQNZozvIlre+Lk7xpT2KPdH1FRfLkPWyW+qonMA==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "mOLFubk+co9rDtRLsB1wobvmkYaiEMvDV+3hRPlhnqe8WhV+vbBSjzj58EpKEprWXLwjyc0kVzsrvlM++PnL0g==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -317,14 +317,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.4.6"
+          "Speckle.Sdk.Dependencies": "3.5.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.4.8, )",
-        "resolved": "3.4.8",
-        "contentHash": "bNpJc2NBvjtJmdYS3xb6Fv4eqI/xZ2URXfWeXUFaWPMfC1QXLTjlK6iFriQk9ptLwr/dt4UPDPYYHOBynY1f2A=="
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "lPYk1E97tWJ5qO6B8F30VZ+vgOxMYQ5cspyUOALwWoyFloM1KZkvwyeBlm8FiQDx0su5KbTS4S10LQvnS2AqKg=="
       }
     },
     "net8.0-windows7.0/win-x64": {

--- a/Connectors/Autocad/Speckle.Connectors.Civil3d2026/packages.lock.json
+++ b/Connectors/Autocad/Speckle.Connectors.Civil3d2026/packages.lock.json
@@ -219,9 +219,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.4.6, )",
-          "Speckle.Sdk": "[3.4.6, )",
-          "Speckle.Sdk.Dependencies": "[3.4.8, )"
+          "Speckle.Objects": "[3.5.0, )",
+          "Speckle.Sdk": "[3.5.0, )",
+          "Speckle.Sdk.Dependencies": "[3.5.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -254,7 +254,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.4.6, )"
+          "Speckle.Objects": "[3.5.0, )"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -298,18 +298,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "JjCdW+gUWq7u1Tb5SlLaFCIYfmrMA9HbUzCdlSPDzyJkPuJFhwK3qKDwe4ggrAs7DuNuBhqL/VKCr/J29Wh2ng==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "k76bpvFvArisd0DbdtpLQbonkl57CYG3szD0sDw0fWZolh8nogw2hRrNL6U2KcrJqCvYVc+zGYSXTJfv9xgntA==",
         "dependencies": {
-          "Speckle.Sdk": "3.4.6"
+          "Speckle.Sdk": "3.5.0"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "YBa/RuwvBbymjWGv7sD2TwMSLhSjz3GYPOGVJtZzBZvev/zDQNZozvIlre+Lk7xpT2KPdH1FRfLkPWyW+qonMA==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "mOLFubk+co9rDtRLsB1wobvmkYaiEMvDV+3hRPlhnqe8WhV+vbBSjzj58EpKEprWXLwjyc0kVzsrvlM++PnL0g==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -317,14 +317,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.4.6"
+          "Speckle.Sdk.Dependencies": "3.5.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.4.8, )",
-        "resolved": "3.4.8",
-        "contentHash": "bNpJc2NBvjtJmdYS3xb6Fv4eqI/xZ2URXfWeXUFaWPMfC1QXLTjlK6iFriQk9ptLwr/dt4UPDPYYHOBynY1f2A=="
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "lPYk1E97tWJ5qO6B8F30VZ+vgOxMYQ5cspyUOALwWoyFloM1KZkvwyeBlm8FiQDx0su5KbTS4S10LQvnS2AqKg=="
       }
     },
     "net8.0-windows7.0/win-x64": {

--- a/Connectors/CSi/Speckle.Connectors.ETABS21/packages.lock.json
+++ b/Connectors/CSi/Speckle.Connectors.ETABS21/packages.lock.json
@@ -259,9 +259,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.4.6, )",
-          "Speckle.Sdk": "[3.4.6, )",
-          "Speckle.Sdk.Dependencies": "[3.4.8, )"
+          "Speckle.Objects": "[3.5.0, )",
+          "Speckle.Sdk": "[3.5.0, )",
+          "Speckle.Sdk.Dependencies": "[3.5.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -285,7 +285,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.4.6, )"
+          "Speckle.Objects": "[3.5.0, )"
         }
       },
       "speckle.converters.etabs21": {
@@ -335,18 +335,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "JjCdW+gUWq7u1Tb5SlLaFCIYfmrMA9HbUzCdlSPDzyJkPuJFhwK3qKDwe4ggrAs7DuNuBhqL/VKCr/J29Wh2ng==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "k76bpvFvArisd0DbdtpLQbonkl57CYG3szD0sDw0fWZolh8nogw2hRrNL6U2KcrJqCvYVc+zGYSXTJfv9xgntA==",
         "dependencies": {
-          "Speckle.Sdk": "3.4.6"
+          "Speckle.Sdk": "3.5.0"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "YBa/RuwvBbymjWGv7sD2TwMSLhSjz3GYPOGVJtZzBZvev/zDQNZozvIlre+Lk7xpT2KPdH1FRfLkPWyW+qonMA==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "mOLFubk+co9rDtRLsB1wobvmkYaiEMvDV+3hRPlhnqe8WhV+vbBSjzj58EpKEprWXLwjyc0kVzsrvlM++PnL0g==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -356,14 +356,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.4.6"
+          "Speckle.Sdk.Dependencies": "3.5.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.4.8, )",
-        "resolved": "3.4.8",
-        "contentHash": "bNpJc2NBvjtJmdYS3xb6Fv4eqI/xZ2URXfWeXUFaWPMfC1QXLTjlK6iFriQk9ptLwr/dt4UPDPYYHOBynY1f2A=="
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "lPYk1E97tWJ5qO6B8F30VZ+vgOxMYQ5cspyUOALwWoyFloM1KZkvwyeBlm8FiQDx0su5KbTS4S10LQvnS2AqKg=="
       }
     }
   }

--- a/Connectors/CSi/Speckle.Connectors.ETABS22/packages.lock.json
+++ b/Connectors/CSi/Speckle.Connectors.ETABS22/packages.lock.json
@@ -210,9 +210,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.4.6, )",
-          "Speckle.Sdk": "[3.4.6, )",
-          "Speckle.Sdk.Dependencies": "[3.4.8, )"
+          "Speckle.Objects": "[3.5.0, )",
+          "Speckle.Sdk": "[3.5.0, )",
+          "Speckle.Sdk.Dependencies": "[3.5.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -236,7 +236,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.4.6, )"
+          "Speckle.Objects": "[3.5.0, )"
         }
       },
       "speckle.converters.etabs22": {
@@ -286,18 +286,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "JjCdW+gUWq7u1Tb5SlLaFCIYfmrMA9HbUzCdlSPDzyJkPuJFhwK3qKDwe4ggrAs7DuNuBhqL/VKCr/J29Wh2ng==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "k76bpvFvArisd0DbdtpLQbonkl57CYG3szD0sDw0fWZolh8nogw2hRrNL6U2KcrJqCvYVc+zGYSXTJfv9xgntA==",
         "dependencies": {
-          "Speckle.Sdk": "3.4.6"
+          "Speckle.Sdk": "3.5.0"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "YBa/RuwvBbymjWGv7sD2TwMSLhSjz3GYPOGVJtZzBZvev/zDQNZozvIlre+Lk7xpT2KPdH1FRfLkPWyW+qonMA==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "mOLFubk+co9rDtRLsB1wobvmkYaiEMvDV+3hRPlhnqe8WhV+vbBSjzj58EpKEprWXLwjyc0kVzsrvlM++PnL0g==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -305,14 +305,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.4.6"
+          "Speckle.Sdk.Dependencies": "3.5.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.4.8, )",
-        "resolved": "3.4.8",
-        "contentHash": "bNpJc2NBvjtJmdYS3xb6Fv4eqI/xZ2URXfWeXUFaWPMfC1QXLTjlK6iFriQk9ptLwr/dt4UPDPYYHOBynY1f2A=="
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "lPYk1E97tWJ5qO6B8F30VZ+vgOxMYQ5cspyUOALwWoyFloM1KZkvwyeBlm8FiQDx0su5KbTS4S10LQvnS2AqKg=="
       }
     }
   }

--- a/Connectors/Navisworks/Speckle.Connectors.Navisworks2020/packages.lock.json
+++ b/Connectors/Navisworks/Speckle.Connectors.Navisworks2020/packages.lock.json
@@ -259,9 +259,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.4.6, )",
-          "Speckle.Sdk": "[3.4.6, )",
-          "Speckle.Sdk.Dependencies": "[3.4.8, )"
+          "Speckle.Objects": "[3.5.0, )",
+          "Speckle.Sdk": "[3.5.0, )",
+          "Speckle.Sdk.Dependencies": "[3.5.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -285,7 +285,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.4.6, )"
+          "Speckle.Objects": "[3.5.0, )"
         }
       },
       "speckle.converters.navisworks2020": {
@@ -337,18 +337,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "JjCdW+gUWq7u1Tb5SlLaFCIYfmrMA9HbUzCdlSPDzyJkPuJFhwK3qKDwe4ggrAs7DuNuBhqL/VKCr/J29Wh2ng==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "k76bpvFvArisd0DbdtpLQbonkl57CYG3szD0sDw0fWZolh8nogw2hRrNL6U2KcrJqCvYVc+zGYSXTJfv9xgntA==",
         "dependencies": {
-          "Speckle.Sdk": "3.4.6"
+          "Speckle.Sdk": "3.5.0"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "YBa/RuwvBbymjWGv7sD2TwMSLhSjz3GYPOGVJtZzBZvev/zDQNZozvIlre+Lk7xpT2KPdH1FRfLkPWyW+qonMA==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "mOLFubk+co9rDtRLsB1wobvmkYaiEMvDV+3hRPlhnqe8WhV+vbBSjzj58EpKEprWXLwjyc0kVzsrvlM++PnL0g==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -358,14 +358,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.4.6"
+          "Speckle.Sdk.Dependencies": "3.5.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.4.8, )",
-        "resolved": "3.4.8",
-        "contentHash": "bNpJc2NBvjtJmdYS3xb6Fv4eqI/xZ2URXfWeXUFaWPMfC1QXLTjlK6iFriQk9ptLwr/dt4UPDPYYHOBynY1f2A=="
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "lPYk1E97tWJ5qO6B8F30VZ+vgOxMYQ5cspyUOALwWoyFloM1KZkvwyeBlm8FiQDx0su5KbTS4S10LQvnS2AqKg=="
       }
     },
     ".NETFramework,Version=v4.8/win-x64": {

--- a/Connectors/Navisworks/Speckle.Connectors.Navisworks2021/packages.lock.json
+++ b/Connectors/Navisworks/Speckle.Connectors.Navisworks2021/packages.lock.json
@@ -259,9 +259,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.4.6, )",
-          "Speckle.Sdk": "[3.4.6, )",
-          "Speckle.Sdk.Dependencies": "[3.4.8, )"
+          "Speckle.Objects": "[3.5.0, )",
+          "Speckle.Sdk": "[3.5.0, )",
+          "Speckle.Sdk.Dependencies": "[3.5.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -285,7 +285,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.4.6, )"
+          "Speckle.Objects": "[3.5.0, )"
         }
       },
       "speckle.converters.navisworks2021": {
@@ -337,18 +337,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "JjCdW+gUWq7u1Tb5SlLaFCIYfmrMA9HbUzCdlSPDzyJkPuJFhwK3qKDwe4ggrAs7DuNuBhqL/VKCr/J29Wh2ng==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "k76bpvFvArisd0DbdtpLQbonkl57CYG3szD0sDw0fWZolh8nogw2hRrNL6U2KcrJqCvYVc+zGYSXTJfv9xgntA==",
         "dependencies": {
-          "Speckle.Sdk": "3.4.6"
+          "Speckle.Sdk": "3.5.0"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "YBa/RuwvBbymjWGv7sD2TwMSLhSjz3GYPOGVJtZzBZvev/zDQNZozvIlre+Lk7xpT2KPdH1FRfLkPWyW+qonMA==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "mOLFubk+co9rDtRLsB1wobvmkYaiEMvDV+3hRPlhnqe8WhV+vbBSjzj58EpKEprWXLwjyc0kVzsrvlM++PnL0g==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -358,14 +358,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.4.6"
+          "Speckle.Sdk.Dependencies": "3.5.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.4.8, )",
-        "resolved": "3.4.8",
-        "contentHash": "bNpJc2NBvjtJmdYS3xb6Fv4eqI/xZ2URXfWeXUFaWPMfC1QXLTjlK6iFriQk9ptLwr/dt4UPDPYYHOBynY1f2A=="
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "lPYk1E97tWJ5qO6B8F30VZ+vgOxMYQ5cspyUOALwWoyFloM1KZkvwyeBlm8FiQDx0su5KbTS4S10LQvnS2AqKg=="
       }
     },
     ".NETFramework,Version=v4.8/win-x64": {

--- a/Connectors/Navisworks/Speckle.Connectors.Navisworks2022/packages.lock.json
+++ b/Connectors/Navisworks/Speckle.Connectors.Navisworks2022/packages.lock.json
@@ -259,9 +259,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.4.6, )",
-          "Speckle.Sdk": "[3.4.6, )",
-          "Speckle.Sdk.Dependencies": "[3.4.8, )"
+          "Speckle.Objects": "[3.5.0, )",
+          "Speckle.Sdk": "[3.5.0, )",
+          "Speckle.Sdk.Dependencies": "[3.5.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -285,7 +285,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.4.6, )"
+          "Speckle.Objects": "[3.5.0, )"
         }
       },
       "speckle.converters.navisworks2022": {
@@ -337,18 +337,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "JjCdW+gUWq7u1Tb5SlLaFCIYfmrMA9HbUzCdlSPDzyJkPuJFhwK3qKDwe4ggrAs7DuNuBhqL/VKCr/J29Wh2ng==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "k76bpvFvArisd0DbdtpLQbonkl57CYG3szD0sDw0fWZolh8nogw2hRrNL6U2KcrJqCvYVc+zGYSXTJfv9xgntA==",
         "dependencies": {
-          "Speckle.Sdk": "3.4.6"
+          "Speckle.Sdk": "3.5.0"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "YBa/RuwvBbymjWGv7sD2TwMSLhSjz3GYPOGVJtZzBZvev/zDQNZozvIlre+Lk7xpT2KPdH1FRfLkPWyW+qonMA==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "mOLFubk+co9rDtRLsB1wobvmkYaiEMvDV+3hRPlhnqe8WhV+vbBSjzj58EpKEprWXLwjyc0kVzsrvlM++PnL0g==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -358,14 +358,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.4.6"
+          "Speckle.Sdk.Dependencies": "3.5.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.4.8, )",
-        "resolved": "3.4.8",
-        "contentHash": "bNpJc2NBvjtJmdYS3xb6Fv4eqI/xZ2URXfWeXUFaWPMfC1QXLTjlK6iFriQk9ptLwr/dt4UPDPYYHOBynY1f2A=="
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "lPYk1E97tWJ5qO6B8F30VZ+vgOxMYQ5cspyUOALwWoyFloM1KZkvwyeBlm8FiQDx0su5KbTS4S10LQvnS2AqKg=="
       }
     },
     ".NETFramework,Version=v4.8/win-x64": {

--- a/Connectors/Navisworks/Speckle.Connectors.Navisworks2023/packages.lock.json
+++ b/Connectors/Navisworks/Speckle.Connectors.Navisworks2023/packages.lock.json
@@ -259,9 +259,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.4.6, )",
-          "Speckle.Sdk": "[3.4.6, )",
-          "Speckle.Sdk.Dependencies": "[3.4.8, )"
+          "Speckle.Objects": "[3.5.0, )",
+          "Speckle.Sdk": "[3.5.0, )",
+          "Speckle.Sdk.Dependencies": "[3.5.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -285,7 +285,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.4.6, )"
+          "Speckle.Objects": "[3.5.0, )"
         }
       },
       "speckle.converters.navisworks2023": {
@@ -337,18 +337,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "JjCdW+gUWq7u1Tb5SlLaFCIYfmrMA9HbUzCdlSPDzyJkPuJFhwK3qKDwe4ggrAs7DuNuBhqL/VKCr/J29Wh2ng==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "k76bpvFvArisd0DbdtpLQbonkl57CYG3szD0sDw0fWZolh8nogw2hRrNL6U2KcrJqCvYVc+zGYSXTJfv9xgntA==",
         "dependencies": {
-          "Speckle.Sdk": "3.4.6"
+          "Speckle.Sdk": "3.5.0"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "YBa/RuwvBbymjWGv7sD2TwMSLhSjz3GYPOGVJtZzBZvev/zDQNZozvIlre+Lk7xpT2KPdH1FRfLkPWyW+qonMA==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "mOLFubk+co9rDtRLsB1wobvmkYaiEMvDV+3hRPlhnqe8WhV+vbBSjzj58EpKEprWXLwjyc0kVzsrvlM++PnL0g==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -358,14 +358,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.4.6"
+          "Speckle.Sdk.Dependencies": "3.5.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.4.8, )",
-        "resolved": "3.4.8",
-        "contentHash": "bNpJc2NBvjtJmdYS3xb6Fv4eqI/xZ2URXfWeXUFaWPMfC1QXLTjlK6iFriQk9ptLwr/dt4UPDPYYHOBynY1f2A=="
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "lPYk1E97tWJ5qO6B8F30VZ+vgOxMYQ5cspyUOALwWoyFloM1KZkvwyeBlm8FiQDx0su5KbTS4S10LQvnS2AqKg=="
       }
     },
     ".NETFramework,Version=v4.8/win-x64": {

--- a/Connectors/Navisworks/Speckle.Connectors.Navisworks2024/packages.lock.json
+++ b/Connectors/Navisworks/Speckle.Connectors.Navisworks2024/packages.lock.json
@@ -259,9 +259,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.4.6, )",
-          "Speckle.Sdk": "[3.4.6, )",
-          "Speckle.Sdk.Dependencies": "[3.4.8, )"
+          "Speckle.Objects": "[3.5.0, )",
+          "Speckle.Sdk": "[3.5.0, )",
+          "Speckle.Sdk.Dependencies": "[3.5.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -285,7 +285,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.4.6, )"
+          "Speckle.Objects": "[3.5.0, )"
         }
       },
       "speckle.converters.navisworks2024": {
@@ -337,18 +337,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "JjCdW+gUWq7u1Tb5SlLaFCIYfmrMA9HbUzCdlSPDzyJkPuJFhwK3qKDwe4ggrAs7DuNuBhqL/VKCr/J29Wh2ng==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "k76bpvFvArisd0DbdtpLQbonkl57CYG3szD0sDw0fWZolh8nogw2hRrNL6U2KcrJqCvYVc+zGYSXTJfv9xgntA==",
         "dependencies": {
-          "Speckle.Sdk": "3.4.6"
+          "Speckle.Sdk": "3.5.0"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "YBa/RuwvBbymjWGv7sD2TwMSLhSjz3GYPOGVJtZzBZvev/zDQNZozvIlre+Lk7xpT2KPdH1FRfLkPWyW+qonMA==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "mOLFubk+co9rDtRLsB1wobvmkYaiEMvDV+3hRPlhnqe8WhV+vbBSjzj58EpKEprWXLwjyc0kVzsrvlM++PnL0g==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -358,14 +358,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.4.6"
+          "Speckle.Sdk.Dependencies": "3.5.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.4.8, )",
-        "resolved": "3.4.8",
-        "contentHash": "bNpJc2NBvjtJmdYS3xb6Fv4eqI/xZ2URXfWeXUFaWPMfC1QXLTjlK6iFriQk9ptLwr/dt4UPDPYYHOBynY1f2A=="
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "lPYk1E97tWJ5qO6B8F30VZ+vgOxMYQ5cspyUOALwWoyFloM1KZkvwyeBlm8FiQDx0su5KbTS4S10LQvnS2AqKg=="
       }
     },
     ".NETFramework,Version=v4.8/win-x64": {

--- a/Connectors/Navisworks/Speckle.Connectors.Navisworks2025/packages.lock.json
+++ b/Connectors/Navisworks/Speckle.Connectors.Navisworks2025/packages.lock.json
@@ -265,9 +265,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.4.6, )",
-          "Speckle.Sdk": "[3.4.6, )",
-          "Speckle.Sdk.Dependencies": "[3.4.8, )"
+          "Speckle.Objects": "[3.5.0, )",
+          "Speckle.Sdk": "[3.5.0, )",
+          "Speckle.Sdk.Dependencies": "[3.5.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -291,7 +291,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.4.6, )"
+          "Speckle.Objects": "[3.5.0, )"
         }
       },
       "speckle.converters.navisworks2025": {
@@ -337,18 +337,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "JjCdW+gUWq7u1Tb5SlLaFCIYfmrMA9HbUzCdlSPDzyJkPuJFhwK3qKDwe4ggrAs7DuNuBhqL/VKCr/J29Wh2ng==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "k76bpvFvArisd0DbdtpLQbonkl57CYG3szD0sDw0fWZolh8nogw2hRrNL6U2KcrJqCvYVc+zGYSXTJfv9xgntA==",
         "dependencies": {
-          "Speckle.Sdk": "3.4.6"
+          "Speckle.Sdk": "3.5.0"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "YBa/RuwvBbymjWGv7sD2TwMSLhSjz3GYPOGVJtZzBZvev/zDQNZozvIlre+Lk7xpT2KPdH1FRfLkPWyW+qonMA==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "mOLFubk+co9rDtRLsB1wobvmkYaiEMvDV+3hRPlhnqe8WhV+vbBSjzj58EpKEprWXLwjyc0kVzsrvlM++PnL0g==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -358,14 +358,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.4.6"
+          "Speckle.Sdk.Dependencies": "3.5.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.4.8, )",
-        "resolved": "3.4.8",
-        "contentHash": "bNpJc2NBvjtJmdYS3xb6Fv4eqI/xZ2URXfWeXUFaWPMfC1QXLTjlK6iFriQk9ptLwr/dt4UPDPYYHOBynY1f2A=="
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "lPYk1E97tWJ5qO6B8F30VZ+vgOxMYQ5cspyUOALwWoyFloM1KZkvwyeBlm8FiQDx0su5KbTS4S10LQvnS2AqKg=="
       }
     },
     ".NETFramework,Version=v4.8/win-x64": {

--- a/Connectors/Navisworks/Speckle.Connectors.Navisworks2026/packages.lock.json
+++ b/Connectors/Navisworks/Speckle.Connectors.Navisworks2026/packages.lock.json
@@ -266,9 +266,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.4.6, )",
-          "Speckle.Sdk": "[3.4.6, )",
-          "Speckle.Sdk.Dependencies": "[3.4.8, )"
+          "Speckle.Objects": "[3.5.0, )",
+          "Speckle.Sdk": "[3.5.0, )",
+          "Speckle.Sdk.Dependencies": "[3.5.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -292,7 +292,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.4.6, )"
+          "Speckle.Objects": "[3.5.0, )"
         }
       },
       "speckle.converters.navisworks2026": {
@@ -339,18 +339,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "JjCdW+gUWq7u1Tb5SlLaFCIYfmrMA9HbUzCdlSPDzyJkPuJFhwK3qKDwe4ggrAs7DuNuBhqL/VKCr/J29Wh2ng==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "k76bpvFvArisd0DbdtpLQbonkl57CYG3szD0sDw0fWZolh8nogw2hRrNL6U2KcrJqCvYVc+zGYSXTJfv9xgntA==",
         "dependencies": {
-          "Speckle.Sdk": "3.4.6"
+          "Speckle.Sdk": "3.5.0"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "YBa/RuwvBbymjWGv7sD2TwMSLhSjz3GYPOGVJtZzBZvev/zDQNZozvIlre+Lk7xpT2KPdH1FRfLkPWyW+qonMA==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "mOLFubk+co9rDtRLsB1wobvmkYaiEMvDV+3hRPlhnqe8WhV+vbBSjzj58EpKEprWXLwjyc0kVzsrvlM++PnL0g==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -360,14 +360,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.4.6"
+          "Speckle.Sdk.Dependencies": "3.5.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.4.8, )",
-        "resolved": "3.4.8",
-        "contentHash": "bNpJc2NBvjtJmdYS3xb6Fv4eqI/xZ2URXfWeXUFaWPMfC1QXLTjlK6iFriQk9ptLwr/dt4UPDPYYHOBynY1f2A=="
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "lPYk1E97tWJ5qO6B8F30VZ+vgOxMYQ5cspyUOALwWoyFloM1KZkvwyeBlm8FiQDx0su5KbTS4S10LQvnS2AqKg=="
       }
     },
     ".NETFramework,Version=v4.8/win-x64": {

--- a/Connectors/Revit/Speckle.Connectors.Revit2022/packages.lock.json
+++ b/Connectors/Revit/Speckle.Connectors.Revit2022/packages.lock.json
@@ -281,9 +281,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.4.6, )",
-          "Speckle.Sdk": "[3.4.6, )",
-          "Speckle.Sdk.Dependencies": "[3.4.8, )"
+          "Speckle.Objects": "[3.5.0, )",
+          "Speckle.Sdk": "[3.5.0, )",
+          "Speckle.Sdk.Dependencies": "[3.5.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -306,7 +306,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.4.6, )"
+          "Speckle.Objects": "[3.5.0, )"
         }
       },
       "speckle.converters.revit2022": {
@@ -351,11 +351,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "JjCdW+gUWq7u1Tb5SlLaFCIYfmrMA9HbUzCdlSPDzyJkPuJFhwK3qKDwe4ggrAs7DuNuBhqL/VKCr/J29Wh2ng==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "k76bpvFvArisd0DbdtpLQbonkl57CYG3szD0sDw0fWZolh8nogw2hRrNL6U2KcrJqCvYVc+zGYSXTJfv9xgntA==",
         "dependencies": {
-          "Speckle.Sdk": "3.4.6"
+          "Speckle.Sdk": "3.5.0"
         }
       },
       "Speckle.Revit.API": {
@@ -366,9 +366,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "YBa/RuwvBbymjWGv7sD2TwMSLhSjz3GYPOGVJtZzBZvev/zDQNZozvIlre+Lk7xpT2KPdH1FRfLkPWyW+qonMA==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "mOLFubk+co9rDtRLsB1wobvmkYaiEMvDV+3hRPlhnqe8WhV+vbBSjzj58EpKEprWXLwjyc0kVzsrvlM++PnL0g==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -378,14 +378,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.4.6"
+          "Speckle.Sdk.Dependencies": "3.5.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.4.8, )",
-        "resolved": "3.4.8",
-        "contentHash": "bNpJc2NBvjtJmdYS3xb6Fv4eqI/xZ2URXfWeXUFaWPMfC1QXLTjlK6iFriQk9ptLwr/dt4UPDPYYHOBynY1f2A=="
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "lPYk1E97tWJ5qO6B8F30VZ+vgOxMYQ5cspyUOALwWoyFloM1KZkvwyeBlm8FiQDx0su5KbTS4S10LQvnS2AqKg=="
       }
     }
   }

--- a/Connectors/Revit/Speckle.Connectors.Revit2023/packages.lock.json
+++ b/Connectors/Revit/Speckle.Connectors.Revit2023/packages.lock.json
@@ -281,9 +281,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.4.6, )",
-          "Speckle.Sdk": "[3.4.6, )",
-          "Speckle.Sdk.Dependencies": "[3.4.8, )"
+          "Speckle.Objects": "[3.5.0, )",
+          "Speckle.Sdk": "[3.5.0, )",
+          "Speckle.Sdk.Dependencies": "[3.5.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -306,7 +306,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.4.6, )"
+          "Speckle.Objects": "[3.5.0, )"
         }
       },
       "speckle.converters.revit2023": {
@@ -351,11 +351,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "JjCdW+gUWq7u1Tb5SlLaFCIYfmrMA9HbUzCdlSPDzyJkPuJFhwK3qKDwe4ggrAs7DuNuBhqL/VKCr/J29Wh2ng==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "k76bpvFvArisd0DbdtpLQbonkl57CYG3szD0sDw0fWZolh8nogw2hRrNL6U2KcrJqCvYVc+zGYSXTJfv9xgntA==",
         "dependencies": {
-          "Speckle.Sdk": "3.4.6"
+          "Speckle.Sdk": "3.5.0"
         }
       },
       "Speckle.Revit.API": {
@@ -366,9 +366,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "YBa/RuwvBbymjWGv7sD2TwMSLhSjz3GYPOGVJtZzBZvev/zDQNZozvIlre+Lk7xpT2KPdH1FRfLkPWyW+qonMA==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "mOLFubk+co9rDtRLsB1wobvmkYaiEMvDV+3hRPlhnqe8WhV+vbBSjzj58EpKEprWXLwjyc0kVzsrvlM++PnL0g==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -378,14 +378,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.4.6"
+          "Speckle.Sdk.Dependencies": "3.5.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.4.8, )",
-        "resolved": "3.4.8",
-        "contentHash": "bNpJc2NBvjtJmdYS3xb6Fv4eqI/xZ2URXfWeXUFaWPMfC1QXLTjlK6iFriQk9ptLwr/dt4UPDPYYHOBynY1f2A=="
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "lPYk1E97tWJ5qO6B8F30VZ+vgOxMYQ5cspyUOALwWoyFloM1KZkvwyeBlm8FiQDx0su5KbTS4S10LQvnS2AqKg=="
       }
     }
   }

--- a/Connectors/Revit/Speckle.Connectors.Revit2024/packages.lock.json
+++ b/Connectors/Revit/Speckle.Connectors.Revit2024/packages.lock.json
@@ -281,9 +281,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.4.6, )",
-          "Speckle.Sdk": "[3.4.6, )",
-          "Speckle.Sdk.Dependencies": "[3.4.8, )"
+          "Speckle.Objects": "[3.5.0, )",
+          "Speckle.Sdk": "[3.5.0, )",
+          "Speckle.Sdk.Dependencies": "[3.5.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -306,7 +306,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.4.6, )"
+          "Speckle.Objects": "[3.5.0, )"
         }
       },
       "speckle.converters.revit2024": {
@@ -351,11 +351,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "JjCdW+gUWq7u1Tb5SlLaFCIYfmrMA9HbUzCdlSPDzyJkPuJFhwK3qKDwe4ggrAs7DuNuBhqL/VKCr/J29Wh2ng==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "k76bpvFvArisd0DbdtpLQbonkl57CYG3szD0sDw0fWZolh8nogw2hRrNL6U2KcrJqCvYVc+zGYSXTJfv9xgntA==",
         "dependencies": {
-          "Speckle.Sdk": "3.4.6"
+          "Speckle.Sdk": "3.5.0"
         }
       },
       "Speckle.Revit.API": {
@@ -366,9 +366,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "YBa/RuwvBbymjWGv7sD2TwMSLhSjz3GYPOGVJtZzBZvev/zDQNZozvIlre+Lk7xpT2KPdH1FRfLkPWyW+qonMA==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "mOLFubk+co9rDtRLsB1wobvmkYaiEMvDV+3hRPlhnqe8WhV+vbBSjzj58EpKEprWXLwjyc0kVzsrvlM++PnL0g==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -378,14 +378,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.4.6"
+          "Speckle.Sdk.Dependencies": "3.5.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.4.8, )",
-        "resolved": "3.4.8",
-        "contentHash": "bNpJc2NBvjtJmdYS3xb6Fv4eqI/xZ2URXfWeXUFaWPMfC1QXLTjlK6iFriQk9ptLwr/dt4UPDPYYHOBynY1f2A=="
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "lPYk1E97tWJ5qO6B8F30VZ+vgOxMYQ5cspyUOALwWoyFloM1KZkvwyeBlm8FiQDx0su5KbTS4S10LQvnS2AqKg=="
       }
     }
   }

--- a/Connectors/Revit/Speckle.Connectors.Revit2025/packages.lock.json
+++ b/Connectors/Revit/Speckle.Connectors.Revit2025/packages.lock.json
@@ -226,9 +226,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.4.6, )",
-          "Speckle.Sdk": "[3.4.6, )",
-          "Speckle.Sdk.Dependencies": "[3.4.8, )"
+          "Speckle.Objects": "[3.5.0, )",
+          "Speckle.Sdk": "[3.5.0, )",
+          "Speckle.Sdk.Dependencies": "[3.5.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -251,7 +251,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.4.6, )"
+          "Speckle.Objects": "[3.5.0, )"
         }
       },
       "speckle.converters.revit2025": {
@@ -296,11 +296,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "JjCdW+gUWq7u1Tb5SlLaFCIYfmrMA9HbUzCdlSPDzyJkPuJFhwK3qKDwe4ggrAs7DuNuBhqL/VKCr/J29Wh2ng==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "k76bpvFvArisd0DbdtpLQbonkl57CYG3szD0sDw0fWZolh8nogw2hRrNL6U2KcrJqCvYVc+zGYSXTJfv9xgntA==",
         "dependencies": {
-          "Speckle.Sdk": "3.4.6"
+          "Speckle.Sdk": "3.5.0"
         }
       },
       "Speckle.Revit.API": {
@@ -311,9 +311,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "YBa/RuwvBbymjWGv7sD2TwMSLhSjz3GYPOGVJtZzBZvev/zDQNZozvIlre+Lk7xpT2KPdH1FRfLkPWyW+qonMA==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "mOLFubk+co9rDtRLsB1wobvmkYaiEMvDV+3hRPlhnqe8WhV+vbBSjzj58EpKEprWXLwjyc0kVzsrvlM++PnL0g==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -321,14 +321,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.4.6"
+          "Speckle.Sdk.Dependencies": "3.5.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.4.8, )",
-        "resolved": "3.4.8",
-        "contentHash": "bNpJc2NBvjtJmdYS3xb6Fv4eqI/xZ2URXfWeXUFaWPMfC1QXLTjlK6iFriQk9ptLwr/dt4UPDPYYHOBynY1f2A=="
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "lPYk1E97tWJ5qO6B8F30VZ+vgOxMYQ5cspyUOALwWoyFloM1KZkvwyeBlm8FiQDx0su5KbTS4S10LQvnS2AqKg=="
       }
     },
     "net8.0-windows7.0/win-x64": {

--- a/Connectors/Revit/Speckle.Connectors.Revit2026/packages.lock.json
+++ b/Connectors/Revit/Speckle.Connectors.Revit2026/packages.lock.json
@@ -219,9 +219,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.4.6, )",
-          "Speckle.Sdk": "[3.4.6, )",
-          "Speckle.Sdk.Dependencies": "[3.4.8, )"
+          "Speckle.Objects": "[3.5.0, )",
+          "Speckle.Sdk": "[3.5.0, )",
+          "Speckle.Sdk.Dependencies": "[3.5.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -244,7 +244,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.4.6, )"
+          "Speckle.Objects": "[3.5.0, )"
         }
       },
       "speckle.converters.revit2026": {
@@ -280,11 +280,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "JjCdW+gUWq7u1Tb5SlLaFCIYfmrMA9HbUzCdlSPDzyJkPuJFhwK3qKDwe4ggrAs7DuNuBhqL/VKCr/J29Wh2ng==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "k76bpvFvArisd0DbdtpLQbonkl57CYG3szD0sDw0fWZolh8nogw2hRrNL6U2KcrJqCvYVc+zGYSXTJfv9xgntA==",
         "dependencies": {
-          "Speckle.Sdk": "3.4.6"
+          "Speckle.Sdk": "3.5.0"
         }
       },
       "Speckle.Revit.API": {
@@ -295,9 +295,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "YBa/RuwvBbymjWGv7sD2TwMSLhSjz3GYPOGVJtZzBZvev/zDQNZozvIlre+Lk7xpT2KPdH1FRfLkPWyW+qonMA==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "mOLFubk+co9rDtRLsB1wobvmkYaiEMvDV+3hRPlhnqe8WhV+vbBSjzj58EpKEprWXLwjyc0kVzsrvlM++PnL0g==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -305,14 +305,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.4.6"
+          "Speckle.Sdk.Dependencies": "3.5.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.4.8, )",
-        "resolved": "3.4.8",
-        "contentHash": "bNpJc2NBvjtJmdYS3xb6Fv4eqI/xZ2URXfWeXUFaWPMfC1QXLTjlK6iFriQk9ptLwr/dt4UPDPYYHOBynY1f2A=="
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "lPYk1E97tWJ5qO6B8F30VZ+vgOxMYQ5cspyUOALwWoyFloM1KZkvwyeBlm8FiQDx0su5KbTS4S10LQvnS2AqKg=="
       }
     },
     "net8.0-windows7.0/win-x64": {

--- a/Connectors/Rhino/Speckle.Connectors.Grasshopper7/packages.lock.json
+++ b/Connectors/Rhino/Speckle.Connectors.Grasshopper7/packages.lock.json
@@ -325,9 +325,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.4.6, )",
-          "Speckle.Sdk": "[3.4.6, )",
-          "Speckle.Sdk.Dependencies": "[3.4.8, )"
+          "Speckle.Objects": "[3.5.0, )",
+          "Speckle.Sdk": "[3.5.0, )",
+          "Speckle.Sdk.Dependencies": "[3.5.0, )"
         }
       },
       "speckle.connectors.logging": {
@@ -337,7 +337,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.4.6, )"
+          "Speckle.Objects": "[3.5.0, )"
         }
       },
       "speckle.converters.rhino7": {
@@ -382,18 +382,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "JjCdW+gUWq7u1Tb5SlLaFCIYfmrMA9HbUzCdlSPDzyJkPuJFhwK3qKDwe4ggrAs7DuNuBhqL/VKCr/J29Wh2ng==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "k76bpvFvArisd0DbdtpLQbonkl57CYG3szD0sDw0fWZolh8nogw2hRrNL6U2KcrJqCvYVc+zGYSXTJfv9xgntA==",
         "dependencies": {
-          "Speckle.Sdk": "3.4.6"
+          "Speckle.Sdk": "3.5.0"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "YBa/RuwvBbymjWGv7sD2TwMSLhSjz3GYPOGVJtZzBZvev/zDQNZozvIlre+Lk7xpT2KPdH1FRfLkPWyW+qonMA==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "mOLFubk+co9rDtRLsB1wobvmkYaiEMvDV+3hRPlhnqe8WhV+vbBSjzj58EpKEprWXLwjyc0kVzsrvlM++PnL0g==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -403,14 +403,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.4.6"
+          "Speckle.Sdk.Dependencies": "3.5.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.4.8, )",
-        "resolved": "3.4.8",
-        "contentHash": "bNpJc2NBvjtJmdYS3xb6Fv4eqI/xZ2URXfWeXUFaWPMfC1QXLTjlK6iFriQk9ptLwr/dt4UPDPYYHOBynY1f2A=="
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "lPYk1E97tWJ5qO6B8F30VZ+vgOxMYQ5cspyUOALwWoyFloM1KZkvwyeBlm8FiQDx0su5KbTS4S10LQvnS2AqKg=="
       }
     }
   }

--- a/Connectors/Rhino/Speckle.Connectors.Grasshopper8/packages.lock.json
+++ b/Connectors/Rhino/Speckle.Connectors.Grasshopper8/packages.lock.json
@@ -325,9 +325,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.4.6, )",
-          "Speckle.Sdk": "[3.4.6, )",
-          "Speckle.Sdk.Dependencies": "[3.4.8, )"
+          "Speckle.Objects": "[3.5.0, )",
+          "Speckle.Sdk": "[3.5.0, )",
+          "Speckle.Sdk.Dependencies": "[3.5.0, )"
         }
       },
       "speckle.connectors.logging": {
@@ -337,7 +337,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.4.6, )"
+          "Speckle.Objects": "[3.5.0, )"
         }
       },
       "speckle.converters.rhino8": {
@@ -382,18 +382,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "JjCdW+gUWq7u1Tb5SlLaFCIYfmrMA9HbUzCdlSPDzyJkPuJFhwK3qKDwe4ggrAs7DuNuBhqL/VKCr/J29Wh2ng==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "k76bpvFvArisd0DbdtpLQbonkl57CYG3szD0sDw0fWZolh8nogw2hRrNL6U2KcrJqCvYVc+zGYSXTJfv9xgntA==",
         "dependencies": {
-          "Speckle.Sdk": "3.4.6"
+          "Speckle.Sdk": "3.5.0"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "YBa/RuwvBbymjWGv7sD2TwMSLhSjz3GYPOGVJtZzBZvev/zDQNZozvIlre+Lk7xpT2KPdH1FRfLkPWyW+qonMA==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "mOLFubk+co9rDtRLsB1wobvmkYaiEMvDV+3hRPlhnqe8WhV+vbBSjzj58EpKEprWXLwjyc0kVzsrvlM++PnL0g==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -403,14 +403,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.4.6"
+          "Speckle.Sdk.Dependencies": "3.5.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.4.8, )",
-        "resolved": "3.4.8",
-        "contentHash": "bNpJc2NBvjtJmdYS3xb6Fv4eqI/xZ2URXfWeXUFaWPMfC1QXLTjlK6iFriQk9ptLwr/dt4UPDPYYHOBynY1f2A=="
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "lPYk1E97tWJ5qO6B8F30VZ+vgOxMYQ5cspyUOALwWoyFloM1KZkvwyeBlm8FiQDx0su5KbTS4S10LQvnS2AqKg=="
       }
     }
   }

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Wizard/SpeckleOperationWizard.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Wizard/SpeckleOperationWizard.cs
@@ -22,7 +22,7 @@ public class SpeckleOperationWizard
 
   public Account? SelectedAccount { get; private set; }
   public List<Account>? Accounts { get; }
-  public Workspace? SelectedWorkspace { get; private set; }
+  public LimitedWorkspace? SelectedWorkspace { get; private set; }
   public Project? SelectedProject { get; private set; }
   public Model? SelectedModel { get; private set; }
   public Version? SelectedVersion { get; private set; }
@@ -416,13 +416,17 @@ public class SpeckleOperationWizard
     {
       return;
     }
+
     using IClient client = _clientFactory.Create(SelectedAccount);
     var activeWorkspace = client.ActiveUser.GetActiveWorkspace().Result;
-    Workspace? selectedWorkspace =
+
+    LimitedWorkspace? selectedWorkspace =
       SelectedWorkspace
       ?? activeWorkspace
       ?? (WorkspaceMenuHandler.Workspaces?.items.Count > 0 ? WorkspaceMenuHandler.Workspaces?.items[0] : null);
+
     SelectedWorkspace = selectedWorkspace;
+
     WorkspaceMenuHandler.RedrawMenuButton(SelectedWorkspace);
   }
 

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Wizard/WorkspaceMenuHandler.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Wizard/WorkspaceMenuHandler.cs
@@ -3,9 +3,9 @@ using Speckle.Sdk.Api.GraphQL.Models;
 
 namespace Speckle.Connectors.GrasshopperShared.Components.Operations.Wizard;
 
-public class WorkspaceSelectedEventArgs(Workspace? model) : EventArgs
+public class WorkspaceSelectedEventArgs(LimitedWorkspace? model) : EventArgs
 {
-  public Workspace? SelectedWorkspace { get; } = model;
+  public LimitedWorkspace? SelectedWorkspace { get; } = model;
 }
 
 public class WorkspaceMenuHandler
@@ -15,7 +15,7 @@ public class WorkspaceMenuHandler
   public bool IsPersonalProjects { get; set; }
   private SearchToolStripMenuItem? _searchItem;
   private readonly Func<Task> _createWorkspace;
-  private Workspace? SelectedWorkspace { get; set; }
+  private LimitedWorkspace? SelectedWorkspace { get; set; }
 
   public ResourceCollection<Workspace>? Workspaces { get; set; }
   public Bitmap? Logo { get; private set; }
@@ -103,7 +103,7 @@ public class WorkspaceMenuHandler
     );
   }
 
-  private void OnWorkspaceSelected(Workspace? workspace)
+  private void OnWorkspaceSelected(LimitedWorkspace? workspace)
   {
     IsPersonalProjects = workspace == null;
     _menu?.Close();
@@ -112,7 +112,7 @@ public class WorkspaceMenuHandler
     WorkspaceSelected?.Invoke(this, new WorkspaceSelectedEventArgs(workspace));
   }
 
-  public void RedrawMenuButton(Workspace? workspace)
+  public void RedrawMenuButton(LimitedWorkspace? workspace)
   {
     var suffix = WorkspaceContextMenuButton.Enabled
       ? "Left-click to select another workspace."

--- a/Connectors/Rhino/Speckle.Connectors.Rhino7/packages.lock.json
+++ b/Connectors/Rhino/Speckle.Connectors.Rhino7/packages.lock.json
@@ -306,9 +306,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.4.6, )",
-          "Speckle.Sdk": "[3.4.6, )",
-          "Speckle.Sdk.Dependencies": "[3.4.8, )"
+          "Speckle.Objects": "[3.5.0, )",
+          "Speckle.Sdk": "[3.5.0, )",
+          "Speckle.Sdk.Dependencies": "[3.5.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -341,7 +341,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.4.6, )"
+          "Speckle.Objects": "[3.5.0, )"
         }
       },
       "speckle.converters.rhino7": {
@@ -401,18 +401,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "JjCdW+gUWq7u1Tb5SlLaFCIYfmrMA9HbUzCdlSPDzyJkPuJFhwK3qKDwe4ggrAs7DuNuBhqL/VKCr/J29Wh2ng==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "k76bpvFvArisd0DbdtpLQbonkl57CYG3szD0sDw0fWZolh8nogw2hRrNL6U2KcrJqCvYVc+zGYSXTJfv9xgntA==",
         "dependencies": {
-          "Speckle.Sdk": "3.4.6"
+          "Speckle.Sdk": "3.5.0"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "YBa/RuwvBbymjWGv7sD2TwMSLhSjz3GYPOGVJtZzBZvev/zDQNZozvIlre+Lk7xpT2KPdH1FRfLkPWyW+qonMA==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "mOLFubk+co9rDtRLsB1wobvmkYaiEMvDV+3hRPlhnqe8WhV+vbBSjzj58EpKEprWXLwjyc0kVzsrvlM++PnL0g==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -422,14 +422,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.4.6"
+          "Speckle.Sdk.Dependencies": "3.5.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.4.8, )",
-        "resolved": "3.4.8",
-        "contentHash": "bNpJc2NBvjtJmdYS3xb6Fv4eqI/xZ2URXfWeXUFaWPMfC1QXLTjlK6iFriQk9ptLwr/dt4UPDPYYHOBynY1f2A=="
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "lPYk1E97tWJ5qO6B8F30VZ+vgOxMYQ5cspyUOALwWoyFloM1KZkvwyeBlm8FiQDx0su5KbTS4S10LQvnS2AqKg=="
       },
       "System.Resources.Extensions": {
         "type": "CentralTransitive",

--- a/Connectors/Rhino/Speckle.Connectors.Rhino8/packages.lock.json
+++ b/Connectors/Rhino/Speckle.Connectors.Rhino8/packages.lock.json
@@ -306,9 +306,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.4.6, )",
-          "Speckle.Sdk": "[3.4.6, )",
-          "Speckle.Sdk.Dependencies": "[3.4.8, )"
+          "Speckle.Objects": "[3.5.0, )",
+          "Speckle.Sdk": "[3.5.0, )",
+          "Speckle.Sdk.Dependencies": "[3.5.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -341,7 +341,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.4.6, )"
+          "Speckle.Objects": "[3.5.0, )"
         }
       },
       "speckle.converters.rhino8": {
@@ -401,18 +401,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "JjCdW+gUWq7u1Tb5SlLaFCIYfmrMA9HbUzCdlSPDzyJkPuJFhwK3qKDwe4ggrAs7DuNuBhqL/VKCr/J29Wh2ng==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "k76bpvFvArisd0DbdtpLQbonkl57CYG3szD0sDw0fWZolh8nogw2hRrNL6U2KcrJqCvYVc+zGYSXTJfv9xgntA==",
         "dependencies": {
-          "Speckle.Sdk": "3.4.6"
+          "Speckle.Sdk": "3.5.0"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "YBa/RuwvBbymjWGv7sD2TwMSLhSjz3GYPOGVJtZzBZvev/zDQNZozvIlre+Lk7xpT2KPdH1FRfLkPWyW+qonMA==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "mOLFubk+co9rDtRLsB1wobvmkYaiEMvDV+3hRPlhnqe8WhV+vbBSjzj58EpKEprWXLwjyc0kVzsrvlM++PnL0g==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -422,14 +422,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.4.6"
+          "Speckle.Sdk.Dependencies": "3.5.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.4.8, )",
-        "resolved": "3.4.8",
-        "contentHash": "bNpJc2NBvjtJmdYS3xb6Fv4eqI/xZ2URXfWeXUFaWPMfC1QXLTjlK6iFriQk9ptLwr/dt4UPDPYYHOBynY1f2A=="
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "lPYk1E97tWJ5qO6B8F30VZ+vgOxMYQ5cspyUOALwWoyFloM1KZkvwyeBlm8FiQDx0su5KbTS4S10LQvnS2AqKg=="
       },
       "System.Resources.Extensions": {
         "type": "CentralTransitive",

--- a/Connectors/Tekla/Speckle.Connector.Tekla2023/packages.lock.json
+++ b/Connectors/Tekla/Speckle.Connector.Tekla2023/packages.lock.json
@@ -325,9 +325,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.4.6, )",
-          "Speckle.Sdk": "[3.4.6, )",
-          "Speckle.Sdk.Dependencies": "[3.4.8, )"
+          "Speckle.Objects": "[3.5.0, )",
+          "Speckle.Sdk": "[3.5.0, )",
+          "Speckle.Sdk.Dependencies": "[3.5.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -360,7 +360,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.4.6, )"
+          "Speckle.Objects": "[3.5.0, )"
         }
       },
       "LibTessDotNet": {
@@ -410,18 +410,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "JjCdW+gUWq7u1Tb5SlLaFCIYfmrMA9HbUzCdlSPDzyJkPuJFhwK3qKDwe4ggrAs7DuNuBhqL/VKCr/J29Wh2ng==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "k76bpvFvArisd0DbdtpLQbonkl57CYG3szD0sDw0fWZolh8nogw2hRrNL6U2KcrJqCvYVc+zGYSXTJfv9xgntA==",
         "dependencies": {
-          "Speckle.Sdk": "3.4.6"
+          "Speckle.Sdk": "3.5.0"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "YBa/RuwvBbymjWGv7sD2TwMSLhSjz3GYPOGVJtZzBZvev/zDQNZozvIlre+Lk7xpT2KPdH1FRfLkPWyW+qonMA==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "mOLFubk+co9rDtRLsB1wobvmkYaiEMvDV+3hRPlhnqe8WhV+vbBSjzj58EpKEprWXLwjyc0kVzsrvlM++PnL0g==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -431,14 +431,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.4.6"
+          "Speckle.Sdk.Dependencies": "3.5.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.4.8, )",
-        "resolved": "3.4.8",
-        "contentHash": "bNpJc2NBvjtJmdYS3xb6Fv4eqI/xZ2URXfWeXUFaWPMfC1QXLTjlK6iFriQk9ptLwr/dt4UPDPYYHOBynY1f2A=="
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "lPYk1E97tWJ5qO6B8F30VZ+vgOxMYQ5cspyUOALwWoyFloM1KZkvwyeBlm8FiQDx0su5KbTS4S10LQvnS2AqKg=="
       }
     }
   }

--- a/Connectors/Tekla/Speckle.Connector.Tekla2024/packages.lock.json
+++ b/Connectors/Tekla/Speckle.Connector.Tekla2024/packages.lock.json
@@ -406,9 +406,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.4.6, )",
-          "Speckle.Sdk": "[3.4.6, )",
-          "Speckle.Sdk.Dependencies": "[3.4.8, )"
+          "Speckle.Objects": "[3.5.0, )",
+          "Speckle.Sdk": "[3.5.0, )",
+          "Speckle.Sdk.Dependencies": "[3.5.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -441,7 +441,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.4.6, )"
+          "Speckle.Objects": "[3.5.0, )"
         }
       },
       "LibTessDotNet": {
@@ -491,18 +491,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "JjCdW+gUWq7u1Tb5SlLaFCIYfmrMA9HbUzCdlSPDzyJkPuJFhwK3qKDwe4ggrAs7DuNuBhqL/VKCr/J29Wh2ng==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "k76bpvFvArisd0DbdtpLQbonkl57CYG3szD0sDw0fWZolh8nogw2hRrNL6U2KcrJqCvYVc+zGYSXTJfv9xgntA==",
         "dependencies": {
-          "Speckle.Sdk": "3.4.6"
+          "Speckle.Sdk": "3.5.0"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "YBa/RuwvBbymjWGv7sD2TwMSLhSjz3GYPOGVJtZzBZvev/zDQNZozvIlre+Lk7xpT2KPdH1FRfLkPWyW+qonMA==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "mOLFubk+co9rDtRLsB1wobvmkYaiEMvDV+3hRPlhnqe8WhV+vbBSjzj58EpKEprWXLwjyc0kVzsrvlM++PnL0g==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -512,14 +512,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.4.6"
+          "Speckle.Sdk.Dependencies": "3.5.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.4.8, )",
-        "resolved": "3.4.8",
-        "contentHash": "bNpJc2NBvjtJmdYS3xb6Fv4eqI/xZ2URXfWeXUFaWPMfC1QXLTjlK6iFriQk9ptLwr/dt4UPDPYYHOBynY1f2A=="
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "lPYk1E97tWJ5qO6B8F30VZ+vgOxMYQ5cspyUOALwWoyFloM1KZkvwyeBlm8FiQDx0su5KbTS4S10LQvnS2AqKg=="
       }
     }
   }

--- a/Connectors/Tekla/Speckle.Connector.Tekla2025/packages.lock.json
+++ b/Connectors/Tekla/Speckle.Connector.Tekla2025/packages.lock.json
@@ -406,9 +406,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.4.6, )",
-          "Speckle.Sdk": "[3.4.6, )",
-          "Speckle.Sdk.Dependencies": "[3.4.8, )"
+          "Speckle.Objects": "[3.5.0, )",
+          "Speckle.Sdk": "[3.5.0, )",
+          "Speckle.Sdk.Dependencies": "[3.5.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -441,7 +441,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.4.6, )"
+          "Speckle.Objects": "[3.5.0, )"
         }
       },
       "LibTessDotNet": {
@@ -491,18 +491,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "JjCdW+gUWq7u1Tb5SlLaFCIYfmrMA9HbUzCdlSPDzyJkPuJFhwK3qKDwe4ggrAs7DuNuBhqL/VKCr/J29Wh2ng==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "k76bpvFvArisd0DbdtpLQbonkl57CYG3szD0sDw0fWZolh8nogw2hRrNL6U2KcrJqCvYVc+zGYSXTJfv9xgntA==",
         "dependencies": {
-          "Speckle.Sdk": "3.4.6"
+          "Speckle.Sdk": "3.5.0"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "YBa/RuwvBbymjWGv7sD2TwMSLhSjz3GYPOGVJtZzBZvev/zDQNZozvIlre+Lk7xpT2KPdH1FRfLkPWyW+qonMA==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "mOLFubk+co9rDtRLsB1wobvmkYaiEMvDV+3hRPlhnqe8WhV+vbBSjzj58EpKEprWXLwjyc0kVzsrvlM++PnL0g==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -512,14 +512,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.4.6"
+          "Speckle.Sdk.Dependencies": "3.5.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.4.8, )",
-        "resolved": "3.4.8",
-        "contentHash": "bNpJc2NBvjtJmdYS3xb6Fv4eqI/xZ2URXfWeXUFaWPMfC1QXLTjlK6iFriQk9ptLwr/dt4UPDPYYHOBynY1f2A=="
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "lPYk1E97tWJ5qO6B8F30VZ+vgOxMYQ5cspyUOALwWoyFloM1KZkvwyeBlm8FiQDx0su5KbTS4S10LQvnS2AqKg=="
       }
     }
   }

--- a/Converters/Autocad/Speckle.Converters.Autocad2022/packages.lock.json
+++ b/Converters/Autocad/Speckle.Converters.Autocad2022/packages.lock.json
@@ -258,7 +258,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.4.6, )"
+          "Speckle.Objects": "[3.5.0, )"
         }
       },
       "Microsoft.Extensions.Logging": {
@@ -287,18 +287,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "JjCdW+gUWq7u1Tb5SlLaFCIYfmrMA9HbUzCdlSPDzyJkPuJFhwK3qKDwe4ggrAs7DuNuBhqL/VKCr/J29Wh2ng==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "k76bpvFvArisd0DbdtpLQbonkl57CYG3szD0sDw0fWZolh8nogw2hRrNL6U2KcrJqCvYVc+zGYSXTJfv9xgntA==",
         "dependencies": {
-          "Speckle.Sdk": "3.4.6"
+          "Speckle.Sdk": "3.5.0"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "YBa/RuwvBbymjWGv7sD2TwMSLhSjz3GYPOGVJtZzBZvev/zDQNZozvIlre+Lk7xpT2KPdH1FRfLkPWyW+qonMA==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "mOLFubk+co9rDtRLsB1wobvmkYaiEMvDV+3hRPlhnqe8WhV+vbBSjzj58EpKEprWXLwjyc0kVzsrvlM++PnL0g==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -308,14 +308,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.4.6"
+          "Speckle.Sdk.Dependencies": "3.5.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.4.8, )",
-        "resolved": "3.4.6",
-        "contentHash": "UHWMZ8zQt3wF3gXfPpEKe3T8Pxo4ZRN1LOp+vZnsnohO8HKt2gNfAY2to2YRnTXnybEKsgqzIJLe372EoIQJHg=="
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "lPYk1E97tWJ5qO6B8F30VZ+vgOxMYQ5cspyUOALwWoyFloM1KZkvwyeBlm8FiQDx0su5KbTS4S10LQvnS2AqKg=="
       }
     }
   }

--- a/Converters/Autocad/Speckle.Converters.Autocad2023/packages.lock.json
+++ b/Converters/Autocad/Speckle.Converters.Autocad2023/packages.lock.json
@@ -258,7 +258,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.4.6, )"
+          "Speckle.Objects": "[3.5.0, )"
         }
       },
       "Microsoft.Extensions.Logging": {
@@ -287,18 +287,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "JjCdW+gUWq7u1Tb5SlLaFCIYfmrMA9HbUzCdlSPDzyJkPuJFhwK3qKDwe4ggrAs7DuNuBhqL/VKCr/J29Wh2ng==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "k76bpvFvArisd0DbdtpLQbonkl57CYG3szD0sDw0fWZolh8nogw2hRrNL6U2KcrJqCvYVc+zGYSXTJfv9xgntA==",
         "dependencies": {
-          "Speckle.Sdk": "3.4.6"
+          "Speckle.Sdk": "3.5.0"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "YBa/RuwvBbymjWGv7sD2TwMSLhSjz3GYPOGVJtZzBZvev/zDQNZozvIlre+Lk7xpT2KPdH1FRfLkPWyW+qonMA==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "mOLFubk+co9rDtRLsB1wobvmkYaiEMvDV+3hRPlhnqe8WhV+vbBSjzj58EpKEprWXLwjyc0kVzsrvlM++PnL0g==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -308,14 +308,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.4.6"
+          "Speckle.Sdk.Dependencies": "3.5.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.4.8, )",
-        "resolved": "3.4.6",
-        "contentHash": "UHWMZ8zQt3wF3gXfPpEKe3T8Pxo4ZRN1LOp+vZnsnohO8HKt2gNfAY2to2YRnTXnybEKsgqzIJLe372EoIQJHg=="
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "lPYk1E97tWJ5qO6B8F30VZ+vgOxMYQ5cspyUOALwWoyFloM1KZkvwyeBlm8FiQDx0su5KbTS4S10LQvnS2AqKg=="
       }
     }
   }

--- a/Converters/Autocad/Speckle.Converters.Autocad2024/packages.lock.json
+++ b/Converters/Autocad/Speckle.Converters.Autocad2024/packages.lock.json
@@ -259,9 +259,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.4.6, )",
-          "Speckle.Sdk": "[3.4.6, )",
-          "Speckle.Sdk.Dependencies": "[3.4.8, )"
+          "Speckle.Objects": "[3.5.0, )",
+          "Speckle.Sdk": "[3.5.0, )",
+          "Speckle.Sdk.Dependencies": "[3.5.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -285,7 +285,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.4.6, )"
+          "Speckle.Objects": "[3.5.0, )"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -329,18 +329,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "JjCdW+gUWq7u1Tb5SlLaFCIYfmrMA9HbUzCdlSPDzyJkPuJFhwK3qKDwe4ggrAs7DuNuBhqL/VKCr/J29Wh2ng==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "k76bpvFvArisd0DbdtpLQbonkl57CYG3szD0sDw0fWZolh8nogw2hRrNL6U2KcrJqCvYVc+zGYSXTJfv9xgntA==",
         "dependencies": {
-          "Speckle.Sdk": "3.4.6"
+          "Speckle.Sdk": "3.5.0"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "YBa/RuwvBbymjWGv7sD2TwMSLhSjz3GYPOGVJtZzBZvev/zDQNZozvIlre+Lk7xpT2KPdH1FRfLkPWyW+qonMA==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "mOLFubk+co9rDtRLsB1wobvmkYaiEMvDV+3hRPlhnqe8WhV+vbBSjzj58EpKEprWXLwjyc0kVzsrvlM++PnL0g==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -350,14 +350,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.4.6"
+          "Speckle.Sdk.Dependencies": "3.5.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.4.8, )",
-        "resolved": "3.4.8",
-        "contentHash": "bNpJc2NBvjtJmdYS3xb6Fv4eqI/xZ2URXfWeXUFaWPMfC1QXLTjlK6iFriQk9ptLwr/dt4UPDPYYHOBynY1f2A=="
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "lPYk1E97tWJ5qO6B8F30VZ+vgOxMYQ5cspyUOALwWoyFloM1KZkvwyeBlm8FiQDx0su5KbTS4S10LQvnS2AqKg=="
       }
     }
   }

--- a/Converters/Autocad/Speckle.Converters.Autocad2025/packages.lock.json
+++ b/Converters/Autocad/Speckle.Converters.Autocad2025/packages.lock.json
@@ -210,9 +210,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.4.6, )",
-          "Speckle.Sdk": "[3.4.6, )",
-          "Speckle.Sdk.Dependencies": "[3.4.8, )"
+          "Speckle.Objects": "[3.5.0, )",
+          "Speckle.Sdk": "[3.5.0, )",
+          "Speckle.Sdk.Dependencies": "[3.5.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -236,7 +236,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.4.6, )"
+          "Speckle.Objects": "[3.5.0, )"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -280,18 +280,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "JjCdW+gUWq7u1Tb5SlLaFCIYfmrMA9HbUzCdlSPDzyJkPuJFhwK3qKDwe4ggrAs7DuNuBhqL/VKCr/J29Wh2ng==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "k76bpvFvArisd0DbdtpLQbonkl57CYG3szD0sDw0fWZolh8nogw2hRrNL6U2KcrJqCvYVc+zGYSXTJfv9xgntA==",
         "dependencies": {
-          "Speckle.Sdk": "3.4.6"
+          "Speckle.Sdk": "3.5.0"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "YBa/RuwvBbymjWGv7sD2TwMSLhSjz3GYPOGVJtZzBZvev/zDQNZozvIlre+Lk7xpT2KPdH1FRfLkPWyW+qonMA==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "mOLFubk+co9rDtRLsB1wobvmkYaiEMvDV+3hRPlhnqe8WhV+vbBSjzj58EpKEprWXLwjyc0kVzsrvlM++PnL0g==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -299,14 +299,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.4.6"
+          "Speckle.Sdk.Dependencies": "3.5.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.4.8, )",
-        "resolved": "3.4.8",
-        "contentHash": "bNpJc2NBvjtJmdYS3xb6Fv4eqI/xZ2URXfWeXUFaWPMfC1QXLTjlK6iFriQk9ptLwr/dt4UPDPYYHOBynY1f2A=="
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "lPYk1E97tWJ5qO6B8F30VZ+vgOxMYQ5cspyUOALwWoyFloM1KZkvwyeBlm8FiQDx0su5KbTS4S10LQvnS2AqKg=="
       }
     }
   }

--- a/Converters/Autocad/Speckle.Converters.Autocad2026/packages.lock.json
+++ b/Converters/Autocad/Speckle.Converters.Autocad2026/packages.lock.json
@@ -210,9 +210,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.4.6, )",
-          "Speckle.Sdk": "[3.4.6, )",
-          "Speckle.Sdk.Dependencies": "[3.4.8, )"
+          "Speckle.Objects": "[3.5.0, )",
+          "Speckle.Sdk": "[3.5.0, )",
+          "Speckle.Sdk.Dependencies": "[3.5.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -236,7 +236,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.4.6, )"
+          "Speckle.Objects": "[3.5.0, )"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -280,18 +280,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "JjCdW+gUWq7u1Tb5SlLaFCIYfmrMA9HbUzCdlSPDzyJkPuJFhwK3qKDwe4ggrAs7DuNuBhqL/VKCr/J29Wh2ng==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "k76bpvFvArisd0DbdtpLQbonkl57CYG3szD0sDw0fWZolh8nogw2hRrNL6U2KcrJqCvYVc+zGYSXTJfv9xgntA==",
         "dependencies": {
-          "Speckle.Sdk": "3.4.6"
+          "Speckle.Sdk": "3.5.0"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "YBa/RuwvBbymjWGv7sD2TwMSLhSjz3GYPOGVJtZzBZvev/zDQNZozvIlre+Lk7xpT2KPdH1FRfLkPWyW+qonMA==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "mOLFubk+co9rDtRLsB1wobvmkYaiEMvDV+3hRPlhnqe8WhV+vbBSjzj58EpKEprWXLwjyc0kVzsrvlM++PnL0g==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -299,14 +299,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.4.6"
+          "Speckle.Sdk.Dependencies": "3.5.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.4.8, )",
-        "resolved": "3.4.8",
-        "contentHash": "bNpJc2NBvjtJmdYS3xb6Fv4eqI/xZ2URXfWeXUFaWPMfC1QXLTjlK6iFriQk9ptLwr/dt4UPDPYYHOBynY1f2A=="
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "lPYk1E97tWJ5qO6B8F30VZ+vgOxMYQ5cspyUOALwWoyFloM1KZkvwyeBlm8FiQDx0su5KbTS4S10LQvnS2AqKg=="
       }
     }
   }

--- a/Converters/CSi/Speckle.Converters.ETABS21/packages.lock.json
+++ b/Converters/CSi/Speckle.Converters.ETABS21/packages.lock.json
@@ -258,7 +258,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.4.6, )"
+          "Speckle.Objects": "[3.5.0, )"
         }
       },
       "Microsoft.Extensions.Logging": {
@@ -287,18 +287,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "JjCdW+gUWq7u1Tb5SlLaFCIYfmrMA9HbUzCdlSPDzyJkPuJFhwK3qKDwe4ggrAs7DuNuBhqL/VKCr/J29Wh2ng==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "k76bpvFvArisd0DbdtpLQbonkl57CYG3szD0sDw0fWZolh8nogw2hRrNL6U2KcrJqCvYVc+zGYSXTJfv9xgntA==",
         "dependencies": {
-          "Speckle.Sdk": "3.4.6"
+          "Speckle.Sdk": "3.5.0"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "YBa/RuwvBbymjWGv7sD2TwMSLhSjz3GYPOGVJtZzBZvev/zDQNZozvIlre+Lk7xpT2KPdH1FRfLkPWyW+qonMA==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "mOLFubk+co9rDtRLsB1wobvmkYaiEMvDV+3hRPlhnqe8WhV+vbBSjzj58EpKEprWXLwjyc0kVzsrvlM++PnL0g==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -308,14 +308,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.4.6"
+          "Speckle.Sdk.Dependencies": "3.5.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.4.8, )",
-        "resolved": "3.4.6",
-        "contentHash": "UHWMZ8zQt3wF3gXfPpEKe3T8Pxo4ZRN1LOp+vZnsnohO8HKt2gNfAY2to2YRnTXnybEKsgqzIJLe372EoIQJHg=="
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "lPYk1E97tWJ5qO6B8F30VZ+vgOxMYQ5cspyUOALwWoyFloM1KZkvwyeBlm8FiQDx0su5KbTS4S10LQvnS2AqKg=="
       }
     }
   }

--- a/Converters/CSi/Speckle.Converters.ETABS22/packages.lock.json
+++ b/Converters/CSi/Speckle.Converters.ETABS22/packages.lock.json
@@ -209,7 +209,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.4.6, )"
+          "Speckle.Objects": "[3.5.0, )"
         }
       },
       "Microsoft.Extensions.Logging": {
@@ -238,18 +238,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "JjCdW+gUWq7u1Tb5SlLaFCIYfmrMA9HbUzCdlSPDzyJkPuJFhwK3qKDwe4ggrAs7DuNuBhqL/VKCr/J29Wh2ng==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "k76bpvFvArisd0DbdtpLQbonkl57CYG3szD0sDw0fWZolh8nogw2hRrNL6U2KcrJqCvYVc+zGYSXTJfv9xgntA==",
         "dependencies": {
-          "Speckle.Sdk": "3.4.6"
+          "Speckle.Sdk": "3.5.0"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "YBa/RuwvBbymjWGv7sD2TwMSLhSjz3GYPOGVJtZzBZvev/zDQNZozvIlre+Lk7xpT2KPdH1FRfLkPWyW+qonMA==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "mOLFubk+co9rDtRLsB1wobvmkYaiEMvDV+3hRPlhnqe8WhV+vbBSjzj58EpKEprWXLwjyc0kVzsrvlM++PnL0g==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -257,14 +257,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.4.6"
+          "Speckle.Sdk.Dependencies": "3.5.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.4.8, )",
-        "resolved": "3.4.6",
-        "contentHash": "UHWMZ8zQt3wF3gXfPpEKe3T8Pxo4ZRN1LOp+vZnsnohO8HKt2gNfAY2to2YRnTXnybEKsgqzIJLe372EoIQJHg=="
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "lPYk1E97tWJ5qO6B8F30VZ+vgOxMYQ5cspyUOALwWoyFloM1KZkvwyeBlm8FiQDx0su5KbTS4S10LQvnS2AqKg=="
       }
     }
   }

--- a/Converters/Civil3d/Speckle.Converters.Civil3d2022/packages.lock.json
+++ b/Converters/Civil3d/Speckle.Converters.Civil3d2022/packages.lock.json
@@ -267,7 +267,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.4.6, )"
+          "Speckle.Objects": "[3.5.0, )"
         }
       },
       "Microsoft.Extensions.Logging": {
@@ -296,18 +296,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "JjCdW+gUWq7u1Tb5SlLaFCIYfmrMA9HbUzCdlSPDzyJkPuJFhwK3qKDwe4ggrAs7DuNuBhqL/VKCr/J29Wh2ng==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "k76bpvFvArisd0DbdtpLQbonkl57CYG3szD0sDw0fWZolh8nogw2hRrNL6U2KcrJqCvYVc+zGYSXTJfv9xgntA==",
         "dependencies": {
-          "Speckle.Sdk": "3.4.6"
+          "Speckle.Sdk": "3.5.0"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "YBa/RuwvBbymjWGv7sD2TwMSLhSjz3GYPOGVJtZzBZvev/zDQNZozvIlre+Lk7xpT2KPdH1FRfLkPWyW+qonMA==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "mOLFubk+co9rDtRLsB1wobvmkYaiEMvDV+3hRPlhnqe8WhV+vbBSjzj58EpKEprWXLwjyc0kVzsrvlM++PnL0g==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -317,14 +317,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.4.6"
+          "Speckle.Sdk.Dependencies": "3.5.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.4.8, )",
-        "resolved": "3.4.6",
-        "contentHash": "UHWMZ8zQt3wF3gXfPpEKe3T8Pxo4ZRN1LOp+vZnsnohO8HKt2gNfAY2to2YRnTXnybEKsgqzIJLe372EoIQJHg=="
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "lPYk1E97tWJ5qO6B8F30VZ+vgOxMYQ5cspyUOALwWoyFloM1KZkvwyeBlm8FiQDx0su5KbTS4S10LQvnS2AqKg=="
       }
     }
   }

--- a/Converters/Civil3d/Speckle.Converters.Civil3d2023/packages.lock.json
+++ b/Converters/Civil3d/Speckle.Converters.Civil3d2023/packages.lock.json
@@ -267,7 +267,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.4.6, )"
+          "Speckle.Objects": "[3.5.0, )"
         }
       },
       "Microsoft.Extensions.Logging": {
@@ -296,18 +296,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "JjCdW+gUWq7u1Tb5SlLaFCIYfmrMA9HbUzCdlSPDzyJkPuJFhwK3qKDwe4ggrAs7DuNuBhqL/VKCr/J29Wh2ng==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "k76bpvFvArisd0DbdtpLQbonkl57CYG3szD0sDw0fWZolh8nogw2hRrNL6U2KcrJqCvYVc+zGYSXTJfv9xgntA==",
         "dependencies": {
-          "Speckle.Sdk": "3.4.6"
+          "Speckle.Sdk": "3.5.0"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "YBa/RuwvBbymjWGv7sD2TwMSLhSjz3GYPOGVJtZzBZvev/zDQNZozvIlre+Lk7xpT2KPdH1FRfLkPWyW+qonMA==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "mOLFubk+co9rDtRLsB1wobvmkYaiEMvDV+3hRPlhnqe8WhV+vbBSjzj58EpKEprWXLwjyc0kVzsrvlM++PnL0g==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -317,14 +317,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.4.6"
+          "Speckle.Sdk.Dependencies": "3.5.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.4.8, )",
-        "resolved": "3.4.6",
-        "contentHash": "UHWMZ8zQt3wF3gXfPpEKe3T8Pxo4ZRN1LOp+vZnsnohO8HKt2gNfAY2to2YRnTXnybEKsgqzIJLe372EoIQJHg=="
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "lPYk1E97tWJ5qO6B8F30VZ+vgOxMYQ5cspyUOALwWoyFloM1KZkvwyeBlm8FiQDx0su5KbTS4S10LQvnS2AqKg=="
       }
     }
   }

--- a/Converters/Civil3d/Speckle.Converters.Civil3d2024/packages.lock.json
+++ b/Converters/Civil3d/Speckle.Converters.Civil3d2024/packages.lock.json
@@ -267,7 +267,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.4.6, )"
+          "Speckle.Objects": "[3.5.0, )"
         }
       },
       "Microsoft.Extensions.Logging": {
@@ -296,18 +296,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "JjCdW+gUWq7u1Tb5SlLaFCIYfmrMA9HbUzCdlSPDzyJkPuJFhwK3qKDwe4ggrAs7DuNuBhqL/VKCr/J29Wh2ng==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "k76bpvFvArisd0DbdtpLQbonkl57CYG3szD0sDw0fWZolh8nogw2hRrNL6U2KcrJqCvYVc+zGYSXTJfv9xgntA==",
         "dependencies": {
-          "Speckle.Sdk": "3.4.6"
+          "Speckle.Sdk": "3.5.0"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "YBa/RuwvBbymjWGv7sD2TwMSLhSjz3GYPOGVJtZzBZvev/zDQNZozvIlre+Lk7xpT2KPdH1FRfLkPWyW+qonMA==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "mOLFubk+co9rDtRLsB1wobvmkYaiEMvDV+3hRPlhnqe8WhV+vbBSjzj58EpKEprWXLwjyc0kVzsrvlM++PnL0g==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -317,14 +317,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.4.6"
+          "Speckle.Sdk.Dependencies": "3.5.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.4.8, )",
-        "resolved": "3.4.6",
-        "contentHash": "UHWMZ8zQt3wF3gXfPpEKe3T8Pxo4ZRN1LOp+vZnsnohO8HKt2gNfAY2to2YRnTXnybEKsgqzIJLe372EoIQJHg=="
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "lPYk1E97tWJ5qO6B8F30VZ+vgOxMYQ5cspyUOALwWoyFloM1KZkvwyeBlm8FiQDx0su5KbTS4S10LQvnS2AqKg=="
       }
     }
   }

--- a/Converters/Civil3d/Speckle.Converters.Civil3d2025/packages.lock.json
+++ b/Converters/Civil3d/Speckle.Converters.Civil3d2025/packages.lock.json
@@ -219,9 +219,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.4.6, )",
-          "Speckle.Sdk": "[3.4.6, )",
-          "Speckle.Sdk.Dependencies": "[3.4.8, )"
+          "Speckle.Objects": "[3.5.0, )",
+          "Speckle.Sdk": "[3.5.0, )",
+          "Speckle.Sdk.Dependencies": "[3.5.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -245,7 +245,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.4.6, )"
+          "Speckle.Objects": "[3.5.0, )"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -289,18 +289,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "JjCdW+gUWq7u1Tb5SlLaFCIYfmrMA9HbUzCdlSPDzyJkPuJFhwK3qKDwe4ggrAs7DuNuBhqL/VKCr/J29Wh2ng==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "k76bpvFvArisd0DbdtpLQbonkl57CYG3szD0sDw0fWZolh8nogw2hRrNL6U2KcrJqCvYVc+zGYSXTJfv9xgntA==",
         "dependencies": {
-          "Speckle.Sdk": "3.4.6"
+          "Speckle.Sdk": "3.5.0"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "YBa/RuwvBbymjWGv7sD2TwMSLhSjz3GYPOGVJtZzBZvev/zDQNZozvIlre+Lk7xpT2KPdH1FRfLkPWyW+qonMA==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "mOLFubk+co9rDtRLsB1wobvmkYaiEMvDV+3hRPlhnqe8WhV+vbBSjzj58EpKEprWXLwjyc0kVzsrvlM++PnL0g==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -308,14 +308,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.4.6"
+          "Speckle.Sdk.Dependencies": "3.5.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.4.8, )",
-        "resolved": "3.4.8",
-        "contentHash": "bNpJc2NBvjtJmdYS3xb6Fv4eqI/xZ2URXfWeXUFaWPMfC1QXLTjlK6iFriQk9ptLwr/dt4UPDPYYHOBynY1f2A=="
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "lPYk1E97tWJ5qO6B8F30VZ+vgOxMYQ5cspyUOALwWoyFloM1KZkvwyeBlm8FiQDx0su5KbTS4S10LQvnS2AqKg=="
       }
     }
   }

--- a/Converters/Civil3d/Speckle.Converters.Civil3d2026/packages.lock.json
+++ b/Converters/Civil3d/Speckle.Converters.Civil3d2026/packages.lock.json
@@ -219,9 +219,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.4.6, )",
-          "Speckle.Sdk": "[3.4.6, )",
-          "Speckle.Sdk.Dependencies": "[3.4.8, )"
+          "Speckle.Objects": "[3.5.0, )",
+          "Speckle.Sdk": "[3.5.0, )",
+          "Speckle.Sdk.Dependencies": "[3.5.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -245,7 +245,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.4.6, )"
+          "Speckle.Objects": "[3.5.0, )"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -289,18 +289,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "JjCdW+gUWq7u1Tb5SlLaFCIYfmrMA9HbUzCdlSPDzyJkPuJFhwK3qKDwe4ggrAs7DuNuBhqL/VKCr/J29Wh2ng==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "k76bpvFvArisd0DbdtpLQbonkl57CYG3szD0sDw0fWZolh8nogw2hRrNL6U2KcrJqCvYVc+zGYSXTJfv9xgntA==",
         "dependencies": {
-          "Speckle.Sdk": "3.4.6"
+          "Speckle.Sdk": "3.5.0"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "YBa/RuwvBbymjWGv7sD2TwMSLhSjz3GYPOGVJtZzBZvev/zDQNZozvIlre+Lk7xpT2KPdH1FRfLkPWyW+qonMA==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "mOLFubk+co9rDtRLsB1wobvmkYaiEMvDV+3hRPlhnqe8WhV+vbBSjzj58EpKEprWXLwjyc0kVzsrvlM++PnL0g==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -308,14 +308,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.4.6"
+          "Speckle.Sdk.Dependencies": "3.5.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.4.8, )",
-        "resolved": "3.4.8",
-        "contentHash": "bNpJc2NBvjtJmdYS3xb6Fv4eqI/xZ2URXfWeXUFaWPMfC1QXLTjlK6iFriQk9ptLwr/dt4UPDPYYHOBynY1f2A=="
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "lPYk1E97tWJ5qO6B8F30VZ+vgOxMYQ5cspyUOALwWoyFloM1KZkvwyeBlm8FiQDx0su5KbTS4S10LQvnS2AqKg=="
       }
     }
   }

--- a/Converters/Navisworks/Speckle.Converters.Navisworks2020/packages.lock.json
+++ b/Converters/Navisworks/Speckle.Converters.Navisworks2020/packages.lock.json
@@ -259,9 +259,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.4.6, )",
-          "Speckle.Sdk": "[3.4.6, )",
-          "Speckle.Sdk.Dependencies": "[3.4.8, )"
+          "Speckle.Objects": "[3.5.0, )",
+          "Speckle.Sdk": "[3.5.0, )",
+          "Speckle.Sdk.Dependencies": "[3.5.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -278,7 +278,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.4.6, )"
+          "Speckle.Objects": "[3.5.0, )"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -316,18 +316,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "JjCdW+gUWq7u1Tb5SlLaFCIYfmrMA9HbUzCdlSPDzyJkPuJFhwK3qKDwe4ggrAs7DuNuBhqL/VKCr/J29Wh2ng==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "k76bpvFvArisd0DbdtpLQbonkl57CYG3szD0sDw0fWZolh8nogw2hRrNL6U2KcrJqCvYVc+zGYSXTJfv9xgntA==",
         "dependencies": {
-          "Speckle.Sdk": "3.4.6"
+          "Speckle.Sdk": "3.5.0"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "YBa/RuwvBbymjWGv7sD2TwMSLhSjz3GYPOGVJtZzBZvev/zDQNZozvIlre+Lk7xpT2KPdH1FRfLkPWyW+qonMA==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "mOLFubk+co9rDtRLsB1wobvmkYaiEMvDV+3hRPlhnqe8WhV+vbBSjzj58EpKEprWXLwjyc0kVzsrvlM++PnL0g==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -337,14 +337,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.4.6"
+          "Speckle.Sdk.Dependencies": "3.5.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.4.8, )",
-        "resolved": "3.4.8",
-        "contentHash": "bNpJc2NBvjtJmdYS3xb6Fv4eqI/xZ2URXfWeXUFaWPMfC1QXLTjlK6iFriQk9ptLwr/dt4UPDPYYHOBynY1f2A=="
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "lPYk1E97tWJ5qO6B8F30VZ+vgOxMYQ5cspyUOALwWoyFloM1KZkvwyeBlm8FiQDx0su5KbTS4S10LQvnS2AqKg=="
       }
     }
   }

--- a/Converters/Navisworks/Speckle.Converters.Navisworks2021/packages.lock.json
+++ b/Converters/Navisworks/Speckle.Converters.Navisworks2021/packages.lock.json
@@ -259,9 +259,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.4.6, )",
-          "Speckle.Sdk": "[3.4.6, )",
-          "Speckle.Sdk.Dependencies": "[3.4.8, )"
+          "Speckle.Objects": "[3.5.0, )",
+          "Speckle.Sdk": "[3.5.0, )",
+          "Speckle.Sdk.Dependencies": "[3.5.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -278,7 +278,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.4.6, )"
+          "Speckle.Objects": "[3.5.0, )"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -316,18 +316,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "JjCdW+gUWq7u1Tb5SlLaFCIYfmrMA9HbUzCdlSPDzyJkPuJFhwK3qKDwe4ggrAs7DuNuBhqL/VKCr/J29Wh2ng==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "k76bpvFvArisd0DbdtpLQbonkl57CYG3szD0sDw0fWZolh8nogw2hRrNL6U2KcrJqCvYVc+zGYSXTJfv9xgntA==",
         "dependencies": {
-          "Speckle.Sdk": "3.4.6"
+          "Speckle.Sdk": "3.5.0"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "YBa/RuwvBbymjWGv7sD2TwMSLhSjz3GYPOGVJtZzBZvev/zDQNZozvIlre+Lk7xpT2KPdH1FRfLkPWyW+qonMA==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "mOLFubk+co9rDtRLsB1wobvmkYaiEMvDV+3hRPlhnqe8WhV+vbBSjzj58EpKEprWXLwjyc0kVzsrvlM++PnL0g==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -337,14 +337,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.4.6"
+          "Speckle.Sdk.Dependencies": "3.5.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.4.8, )",
-        "resolved": "3.4.8",
-        "contentHash": "bNpJc2NBvjtJmdYS3xb6Fv4eqI/xZ2URXfWeXUFaWPMfC1QXLTjlK6iFriQk9ptLwr/dt4UPDPYYHOBynY1f2A=="
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "lPYk1E97tWJ5qO6B8F30VZ+vgOxMYQ5cspyUOALwWoyFloM1KZkvwyeBlm8FiQDx0su5KbTS4S10LQvnS2AqKg=="
       }
     }
   }

--- a/Converters/Navisworks/Speckle.Converters.Navisworks2022/packages.lock.json
+++ b/Converters/Navisworks/Speckle.Converters.Navisworks2022/packages.lock.json
@@ -259,9 +259,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.4.6, )",
-          "Speckle.Sdk": "[3.4.6, )",
-          "Speckle.Sdk.Dependencies": "[3.4.8, )"
+          "Speckle.Objects": "[3.5.0, )",
+          "Speckle.Sdk": "[3.5.0, )",
+          "Speckle.Sdk.Dependencies": "[3.5.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -278,7 +278,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.4.6, )"
+          "Speckle.Objects": "[3.5.0, )"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -316,18 +316,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "JjCdW+gUWq7u1Tb5SlLaFCIYfmrMA9HbUzCdlSPDzyJkPuJFhwK3qKDwe4ggrAs7DuNuBhqL/VKCr/J29Wh2ng==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "k76bpvFvArisd0DbdtpLQbonkl57CYG3szD0sDw0fWZolh8nogw2hRrNL6U2KcrJqCvYVc+zGYSXTJfv9xgntA==",
         "dependencies": {
-          "Speckle.Sdk": "3.4.6"
+          "Speckle.Sdk": "3.5.0"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "YBa/RuwvBbymjWGv7sD2TwMSLhSjz3GYPOGVJtZzBZvev/zDQNZozvIlre+Lk7xpT2KPdH1FRfLkPWyW+qonMA==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "mOLFubk+co9rDtRLsB1wobvmkYaiEMvDV+3hRPlhnqe8WhV+vbBSjzj58EpKEprWXLwjyc0kVzsrvlM++PnL0g==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -337,14 +337,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.4.6"
+          "Speckle.Sdk.Dependencies": "3.5.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.4.8, )",
-        "resolved": "3.4.8",
-        "contentHash": "bNpJc2NBvjtJmdYS3xb6Fv4eqI/xZ2URXfWeXUFaWPMfC1QXLTjlK6iFriQk9ptLwr/dt4UPDPYYHOBynY1f2A=="
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "lPYk1E97tWJ5qO6B8F30VZ+vgOxMYQ5cspyUOALwWoyFloM1KZkvwyeBlm8FiQDx0su5KbTS4S10LQvnS2AqKg=="
       }
     }
   }

--- a/Converters/Navisworks/Speckle.Converters.Navisworks2023/packages.lock.json
+++ b/Converters/Navisworks/Speckle.Converters.Navisworks2023/packages.lock.json
@@ -259,9 +259,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.4.6, )",
-          "Speckle.Sdk": "[3.4.6, )",
-          "Speckle.Sdk.Dependencies": "[3.4.8, )"
+          "Speckle.Objects": "[3.5.0, )",
+          "Speckle.Sdk": "[3.5.0, )",
+          "Speckle.Sdk.Dependencies": "[3.5.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -278,7 +278,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.4.6, )"
+          "Speckle.Objects": "[3.5.0, )"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -316,18 +316,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "JjCdW+gUWq7u1Tb5SlLaFCIYfmrMA9HbUzCdlSPDzyJkPuJFhwK3qKDwe4ggrAs7DuNuBhqL/VKCr/J29Wh2ng==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "k76bpvFvArisd0DbdtpLQbonkl57CYG3szD0sDw0fWZolh8nogw2hRrNL6U2KcrJqCvYVc+zGYSXTJfv9xgntA==",
         "dependencies": {
-          "Speckle.Sdk": "3.4.6"
+          "Speckle.Sdk": "3.5.0"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "YBa/RuwvBbymjWGv7sD2TwMSLhSjz3GYPOGVJtZzBZvev/zDQNZozvIlre+Lk7xpT2KPdH1FRfLkPWyW+qonMA==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "mOLFubk+co9rDtRLsB1wobvmkYaiEMvDV+3hRPlhnqe8WhV+vbBSjzj58EpKEprWXLwjyc0kVzsrvlM++PnL0g==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -337,14 +337,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.4.6"
+          "Speckle.Sdk.Dependencies": "3.5.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.4.8, )",
-        "resolved": "3.4.8",
-        "contentHash": "bNpJc2NBvjtJmdYS3xb6Fv4eqI/xZ2URXfWeXUFaWPMfC1QXLTjlK6iFriQk9ptLwr/dt4UPDPYYHOBynY1f2A=="
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "lPYk1E97tWJ5qO6B8F30VZ+vgOxMYQ5cspyUOALwWoyFloM1KZkvwyeBlm8FiQDx0su5KbTS4S10LQvnS2AqKg=="
       }
     }
   }

--- a/Converters/Navisworks/Speckle.Converters.Navisworks2024/packages.lock.json
+++ b/Converters/Navisworks/Speckle.Converters.Navisworks2024/packages.lock.json
@@ -259,9 +259,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.4.6, )",
-          "Speckle.Sdk": "[3.4.6, )",
-          "Speckle.Sdk.Dependencies": "[3.4.8, )"
+          "Speckle.Objects": "[3.5.0, )",
+          "Speckle.Sdk": "[3.5.0, )",
+          "Speckle.Sdk.Dependencies": "[3.5.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -278,7 +278,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.4.6, )"
+          "Speckle.Objects": "[3.5.0, )"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -316,18 +316,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "JjCdW+gUWq7u1Tb5SlLaFCIYfmrMA9HbUzCdlSPDzyJkPuJFhwK3qKDwe4ggrAs7DuNuBhqL/VKCr/J29Wh2ng==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "k76bpvFvArisd0DbdtpLQbonkl57CYG3szD0sDw0fWZolh8nogw2hRrNL6U2KcrJqCvYVc+zGYSXTJfv9xgntA==",
         "dependencies": {
-          "Speckle.Sdk": "3.4.6"
+          "Speckle.Sdk": "3.5.0"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "YBa/RuwvBbymjWGv7sD2TwMSLhSjz3GYPOGVJtZzBZvev/zDQNZozvIlre+Lk7xpT2KPdH1FRfLkPWyW+qonMA==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "mOLFubk+co9rDtRLsB1wobvmkYaiEMvDV+3hRPlhnqe8WhV+vbBSjzj58EpKEprWXLwjyc0kVzsrvlM++PnL0g==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -337,14 +337,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.4.6"
+          "Speckle.Sdk.Dependencies": "3.5.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.4.8, )",
-        "resolved": "3.4.8",
-        "contentHash": "bNpJc2NBvjtJmdYS3xb6Fv4eqI/xZ2URXfWeXUFaWPMfC1QXLTjlK6iFriQk9ptLwr/dt4UPDPYYHOBynY1f2A=="
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "lPYk1E97tWJ5qO6B8F30VZ+vgOxMYQ5cspyUOALwWoyFloM1KZkvwyeBlm8FiQDx0su5KbTS4S10LQvnS2AqKg=="
       }
     }
   }

--- a/Converters/Navisworks/Speckle.Converters.Navisworks2025/packages.lock.json
+++ b/Converters/Navisworks/Speckle.Converters.Navisworks2025/packages.lock.json
@@ -259,9 +259,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.4.6, )",
-          "Speckle.Sdk": "[3.4.6, )",
-          "Speckle.Sdk.Dependencies": "[3.4.8, )"
+          "Speckle.Objects": "[3.5.0, )",
+          "Speckle.Sdk": "[3.5.0, )",
+          "Speckle.Sdk.Dependencies": "[3.5.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -278,7 +278,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.4.6, )"
+          "Speckle.Objects": "[3.5.0, )"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -316,18 +316,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "JjCdW+gUWq7u1Tb5SlLaFCIYfmrMA9HbUzCdlSPDzyJkPuJFhwK3qKDwe4ggrAs7DuNuBhqL/VKCr/J29Wh2ng==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "k76bpvFvArisd0DbdtpLQbonkl57CYG3szD0sDw0fWZolh8nogw2hRrNL6U2KcrJqCvYVc+zGYSXTJfv9xgntA==",
         "dependencies": {
-          "Speckle.Sdk": "3.4.6"
+          "Speckle.Sdk": "3.5.0"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "YBa/RuwvBbymjWGv7sD2TwMSLhSjz3GYPOGVJtZzBZvev/zDQNZozvIlre+Lk7xpT2KPdH1FRfLkPWyW+qonMA==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "mOLFubk+co9rDtRLsB1wobvmkYaiEMvDV+3hRPlhnqe8WhV+vbBSjzj58EpKEprWXLwjyc0kVzsrvlM++PnL0g==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -337,14 +337,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.4.6"
+          "Speckle.Sdk.Dependencies": "3.5.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.4.8, )",
-        "resolved": "3.4.8",
-        "contentHash": "bNpJc2NBvjtJmdYS3xb6Fv4eqI/xZ2URXfWeXUFaWPMfC1QXLTjlK6iFriQk9ptLwr/dt4UPDPYYHOBynY1f2A=="
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "lPYk1E97tWJ5qO6B8F30VZ+vgOxMYQ5cspyUOALwWoyFloM1KZkvwyeBlm8FiQDx0su5KbTS4S10LQvnS2AqKg=="
       }
     }
   }

--- a/Converters/Navisworks/Speckle.Converters.Navisworks2026/packages.lock.json
+++ b/Converters/Navisworks/Speckle.Converters.Navisworks2026/packages.lock.json
@@ -260,9 +260,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.4.6, )",
-          "Speckle.Sdk": "[3.4.6, )",
-          "Speckle.Sdk.Dependencies": "[3.4.8, )"
+          "Speckle.Objects": "[3.5.0, )",
+          "Speckle.Sdk": "[3.5.0, )",
+          "Speckle.Sdk.Dependencies": "[3.5.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -279,7 +279,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.4.6, )"
+          "Speckle.Objects": "[3.5.0, )"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -317,18 +317,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "JjCdW+gUWq7u1Tb5SlLaFCIYfmrMA9HbUzCdlSPDzyJkPuJFhwK3qKDwe4ggrAs7DuNuBhqL/VKCr/J29Wh2ng==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "k76bpvFvArisd0DbdtpLQbonkl57CYG3szD0sDw0fWZolh8nogw2hRrNL6U2KcrJqCvYVc+zGYSXTJfv9xgntA==",
         "dependencies": {
-          "Speckle.Sdk": "3.4.6"
+          "Speckle.Sdk": "3.5.0"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "YBa/RuwvBbymjWGv7sD2TwMSLhSjz3GYPOGVJtZzBZvev/zDQNZozvIlre+Lk7xpT2KPdH1FRfLkPWyW+qonMA==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "mOLFubk+co9rDtRLsB1wobvmkYaiEMvDV+3hRPlhnqe8WhV+vbBSjzj58EpKEprWXLwjyc0kVzsrvlM++PnL0g==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -338,14 +338,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.4.6"
+          "Speckle.Sdk.Dependencies": "3.5.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.4.8, )",
-        "resolved": "3.4.8",
-        "contentHash": "bNpJc2NBvjtJmdYS3xb6Fv4eqI/xZ2URXfWeXUFaWPMfC1QXLTjlK6iFriQk9ptLwr/dt4UPDPYYHOBynY1f2A=="
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "lPYk1E97tWJ5qO6B8F30VZ+vgOxMYQ5cspyUOALwWoyFloM1KZkvwyeBlm8FiQDx0su5KbTS4S10LQvnS2AqKg=="
       }
     }
   }

--- a/Converters/Revit/Speckle.Converters.Revit2022/packages.lock.json
+++ b/Converters/Revit/Speckle.Converters.Revit2022/packages.lock.json
@@ -258,7 +258,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.4.6, )"
+          "Speckle.Objects": "[3.5.0, )"
         }
       },
       "Microsoft.Extensions.Logging": {
@@ -287,18 +287,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "JjCdW+gUWq7u1Tb5SlLaFCIYfmrMA9HbUzCdlSPDzyJkPuJFhwK3qKDwe4ggrAs7DuNuBhqL/VKCr/J29Wh2ng==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "k76bpvFvArisd0DbdtpLQbonkl57CYG3szD0sDw0fWZolh8nogw2hRrNL6U2KcrJqCvYVc+zGYSXTJfv9xgntA==",
         "dependencies": {
-          "Speckle.Sdk": "3.4.6"
+          "Speckle.Sdk": "3.5.0"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "YBa/RuwvBbymjWGv7sD2TwMSLhSjz3GYPOGVJtZzBZvev/zDQNZozvIlre+Lk7xpT2KPdH1FRfLkPWyW+qonMA==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "mOLFubk+co9rDtRLsB1wobvmkYaiEMvDV+3hRPlhnqe8WhV+vbBSjzj58EpKEprWXLwjyc0kVzsrvlM++PnL0g==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -308,14 +308,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.4.6"
+          "Speckle.Sdk.Dependencies": "3.5.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.4.8, )",
-        "resolved": "3.4.6",
-        "contentHash": "UHWMZ8zQt3wF3gXfPpEKe3T8Pxo4ZRN1LOp+vZnsnohO8HKt2gNfAY2to2YRnTXnybEKsgqzIJLe372EoIQJHg=="
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "lPYk1E97tWJ5qO6B8F30VZ+vgOxMYQ5cspyUOALwWoyFloM1KZkvwyeBlm8FiQDx0su5KbTS4S10LQvnS2AqKg=="
       }
     }
   }

--- a/Converters/Revit/Speckle.Converters.Revit2023/packages.lock.json
+++ b/Converters/Revit/Speckle.Converters.Revit2023/packages.lock.json
@@ -258,7 +258,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.4.6, )"
+          "Speckle.Objects": "[3.5.0, )"
         }
       },
       "Microsoft.Extensions.Logging": {
@@ -287,18 +287,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "JjCdW+gUWq7u1Tb5SlLaFCIYfmrMA9HbUzCdlSPDzyJkPuJFhwK3qKDwe4ggrAs7DuNuBhqL/VKCr/J29Wh2ng==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "k76bpvFvArisd0DbdtpLQbonkl57CYG3szD0sDw0fWZolh8nogw2hRrNL6U2KcrJqCvYVc+zGYSXTJfv9xgntA==",
         "dependencies": {
-          "Speckle.Sdk": "3.4.6"
+          "Speckle.Sdk": "3.5.0"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "YBa/RuwvBbymjWGv7sD2TwMSLhSjz3GYPOGVJtZzBZvev/zDQNZozvIlre+Lk7xpT2KPdH1FRfLkPWyW+qonMA==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "mOLFubk+co9rDtRLsB1wobvmkYaiEMvDV+3hRPlhnqe8WhV+vbBSjzj58EpKEprWXLwjyc0kVzsrvlM++PnL0g==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -308,14 +308,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.4.6"
+          "Speckle.Sdk.Dependencies": "3.5.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.4.8, )",
-        "resolved": "3.4.6",
-        "contentHash": "UHWMZ8zQt3wF3gXfPpEKe3T8Pxo4ZRN1LOp+vZnsnohO8HKt2gNfAY2to2YRnTXnybEKsgqzIJLe372EoIQJHg=="
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "lPYk1E97tWJ5qO6B8F30VZ+vgOxMYQ5cspyUOALwWoyFloM1KZkvwyeBlm8FiQDx0su5KbTS4S10LQvnS2AqKg=="
       }
     }
   }

--- a/Converters/Revit/Speckle.Converters.Revit2024/packages.lock.json
+++ b/Converters/Revit/Speckle.Converters.Revit2024/packages.lock.json
@@ -258,7 +258,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.4.6, )"
+          "Speckle.Objects": "[3.5.0, )"
         }
       },
       "Microsoft.Extensions.Logging": {
@@ -287,18 +287,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "JjCdW+gUWq7u1Tb5SlLaFCIYfmrMA9HbUzCdlSPDzyJkPuJFhwK3qKDwe4ggrAs7DuNuBhqL/VKCr/J29Wh2ng==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "k76bpvFvArisd0DbdtpLQbonkl57CYG3szD0sDw0fWZolh8nogw2hRrNL6U2KcrJqCvYVc+zGYSXTJfv9xgntA==",
         "dependencies": {
-          "Speckle.Sdk": "3.4.6"
+          "Speckle.Sdk": "3.5.0"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "YBa/RuwvBbymjWGv7sD2TwMSLhSjz3GYPOGVJtZzBZvev/zDQNZozvIlre+Lk7xpT2KPdH1FRfLkPWyW+qonMA==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "mOLFubk+co9rDtRLsB1wobvmkYaiEMvDV+3hRPlhnqe8WhV+vbBSjzj58EpKEprWXLwjyc0kVzsrvlM++PnL0g==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -308,14 +308,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.4.6"
+          "Speckle.Sdk.Dependencies": "3.5.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.4.8, )",
-        "resolved": "3.4.6",
-        "contentHash": "UHWMZ8zQt3wF3gXfPpEKe3T8Pxo4ZRN1LOp+vZnsnohO8HKt2gNfAY2to2YRnTXnybEKsgqzIJLe372EoIQJHg=="
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "lPYk1E97tWJ5qO6B8F30VZ+vgOxMYQ5cspyUOALwWoyFloM1KZkvwyeBlm8FiQDx0su5KbTS4S10LQvnS2AqKg=="
       }
     }
   }

--- a/Converters/Revit/Speckle.Converters.Revit2025/packages.lock.json
+++ b/Converters/Revit/Speckle.Converters.Revit2025/packages.lock.json
@@ -209,7 +209,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.4.6, )"
+          "Speckle.Objects": "[3.5.0, )"
         }
       },
       "Microsoft.Extensions.Logging": {
@@ -238,18 +238,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "JjCdW+gUWq7u1Tb5SlLaFCIYfmrMA9HbUzCdlSPDzyJkPuJFhwK3qKDwe4ggrAs7DuNuBhqL/VKCr/J29Wh2ng==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "k76bpvFvArisd0DbdtpLQbonkl57CYG3szD0sDw0fWZolh8nogw2hRrNL6U2KcrJqCvYVc+zGYSXTJfv9xgntA==",
         "dependencies": {
-          "Speckle.Sdk": "3.4.6"
+          "Speckle.Sdk": "3.5.0"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "YBa/RuwvBbymjWGv7sD2TwMSLhSjz3GYPOGVJtZzBZvev/zDQNZozvIlre+Lk7xpT2KPdH1FRfLkPWyW+qonMA==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "mOLFubk+co9rDtRLsB1wobvmkYaiEMvDV+3hRPlhnqe8WhV+vbBSjzj58EpKEprWXLwjyc0kVzsrvlM++PnL0g==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -257,14 +257,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.4.6"
+          "Speckle.Sdk.Dependencies": "3.5.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.4.8, )",
-        "resolved": "3.4.6",
-        "contentHash": "UHWMZ8zQt3wF3gXfPpEKe3T8Pxo4ZRN1LOp+vZnsnohO8HKt2gNfAY2to2YRnTXnybEKsgqzIJLe372EoIQJHg=="
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "lPYk1E97tWJ5qO6B8F30VZ+vgOxMYQ5cspyUOALwWoyFloM1KZkvwyeBlm8FiQDx0su5KbTS4S10LQvnS2AqKg=="
       }
     }
   }

--- a/Converters/Revit/Speckle.Converters.Revit2026/packages.lock.json
+++ b/Converters/Revit/Speckle.Converters.Revit2026/packages.lock.json
@@ -209,7 +209,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.4.6, )"
+          "Speckle.Objects": "[3.5.0, )"
         }
       },
       "Microsoft.Extensions.Logging": {
@@ -238,18 +238,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "JjCdW+gUWq7u1Tb5SlLaFCIYfmrMA9HbUzCdlSPDzyJkPuJFhwK3qKDwe4ggrAs7DuNuBhqL/VKCr/J29Wh2ng==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "k76bpvFvArisd0DbdtpLQbonkl57CYG3szD0sDw0fWZolh8nogw2hRrNL6U2KcrJqCvYVc+zGYSXTJfv9xgntA==",
         "dependencies": {
-          "Speckle.Sdk": "3.4.6"
+          "Speckle.Sdk": "3.5.0"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "YBa/RuwvBbymjWGv7sD2TwMSLhSjz3GYPOGVJtZzBZvev/zDQNZozvIlre+Lk7xpT2KPdH1FRfLkPWyW+qonMA==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "mOLFubk+co9rDtRLsB1wobvmkYaiEMvDV+3hRPlhnqe8WhV+vbBSjzj58EpKEprWXLwjyc0kVzsrvlM++PnL0g==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -257,14 +257,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.4.6"
+          "Speckle.Sdk.Dependencies": "3.5.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.4.8, )",
-        "resolved": "3.4.6",
-        "contentHash": "UHWMZ8zQt3wF3gXfPpEKe3T8Pxo4ZRN1LOp+vZnsnohO8HKt2gNfAY2to2YRnTXnybEKsgqzIJLe372EoIQJHg=="
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "lPYk1E97tWJ5qO6B8F30VZ+vgOxMYQ5cspyUOALwWoyFloM1KZkvwyeBlm8FiQDx0su5KbTS4S10LQvnS2AqKg=="
       }
     }
   }

--- a/Converters/Rhino/Speckle.Converters.Rhino7/packages.lock.json
+++ b/Converters/Rhino/Speckle.Converters.Rhino7/packages.lock.json
@@ -258,7 +258,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.4.6, )"
+          "Speckle.Objects": "[3.5.0, )"
         }
       },
       "Microsoft.Extensions.Logging": {
@@ -287,18 +287,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "JjCdW+gUWq7u1Tb5SlLaFCIYfmrMA9HbUzCdlSPDzyJkPuJFhwK3qKDwe4ggrAs7DuNuBhqL/VKCr/J29Wh2ng==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "k76bpvFvArisd0DbdtpLQbonkl57CYG3szD0sDw0fWZolh8nogw2hRrNL6U2KcrJqCvYVc+zGYSXTJfv9xgntA==",
         "dependencies": {
-          "Speckle.Sdk": "3.4.6"
+          "Speckle.Sdk": "3.5.0"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "YBa/RuwvBbymjWGv7sD2TwMSLhSjz3GYPOGVJtZzBZvev/zDQNZozvIlre+Lk7xpT2KPdH1FRfLkPWyW+qonMA==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "mOLFubk+co9rDtRLsB1wobvmkYaiEMvDV+3hRPlhnqe8WhV+vbBSjzj58EpKEprWXLwjyc0kVzsrvlM++PnL0g==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -308,14 +308,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.4.6"
+          "Speckle.Sdk.Dependencies": "3.5.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.4.8, )",
-        "resolved": "3.4.6",
-        "contentHash": "UHWMZ8zQt3wF3gXfPpEKe3T8Pxo4ZRN1LOp+vZnsnohO8HKt2gNfAY2to2YRnTXnybEKsgqzIJLe372EoIQJHg=="
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "lPYk1E97tWJ5qO6B8F30VZ+vgOxMYQ5cspyUOALwWoyFloM1KZkvwyeBlm8FiQDx0su5KbTS4S10LQvnS2AqKg=="
       }
     }
   }

--- a/Converters/Rhino/Speckle.Converters.Rhino8/packages.lock.json
+++ b/Converters/Rhino/Speckle.Converters.Rhino8/packages.lock.json
@@ -258,7 +258,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.4.6, )"
+          "Speckle.Objects": "[3.5.0, )"
         }
       },
       "Microsoft.Extensions.Logging": {
@@ -287,18 +287,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "JjCdW+gUWq7u1Tb5SlLaFCIYfmrMA9HbUzCdlSPDzyJkPuJFhwK3qKDwe4ggrAs7DuNuBhqL/VKCr/J29Wh2ng==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "k76bpvFvArisd0DbdtpLQbonkl57CYG3szD0sDw0fWZolh8nogw2hRrNL6U2KcrJqCvYVc+zGYSXTJfv9xgntA==",
         "dependencies": {
-          "Speckle.Sdk": "3.4.6"
+          "Speckle.Sdk": "3.5.0"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "YBa/RuwvBbymjWGv7sD2TwMSLhSjz3GYPOGVJtZzBZvev/zDQNZozvIlre+Lk7xpT2KPdH1FRfLkPWyW+qonMA==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "mOLFubk+co9rDtRLsB1wobvmkYaiEMvDV+3hRPlhnqe8WhV+vbBSjzj58EpKEprWXLwjyc0kVzsrvlM++PnL0g==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -308,14 +308,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.4.6"
+          "Speckle.Sdk.Dependencies": "3.5.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.4.8, )",
-        "resolved": "3.4.6",
-        "contentHash": "UHWMZ8zQt3wF3gXfPpEKe3T8Pxo4ZRN1LOp+vZnsnohO8HKt2gNfAY2to2YRnTXnybEKsgqzIJLe372EoIQJHg=="
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "lPYk1E97tWJ5qO6B8F30VZ+vgOxMYQ5cspyUOALwWoyFloM1KZkvwyeBlm8FiQDx0su5KbTS4S10LQvnS2AqKg=="
       }
     }
   }

--- a/Converters/Tekla/Speckle.Converter.Tekla2023/packages.lock.json
+++ b/Converters/Tekla/Speckle.Converter.Tekla2023/packages.lock.json
@@ -302,7 +302,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.4.6, )"
+          "Speckle.Objects": "[3.5.0, )"
         }
       },
       "LibTessDotNet": {
@@ -337,18 +337,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "JjCdW+gUWq7u1Tb5SlLaFCIYfmrMA9HbUzCdlSPDzyJkPuJFhwK3qKDwe4ggrAs7DuNuBhqL/VKCr/J29Wh2ng==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "k76bpvFvArisd0DbdtpLQbonkl57CYG3szD0sDw0fWZolh8nogw2hRrNL6U2KcrJqCvYVc+zGYSXTJfv9xgntA==",
         "dependencies": {
-          "Speckle.Sdk": "3.4.6"
+          "Speckle.Sdk": "3.5.0"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "YBa/RuwvBbymjWGv7sD2TwMSLhSjz3GYPOGVJtZzBZvev/zDQNZozvIlre+Lk7xpT2KPdH1FRfLkPWyW+qonMA==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "mOLFubk+co9rDtRLsB1wobvmkYaiEMvDV+3hRPlhnqe8WhV+vbBSjzj58EpKEprWXLwjyc0kVzsrvlM++PnL0g==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -358,14 +358,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.4.6"
+          "Speckle.Sdk.Dependencies": "3.5.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.4.8, )",
-        "resolved": "3.4.6",
-        "contentHash": "UHWMZ8zQt3wF3gXfPpEKe3T8Pxo4ZRN1LOp+vZnsnohO8HKt2gNfAY2to2YRnTXnybEKsgqzIJLe372EoIQJHg=="
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "lPYk1E97tWJ5qO6B8F30VZ+vgOxMYQ5cspyUOALwWoyFloM1KZkvwyeBlm8FiQDx0su5KbTS4S10LQvnS2AqKg=="
       },
       "Tekla.Structures.Dialog": {
         "type": "CentralTransitive",

--- a/Converters/Tekla/Speckle.Converter.Tekla2024/packages.lock.json
+++ b/Converters/Tekla/Speckle.Converter.Tekla2024/packages.lock.json
@@ -343,7 +343,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.4.6, )"
+          "Speckle.Objects": "[3.5.0, )"
         }
       },
       "LibTessDotNet": {
@@ -378,18 +378,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "JjCdW+gUWq7u1Tb5SlLaFCIYfmrMA9HbUzCdlSPDzyJkPuJFhwK3qKDwe4ggrAs7DuNuBhqL/VKCr/J29Wh2ng==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "k76bpvFvArisd0DbdtpLQbonkl57CYG3szD0sDw0fWZolh8nogw2hRrNL6U2KcrJqCvYVc+zGYSXTJfv9xgntA==",
         "dependencies": {
-          "Speckle.Sdk": "3.4.6"
+          "Speckle.Sdk": "3.5.0"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "YBa/RuwvBbymjWGv7sD2TwMSLhSjz3GYPOGVJtZzBZvev/zDQNZozvIlre+Lk7xpT2KPdH1FRfLkPWyW+qonMA==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "mOLFubk+co9rDtRLsB1wobvmkYaiEMvDV+3hRPlhnqe8WhV+vbBSjzj58EpKEprWXLwjyc0kVzsrvlM++PnL0g==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -399,14 +399,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.4.6"
+          "Speckle.Sdk.Dependencies": "3.5.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.4.8, )",
-        "resolved": "3.4.6",
-        "contentHash": "UHWMZ8zQt3wF3gXfPpEKe3T8Pxo4ZRN1LOp+vZnsnohO8HKt2gNfAY2to2YRnTXnybEKsgqzIJLe372EoIQJHg=="
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "lPYk1E97tWJ5qO6B8F30VZ+vgOxMYQ5cspyUOALwWoyFloM1KZkvwyeBlm8FiQDx0su5KbTS4S10LQvnS2AqKg=="
       },
       "Tekla.Structures.Plugins": {
         "type": "CentralTransitive",

--- a/Converters/Tekla/Speckle.Converter.Tekla2025/packages.lock.json
+++ b/Converters/Tekla/Speckle.Converter.Tekla2025/packages.lock.json
@@ -343,7 +343,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.4.6, )"
+          "Speckle.Objects": "[3.5.0, )"
         }
       },
       "LibTessDotNet": {
@@ -378,18 +378,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "JjCdW+gUWq7u1Tb5SlLaFCIYfmrMA9HbUzCdlSPDzyJkPuJFhwK3qKDwe4ggrAs7DuNuBhqL/VKCr/J29Wh2ng==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "k76bpvFvArisd0DbdtpLQbonkl57CYG3szD0sDw0fWZolh8nogw2hRrNL6U2KcrJqCvYVc+zGYSXTJfv9xgntA==",
         "dependencies": {
-          "Speckle.Sdk": "3.4.6"
+          "Speckle.Sdk": "3.5.0"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "YBa/RuwvBbymjWGv7sD2TwMSLhSjz3GYPOGVJtZzBZvev/zDQNZozvIlre+Lk7xpT2KPdH1FRfLkPWyW+qonMA==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "mOLFubk+co9rDtRLsB1wobvmkYaiEMvDV+3hRPlhnqe8WhV+vbBSjzj58EpKEprWXLwjyc0kVzsrvlM++PnL0g==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -399,14 +399,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.4.6"
+          "Speckle.Sdk.Dependencies": "3.5.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.4.8, )",
-        "resolved": "3.4.6",
-        "contentHash": "UHWMZ8zQt3wF3gXfPpEKe3T8Pxo4ZRN1LOp+vZnsnohO8HKt2gNfAY2to2YRnTXnybEKsgqzIJLe372EoIQJHg=="
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "lPYk1E97tWJ5qO6B8F30VZ+vgOxMYQ5cspyUOALwWoyFloM1KZkvwyeBlm8FiQDx0su5KbTS4S10LQvnS2AqKg=="
       },
       "Tekla.Structures.Plugins": {
         "type": "CentralTransitive",

--- a/DUI3/Speckle.Connectors.DUI.Tests/packages.lock.json
+++ b/DUI3/Speckle.Connectors.DUI.Tests/packages.lock.json
@@ -314,9 +314,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.4.6, )",
-          "Speckle.Sdk": "[3.4.6, )",
-          "Speckle.Sdk.Dependencies": "[3.4.8, )"
+          "Speckle.Objects": "[3.5.0, )",
+          "Speckle.Sdk": "[3.5.0, )",
+          "Speckle.Sdk.Dependencies": "[3.5.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -335,7 +335,7 @@
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Moq": "[4.20.70, )",
           "NUnit": "[4.1.0, )",
-          "Speckle.Sdk": "[3.4.6, )"
+          "Speckle.Sdk": "[3.5.0, )"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -373,18 +373,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "JjCdW+gUWq7u1Tb5SlLaFCIYfmrMA9HbUzCdlSPDzyJkPuJFhwK3qKDwe4ggrAs7DuNuBhqL/VKCr/J29Wh2ng==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "k76bpvFvArisd0DbdtpLQbonkl57CYG3szD0sDw0fWZolh8nogw2hRrNL6U2KcrJqCvYVc+zGYSXTJfv9xgntA==",
         "dependencies": {
-          "Speckle.Sdk": "3.4.6"
+          "Speckle.Sdk": "3.5.0"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "YBa/RuwvBbymjWGv7sD2TwMSLhSjz3GYPOGVJtZzBZvev/zDQNZozvIlre+Lk7xpT2KPdH1FRfLkPWyW+qonMA==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "mOLFubk+co9rDtRLsB1wobvmkYaiEMvDV+3hRPlhnqe8WhV+vbBSjzj58EpKEprWXLwjyc0kVzsrvlM++PnL0g==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -392,14 +392,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.4.6"
+          "Speckle.Sdk.Dependencies": "3.5.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.4.8, )",
-        "resolved": "3.4.8",
-        "contentHash": "bNpJc2NBvjtJmdYS3xb6Fv4eqI/xZ2URXfWeXUFaWPMfC1QXLTjlK6iFriQk9ptLwr/dt4UPDPYYHOBynY1f2A=="
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "lPYk1E97tWJ5qO6B8F30VZ+vgOxMYQ5cspyUOALwWoyFloM1KZkvwyeBlm8FiQDx0su5KbTS4S10LQvnS2AqKg=="
       }
     }
   }

--- a/DUI3/Speckle.Connectors.DUI.WebView/packages.lock.json
+++ b/DUI3/Speckle.Connectors.DUI.WebView/packages.lock.json
@@ -259,9 +259,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.4.6, )",
-          "Speckle.Sdk": "[3.4.6, )",
-          "Speckle.Sdk.Dependencies": "[3.4.8, )"
+          "Speckle.Objects": "[3.5.0, )",
+          "Speckle.Sdk": "[3.5.0, )",
+          "Speckle.Sdk.Dependencies": "[3.5.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -309,18 +309,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "JjCdW+gUWq7u1Tb5SlLaFCIYfmrMA9HbUzCdlSPDzyJkPuJFhwK3qKDwe4ggrAs7DuNuBhqL/VKCr/J29Wh2ng==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "k76bpvFvArisd0DbdtpLQbonkl57CYG3szD0sDw0fWZolh8nogw2hRrNL6U2KcrJqCvYVc+zGYSXTJfv9xgntA==",
         "dependencies": {
-          "Speckle.Sdk": "3.4.6"
+          "Speckle.Sdk": "3.5.0"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "YBa/RuwvBbymjWGv7sD2TwMSLhSjz3GYPOGVJtZzBZvev/zDQNZozvIlre+Lk7xpT2KPdH1FRfLkPWyW+qonMA==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "mOLFubk+co9rDtRLsB1wobvmkYaiEMvDV+3hRPlhnqe8WhV+vbBSjzj58EpKEprWXLwjyc0kVzsrvlM++PnL0g==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -330,14 +330,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.4.6"
+          "Speckle.Sdk.Dependencies": "3.5.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.4.8, )",
-        "resolved": "3.4.8",
-        "contentHash": "bNpJc2NBvjtJmdYS3xb6Fv4eqI/xZ2URXfWeXUFaWPMfC1QXLTjlK6iFriQk9ptLwr/dt4UPDPYYHOBynY1f2A=="
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "lPYk1E97tWJ5qO6B8F30VZ+vgOxMYQ5cspyUOALwWoyFloM1KZkvwyeBlm8FiQDx0su5KbTS4S10LQvnS2AqKg=="
       }
     },
     "net8.0-windows7.0": {
@@ -549,9 +549,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.4.6, )",
-          "Speckle.Sdk": "[3.4.6, )",
-          "Speckle.Sdk.Dependencies": "[3.4.8, )"
+          "Speckle.Objects": "[3.5.0, )",
+          "Speckle.Sdk": "[3.5.0, )",
+          "Speckle.Sdk.Dependencies": "[3.5.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -599,18 +599,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "JjCdW+gUWq7u1Tb5SlLaFCIYfmrMA9HbUzCdlSPDzyJkPuJFhwK3qKDwe4ggrAs7DuNuBhqL/VKCr/J29Wh2ng==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "k76bpvFvArisd0DbdtpLQbonkl57CYG3szD0sDw0fWZolh8nogw2hRrNL6U2KcrJqCvYVc+zGYSXTJfv9xgntA==",
         "dependencies": {
-          "Speckle.Sdk": "3.4.6"
+          "Speckle.Sdk": "3.5.0"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "YBa/RuwvBbymjWGv7sD2TwMSLhSjz3GYPOGVJtZzBZvev/zDQNZozvIlre+Lk7xpT2KPdH1FRfLkPWyW+qonMA==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "mOLFubk+co9rDtRLsB1wobvmkYaiEMvDV+3hRPlhnqe8WhV+vbBSjzj58EpKEprWXLwjyc0kVzsrvlM++PnL0g==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -618,14 +618,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.4.6"
+          "Speckle.Sdk.Dependencies": "3.5.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.4.8, )",
-        "resolved": "3.4.8",
-        "contentHash": "bNpJc2NBvjtJmdYS3xb6Fv4eqI/xZ2URXfWeXUFaWPMfC1QXLTjlK6iFriQk9ptLwr/dt4UPDPYYHOBynY1f2A=="
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "lPYk1E97tWJ5qO6B8F30VZ+vgOxMYQ5cspyUOALwWoyFloM1KZkvwyeBlm8FiQDx0su5KbTS4S10LQvnS2AqKg=="
       }
     }
   }

--- a/DUI3/Speckle.Connectors.DUI/packages.lock.json
+++ b/DUI3/Speckle.Connectors.DUI/packages.lock.json
@@ -259,9 +259,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.4.6, )",
-          "Speckle.Sdk": "[3.4.6, )",
-          "Speckle.Sdk.Dependencies": "[3.4.8, )"
+          "Speckle.Objects": "[3.5.0, )",
+          "Speckle.Sdk": "[3.5.0, )",
+          "Speckle.Sdk.Dependencies": "[3.5.0, )"
         }
       },
       "speckle.connectors.logging": {
@@ -296,18 +296,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "JjCdW+gUWq7u1Tb5SlLaFCIYfmrMA9HbUzCdlSPDzyJkPuJFhwK3qKDwe4ggrAs7DuNuBhqL/VKCr/J29Wh2ng==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "k76bpvFvArisd0DbdtpLQbonkl57CYG3szD0sDw0fWZolh8nogw2hRrNL6U2KcrJqCvYVc+zGYSXTJfv9xgntA==",
         "dependencies": {
-          "Speckle.Sdk": "3.4.6"
+          "Speckle.Sdk": "3.5.0"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "YBa/RuwvBbymjWGv7sD2TwMSLhSjz3GYPOGVJtZzBZvev/zDQNZozvIlre+Lk7xpT2KPdH1FRfLkPWyW+qonMA==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "mOLFubk+co9rDtRLsB1wobvmkYaiEMvDV+3hRPlhnqe8WhV+vbBSjzj58EpKEprWXLwjyc0kVzsrvlM++PnL0g==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -317,14 +317,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.4.6"
+          "Speckle.Sdk.Dependencies": "3.5.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.4.8, )",
-        "resolved": "3.4.8",
-        "contentHash": "bNpJc2NBvjtJmdYS3xb6Fv4eqI/xZ2URXfWeXUFaWPMfC1QXLTjlK6iFriQk9ptLwr/dt4UPDPYYHOBynY1f2A=="
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "lPYk1E97tWJ5qO6B8F30VZ+vgOxMYQ5cspyUOALwWoyFloM1KZkvwyeBlm8FiQDx0su5KbTS4S10LQvnS2AqKg=="
       }
     },
     "net8.0": {
@@ -536,9 +536,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.4.6, )",
-          "Speckle.Sdk": "[3.4.6, )",
-          "Speckle.Sdk.Dependencies": "[3.4.8, )"
+          "Speckle.Objects": "[3.5.0, )",
+          "Speckle.Sdk": "[3.5.0, )",
+          "Speckle.Sdk.Dependencies": "[3.5.0, )"
         }
       },
       "speckle.connectors.logging": {
@@ -573,18 +573,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "JjCdW+gUWq7u1Tb5SlLaFCIYfmrMA9HbUzCdlSPDzyJkPuJFhwK3qKDwe4ggrAs7DuNuBhqL/VKCr/J29Wh2ng==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "k76bpvFvArisd0DbdtpLQbonkl57CYG3szD0sDw0fWZolh8nogw2hRrNL6U2KcrJqCvYVc+zGYSXTJfv9xgntA==",
         "dependencies": {
-          "Speckle.Sdk": "3.4.6"
+          "Speckle.Sdk": "3.5.0"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "YBa/RuwvBbymjWGv7sD2TwMSLhSjz3GYPOGVJtZzBZvev/zDQNZozvIlre+Lk7xpT2KPdH1FRfLkPWyW+qonMA==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "mOLFubk+co9rDtRLsB1wobvmkYaiEMvDV+3hRPlhnqe8WhV+vbBSjzj58EpKEprWXLwjyc0kVzsrvlM++PnL0g==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -592,14 +592,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.4.6"
+          "Speckle.Sdk.Dependencies": "3.5.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.4.8, )",
-        "resolved": "3.4.8",
-        "contentHash": "bNpJc2NBvjtJmdYS3xb6Fv4eqI/xZ2URXfWeXUFaWPMfC1QXLTjlK6iFriQk9ptLwr/dt4UPDPYYHOBynY1f2A=="
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "lPYk1E97tWJ5qO6B8F30VZ+vgOxMYQ5cspyUOALwWoyFloM1KZkvwyeBlm8FiQDx0su5KbTS4S10LQvnS2AqKg=="
       }
     }
   }

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -50,9 +50,9 @@
     <PackageVersion Include="Speckle.Civil3D.API" Version="2022.0.2" />
     <PackageVersion Include="Speckle.Revit.API" Version="2023.0.0" />
     <PackageVersion Include="Speckle.Navisworks.API" Version="2024.0.0" />
-    <PackageVersion Include="Speckle.Objects" Version="3.4.6" />
-    <PackageVersion Include="Speckle.Sdk" Version="3.4.6" />
-    <PackageVersion Include="Speckle.Sdk.Dependencies" Version="3.4.8" />
+    <PackageVersion Include="Speckle.Objects" Version="3.5.0" />
+    <PackageVersion Include="Speckle.Sdk" Version="3.5.0" />
+    <PackageVersion Include="Speckle.Sdk.Dependencies" Version="3.5.0" />
     <PackageVersion Include="SimpleExec" Version="12.0.0" />
     <GlobalPackageReference Include="PolySharp" Version="1.14.1" />
     <GlobalPackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />

--- a/Importers/Ifc/Speckle.Importers.Ifc.Tester/packages.lock.json
+++ b/Importers/Ifc/Speckle.Importers.Ifc.Tester/packages.lock.json
@@ -204,9 +204,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.4.6, )",
-          "Speckle.Sdk": "[3.4.6, )",
-          "Speckle.Sdk.Dependencies": "[3.4.8, )"
+          "Speckle.Objects": "[3.5.0, )",
+          "Speckle.Sdk": "[3.5.0, )",
+          "Speckle.Sdk.Dependencies": "[3.5.0, )"
         }
       },
       "speckle.connectors.logging": {
@@ -220,8 +220,8 @@
           "Ara3D.Utils": "[1.4.5, )",
           "Microsoft.Extensions.DependencyInjection": "[8.0.0, )",
           "Speckle.Connectors.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.4.6, )",
-          "Speckle.Sdk": "[3.4.6, )"
+          "Speckle.Objects": "[3.5.0, )",
+          "Speckle.Sdk": "[3.5.0, )"
         }
       },
       "Ara3D.Buffers": {
@@ -283,18 +283,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "JjCdW+gUWq7u1Tb5SlLaFCIYfmrMA9HbUzCdlSPDzyJkPuJFhwK3qKDwe4ggrAs7DuNuBhqL/VKCr/J29Wh2ng==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "k76bpvFvArisd0DbdtpLQbonkl57CYG3szD0sDw0fWZolh8nogw2hRrNL6U2KcrJqCvYVc+zGYSXTJfv9xgntA==",
         "dependencies": {
-          "Speckle.Sdk": "3.4.6"
+          "Speckle.Sdk": "3.5.0"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "YBa/RuwvBbymjWGv7sD2TwMSLhSjz3GYPOGVJtZzBZvev/zDQNZozvIlre+Lk7xpT2KPdH1FRfLkPWyW+qonMA==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "mOLFubk+co9rDtRLsB1wobvmkYaiEMvDV+3hRPlhnqe8WhV+vbBSjzj58EpKEprWXLwjyc0kVzsrvlM++PnL0g==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -302,14 +302,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.4.6"
+          "Speckle.Sdk.Dependencies": "3.5.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.4.8, )",
-        "resolved": "3.4.8",
-        "contentHash": "bNpJc2NBvjtJmdYS3xb6Fv4eqI/xZ2URXfWeXUFaWPMfC1QXLTjlK6iFriQk9ptLwr/dt4UPDPYYHOBynY1f2A=="
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "lPYk1E97tWJ5qO6B8F30VZ+vgOxMYQ5cspyUOALwWoyFloM1KZkvwyeBlm8FiQDx0su5KbTS4S10LQvnS2AqKg=="
       }
     }
   }

--- a/Importers/Ifc/Speckle.Importers.Ifc.Tester2/packages.lock.json
+++ b/Importers/Ifc/Speckle.Importers.Ifc.Tester2/packages.lock.json
@@ -204,9 +204,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.4.6, )",
-          "Speckle.Sdk": "[3.4.6, )",
-          "Speckle.Sdk.Dependencies": "[3.4.8, )"
+          "Speckle.Objects": "[3.5.0, )",
+          "Speckle.Sdk": "[3.5.0, )",
+          "Speckle.Sdk.Dependencies": "[3.5.0, )"
         }
       },
       "speckle.connectors.logging": {
@@ -220,8 +220,8 @@
           "Ara3D.Utils": "[1.4.5, )",
           "Microsoft.Extensions.DependencyInjection": "[8.0.0, )",
           "Speckle.Connectors.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.4.6, )",
-          "Speckle.Sdk": "[3.4.6, )"
+          "Speckle.Objects": "[3.5.0, )",
+          "Speckle.Sdk": "[3.5.0, )"
         }
       },
       "Ara3D.Buffers": {
@@ -283,18 +283,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "JjCdW+gUWq7u1Tb5SlLaFCIYfmrMA9HbUzCdlSPDzyJkPuJFhwK3qKDwe4ggrAs7DuNuBhqL/VKCr/J29Wh2ng==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "k76bpvFvArisd0DbdtpLQbonkl57CYG3szD0sDw0fWZolh8nogw2hRrNL6U2KcrJqCvYVc+zGYSXTJfv9xgntA==",
         "dependencies": {
-          "Speckle.Sdk": "3.4.6"
+          "Speckle.Sdk": "3.5.0"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "YBa/RuwvBbymjWGv7sD2TwMSLhSjz3GYPOGVJtZzBZvev/zDQNZozvIlre+Lk7xpT2KPdH1FRfLkPWyW+qonMA==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "mOLFubk+co9rDtRLsB1wobvmkYaiEMvDV+3hRPlhnqe8WhV+vbBSjzj58EpKEprWXLwjyc0kVzsrvlM++PnL0g==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -302,14 +302,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.4.6"
+          "Speckle.Sdk.Dependencies": "3.5.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.4.8, )",
-        "resolved": "3.4.8",
-        "contentHash": "bNpJc2NBvjtJmdYS3xb6Fv4eqI/xZ2URXfWeXUFaWPMfC1QXLTjlK6iFriQk9ptLwr/dt4UPDPYYHOBynY1f2A=="
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "lPYk1E97tWJ5qO6B8F30VZ+vgOxMYQ5cspyUOALwWoyFloM1KZkvwyeBlm8FiQDx0su5KbTS4S10LQvnS2AqKg=="
       }
     }
   }

--- a/Importers/Ifc/Speckle.Importers.Ifc/packages.lock.json
+++ b/Importers/Ifc/Speckle.Importers.Ifc/packages.lock.json
@@ -68,18 +68,18 @@
       },
       "Speckle.Objects": {
         "type": "Direct",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "JjCdW+gUWq7u1Tb5SlLaFCIYfmrMA9HbUzCdlSPDzyJkPuJFhwK3qKDwe4ggrAs7DuNuBhqL/VKCr/J29Wh2ng==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "k76bpvFvArisd0DbdtpLQbonkl57CYG3szD0sDw0fWZolh8nogw2hRrNL6U2KcrJqCvYVc+zGYSXTJfv9xgntA==",
         "dependencies": {
-          "Speckle.Sdk": "3.4.6"
+          "Speckle.Sdk": "3.5.0"
         }
       },
       "Speckle.Sdk": {
         "type": "Direct",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "YBa/RuwvBbymjWGv7sD2TwMSLhSjz3GYPOGVJtZzBZvev/zDQNZozvIlre+Lk7xpT2KPdH1FRfLkPWyW+qonMA==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "mOLFubk+co9rDtRLsB1wobvmkYaiEMvDV+3hRPlhnqe8WhV+vbBSjzj58EpKEprWXLwjyc0kVzsrvlM++PnL0g==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -87,7 +87,7 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.4.6"
+          "Speckle.Sdk.Dependencies": "3.5.0"
         }
       },
       "GraphQL.Client": {
@@ -261,9 +261,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.4.6, )",
-          "Speckle.Sdk": "[3.4.6, )",
-          "Speckle.Sdk.Dependencies": "[3.4.8, )"
+          "Speckle.Objects": "[3.5.0, )",
+          "Speckle.Sdk": "[3.5.0, )",
+          "Speckle.Sdk.Dependencies": "[3.5.0, )"
         }
       },
       "speckle.connectors.logging": {
@@ -295,9 +295,9 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.4.8, )",
-        "resolved": "3.4.8",
-        "contentHash": "bNpJc2NBvjtJmdYS3xb6Fv4eqI/xZ2URXfWeXUFaWPMfC1QXLTjlK6iFriQk9ptLwr/dt4UPDPYYHOBynY1f2A=="
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "lPYk1E97tWJ5qO6B8F30VZ+vgOxMYQ5cspyUOALwWoyFloM1KZkvwyeBlm8FiQDx0su5KbTS4S10LQvnS2AqKg=="
       }
     }
   }

--- a/Importers/Rhino/Speckle.Importers.Rhino/packages.lock.json
+++ b/Importers/Rhino/Speckle.Importers.Rhino/packages.lock.json
@@ -335,9 +335,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.4.6, )",
-          "Speckle.Sdk": "[3.4.6, )",
-          "Speckle.Sdk.Dependencies": "[3.4.8, )"
+          "Speckle.Objects": "[3.5.0, )",
+          "Speckle.Sdk": "[3.5.0, )",
+          "Speckle.Sdk.Dependencies": "[3.5.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -377,7 +377,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.4.6, )"
+          "Speckle.Objects": "[3.5.0, )"
         }
       },
       "speckle.converters.rhino8": {
@@ -456,18 +456,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "JjCdW+gUWq7u1Tb5SlLaFCIYfmrMA9HbUzCdlSPDzyJkPuJFhwK3qKDwe4ggrAs7DuNuBhqL/VKCr/J29Wh2ng==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "k76bpvFvArisd0DbdtpLQbonkl57CYG3szD0sDw0fWZolh8nogw2hRrNL6U2KcrJqCvYVc+zGYSXTJfv9xgntA==",
         "dependencies": {
-          "Speckle.Sdk": "3.4.6"
+          "Speckle.Sdk": "3.5.0"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "YBa/RuwvBbymjWGv7sD2TwMSLhSjz3GYPOGVJtZzBZvev/zDQNZozvIlre+Lk7xpT2KPdH1FRfLkPWyW+qonMA==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "mOLFubk+co9rDtRLsB1wobvmkYaiEMvDV+3hRPlhnqe8WhV+vbBSjzj58EpKEprWXLwjyc0kVzsrvlM++PnL0g==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -477,14 +477,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.4.6"
+          "Speckle.Sdk.Dependencies": "3.5.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.4.8, )",
-        "resolved": "3.4.8",
-        "contentHash": "bNpJc2NBvjtJmdYS3xb6Fv4eqI/xZ2URXfWeXUFaWPMfC1QXLTjlK6iFriQk9ptLwr/dt4UPDPYYHOBynY1f2A=="
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "lPYk1E97tWJ5qO6B8F30VZ+vgOxMYQ5cspyUOALwWoyFloM1KZkvwyeBlm8FiQDx0su5KbTS4S10LQvnS2AqKg=="
       },
       "System.Resources.Extensions": {
         "type": "CentralTransitive",

--- a/Sdk/Speckle.Connectors.Common.Tests/packages.lock.json
+++ b/Sdk/Speckle.Connectors.Common.Tests/packages.lock.json
@@ -308,9 +308,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.4.6, )",
-          "Speckle.Sdk": "[3.4.6, )",
-          "Speckle.Sdk.Dependencies": "[3.4.8, )"
+          "Speckle.Objects": "[3.5.0, )",
+          "Speckle.Sdk": "[3.5.0, )",
+          "Speckle.Sdk.Dependencies": "[3.5.0, )"
         }
       },
       "speckle.connectors.logging": {
@@ -322,7 +322,7 @@
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Moq": "[4.20.70, )",
           "NUnit": "[4.1.0, )",
-          "Speckle.Sdk": "[3.4.6, )"
+          "Speckle.Sdk": "[3.5.0, )"
         }
       },
       "Microsoft.Extensions.Logging": {
@@ -366,18 +366,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "JjCdW+gUWq7u1Tb5SlLaFCIYfmrMA9HbUzCdlSPDzyJkPuJFhwK3qKDwe4ggrAs7DuNuBhqL/VKCr/J29Wh2ng==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "k76bpvFvArisd0DbdtpLQbonkl57CYG3szD0sDw0fWZolh8nogw2hRrNL6U2KcrJqCvYVc+zGYSXTJfv9xgntA==",
         "dependencies": {
-          "Speckle.Sdk": "3.4.6"
+          "Speckle.Sdk": "3.5.0"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "YBa/RuwvBbymjWGv7sD2TwMSLhSjz3GYPOGVJtZzBZvev/zDQNZozvIlre+Lk7xpT2KPdH1FRfLkPWyW+qonMA==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "mOLFubk+co9rDtRLsB1wobvmkYaiEMvDV+3hRPlhnqe8WhV+vbBSjzj58EpKEprWXLwjyc0kVzsrvlM++PnL0g==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -385,14 +385,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.4.6"
+          "Speckle.Sdk.Dependencies": "3.5.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.4.8, )",
-        "resolved": "3.4.8",
-        "contentHash": "bNpJc2NBvjtJmdYS3xb6Fv4eqI/xZ2URXfWeXUFaWPMfC1QXLTjlK6iFriQk9ptLwr/dt4UPDPYYHOBynY1f2A=="
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "lPYk1E97tWJ5qO6B8F30VZ+vgOxMYQ5cspyUOALwWoyFloM1KZkvwyeBlm8FiQDx0su5KbTS4S10LQvnS2AqKg=="
       }
     }
   }

--- a/Sdk/Speckle.Connectors.Common/packages.lock.json
+++ b/Sdk/Speckle.Connectors.Common/packages.lock.json
@@ -44,18 +44,18 @@
       },
       "Speckle.Objects": {
         "type": "Direct",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "JjCdW+gUWq7u1Tb5SlLaFCIYfmrMA9HbUzCdlSPDzyJkPuJFhwK3qKDwe4ggrAs7DuNuBhqL/VKCr/J29Wh2ng==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "k76bpvFvArisd0DbdtpLQbonkl57CYG3szD0sDw0fWZolh8nogw2hRrNL6U2KcrJqCvYVc+zGYSXTJfv9xgntA==",
         "dependencies": {
-          "Speckle.Sdk": "3.4.6"
+          "Speckle.Sdk": "3.5.0"
         }
       },
       "Speckle.Sdk": {
         "type": "Direct",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "YBa/RuwvBbymjWGv7sD2TwMSLhSjz3GYPOGVJtZzBZvev/zDQNZozvIlre+Lk7xpT2KPdH1FRfLkPWyW+qonMA==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "mOLFubk+co9rDtRLsB1wobvmkYaiEMvDV+3hRPlhnqe8WhV+vbBSjzj58EpKEprWXLwjyc0kVzsrvlM++PnL0g==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -65,14 +65,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.4.6"
+          "Speckle.Sdk.Dependencies": "3.5.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Direct",
-        "requested": "[3.4.8, )",
-        "resolved": "3.4.8",
-        "contentHash": "bNpJc2NBvjtJmdYS3xb6Fv4eqI/xZ2URXfWeXUFaWPMfC1QXLTjlK6iFriQk9ptLwr/dt4UPDPYYHOBynY1f2A=="
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "lPYk1E97tWJ5qO6B8F30VZ+vgOxMYQ5cspyUOALwWoyFloM1KZkvwyeBlm8FiQDx0su5KbTS4S10LQvnS2AqKg=="
       },
       "GraphQL.Client": {
         "type": "Transitive",
@@ -360,18 +360,18 @@
       },
       "Speckle.Objects": {
         "type": "Direct",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "JjCdW+gUWq7u1Tb5SlLaFCIYfmrMA9HbUzCdlSPDzyJkPuJFhwK3qKDwe4ggrAs7DuNuBhqL/VKCr/J29Wh2ng==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "k76bpvFvArisd0DbdtpLQbonkl57CYG3szD0sDw0fWZolh8nogw2hRrNL6U2KcrJqCvYVc+zGYSXTJfv9xgntA==",
         "dependencies": {
-          "Speckle.Sdk": "3.4.6"
+          "Speckle.Sdk": "3.5.0"
         }
       },
       "Speckle.Sdk": {
         "type": "Direct",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "YBa/RuwvBbymjWGv7sD2TwMSLhSjz3GYPOGVJtZzBZvev/zDQNZozvIlre+Lk7xpT2KPdH1FRfLkPWyW+qonMA==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "mOLFubk+co9rDtRLsB1wobvmkYaiEMvDV+3hRPlhnqe8WhV+vbBSjzj58EpKEprWXLwjyc0kVzsrvlM++PnL0g==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -379,14 +379,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.4.6"
+          "Speckle.Sdk.Dependencies": "3.5.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Direct",
-        "requested": "[3.4.8, )",
-        "resolved": "3.4.8",
-        "contentHash": "bNpJc2NBvjtJmdYS3xb6Fv4eqI/xZ2URXfWeXUFaWPMfC1QXLTjlK6iFriQk9ptLwr/dt4UPDPYYHOBynY1f2A=="
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "lPYk1E97tWJ5qO6B8F30VZ+vgOxMYQ5cspyUOALwWoyFloM1KZkvwyeBlm8FiQDx0su5KbTS4S10LQvnS2AqKg=="
       },
       "GraphQL.Client": {
         "type": "Transitive",

--- a/Sdk/Speckle.Converters.Common.Tests/packages.lock.json
+++ b/Sdk/Speckle.Converters.Common.Tests/packages.lock.json
@@ -322,7 +322,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.4.6, )"
+          "Speckle.Objects": "[3.5.0, )"
         }
       },
       "speckle.testing": {
@@ -331,7 +331,7 @@
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Moq": "[4.20.70, )",
           "NUnit": "[4.1.0, )",
-          "Speckle.Sdk": "[3.4.6, )"
+          "Speckle.Sdk": "[3.5.0, )"
         }
       },
       "Microsoft.Extensions.Logging": {
@@ -360,18 +360,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "JjCdW+gUWq7u1Tb5SlLaFCIYfmrMA9HbUzCdlSPDzyJkPuJFhwK3qKDwe4ggrAs7DuNuBhqL/VKCr/J29Wh2ng==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "k76bpvFvArisd0DbdtpLQbonkl57CYG3szD0sDw0fWZolh8nogw2hRrNL6U2KcrJqCvYVc+zGYSXTJfv9xgntA==",
         "dependencies": {
-          "Speckle.Sdk": "3.4.6"
+          "Speckle.Sdk": "3.5.0"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "YBa/RuwvBbymjWGv7sD2TwMSLhSjz3GYPOGVJtZzBZvev/zDQNZozvIlre+Lk7xpT2KPdH1FRfLkPWyW+qonMA==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "mOLFubk+co9rDtRLsB1wobvmkYaiEMvDV+3hRPlhnqe8WhV+vbBSjzj58EpKEprWXLwjyc0kVzsrvlM++PnL0g==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -379,14 +379,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.4.6"
+          "Speckle.Sdk.Dependencies": "3.5.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.4.8, )",
-        "resolved": "3.4.6",
-        "contentHash": "UHWMZ8zQt3wF3gXfPpEKe3T8Pxo4ZRN1LOp+vZnsnohO8HKt2gNfAY2to2YRnTXnybEKsgqzIJLe372EoIQJHg=="
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "lPYk1E97tWJ5qO6B8F30VZ+vgOxMYQ5cspyUOALwWoyFloM1KZkvwyeBlm8FiQDx0su5KbTS4S10LQvnS2AqKg=="
       }
     }
   }

--- a/Sdk/Speckle.Converters.Common/packages.lock.json
+++ b/Sdk/Speckle.Converters.Common/packages.lock.json
@@ -41,11 +41,11 @@
       },
       "Speckle.Objects": {
         "type": "Direct",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "JjCdW+gUWq7u1Tb5SlLaFCIYfmrMA9HbUzCdlSPDzyJkPuJFhwK3qKDwe4ggrAs7DuNuBhqL/VKCr/J29Wh2ng==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "k76bpvFvArisd0DbdtpLQbonkl57CYG3szD0sDw0fWZolh8nogw2hRrNL6U2KcrJqCvYVc+zGYSXTJfv9xgntA==",
         "dependencies": {
-          "Speckle.Sdk": "3.4.6"
+          "Speckle.Sdk": "3.5.0"
         }
       },
       "GraphQL.Client": {
@@ -283,9 +283,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "YBa/RuwvBbymjWGv7sD2TwMSLhSjz3GYPOGVJtZzBZvev/zDQNZozvIlre+Lk7xpT2KPdH1FRfLkPWyW+qonMA==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "mOLFubk+co9rDtRLsB1wobvmkYaiEMvDV+3hRPlhnqe8WhV+vbBSjzj58EpKEprWXLwjyc0kVzsrvlM++PnL0g==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -295,14 +295,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.4.6"
+          "Speckle.Sdk.Dependencies": "3.5.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.4.8, )",
-        "resolved": "3.4.6",
-        "contentHash": "UHWMZ8zQt3wF3gXfPpEKe3T8Pxo4ZRN1LOp+vZnsnohO8HKt2gNfAY2to2YRnTXnybEKsgqzIJLe372EoIQJHg=="
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "lPYk1E97tWJ5qO6B8F30VZ+vgOxMYQ5cspyUOALwWoyFloM1KZkvwyeBlm8FiQDx0su5KbTS4S10LQvnS2AqKg=="
       }
     },
     "net8.0": {
@@ -345,11 +345,11 @@
       },
       "Speckle.Objects": {
         "type": "Direct",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "JjCdW+gUWq7u1Tb5SlLaFCIYfmrMA9HbUzCdlSPDzyJkPuJFhwK3qKDwe4ggrAs7DuNuBhqL/VKCr/J29Wh2ng==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "k76bpvFvArisd0DbdtpLQbonkl57CYG3szD0sDw0fWZolh8nogw2hRrNL6U2KcrJqCvYVc+zGYSXTJfv9xgntA==",
         "dependencies": {
-          "Speckle.Sdk": "3.4.6"
+          "Speckle.Sdk": "3.5.0"
         }
       },
       "GraphQL.Client": {
@@ -538,9 +538,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "YBa/RuwvBbymjWGv7sD2TwMSLhSjz3GYPOGVJtZzBZvev/zDQNZozvIlre+Lk7xpT2KPdH1FRfLkPWyW+qonMA==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "mOLFubk+co9rDtRLsB1wobvmkYaiEMvDV+3hRPlhnqe8WhV+vbBSjzj58EpKEprWXLwjyc0kVzsrvlM++PnL0g==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -548,14 +548,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.4.6"
+          "Speckle.Sdk.Dependencies": "3.5.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.4.8, )",
-        "resolved": "3.4.6",
-        "contentHash": "UHWMZ8zQt3wF3gXfPpEKe3T8Pxo4ZRN1LOp+vZnsnohO8HKt2gNfAY2to2YRnTXnybEKsgqzIJLe372EoIQJHg=="
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "lPYk1E97tWJ5qO6B8F30VZ+vgOxMYQ5cspyUOALwWoyFloM1KZkvwyeBlm8FiQDx0su5KbTS4S10LQvnS2AqKg=="
       }
     }
   }

--- a/Sdk/Speckle.Testing/packages.lock.json
+++ b/Sdk/Speckle.Testing/packages.lock.json
@@ -59,9 +59,9 @@
       },
       "Speckle.Sdk": {
         "type": "Direct",
-        "requested": "[3.4.6, )",
-        "resolved": "3.4.6",
-        "contentHash": "YBa/RuwvBbymjWGv7sD2TwMSLhSjz3GYPOGVJtZzBZvev/zDQNZozvIlre+Lk7xpT2KPdH1FRfLkPWyW+qonMA==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "mOLFubk+co9rDtRLsB1wobvmkYaiEMvDV+3hRPlhnqe8WhV+vbBSjzj58EpKEprWXLwjyc0kVzsrvlM++PnL0g==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -69,7 +69,7 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.4.6"
+          "Speckle.Sdk.Dependencies": "3.5.0"
         }
       },
       "Castle.Core": {
@@ -277,9 +277,9 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.4.8, )",
-        "resolved": "3.4.6",
-        "contentHash": "UHWMZ8zQt3wF3gXfPpEKe3T8Pxo4ZRN1LOp+vZnsnohO8HKt2gNfAY2to2YRnTXnybEKsgqzIJLe372EoIQJHg=="
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "lPYk1E97tWJ5qO6B8F30VZ+vgOxMYQ5cspyUOALwWoyFloM1KZkvwyeBlm8FiQDx0su5KbTS4S10LQvnS2AqKg=="
       }
     }
   }


### PR DESCRIPTION
## Description
Updates the connector to use `LimitedWorkspace` type instead of `Workspace` type to align with recent SDK changes.
Related to [CNX-2220](https://linear.app/speckle/issue/CNX-2220/fix-active-workspace-in-grasshopper).

## User Value
Something that works.


## Changes:
- Updated `SelectedWorkspace` prop type from `Workspace?` to `LimitedWorkspace?` (and all other related types)
- Updated `selectedWorkspace` variable type in `SetDefaultWorkspaceSync()` method
- Bumped SDK version in packages

## To-do before merge:
- [x] Test with SDK

## Validation of Changes:
Active workspace `Connectors Team`:

<img width="778" height="684" alt="image" src="https://github.com/user-attachments/assets/a3247c99-11b5-4666-8522-eead98ed4090" />

Default workspace when dropping component == `Connectors Team`

![default_workspace](https://github.com/user-attachments/assets/41cf043d-ab49-4fb2-90e8-c11ea171d903)

## Checklist:
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] I have added appropriate tests.
- [x] I have updated or added relevant documentation.

