### PR TITLE
feat(rhino): implement Revit category mapper for interop lite

### DIFF
--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/Bindings/RhinoMapperBinding.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/Bindings/RhinoMapperBinding.cs
@@ -171,7 +171,7 @@ public class RhinoMapperBinding : IBinding
   /// <summary>
   /// Called when object attributes are modified in Rhino.
   /// </summary>
-  private void OnObjectAttributesChanged(object? sender, RhinoModifyObjectAttributesEventArgs e) // Fixed: Correct event signature
+  private void OnObjectAttributesChanged(object? sender, RhinoModifyObjectAttributesEventArgs e)
   {
     var rhinoObject = e.RhinoObject;
     if (!string.IsNullOrEmpty(rhinoObject.Attributes.GetUserString(CATEGORY_USER_STRING_KEY)))

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/Bindings/RhinoMapperBinding.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/Bindings/RhinoMapperBinding.cs
@@ -128,15 +128,6 @@ public class RhinoMapperBinding : IBinding
   }
 
   /// <summary>
-  /// Get all objects assigned to a specific category.
-  /// </summary>
-  public string[] GetObjectsByCategory(string categoryValue) =>
-    RhinoDoc
-      .ActiveDoc.Objects.Where(obj => obj.Attributes.GetUserString(CATEGORY_USER_STRING_KEY) == categoryValue)
-      .Select(obj => obj.Id.ToString())
-      .ToArray();
-
-  /// <summary>
   /// Selects/highlights specific objects in Rhino.
   /// </summary>
   public async Task HighlightObjects(string[] objectIds) => await _basicConnectorBinding.HighlightObjects(objectIds);

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/Bindings/RhinoMapperBinding.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/Bindings/RhinoMapperBinding.cs
@@ -1,0 +1,238 @@
+using Rhino;
+using Rhino.DocObjects;
+using Speckle.Connectors.DUI.Bindings;
+using Speckle.Connectors.DUI.Bridge;
+using Speckle.Connectors.Rhino.HostApp;
+
+namespace Speckle.Connectors.Rhino.Bindings;
+
+/// <summary>
+/// Represents a group of objects that are all assigned to the same category.
+/// </summary>
+/// <param name="CategoryValue">The Revit category enum name</param>
+/// <param name="CategoryLabel">Human-readable category name</param>
+/// <param name="ObjectIds">Array of Rhino object IDs assigned to this category</param>
+/// <param name="ObjectCount">Number of objects (for convenience)</param>
+public record CategoryMapping(
+  string CategoryValue,
+  string CategoryLabel,
+  IReadOnlyList<string> ObjectIds,
+  int ObjectCount
+);
+
+/// <summary>
+/// Binding for managing Rhino object mappings to Revit categories.
+/// </summary>
+public class RhinoMapperBinding : IBinding
+{
+  private readonly IAppIdleManager _idleManager;
+  private readonly IBasicConnectorBinding _basicConnectorBinding;
+  private const string CATEGORY_USER_STRING_KEY = "builtInCategory";
+  private const string MAPPINGS_CHANGED_EVENT = "mappingsChanged";
+  public string Name => "revitMapperBinding";
+  public IBrowserBridge Parent { get; }
+
+  public RhinoMapperBinding(
+    IAppIdleManager idleManager,
+    IBrowserBridge parent,
+    IBasicConnectorBinding basicConnectorBinding
+  )
+  {
+    _idleManager = idleManager;
+    Parent = parent;
+    _basicConnectorBinding = basicConnectorBinding;
+
+    // Subscribe to Rhino events so we know about changes
+    // Events fire on delete, undo delete and modify objects
+    RhinoDoc.DeleteRhinoObject += OnObjectChanged;
+    RhinoDoc.UndeleteRhinoObject += OnObjectChanged;
+    RhinoDoc.ModifyObjectAttributes += OnObjectAttributesChanged;
+  }
+
+  #region UI-Callable Methods
+
+  /// <summary>
+  /// Gets list of available Revit categories for the UI dropdown
+  /// </summary>
+  public CategoryOption[] GetAvailableCategories() => RevitBuiltInCategoryStore.Categories;
+
+  /// <summary>
+  /// Assigns selected objects to a specific Revit category
+  /// </summary>
+  public void AssignToCategory(string[] objectIds, string categoryValue)
+  {
+    var doc = RhinoDoc.ActiveDoc;
+
+    if (doc == null)
+    {
+      return; // or throw here?
+    }
+
+    // Is this really the best way?
+    foreach (var objectIdString in objectIds)
+    {
+      var rhinoObject = GetRhinoObject(doc, objectIdString);
+      if (rhinoObject is not null)
+      {
+        // NOTE: should we be checking if key already exists?
+        // For POC, straightforward set on object
+        rhinoObject.Attributes.SetUserString(CATEGORY_USER_STRING_KEY, categoryValue);
+        rhinoObject.CommitChanges();
+      }
+    }
+  }
+
+  /// <summary>
+  /// Removes category assignments from specific objects.
+  /// </summary>
+  public void ClearCategoryAssignment(string[] objectIds)
+  {
+    var doc = RhinoDoc.ActiveDoc;
+
+    if (doc == null)
+    {
+      return; // or throw here?
+    }
+
+    // Is this really the best way?
+    foreach (var objectIdString in objectIds)
+    {
+      var rhinoObject = GetRhinoObject(doc, objectIdString);
+      if (rhinoObject is not null)
+      {
+        // NOTE: should we be checking if key already exists?
+        // For POC, straightforward delete on object
+        rhinoObject.Attributes.DeleteUserString(CATEGORY_USER_STRING_KEY);
+        rhinoObject.CommitChanges();
+      }
+    }
+  }
+
+  /// <summary>
+  /// Removes all category assignments in the doc.
+  /// </summary>
+  public void ClearAllCategoryAssignments()
+  {
+    var doc = RhinoDoc.ActiveDoc;
+
+    if (doc == null)
+    {
+      return;
+    }
+
+    // Or should we rather be getting a flattened list of objectIds from mappings table?
+    foreach (var rhinoObject in doc.Objects)
+    {
+      var categoryValue = rhinoObject.Attributes.GetUserString(CATEGORY_USER_STRING_KEY);
+      if (!string.IsNullOrEmpty(categoryValue))
+      {
+        rhinoObject.Attributes.DeleteUserString(CATEGORY_USER_STRING_KEY);
+        rhinoObject.CommitChanges();
+      }
+    }
+  }
+
+  /// <summary>
+  /// Gets all current mappings to show in the UI table.
+  /// </summary>
+  /// <returns></returns>
+  public CategoryMapping[] GetCurrentMappings()
+  {
+    var doc = RhinoDoc.ActiveDoc;
+
+    if (doc == null)
+    {
+      return [];
+    }
+
+    // Step 1: Find objects with mappings
+    var mappedObjects = doc
+      .Objects.Where(obj => !string.IsNullOrEmpty(obj.Attributes.GetUserString(CATEGORY_USER_STRING_KEY)))
+      .ToList();
+
+    // Step 2: Group by category value and create CategoryMappings
+    var categoryMappings = mappedObjects
+      .GroupBy(obj => obj.Attributes.GetUserString(CATEGORY_USER_STRING_KEY))
+      .Select(group => new CategoryMapping(
+        group.Key, // categoryValue
+        RevitBuiltInCategoryStore.GetLabel(group.Key), // categoryLabel
+        group.Select(obj => obj.Id.ToString()).ToArray(), // objectIds
+        group.Count() // objectCount
+      ))
+      .ToArray();
+
+    return categoryMappings;
+  }
+
+  /// <summary>
+  /// Get all objects assigned to a specific category
+  /// </summary>
+  public string[] GetObjectsByCategory(string categoryValue)
+  {
+    var doc = RhinoDoc.ActiveDoc;
+
+    if (doc == null)
+    {
+      return [];
+    }
+
+    var objectIds = doc
+      .Objects.Where(obj => obj.Attributes.GetUserString(CATEGORY_USER_STRING_KEY) == categoryValue)
+      .Select(obj => obj.Id.ToString())
+      .ToArray();
+
+    return objectIds;
+  }
+
+  /// <summary>
+  /// Selects/highlights specific objects in Rhino.
+  /// </summary>
+  public async Task HighlightObjects(string[] objectIds) => await _basicConnectorBinding.HighlightObjects(objectIds);
+
+  /// <summary>
+  /// Converts a string object ID to a RhinoObject.
+  /// </summary>
+  /// <returns>RhinoObject if found and valid, null otherwise</returns>
+  /// <remarks>Reducing repetitive code.</remarks>
+  private static RhinoObject? GetRhinoObject(RhinoDoc doc, string objectIdString) =>
+    !Guid.TryParse(objectIdString, out Guid objectId) ? null : doc.Objects.FindId(objectId);
+
+  #endregion
+
+  #region Event Handling
+
+  /// <summary>
+  /// Called when objects are deleted or undeleted in Rhino.
+  /// </summary>
+  private void OnObjectChanged(object? sender, RhinoObjectEventArgs e)
+  {
+    var rhinoObject = e.TheObject;
+    if (!string.IsNullOrEmpty(rhinoObject.Attributes.GetUserString(CATEGORY_USER_STRING_KEY)))
+    {
+      _idleManager.SubscribeToIdle(nameof(NotifyMappingsChanged), NotifyMappingsChanged);
+    }
+  }
+
+  /// <summary>
+  /// Called when object attributes are modified in Rhino.
+  /// </summary>
+  private void OnObjectAttributesChanged(object? sender, RhinoModifyObjectAttributesEventArgs e) // Fixed: Correct event signature
+  {
+    var rhinoObject = e.RhinoObject;
+    if (!string.IsNullOrEmpty(rhinoObject.Attributes.GetUserString(CATEGORY_USER_STRING_KEY)))
+    {
+      _idleManager.SubscribeToIdle(nameof(NotifyMappingsChanged), NotifyMappingsChanged);
+    }
+  }
+
+  /// <summary>
+  /// Sends updated mappings to the frontend.
+  /// </summary>
+  private void NotifyMappingsChanged()
+  {
+    var currentMappings = GetCurrentMappings();
+    Parent.Send(MAPPINGS_CHANGED_EVENT, currentMappings);
+  }
+
+  #endregion
+}

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/Bindings/RhinoMapperBinding.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/Bindings/RhinoMapperBinding.cs
@@ -3,7 +3,7 @@ using Rhino.DocObjects;
 using Speckle.Connectors.DUI.Bindings;
 using Speckle.Connectors.DUI.Bridge;
 using Speckle.Connectors.DUI.Models;
