### PR TITLE
fix(revit): Revit files persist model card data to a file like Tekla instead of into the file

### DIFF
--- a/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/RevitDocumentStore.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/RevitDocumentStore.cs
@@ -105,7 +105,8 @@ internal sealed class RevitDocumentStore : DocumentModelStore
     }
     catch (Exception ex) when (!ex.IsFatal())
     {
-      _logger.LogError(ex.Message);
+      var key = document.ProjectInformation.UniqueId.NotNull();
+      _logger.LogError(ex, "Failed to save model card state for document {DocumentId}", key);
     }
   }
 

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/RevitDocumentStore.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/RevitDocumentStore.cs
@@ -32,7 +32,9 @@ internal sealed class RevitDocumentStore : DocumentModelStore
     DocumentModelStorageSchema documentModelStorageSchema,
     ITopLevelExceptionHandler topLevelExceptionHandler,
     IRevitTask revitTask,
-    ISqLiteJsonCacheManagerFactory jsonCacheManagerFactory, ILogger<RevitDocumentStore> logger1)
+    ISqLiteJsonCacheManagerFactory jsonCacheManagerFactory,
+    ILogger<RevitDocumentStore> logger1
+  )
     : base(logger, jsonSerializer)
   {
     _jsonCacheManager = jsonCacheManagerFactory.CreateForUser("ConnectorsFileData");
@@ -107,7 +109,7 @@ internal sealed class RevitDocumentStore : DocumentModelStore
       _logger.LogError(ex.Message);
     }
   }
-  
+
   protected override void LoadState()
   {
     var document = _revitContext.UIApplication?.ActiveUIDocument?.Document;

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/RevitDocumentStore.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/RevitDocumentStore.cs
@@ -25,7 +25,6 @@ internal sealed class RevitDocumentStore : DocumentModelStore
   private readonly ISqLiteJsonCacheManager _jsonCacheManager;
 
   public RevitDocumentStore(
-    ILogger<DocumentModelStore> logger,
     IAppIdleManager idleManager,
     RevitContext revitContext,
     IJsonSerializer jsonSerializer,
@@ -33,7 +32,7 @@ internal sealed class RevitDocumentStore : DocumentModelStore
     ITopLevelExceptionHandler topLevelExceptionHandler,
     IRevitTask revitTask,
     ISqLiteJsonCacheManagerFactory jsonCacheManagerFactory,
-    ILogger<RevitDocumentStore> logger1
+    ILogger<RevitDocumentStore> logger
   )
     : base(logger, jsonSerializer)
   {
@@ -42,7 +41,7 @@ internal sealed class RevitDocumentStore : DocumentModelStore
     _revitContext = revitContext;
     _documentModelStorageSchema = documentModelStorageSchema;
     _topLevelExceptionHandler = topLevelExceptionHandler;
-    _logger = logger1;
+    _logger = logger;
 
     UIApplication uiApplication = _revitContext.UIApplication.NotNull();
 


### PR DESCRIPTION
This avoids locking issues for sharing in Autodesk Work Sharing

This does what Tekla does

This pull request refactors how the `RevitDocumentStore` persists and loads its state, moving away from storing data within the Revit document itself to using a user-scoped SQLite JSON cache. This change simplifies the persistence logic and removes dependencies on Revit's `DataStorage` and threading context.

**Persistence and state management changes:**

* Replaced the use of Revit's `DataStorage` and custom storage schemas for saving and loading state with a user-scoped SQLite JSON cache managed by `ISqLiteJsonCacheManager`. The state is now keyed by the project's unique ID. [[1]](diffhunk://#diff-62f93bf406e759ce39f8825f80bfa0cbe8417b98195028ec9440d8e3b8c4c120L6-R45) [[2]](diffhunk://#diff-62f93bf406e759ce39f8825f80bfa0cbe8417b98195028ec9440d8e3b8c4c120L104-R130)
* Removed threading context (`IThreadContext`) and main-thread invocation logic, as persistence no longer requires Revit document transactions. [[1]](diffhunk://#diff-62f93bf406e759ce39f8825f80bfa0cbe8417b98195028ec9440d8e3b8c4c120L6-R45) [[2]](diffhunk://#diff-62f93bf406e759ce39f8825f80bfa0cbe8417b98195028ec9440d8e3b8c4c120L104-R130)
* Updated error handling to log exceptions when saving state fails, instead of relying on transaction rollback.

**Dependency and constructor updates:**

* Updated the constructor to inject `ISqLiteJsonCacheManagerFactory` and use it to create a cache manager instance for user data.
* Removed unused dependencies related to document storage and threading.