### PR TITLE
fix(rhino): block instances now respect layer visibility of constituent objects

### DIFF
--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/HostApp/RhinoLayerHelper.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/HostApp/RhinoLayerHelper.cs
@@ -131,4 +131,24 @@ public class RhinoLayerHelper
       }
     }
   }
+
+  /// <summary>
+  /// Checks if a layer is visible by its index.
+  /// </summary>
+  public bool IsLayerVisible(int layerIndex)
+  {
+    if (layerIndex < 0 || layerIndex >= RhinoDoc.ActiveDoc.Layers.Count)
+    {
+      return true; // default to visible for invalid indices (safe fallback)
+    }
+
+    var layer = RhinoDoc.ActiveDoc.Layers[layerIndex];
+    return layer != null && !layer.IsDeleted && layer.IsVisible;
+  }
+
+  /// <summary>
+  /// Filters a collection of objects to only include those on visible layers.
+  /// </summary>
+  public IEnumerable<T> FilterByLayerVisibility<T>(IEnumerable<T> objects)
+    where T : RhinoObject => objects.Where(obj => IsLayerVisible(obj.Attributes.LayerIndex));
 }


### PR DESCRIPTION
## Description
Block instances in Rhino were publishing all constituent objects regardless of layer visibility state of the constituent objects. When you create a block from objects on multiple layers, then hide some of those layers, the block instance should only show/publish the objects from visible layers - matching native Rhino behavior.

The fix filters objects during instance unpacking to only include those on visible layers. Related to [CNX-2254](https://linear.app/speckle/issue/CNX-2254/rhino-publish-blocks-with-hidden-objects).

## User Value
Block instances now behave consistently with Rhino's native layer visibility - hidden layer objects within blocks are properly excluded from selection and publishing.

## Changes:
- Added `IsLayerVisible()` and `FilterByLayerVisibility<T>()` methods to `RhinoLayerHelper`
- Modified `RhinoInstanceUnpacker.UnpackInstance()` to filter objects by layer visibility before adding to definition

## Validation of changes:
- Create block from objects on Layer 1 (visible) and Layer 2 (hidden)
- Turn off Layer 2 visibility  
- Select and publish block instance
- Verify only Layer 1 objects are included in published data
- Test nested blocks with mixed layer visibility

## Performance implications:
_TBD_

## Checklist:
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] I have added appropriate tests.
- [x] I have updated or added relevant documentation.