-using Speckle.Connectors.Rhino.HostApp;
+using Speckle.Connectors.Rhino.Mapper.Revit;
 
 namespace Speckle.Connectors.Rhino.Bindings;
 

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/Bindings/RhinoMapperBinding.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/Bindings/RhinoMapperBinding.cs
@@ -47,6 +47,9 @@ public class RhinoMapperBinding : IBinding
     RhinoDoc.DeleteRhinoObject += OnObjectChanged;
     RhinoDoc.UndeleteRhinoObject += OnObjectChanged;
     RhinoDoc.ModifyObjectAttributes += OnObjectAttributesChanged;
+
+    // Subscribe to document changes to refresh mappings when switching documents
+    _store.DocumentChanged += OnDocumentChanged;
   }
 
   #region UI Methods
@@ -175,6 +178,21 @@ public class RhinoMapperBinding : IBinding
     {
       _idleManager.SubscribeToIdle(nameof(NotifyMappingsChanged), NotifyMappingsChanged);
     }
+  }
+
+  /// <summary>
+  /// Called when the document changes (e.g., switching to a different Rhino model).
+  /// Refreshes the mappings table to reflect the new document's state.
+  /// </summary>
+  private void OnDocumentChanged(object? sender, EventArgs e)
+  {
+    if (!_store.IsDocumentInit)
+    {
+      return;
+    }
+
+    // Refresh mappings for the new document
+    _idleManager.SubscribeToIdle(nameof(NotifyMappingsChanged), NotifyMappingsChanged);
   }
 
   /// <summary>

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/Bindings/RhinoMapperBinding.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/Bindings/RhinoMapperBinding.cs
@@ -54,7 +54,8 @@ public class RhinoMapperBinding : IBinding
   /// <summary>
   /// Gets list of available Revit categories for the UI dropdown.
   /// </summary>
