### PR TITLE
feat(etabs): add UI integration for dynamic result type selection

### DIFF
--- a/Connectors/CSi/Speckle.Connectors.CSiShared/Bindings/CsiSharedSendBinding.cs
+++ b/Connectors/CSi/Speckle.Connectors.CSiShared/Bindings/CsiSharedSendBinding.cs
@@ -64,7 +64,8 @@ public sealed class CsiSharedSendBinding : ISendBinding
           .Initialize(
             _csiConversionSettingsFactory.Create(
               _csiApplicationService.SapModel,
-              _toSpeckleSettingsManager.GetLoadCasesAndCombinations(card)
+              _toSpeckleSettingsManager.GetLoadCasesAndCombinations(card),
+              _toSpeckleSettingsManager.GetResultTypes(card)
             )
           );
       },

--- a/Connectors/CSi/Speckle.Connectors.CSiShared/HostApp/Helpers/CsiResultsExtractorFactory.cs
+++ b/Connectors/CSi/Speckle.Connectors.CSiShared/HostApp/Helpers/CsiResultsExtractorFactory.cs
@@ -1,0 +1,21 @@
+using Microsoft.Extensions.DependencyInjection;
+using Speckle.Converters.CSiShared.ToSpeckle.Helpers;
+
+namespace Speckle.Connectors.CSiShared.HostApp.Helpers;
+
+public class CsiResultsExtractorFactory
+{
+  private readonly IServiceProvider _serviceProvider;
+
+  public CsiResultsExtractorFactory(IServiceProvider serviceProvider)
+  {
+    _serviceProvider = serviceProvider;
+  }
+
+  public IApplicationResultsExtractor GetExtractor(string resultsKey) =>
+    resultsKey switch
+    {
+      "FrameForces" => _serviceProvider.GetRequiredService<CsiFrameForceResultsExtractor>(),
+      _ => throw new InvalidOperationException($"{resultsKey} not accounted for in CsiResultsExtractorFactory")
+    };
+}

--- a/Connectors/CSi/Speckle.Connectors.CSiShared/Operations/Send/CsiRootObjectBuilder.cs
+++ b/Connectors/CSi/Speckle.Connectors.CSiShared/Operations/Send/CsiRootObjectBuilder.cs
@@ -120,6 +120,7 @@ public class CsiRootObjectBuilder : IRootObjectBuilder<ICsiWrapper>
       rootObjectCollection[ProxyKeys.SECTION] = _sectionUnpacker.UnpackSections().ToList();
     }
 
+    // Extract analysis results (if applicable)
     // NOTE: used in the results extraction to extract results for objects being published only
     var objectSelectionSummary = GetObjectSummary(csiObjects);
     var selectedCasesAndCombinations = _converterSettings.Current.SelectedLoadCasesAndCombinations;

--- a/Connectors/CSi/Speckle.Connectors.CSiShared/ServiceRegistration.cs
+++ b/Connectors/CSi/Speckle.Connectors.CSiShared/ServiceRegistration.cs
@@ -46,6 +46,7 @@ public static class ServiceRegistration
     services.AddScoped<SendOperation<ICsiWrapper>>();
 
     services.AddScoped<CsiMaterialPropertyExtractor>();
+    services.AddScoped<CsiResultsExtractorFactory>();
     services.AddScoped<MaterialUnpacker>();
     services.AddScoped<IFrameSectionPropertyExtractor, CsiFrameSectionPropertyExtractor>();
     services.AddScoped<IShellSectionPropertyExtractor, CsiShellSectionPropertyExtractor>();

--- a/Connectors/CSi/Speckle.Connectors.CSiShared/Settings/ResultTypeSetting.cs
+++ b/Connectors/CSi/Speckle.Connectors.CSiShared/Settings/ResultTypeSetting.cs
@@ -8,5 +8,5 @@ public class ResultTypeSetting(List<string> values) : ICardSetting
   public string? Title { get; set; } = "Result Type";
   public string? Type { get; set; } = "array";
   public object? Value { get; set; } = values;
-  public List<string>? Enum { get; set; } = new List<string> { "Joint Reactions", "Joint Displacements", };
+  public List<string>? Enum { get; set; } = ["FrameForces"];
 }

--- a/Connectors/CSi/Speckle.Connectors.CSiShared/Speckle.Connectors.CSiShared.projitems
+++ b/Connectors/CSi/Speckle.Connectors.CSiShared/Speckle.Connectors.CSiShared.projitems
@@ -18,6 +18,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bindings\CsiSharedSelectionBinding.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bindings\CsiSharedSendBinding.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Filters\CsiSharedSelectionFilter.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)HostApp\Helpers\CsiResultsExtractorFactory.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HostApp\MaterialUnpacker.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HostApp\CsiSendCollectionManager.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HostApp\Helpers\CsiFrameSectionPropertyExtractor.cs" />

