### PR TITLE
fix(rhino): Workaround for rhino materials being null in importer

### DIFF
--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/HostApp/RhinoMaterialUnpacker.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/HostApp/RhinoMaterialUnpacker.cs
@@ -177,7 +177,7 @@ public class RhinoMaterialUnpacker
   }
 
   // converts a rhino material to a rhino render material
-  private RenderMaterial? ConvertMaterialToRenderMaterial(Material material)
+  private static RenderMaterial? ConvertMaterialToRenderMaterial(Material material)
   {
     // get physically based render material
     Material pbMaterial = material;
@@ -188,7 +188,18 @@ public class RhinoMaterialUnpacker
       pbMaterial.ToPhysicallyBased();
     }
 
-    return RenderMaterial.FromMaterial(pbMaterial, null);
+    var result = RenderMaterial.FromMaterial(pbMaterial, null);
+
+    if (result is null)
+    {
+      // We're seeing some weird behaviour running in the File Importer
+      // where RenderMaterial.FromMaterial returns null.
+      // Could be related to headless RhinoDoc or windowless RhinoCore (unsure the cause)
+      // CreateBasicMaterial appears to work, so we'll use it as fall back
+      result = RenderMaterial.CreateBasicMaterial(pbMaterial, null);
+    }
+
+    return result;
   }
 
   private SpeckleRenderMaterial ConvertRenderMaterialToSpeckle(RenderMaterial renderMaterial)


### PR DESCRIPTION
In cases where there's no `RenderMaterial` on a rhino object, but there is a `Material` applied to a geometry we use the `RenderMaterial.FromMaterial` function to create a new `RenderMaterial` from that `Material` to perform conversion.
But for some reason, this function returns null consistently for our importer.
Perhaps it's because converting things from a headless rhino. Or from windowsless rhino (where some rendering engine parts might not be initalised)

This feels like a bug in Rhino. So I'm tempted to report it to McNeel.

However, I have found this workaround that might work nicely for us.

Using `RenderMaterial.CreateBasicMaterial` as fallback appears to work for the importer.

I'll be honest, I'm not sure I understand the difference between this function and `RenderMaterial.FromMaterial`, so there's a chance this does give us a slightly different result. But visually the materials I tested end up looking the same.
