### PR TITLE
feat(metrics): Add metrics to rhino Importer

### DIFF
--- a/Importers/Rhino/Speckle.Importers.JobProcessor/Domain/FileimportPayload.cs
+++ b/Importers/Rhino/Speckle.Importers.JobProcessor/Domain/FileimportPayload.cs
@@ -11,6 +11,8 @@ internal sealed class FileimportPayload
   public required string JobType { get; init; }
   public required string ModelId { get; init; }
   public required string FileName { get; init; }
+
+  /// <summary>File extension, no dot</summary>
   public required string FileType { get; init; }
   public required string ProjectId { get; init; }
   public required Uri ServerUrl { get; init; }

--- a/Importers/Rhino/Speckle.Importers.JobProcessor/JobHandlers/IPCModels.cs
+++ b/Importers/Rhino/Speckle.Importers.JobProcessor/JobHandlers/IPCModels.cs
@@ -1,4 +1,6 @@
-﻿using Speckle.Sdk.Credentials;
+﻿using Speckle.Sdk;
+using Speckle.Sdk.Api.GraphQL.Models;
+using Speckle.Sdk.Credentials;
 using Version = Speckle.Sdk.Api.GraphQL.Models.Version;
 
 namespace Speckle.Importers.JobProcessor.JobHandlers;
@@ -11,9 +13,10 @@ internal readonly struct ImporterArgs
   public required string BlobId { get; init; }
   public required int Attempt { get; init; }
   public required string ResultsPath { get; init; }
-  public required string ProjectId { get; init; }
+  public required Project Project { get; init; }
   public required string ModelId { get; init; }
   public required Account Account { get; init; }
+  public required Application HostApplication { get; init; }
 }
 
 public readonly struct ImporterResponse

--- a/Importers/Rhino/Speckle.Importers.Rhino/Internal/IPCModels.cs
+++ b/Importers/Rhino/Speckle.Importers.Rhino/Internal/IPCModels.cs
@@ -1,4 +1,6 @@
-﻿using Speckle.Sdk.Credentials;
+﻿using Speckle.Sdk;
+using Speckle.Sdk.Api.GraphQL.Models;
+using Speckle.Sdk.Credentials;
 using Version = Speckle.Sdk.Api.GraphQL.Models.Version;
 
 namespace Speckle.Importers.Rhino.Internal;
@@ -11,9 +13,10 @@ internal readonly struct ImporterArgs
   public required string BlobId { get; init; }
   public required int Attempt { get; init; }
   public required string ResultsPath { get; init; }
-  public required string ProjectId { get; init; }
+  public required Project Project { get; init; }
   public required string ModelId { get; init; }
   public required Account Account { get; init; }
+  public required Application HostApplication { get; init; }
 }
 
 public readonly struct ImporterResponse

--- a/Importers/Rhino/Speckle.Importers.Rhino/Internal/Sender.cs
+++ b/Importers/Rhino/Speckle.Importers.Rhino/Internal/Sender.cs
@@ -2,11 +2,12 @@
 using Microsoft.Extensions.Logging;
 using Rhino;
 using Rhino.DocObjects;
-using Speckle.Connectors.Common;
+using Speckle.Connectors.Common.Analytics;
 using Speckle.Connectors.Common.Operations;
 using Speckle.Converters.Common;
 using Speckle.Converters.Rhino;
 using Speckle.Sdk;
+using Speckle.Sdk.Api.GraphQL.Models;
 using Speckle.Sdk.Credentials;
 using Speckle.Sdk.Logging;
 using Version = Speckle.Sdk.Api.GraphQL.Models.Version;
