### PR TITLE
fix(revit): improve error messages when publishing fails

### DIFF
--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/RevitRootObjectBuilder.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/RevitRootObjectBuilder.cs
@@ -225,10 +225,9 @@ public class RevitRootObjectBuilder(
       }
     }
 
-    // if we ended up skipping everything, there is a reason for this, so we shouldn't hit users with a
-    // "failed to convert all" message. at least this way, they can check their inputs
-    // this can occur if a published view contains only unsupported objects or if user trying to ONLY send linked
-    // model docs but the setting is disabled
+    // if we ended up skipping everything, there is a reason for this, that users can diagnose themselves
+    // this can occur if a published view contains only unsupported objects or if user trying to ONLY send linked model
+    // docs but the setting is disabled
     if (skippedObjectCount == atomicObjectCount)
     {
       throw new SpeckleException("No supported objects visible. Update publish filter or check publish settings.");

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/RevitRootObjectBuilder.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/RevitRootObjectBuilder.cs
@@ -225,7 +225,17 @@ public class RevitRootObjectBuilder(
       }
     }
 
-    if (results.All(x => x.Status == Status.ERROR) || skippedObjectCount == atomicObjectCount)
+    // if we ended up skipping everything, there is a reason for this, so we shouldn't hit users with a
+    // "failed to convert all" message. at least this way, they can check their inputs
+    // this can occur if a published view contains only unsupported objects or if user trying to ONLY send linked
+    // model docs but the setting is disabled
+    if (skippedObjectCount == atomicObjectCount)
+    {
+      throw new SpeckleException("No supported objects visible. Update publish filter or check publish settings.");
+    }
+
+    // this is, I suppose, fully on us?
+    if (results.All(x => x.Status == Status.ERROR))
     {
       throw new SpeckleException("Failed to convert all objects.");
     }

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Plugin/SpeckleRevitTaskException.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Plugin/SpeckleRevitTaskException.cs
@@ -7,7 +7,7 @@ using Speckle.Sdk.Common;
 namespace Speckle.Connectors.Revit.Plugin;
 
 #pragma warning disable CA1032
-public class SpeckleRevitTaskException(Exception exception) : SpeckleException("Revit operation failed", exception)
+public class SpeckleRevitTaskException(Exception exception) : SpeckleException(exception.Message, exception)
 #pragma warning restore CA1032
 {
   public static async Task ProcessException<T>(


### PR DESCRIPTION
## Description

Fixed UX where users saw generic `Revit operation failed` instead of actionable error messages when publishing failed due to view visibility or unsupported objects.

## User Value

Users now see clear, actionable error messages like "No supported objects visible. Update publish filter or check publish settings." instead of a generic error, where they don't know what to do -> post something on the forum -> have to send logs etc. etc.

## Changes:

- Updated `SpeckleRevitTaskException` to show inner exception message instead of generic `Revit operation failed`
- Split error handling logic in `RevitRootObjectBuilder` to distinguish between skipped objects vs conversion failures
- Added specific error message for when all objects are filtered out due to view visibility or unsupported categories

## Screenshots:

**Before:** "Revit operation failed" 
Unless user really knows what's going on, they won't know how to fix it.

https://github.com/user-attachments/assets/b851cb91-d6bf-4b3e-9b0c-d8ed816636aa

**After:** "No supported objects visible. Update publish filter or check publish settings."
Hopefully a more descriptive error, saying "hey, we don't have anything for you to convert"

https://github.com/user-attachments/assets/4f5f8cf1-19a1-4681-95b9-3f14d8dacc66

## Checklist:

- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] I have added appropriate tests.
- [x] I have updated or added relevant documentation.