-  public CategoryOption[] GetAvailableCategories() => RevitBuiltInCategoryStore.Categories;
+  public CategoryOption[] GetAvailableCategories() =>
+    RevitBuiltInCategoryStore.Categories.OrderBy(category => category.Label).ToArray();
 
   /// <summary>
   /// Assigns selected objects to a specific Revit category.

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/Bindings/RhinoMapperBinding.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/Bindings/RhinoMapperBinding.cs
@@ -1,8 +1,8 @@
-using System.Collections.Concurrent;
 using Rhino;
 using Rhino.DocObjects;
 using Speckle.Connectors.DUI.Bindings;
 using Speckle.Connectors.DUI.Bridge;
+using Speckle.Connectors.DUI.Models;
 using Speckle.Connectors.Rhino.HostApp;
 
 namespace Speckle.Connectors.Rhino.Bindings;
@@ -22,6 +22,7 @@ public record CategoryMapping(
 /// </summary>
 public class RhinoMapperBinding : IBinding
 {
+  private readonly DocumentModelStore _store;
   private readonly IAppIdleManager _idleManager;
   private readonly IBasicConnectorBinding _basicConnectorBinding;
   private const string CATEGORY_USER_STRING_KEY = "builtInCategory";
@@ -30,11 +31,13 @@ public class RhinoMapperBinding : IBinding
   public IBrowserBridge Parent { get; }
 
   public RhinoMapperBinding(
+    DocumentModelStore store,
     IAppIdleManager idleManager,
     IBrowserBridge parent,
     IBasicConnectorBinding basicConnectorBinding
   )
   {
+    _store = store;
     _idleManager = idleManager;
     Parent = parent;
     _basicConnectorBinding = basicConnectorBinding;
@@ -149,6 +152,11 @@ public class RhinoMapperBinding : IBinding
   /// </summary>
   private void OnObjectChanged(object? sender, RhinoObjectEventArgs e)
   {
+    if (!_store.IsDocumentInit)
+    {
+      return;
+    }
+
     var rhinoObject = e.TheObject;
     if (!string.IsNullOrEmpty(rhinoObject.Attributes.GetUserString(CATEGORY_USER_STRING_KEY)))
     {

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/Bindings/RhinoMapperBinding.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/Bindings/RhinoMapperBinding.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using Rhino;
 using Rhino.DocObjects;
 using Speckle.Connectors.DUI.Bindings;
@@ -9,10 +10,6 @@ namespace Speckle.Connectors.Rhino.Bindings;
 /// <summary>
 /// Represents a group of objects that are all assigned to the same category.
 /// </summary>
-/// <param name="CategoryValue">The Revit category enum name</param>
-/// <param name="CategoryLabel">Human-readable category name</param>
-/// <param name="ObjectIds">Array of Rhino object IDs assigned to this category</param>
-/// <param name="ObjectCount">Number of objects (for convenience)</param>
 public record CategoryMapping(
   string CategoryValue,
   string CategoryLabel,
@@ -49,15 +46,15 @@ public class RhinoMapperBinding : IBinding
     RhinoDoc.ModifyObjectAttributes += OnObjectAttributesChanged;
   }
 
-  #region UI-Callable Methods
+  #region UI Methods
 
   /// <summary>
-  /// Gets list of available Revit categories for the UI dropdown
+  /// Gets list of available Revit categories for the UI dropdown.
   /// </summary>
   public CategoryOption[] GetAvailableCategories() => RevitBuiltInCategoryStore.Categories;
 
   /// <summary>
-  /// Assigns selected objects to a specific Revit category
+  /// Assigns selected objects to a specific Revit category.
   /// </summary>
   public void AssignToCategory(string[] objectIds, string categoryValue)
   {
@@ -80,6 +77,9 @@ public class RhinoMapperBinding : IBinding
         rhinoObject.CommitChanges();
       }
     }
+
+    // Trigger single update after all changes
+    _idleManager.SubscribeToIdle(nameof(NotifyMappingsChanged), NotifyMappingsChanged);
   }
 
   /// <summary>
@@ -106,6 +106,9 @@ public class RhinoMapperBinding : IBinding
         rhinoObject.CommitChanges();
       }
     }
+
+    // Trigger single update after all changes
+    _idleManager.SubscribeToIdle(nameof(NotifyMappingsChanged), NotifyMappingsChanged);
   }
 
   /// <summary>
