### PR TITLE
fix(Revit) - Never use First() as it can be missing

### DIFF
--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Receive/ToHostSettingsManager.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Receive/ToHostSettingsManager.cs
@@ -19,7 +19,7 @@ public class ToHostSettingsManager : IToHostSettingsManager
 
   public Transform? GetReferencePointSetting(ModelCard modelCard)
   {
-    var referencePointString = modelCard.Settings?.First(s => s.Id == "referencePoint").Value as string;
+    var referencePointString = modelCard.Settings?.FirstOrDefault(s => s.Id == "referencePoint")?.Value as string;
     if (
       referencePointString is not null
       && ReferencePointSetting.ReferencePointMap.TryGetValue(


### PR DESCRIPTION
Better error than this...can still be null?
<img width="1184" height="582" alt="image" src="https://github.com/user-attachments/assets/5f35b3da-7465-4830-bfaf-2e72e6475218" />