@@ -17,16 +18,13 @@ internal sealed class Sender(
   ISdkActivityFactory activityFactory,
   IServiceProvider serviceProvider,
   IRhinoConversionSettingsFactory rhinoConversionSettingsFactory,
+  IMixPanelManager mixpanel,
   Progress progress,
+  Application applicationInfo,
   ILogger<Sender> logger
 )
 {
-  public async Task<Version> Send(
-    string projectId,
-    string modelId,
-    Account account,
-    CancellationToken cancellationToken
-  )
+  public async Task<Version> Send(Project project, string modelId, Account account, CancellationToken cancellationToken)
   {
     // NOTE: introduction of AddVisualizationProperties setting not accounted for, hence hardcoded as true (i.e. "as before")
     using var activity = activityFactory.Start();
@@ -46,18 +44,26 @@ internal sealed class Sender(
     }
 
     var operation = scope.ServiceProvider.GetRequiredService<SendOperation<RhinoObject>>();
-    var buildResults = await operation.Build(rhinoObjects, projectId, progress, cancellationToken);
+    var buildResults = await operation.Build(rhinoObjects, project.id, progress, cancellationToken);
     var (results, version) = await operation.Send(
       buildResults.RootObject,
-      projectId,
+      project.id,
       modelId,
-      HostApplications.RhinoImporter.Name,
+      applicationInfo.Slug,
       null,
       account,
       progress,
       cancellationToken
     );
 
+    Dictionary<string, object> customProperties = [];
+    customProperties.Add("actionSource", "import");
+    if (project.workspaceId != null)
+    {
+      customProperties.Add("workspace_id", project.workspaceId);
+    }
+
+    await mixpanel.TrackEvent(MixPanelEvents.Send, account, customProperties);
     logger.LogInformation($"Root: {results.RootId}");
 
     return version;

--- a/Importers/Rhino/Speckle.Importers.Rhino/Internal/ServiceRegistration.cs
+++ b/Importers/Rhino/Speckle.Importers.Rhino/Internal/ServiceRegistration.cs
@@ -3,15 +3,17 @@ using Speckle.Connectors.Common;
 using Speckle.Connectors.Common.Threading;
 using Speckle.Connectors.Rhino.DependencyInjection;
 using Speckle.Converters.Rhino;
+using Speckle.Sdk;
 using Speckle.Sdk.SQLite;
 
 namespace Speckle.Importers.Rhino.Internal;
 
 internal static class ServiceRegistration
 {
-  public static IServiceCollection AddRhinoImporter(this IServiceCollection services)
+  public static IServiceCollection AddRhinoImporter(this IServiceCollection services, Application applicationInfo)
   {
-    services.Initialize(HostApplications.RhinoImporter, HostAppVersion.v8);
+    services.Initialize(applicationInfo, HostAppVersion.v8);
+    services.AddSingleton(applicationInfo);
 
     services.AddRhino(false);
     services.AddRhinoConverters();

--- a/Sdk/Speckle.Connectors.Common/HostApplications.cs
+++ b/Sdk/Speckle.Connectors.Common/HostApplications.cs
@@ -39,14 +39,13 @@ public static class HostApplications
     NET = new(".NET", "net"),
     Navisworks = new("Navisworks", "navisworks"),
     AdvanceSteel = new("Advance Steel", "advancesteel"),
-    Other = new("Other", "other"),
-    RhinoImporter = new("File Import", "fileImport");
+    Other = new("Other", "other");
 
   /// <summary>
   /// Gets a slug from a host application name and version.
   /// </summary>
   /// <param name="appName">Application name with its version, e.g., "Rhino 7", "Revit 2024".</param>
-  /// <remarks>I hate that this function needs to exist</remarks>
+  /// <remarks>This function is soon to be needed only for backwards compatibility</remarks>
   /// <returns>Slug string.</returns>
   public static string GetSlugFromHostAppNameAndVersion(string appName)
   {


### PR DESCRIPTION
Implemented the changes we discussed @gjedlicska @clairekuang for the Rhino importer
I've not touched the other connectors yet, I'll do them in another PR.

This PR adds Mixpanel Send event tracking to the Rhino Importer
It also changes the slugs reported from the importers to include both the file type and "rhino-importer"
so the result is "obj-rhino-importer"

In Mixpanel
<img width="1111" height="1067" alt="image" src="https://github.com/user-attachments/assets/2f4afab3-ca1b-4103-93cc-6d9e2f877cfb" />

in FE
<img width="481" height="250" alt="image" src="https://github.com/user-attachments/assets/a1bb6f4a-7bbb-4688-91a1-c72f88b3eb0a" />

I'm sure we can do something interesting to display this text better in the FE if we wanted