@@ -130,6 +133,9 @@ public class RhinoMapperBinding : IBinding
         rhinoObject.CommitChanges();
       }
     }
+
+    // Trigger single update
+    _idleManager.SubscribeToIdle(nameof(NotifyMappingsChanged), NotifyMappingsChanged);
   }
 
   /// <summary>

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/HostApp/RevitBuiltInCategoryStore.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/HostApp/RevitBuiltInCategoryStore.cs
@@ -1,4 +1,13 @@
+// TODO: Where should this live? Speckle.Connectors.Common.Interop??
+
 namespace Speckle.Connectors.Rhino.HostApp;
+
+/// <summary>
+/// Represents a category option for the dropdown in the UI.
+/// </summary>
+/// <param name="Value">The Revit category enum name (e.g., "OST_Walls")</param>
+/// <param name="Label">Human-readable name for the UI (e.g., "Walls")</param>
+public record CategoryOption(string Value, string Label);
 
 /// <summary>
 /// Currently hardcoded Revit BuiltInCategories for the Interop Lite mapper.
@@ -13,50 +22,62 @@ namespace Speckle.Connectors.Rhino.HostApp;
 public static class RevitBuiltInCategoryStore
 {
   /// <summary>
-  /// Curated list of Revit BuiltInCategory enum names for the lite interop mapper.
-  /// These are the exact enum names as they appear in the Revit API.
+  /// Dictionary mapping Revit BuiltInCategory enum names to human-readable labels.
+  /// Key: BuiltInCategory enum name (e.g., "OST_Walls")
+  /// Value: Human-readable label (e.g., "Walls")
   /// </summary>
-  public static readonly List<string> Categories =
+  public static readonly CategoryOption[] Categories =
   [
-    "OST_Ceilings",
-    "OST_Columns",
-    "OST_CurtainGrids",
-    "OST_CurtainGridsCurtaSystem",
-    "OST_CurtainGridsRoof",
-    "OST_CurtainGridsSystem",
-    "OST_CurtainGridsWall",
-    "OST_Curtain_Systems",
-    "OST_CurtainWallMullions",
-    "OST_CurtainWallPanels",
-    "OST_Floors",
-    "OST_Furniture",
-    "OST_FurnitureSystems",
-    "OST_Roofs",
-    "OST_StackedWalls",
-    "OST_Walls",
+    new("OST_Ceilings", "Ceilings"),
+    new("OST_Columns", "Columns"),
+    new("OST_CurtainGrids", "Curtain Grids"),
+    new("OST_CurtainGridsCurtaSystem", "Curtain Grids - Curtain System"),
+    new("OST_CurtainGridsRoof", "Curtain Grids - Roof"),
+    new("OST_CurtainGridsSystem", "Curtain Grids - System"),
+    new("OST_CurtainGridsWall", "Curtain Grids - Wall"),
+    new("OST_Curtain_Systems", "Curtain Systems"),
+    new("OST_CurtainWallMullions", "Curtain Wall Mullions"),
+    new("OST_CurtainWallPanels", "Curtain Wall Panels"),
+    new("OST_Floors", "Floors"),
+    new("OST_Furniture", "Furniture"),
+    new("OST_FurnitureSystems", "Furniture Systems"),
+    new("OST_Roofs", "Roofs"),
+    new("OST_StackedWalls", "Stacked Walls"),
+    new("OST_Walls", "Walls"),
     // STRUCTURAL
-    "OST_StructuralColumns",
-    "OST_StructuralFoundation",
-    "OST_StructuralFraming",
-    "OST_StructuralFramingSystem",
-    "OST_StructuralTruss",
+    new("OST_StructuralColumns", "Structural Columns"),
+    new("OST_StructuralFoundation", "Structural Foundation"),
+    new("OST_StructuralFraming", "Structural Framing"),
+    new("OST_StructuralFramingSystem", "Structural Framing System"),
+    new("OST_StructuralTruss", "Structural Truss"),
     // MISC
-    "OST_Levels",
-    "OST_Grids",
-    "OST_Rooms",
-    "OST_Areas",
+    new("OST_Levels", "Levels"),
+    new("OST_Grids", "Grids"),
+    new("OST_Rooms", "Rooms"),
+    new("OST_Areas", "Areas"),
     // MEP
-    "OST_DuctCurves",
-    "OST_DuctSystem",
-    "OST_DuctFitting",
-    "OST_PipeCurves",
-    "OST_PipeCurvesCenterLine",
-    "OST_PipeSegments",
-    "OST_PipeFitting",
-    "OST_Conduit",
-    "OST_ConduitFitting",
-    "OST_Cable",
-    "OST_CableTray",
-    "OST_CableTrayFitting"
+    new("OST_DuctCurves", "Duct Curves"),
+    new("OST_DuctSystem", "Duct System"),
+    new("OST_DuctFitting", "Duct Fitting"),
+    new("OST_PipeCurves", "Pipe Curves"),
+    new("OST_PipeCurvesCenterLine", "Pipe Curves - Center Line"),
+    new("OST_PipeSegments", "Pipe Segments"),
+    new("OST_PipeFitting", "Pipe Fitting"),
+    new("OST_Conduit", "Conduit"),
+    new("OST_ConduitFitting", "Conduit Fitting"),
+    new("OST_Cable", "Cable"),
+    new("OST_CableTray", "Cable Tray"),
+    new("OST_CableTrayFitting", "Cable Tray Fitting")
   ];
+
+  /// <summary>
+  /// Gets the human-readable label for a category value.
+  /// </summary>
+  /// <param name="categoryValue">The category enum name (e.g., "OST_Walls")</param>
+  /// <returns>Human-readable label (e.g., "Walls") or the original value if not found</returns>
+  public static string GetLabel(string categoryValue)
+  {
+    var category = Categories.FirstOrDefault(c => c.Value == categoryValue);
+    return category?.Label ?? categoryValue;
+  }
 }

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/HostApp/RevitBuiltInCategoryStore.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/HostApp/RevitBuiltInCategoryStore.cs
@@ -1,0 +1,62 @@
+namespace Speckle.Connectors.Rhino.HostApp;
+
+/// <summary>
+/// Currently hardcoded Revit BuiltInCategories for the Interop Lite mapper.
+/// This provides a select list of commonly used categories for object mapping
+/// from Rhino to Revit.
+///
+/// NOTE: Currently located in Rhino codebase for Rhino-to-Revit POC use case.
+/// When we extend to other connectors implementing a RevitMapper interface,
+/// this should be moved to a shared location (e.g., Speckle.Connectors.Common
+/// or Speckle.Converters.RevitShared).
+/// </summary>
+public static class RevitBuiltInCategoryStore
+{
+  /// <summary>
+  /// Curated list of Revit BuiltInCategory enum names for the lite interop mapper.
+  /// These are the exact enum names as they appear in the Revit API.
+  /// </summary>
+  public static readonly List<string> Categories =
+  [
+    "OST_Ceilings",
+    "OST_Columns",
+    "OST_CurtainGrids",
+    "OST_CurtainGridsCurtaSystem",
+    "OST_CurtainGridsRoof",
+    "OST_CurtainGridsSystem",
+    "OST_CurtainGridsWall",
+    "OST_Curtain_Systems",
+    "OST_CurtainWallMullions",
+    "OST_CurtainWallPanels",
+    "OST_Floors",
+    "OST_Furniture",
+    "OST_FurnitureSystems",
+    "OST_Roofs",
+    "OST_StackedWalls",
+    "OST_Walls",
+    // STRUCTURAL
+    "OST_StructuralColumns",
+    "OST_StructuralFoundation",
+    "OST_StructuralFraming",
+    "OST_StructuralFramingSystem",
+    "OST_StructuralTruss",
+    // MISC
+    "OST_Levels",
+    "OST_Grids",
+    "OST_Rooms",
+    "OST_Areas",
+    // MEP
+    "OST_DuctCurves",
+    "OST_DuctSystem",
+    "OST_DuctFitting",
+    "OST_PipeCurves",
+    "OST_PipeCurvesCenterLine",
+    "OST_PipeSegments",
+    "OST_PipeFitting",
+    "OST_Conduit",
+    "OST_ConduitFitting",
+    "OST_Cable",
+    "OST_CableTray",
+    "OST_CableTrayFitting"
+  ];
+}

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/Mapper/Revit/RevitBuiltInCategoryStore.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/Mapper/Revit/RevitBuiltInCategoryStore.cs
@@ -1,6 +1,6 @@
 // TODO: Where should this live? Speckle.Connectors.Common.Interop??
 
