### PR TITLE
feat(rhino): add category mapping query methods for revit mapper

### DIFF
--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/Bindings/RhinoMapperBinding.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/Bindings/RhinoMapperBinding.cs
@@ -165,6 +165,19 @@ public class RhinoMapperBinding : IBinding
     return mappedObjects;
   }
 
+  /// <summary>
+  /// Gets category mappings for specific object IDs.
+  /// </summary>
+  public string[] GetCategoryMappingsForObjects(string[] objectIds) =>
+    objectIds
+      .Select(id =>
+        _rhinoObjectHelper.GetRhinoObject(id)?.Attributes.GetUserString(RevitMappingConstants.CATEGORY_USER_STRING_KEY)
+      )
+      .Where(category => category != null)
+      .Cast<string>()
+      .Distinct()
+      .ToArray();
+
   #endregion
 
   #region UI Methods - Layer Mapping Methods
@@ -240,6 +253,17 @@ public class RhinoMapperBinding : IBinding
 
     return mappedLayers;
   }
+
+  /// <summary>
+  /// Gets category mappings for specific layer IDs.
+  /// </summary>
+  public string[] GetCategoryMappingsForLayers(string[] layerIds) =>
+    layerIds
+      .Select(id => _rhinoLayerHelper.GetLayer(id)?.GetUserString(RevitMappingConstants.CATEGORY_USER_STRING_KEY))
+      .Where(category => !string.IsNullOrEmpty(category))
+      .Cast<string>()
+      .Distinct()
+      .ToArray();
 
   public string[] GetEffectiveObjectsForLayerMapping(string[] layerIds, string categoryValue) =>
     _revitMappingResolver.GetEffectiveObjectsForLayerMapping(layerIds, categoryValue);


### PR DESCRIPTION
## Description
Added methods to query existing category mappings for objects and layers, enabling the frontend to display current mapping state in the dropdown.

## User Value
Users can now see what category mappings are already applied to their selected objects/layers. See https://github.com/specklesystems/speckle-connectors-dui/pull/48.

## Changes:
- Added `GetCategoryMappingsForObjects()` method to return a set (i.e. unique list) of categories for given object IDs
- Added `GetCategoryMappingsForLayers()` method to return distinct categories for given layer IDs

## Validation of changes:
https://github.com/user-attachments/assets/c11a855c-6fd7-4750-87e2-e19f3bdc07be