### PR TITLE
fix(grasshopper): QuerySpeckleObjects crashes with type-specific outputs when path is set

### DIFF
--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Objects/QuerySpeckleObjects.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Objects/QuerySpeckleObjects.cs
@@ -136,13 +136,22 @@ public class QuerySpeckleObjects : GH_Component, IGH_VariableParameterComponent
     for (int i = 0; i < Params.Output.Count; i++)
     {
       // determine output values based on parameter type
-      List<SpeckleWrapper> outputValues =
-        i == 0
-          ? filteredObjects
-          : Enum.TryParse(Params.Output[i].Name, out ObjectType filterType)
-          && _filterDict.TryGetValue(filterType, out var filteredList)
-            ? filteredList.Cast<SpeckleWrapper>().ToList()
-            : new List<SpeckleWrapper>();
+      List<SpeckleWrapper> outputValues;
+      if (i == 0)
+      {
+        outputValues = filteredObjects;
+      }
+      else if (
+        Enum.TryParse(Params.Output[i].Name, out ObjectType filterType)
+        && _filterDict.TryGetValue(filterType, out var filteredList)
+      )
+      {
+        outputValues = filteredList.Cast<SpeckleWrapper>().ToList();
+      }
+      else
+      {
+        outputValues = [];
+      }
 
       var outputGoos = outputValues.Select(o => o.CreateGoo()).ToList();
 

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Objects/QuerySpeckleObjects.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Objects/QuerySpeckleObjects.cs
@@ -1,6 +1,5 @@
 using System.Runtime.InteropServices;
 using Grasshopper.Kernel;
-using Grasshopper.Kernel.Types;
 using Rhino.DocObjects;
 using Speckle.Connectors.GrasshopperShared.HostApp;
 using Speckle.Connectors.GrasshopperShared.Parameters;

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Objects/QuerySpeckleObjects.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Objects/QuerySpeckleObjects.cs
@@ -136,10 +136,19 @@ public class QuerySpeckleObjects : GH_Component, IGH_VariableParameterComponent
     // Set output objects
     for (int i = 0; i < Params.Output.Count; i++)
     {
+      // determine output values based on parameter type
       List<SpeckleWrapper> outputValues =
-        i == 0 ? filteredObjects : _filterDict[Filters[i - 1]].Select(o => (SpeckleWrapper)o).ToList();
-      List<IGH_Goo> outputGoos = outputValues.Select(o => o.CreateGoo()).ToList();
-      if (targetCollectionWrapper?.Topology is string topology && !string.IsNullOrEmpty(topology))
+        i == 0
+          ? filteredObjects
+          : Enum.TryParse(Params.Output[i].Name, out ObjectType filterType)
+          && _filterDict.TryGetValue(filterType, out var filteredList)
+            ? filteredList.Cast<SpeckleWrapper>().ToList()
+            : new List<SpeckleWrapper>();
+
+      var outputGoos = outputValues.Select(o => o.CreateGoo()).ToList();
+
+      // only use topology for the first output when we have a path
+      if (i == 0 && targetCollectionWrapper?.Topology is string topology && !string.IsNullOrEmpty(topology))
       {
         var tree = GrasshopperHelpers.CreateDataTreeFromTopologyAndItems(topology, outputGoos);
         dataAccess.SetDataTree(i, tree);
@@ -272,10 +281,8 @@ public class QuerySpeckleObjects : GH_Component, IGH_VariableParameterComponent
     base.RemovedFromDocument(document);
   }
 
-  private void OnParameterSourceChanged(object sender, GH_ParamServerEventArgs args)
-  {
+  private void OnParameterSourceChanged(object sender, GH_ParamServerEventArgs args) =>
     // an empty filter dict will trigger the SortObjectsByGeometryBaseType method.
     // we only want to re-sort objects if an input has changed, not on every trigger of solve instance.
     _filterDict.Clear();
-  }
 }


### PR DESCRIPTION
## Description

Fixed an index out of range exception that occurred when users clicked the "+" button to add type-specific outputs (Block Instances, Points, etc.) to the Query Speckle Objects component **while having a path input connected**.

**Note:** this was never working when users piped in a path input.

## User Value
Users can now use type-specific outputs on Query Speckle Objects with collection paths without errors.

## Changes:
- Replaced `Filters[i - 1]` array indexing with safe param name parsing
- Fixed type-specific outputs to correctly use path-filtered objects instead of the entire collection
- Simplified output logic while maintaining the original code structure

## Screenshots:
### Before
Component goes red with "Index was out of range" error when adding type-specific outputs **with path input**

<img width="2348" height="1690" alt="image" src="https://github.com/user-attachments/assets/33679581-249f-4702-af39-74264feb634b" />

### After
Component works correctly, showing filtered objects for each type-specific output. Type-specific properties count also shows that we're respecting the filter on the objects.

![after-fix](https://github.com/user-attachments/assets/539d53d8-1968-4afc-9e68-026a67264ada)

## Checklist:
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] I have added appropriate tests.
- [x] I have updated or added relevant documentation.