-namespace Speckle.Connectors.Rhino.HostApp;
+namespace Speckle.Connectors.Rhino.Mapper.Revit;
 
 /// <summary>
 /// Represents a category option for the dropdown in the UI.

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/Registration/ServiceRegistration.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/Registration/ServiceRegistration.cs
@@ -50,6 +50,7 @@ public static class ServiceRegistration
     serviceCollection.AddSingleton<IBinding, RhinoSelectionBinding>();
     serviceCollection.AddSingleton<IBinding, RhinoSendBinding>();
     serviceCollection.AddSingleton<IBinding, RhinoReceiveBinding>();
+    serviceCollection.AddSingleton<IBinding, RhinoMapperBinding>();
 
     // register send filters
     serviceCollection.AddScoped<ISendFilter, RhinoSelectionFilter>();

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/Speckle.Connectors.RhinoShared.projitems
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/Speckle.Connectors.RhinoShared.projitems
@@ -23,6 +23,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bindings\RhinoSelectionBinding.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\AttributeExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HostApp\Properties\PropertiesExtractor.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)HostApp\RevitBuiltInCategoryStore.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HostApp\RhinoIdleManager.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HostApp\RhinoUtils.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Operations\Send\Filters\RhinoSelectionFilter.cs" />

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/Speckle.Connectors.RhinoShared.projitems
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/Speckle.Connectors.RhinoShared.projitems
@@ -24,9 +24,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bindings\RhinoSelectionBinding.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\AttributeExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HostApp\Properties\PropertiesExtractor.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)HostApp\RevitBuiltInCategoryStore.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HostApp\RhinoIdleManager.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HostApp\RhinoUtils.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Mapper\Revit\RevitBuiltInCategoryStore.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Operations\Send\Filters\RhinoSelectionFilter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Operations\Send\Filters\RhinoLayersFilter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)RhinoEvents.cs" />

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/Speckle.Connectors.RhinoShared.projitems
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/Speckle.Connectors.RhinoShared.projitems
@@ -18,6 +18,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)Bindings\RhinoBasicConnectorBinding.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bindings\RhinoMapperBinding.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bindings\RhinoReceiveBinding.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bindings\RhinoSendBinding.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bindings\RhinoSelectionBinding.cs" />