--- a/Converters/CSi/Speckle.Converters.CSiShared/CsiConversionSettings.cs
+++ b/Converters/CSi/Speckle.Converters.CSiShared/CsiConversionSettings.cs
@@ -3,5 +3,6 @@ namespace Speckle.Converters.CSiShared;
 public record CsiConversionSettings(
   cSapModel SapModel,
   string SpeckleUnits,
-  List<string>? SelectedLoadCasesAndCombinations = null
+  List<string>? SelectedLoadCasesAndCombinations = null,
+  List<string>? SelectedResultTypes = null
 );

--- a/Converters/CSi/Speckle.Converters.CSiShared/CsiConversionSettingsFactory.cs
+++ b/Converters/CSi/Speckle.Converters.CSiShared/CsiConversionSettingsFactory.cs
@@ -11,6 +11,15 @@ public class CsiConversionSettingsFactory(
 {
   public CsiConversionSettings Current => settingsStore.Current;
 
-  public CsiConversionSettings Create(cSapModel document, List<string>? selectedLoadCasesAndCombinations = null) =>
-    new(document, unitsConverter.ConvertOrThrow(document.GetPresentUnits()), selectedLoadCasesAndCombinations ?? []);
+  public CsiConversionSettings Create(
+    cSapModel document,
+    List<string>? selectedLoadCasesAndCombinations = null,
+    List<string>? selectedResultTypes = null
+  ) =>
+    new(
+      document,
+      unitsConverter.ConvertOrThrow(document.GetPresentUnits()),
+      selectedLoadCasesAndCombinations ?? [],
+      selectedResultTypes ?? []
+    );
 }

--- a/Converters/CSi/Speckle.Converters.CSiShared/ToSpeckle/Helpers/CsiFrameForceResultsExtractor.cs
+++ b/Converters/CSi/Speckle.Converters.CSiShared/ToSpeckle/Helpers/CsiFrameForceResultsExtractor.cs
@@ -9,6 +9,7 @@ public sealed class CsiFrameForceResultsExtractor : IApplicationResultsExtractor
   private readonly ResultsArrayProcessor _resultsArrayProcessor;
 
   public string ResultsKey => "FrameForces";
+  public ModelObjectType TargetObjectType => ModelObjectType.FRAME;
 
   public ResultsConfiguration Configuration { get; } =
     new(["Elm", "LoadCase", "Wrap:ElmSta", "Wrap:StepNum"], ["P", "V2", "V3", "T", "M2", "M3"]);

--- a/Converters/CSi/Speckle.Converters.CSiShared/ToSpeckle/Helpers/IApplicationResultsExtractor.cs
+++ b/Converters/CSi/Speckle.Converters.CSiShared/ToSpeckle/Helpers/IApplicationResultsExtractor.cs
@@ -15,6 +15,12 @@ public interface IApplicationResultsExtractor
   string ResultsKey { get; }
 
   /// <summary>
+  /// Gets the type of CSI model objects that this extractor operates on.
+  /// Used to automatically resolve the correct object names from the selection summary.
+  /// </summary>
+  ModelObjectType TargetObjectType { get; }
+
+  /// <summary>
   /// Gets the configuration defining how to process raw API arrays into hierarchical structure.
   /// Specifies grouping hierarchy and result value keys.
   /// </summary>


### PR DESCRIPTION
## Description
Integrates analysis results extraction with UI settings system. Users can now select result types through the connector interface, replacing hard-coded extraction logic.

Relates to [CNX-2239](https://linear.app/speckle/issue/CNX-2239/integrate-results-type-dropdown-to-extractor)

## User Value
Users can dynamically choose which analysis result types to extract without code changes.

## Changes:
- Added `CsiResultsExtractorFactory` for dynamic extractor resolution
- Updated `IApplicationResultsExtractor` with `TargetObjectType` property
- Integrated `ResultTypeSetting` with extractor factory
- Modified `CsiRootObjectBuilder` to use factory-based extraction loop
- Connected UI settings to converter settings pipeline

## Validation of changes:
Result type selection now flows from UI dropdown through settings manager to extractor factory, enabling dynamic result extraction based on user selection.

## Checklist:
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] I have added appropriate tests.
- [x] I have updated or added relevant documentation.