### PR TITLE
fix(revit): extend DirectShape category mapping to all geometry objects

### DIFF
--- a/Converters/Revit/Speckle.Converters.RevitShared/ToHost/Raw/LocalToGlobalToDirectShapeConverter.cs
+++ b/Converters/Revit/Speckle.Converters.RevitShared/ToHost/Raw/LocalToGlobalToDirectShapeConverter.cs
@@ -2,7 +2,6 @@ using Speckle.Converters.Common;
 using Speckle.Converters.Common.Objects;
 using Speckle.Converters.RevitShared.Settings;
 using Speckle.DoubleNumerics;
-using Speckle.Objects.Data;
 using Speckle.Sdk.Common;
 using Speckle.Sdk.Models;
 using Speckle.Sdk.Models.Extensions;
@@ -35,12 +34,13 @@ public class LocalToGlobalToDirectShapeConverter
     // NOTE: previously, builtInCategory was on the atomicObject level. this was subsequently moved to properties
     string? category = null;
 
-    if (target.atomicObject is DataObject dataObject)
+    // NOTE: no longer limited to DataObject since the introduction of mapper
+    if (
+      target.atomicObject["properties"] is Dictionary<string, object?> properties
+      && properties.TryGetValue("builtInCategory", out var builtInCategory)
+    )
     {
-      if (dataObject.properties.TryGetValue("builtInCategory", out var builtInCategory))
-      {
-        category = builtInCategory?.ToString();
-      }
+      category = builtInCategory?.ToString();
     }
 
     var dsCategory = DB.BuiltInCategory.OST_GenericModel;


### PR DESCRIPTION
## Description
`LocalToGlobalToDirectShapeConverter` only checked for `builtInCategory` mappings on `DataObject` instances. Rhino geometry objects with mapper-assigned categories (stored as user strings and converted to properties) were not being assigned to the correct Revit categories.

This change extends the category detection logic to work with any `Base` object that has properties containing a `builtInCategory` value, enabling the Rhino-to-Revit mapper functionality for all geometry types.

## User Value
Users can now assign any Rhino geometry object to specific Revit categories using the mapper, and these objects will be correctly categorized when received in Revit, regardless of geometry type.

## Changes:
- Modified `LocalToGlobalToDirectShapeConverter.cs` to check for `builtInCategory` in any Base object's properties, not just DataObjects

## Checklist:
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] I have added appropriate tests.
- [x] I have updated or added relevant documentation.