--- a/Converters/Revit/Speckle.Converters.RevitShared/ToHost/Raw/LocalToGlobalToDirectShapeConverter.cs
+++ b/Converters/Revit/Speckle.Converters.RevitShared/ToHost/Raw/LocalToGlobalToDirectShapeConverter.cs
@@ -2,7 +2,6 @@ using Speckle.Converters.Common;
 using Speckle.Converters.Common.Objects;
 using Speckle.Converters.RevitShared.Settings;
 using Speckle.DoubleNumerics;
-using Speckle.Objects.Data;
 using Speckle.Sdk.Common;
 using Speckle.Sdk.Models;
 using Speckle.Sdk.Models.Extensions;
@@ -35,12 +34,13 @@ public class LocalToGlobalToDirectShapeConverter
     // NOTE: previously, builtInCategory was on the atomicObject level. this was subsequently moved to properties
     string? category = null;
 
-    if (target.atomicObject is DataObject dataObject)
+    // NOTE: no longer limited to DataObject since the introduction of mapper
+    if (
+      target.atomicObject["properties"] is Dictionary<string, object?> properties
+      && properties.TryGetValue("builtInCategory", out var builtInCategory)
+    )
     {
-      if (dataObject.properties.TryGetValue("builtInCategory", out var builtInCategory))
-      {
-        category = builtInCategory?.ToString();
-      }
+      category = builtInCategory?.ToString();
     }
 
     var dsCategory = DB.BuiltInCategory.OST_GenericModel;

--- a/Converters/Revit/Speckle.Converters.RevitShared/ToHost/Raw/LocalToGlobalToDirectShapeConverter.cs
+++ b/Converters/Revit/Speckle.Converters.RevitShared/ToHost/Raw/LocalToGlobalToDirectShapeConverter.cs
@@ -35,6 +35,8 @@ public class LocalToGlobalToDirectShapeConverter
     string? category = null;
 
     // NOTE: no longer limited to DataObject since the introduction of mapper
+    // The change from `if (target.atomicObject is DataObject dataObject)` is very hacky, but nothing else to do for now
+    // TODO: better define prop interfaces for different applications
     if (
       target.atomicObject["properties"] is Dictionary<string, object?> properties
       && properties.TryGetValue("builtInCategory", out var builtInCategory)


### PR DESCRIPTION
## Description
Rhino-to-Revit object mapping for categories (**LITE**). Users can assign Rhino geometry to specific Revit `BuiltInCategory` values through the UI. The mapping data is stored as user strings on Rhino objects and stored as a prop during send operations.

Related to [Interop Lite Project](https://linear.app/speckle/project/interop-lite-80ec82529c1a).

## User Value
Interoperability **LITE** between Rhino and Revit by allowing users to pre-assign Revit categories to Rhino objects before publishing.

## Changes:
- Added `RhinoMapperBinding` with category assignment/clearing functionality
- Added `RevitBuiltInCategoryStore` with select hardcoded Revit categories  

## Validation of changes:
https://github.com/user-attachments/assets/4276ce0a-c20f-42d4-b4ba-cfd7498a8b51

## Checklist:
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] I have added appropriate tests.
- [x] I have updated or added relevant documentation.

