### PR TITLE
fix: collection order inconsistency in `RootObjectUnpacker`

### DIFF
--- a/Connectors/Autocad/Speckle.Connectors.Autocad2022/packages.lock.json
+++ b/Connectors/Autocad/Speckle.Connectors.Autocad2022/packages.lock.json
@@ -259,9 +259,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.5.2, )",
-          "Speckle.Sdk": "[3.5.2, )",
-          "Speckle.Sdk.Dependencies": "[3.5.2, )"
+          "Speckle.Objects": "[3.5.3, )",
+          "Speckle.Sdk": "[3.5.3, )",
+          "Speckle.Sdk.Dependencies": "[3.5.3, )"
         }
       },
       "speckle.connectors.dui": {
@@ -292,7 +292,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.5.2, )"
+          "Speckle.Objects": "[3.5.3, )"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -336,18 +336,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "4OlvSSV1cxPeIs3gK4GRvq9X0Su3NE/TBxE6uA/rBS4tCCUdRRiF8wJMFSOxj8K6CRuJcdCxAqD6TIB0cwJ/9Q==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "T3xwwoALVGmhIuEjlDrTdDXZ9haFILT32r8OACWrRUItU3xMkOWGyob51Ca1MHPmo8B5gvbk2Gnm8AgReGnxWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.5.2"
+          "Speckle.Sdk": "3.5.3"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "6WUC7nbLOQURVb12eONGewhNdJHJb03jJ74QO8Tc5XODG+Q7Z5ZUcXu62ID/Hst3S0c2dlSXVZLw8WOLE2rGzQ==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "o+HefwtPZBqyuUHEnKF+qb/ctCAlNc2BYIw3ULEsZ93zweHt5wOMvOeuPxIXR0Gvj3fg6yNlY2nUcdFEduIXYA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -357,14 +357,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.5.2"
+          "Speckle.Sdk.Dependencies": "3.5.3"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "EsNd0OIbubhjFptextM6DeiN74hqb+s8J+HwfAmIFU9XOlmZPfznqjPMJnK9B+8sCpcM2pFsWZys0g/g00m1aw=="
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "kC15SE4yZoVTasgywCm0SpY9yjBsQeUIDt4qoscYAgbn9pe0jj3uM0hZeJUCxn9Fdoj64OfQBpCKzR7VqhkwHQ=="
       }
     }
   }

--- a/Connectors/Autocad/Speckle.Connectors.Autocad2023/packages.lock.json
+++ b/Connectors/Autocad/Speckle.Connectors.Autocad2023/packages.lock.json
@@ -259,9 +259,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.5.2, )",
-          "Speckle.Sdk": "[3.5.2, )",
-          "Speckle.Sdk.Dependencies": "[3.5.2, )"
+          "Speckle.Objects": "[3.5.3, )",
+          "Speckle.Sdk": "[3.5.3, )",
+          "Speckle.Sdk.Dependencies": "[3.5.3, )"
         }
       },
       "speckle.connectors.dui": {
@@ -292,7 +292,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.5.2, )"
+          "Speckle.Objects": "[3.5.3, )"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -336,18 +336,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "4OlvSSV1cxPeIs3gK4GRvq9X0Su3NE/TBxE6uA/rBS4tCCUdRRiF8wJMFSOxj8K6CRuJcdCxAqD6TIB0cwJ/9Q==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "T3xwwoALVGmhIuEjlDrTdDXZ9haFILT32r8OACWrRUItU3xMkOWGyob51Ca1MHPmo8B5gvbk2Gnm8AgReGnxWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.5.2"
+          "Speckle.Sdk": "3.5.3"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "6WUC7nbLOQURVb12eONGewhNdJHJb03jJ74QO8Tc5XODG+Q7Z5ZUcXu62ID/Hst3S0c2dlSXVZLw8WOLE2rGzQ==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "o+HefwtPZBqyuUHEnKF+qb/ctCAlNc2BYIw3ULEsZ93zweHt5wOMvOeuPxIXR0Gvj3fg6yNlY2nUcdFEduIXYA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -357,14 +357,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.5.2"
+          "Speckle.Sdk.Dependencies": "3.5.3"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "EsNd0OIbubhjFptextM6DeiN74hqb+s8J+HwfAmIFU9XOlmZPfznqjPMJnK9B+8sCpcM2pFsWZys0g/g00m1aw=="
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "kC15SE4yZoVTasgywCm0SpY9yjBsQeUIDt4qoscYAgbn9pe0jj3uM0hZeJUCxn9Fdoj64OfQBpCKzR7VqhkwHQ=="
       }
     }
   }

--- a/Connectors/Autocad/Speckle.Connectors.Autocad2024/packages.lock.json
+++ b/Connectors/Autocad/Speckle.Connectors.Autocad2024/packages.lock.json
@@ -259,9 +259,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.5.2, )",
-          "Speckle.Sdk": "[3.5.2, )",
-          "Speckle.Sdk.Dependencies": "[3.5.2, )"
+          "Speckle.Objects": "[3.5.3, )",
+          "Speckle.Sdk": "[3.5.3, )",
+          "Speckle.Sdk.Dependencies": "[3.5.3, )"
         }
       },
       "speckle.connectors.dui": {
@@ -293,7 +293,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.5.2, )"
+          "Speckle.Objects": "[3.5.3, )"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -337,18 +337,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "4OlvSSV1cxPeIs3gK4GRvq9X0Su3NE/TBxE6uA/rBS4tCCUdRRiF8wJMFSOxj8K6CRuJcdCxAqD6TIB0cwJ/9Q==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "T3xwwoALVGmhIuEjlDrTdDXZ9haFILT32r8OACWrRUItU3xMkOWGyob51Ca1MHPmo8B5gvbk2Gnm8AgReGnxWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.5.2"
+          "Speckle.Sdk": "3.5.3"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "6WUC7nbLOQURVb12eONGewhNdJHJb03jJ74QO8Tc5XODG+Q7Z5ZUcXu62ID/Hst3S0c2dlSXVZLw8WOLE2rGzQ==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "o+HefwtPZBqyuUHEnKF+qb/ctCAlNc2BYIw3ULEsZ93zweHt5wOMvOeuPxIXR0Gvj3fg6yNlY2nUcdFEduIXYA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -358,14 +358,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.5.2"
+          "Speckle.Sdk.Dependencies": "3.5.3"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "EsNd0OIbubhjFptextM6DeiN74hqb+s8J+HwfAmIFU9XOlmZPfznqjPMJnK9B+8sCpcM2pFsWZys0g/g00m1aw=="
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "kC15SE4yZoVTasgywCm0SpY9yjBsQeUIDt4qoscYAgbn9pe0jj3uM0hZeJUCxn9Fdoj64OfQBpCKzR7VqhkwHQ=="
       }
     }
   }

--- a/Connectors/Autocad/Speckle.Connectors.Autocad2025/packages.lock.json
+++ b/Connectors/Autocad/Speckle.Connectors.Autocad2025/packages.lock.json
@@ -210,9 +210,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.5.2, )",
-          "Speckle.Sdk": "[3.5.2, )",
-          "Speckle.Sdk.Dependencies": "[3.5.2, )"
+          "Speckle.Objects": "[3.5.3, )",
+          "Speckle.Sdk": "[3.5.3, )",
+          "Speckle.Sdk.Dependencies": "[3.5.3, )"
         }
       },
       "speckle.connectors.dui": {
@@ -244,7 +244,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.5.2, )"
+          "Speckle.Objects": "[3.5.3, )"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -288,18 +288,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "4OlvSSV1cxPeIs3gK4GRvq9X0Su3NE/TBxE6uA/rBS4tCCUdRRiF8wJMFSOxj8K6CRuJcdCxAqD6TIB0cwJ/9Q==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "T3xwwoALVGmhIuEjlDrTdDXZ9haFILT32r8OACWrRUItU3xMkOWGyob51Ca1MHPmo8B5gvbk2Gnm8AgReGnxWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.5.2"
+          "Speckle.Sdk": "3.5.3"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "6WUC7nbLOQURVb12eONGewhNdJHJb03jJ74QO8Tc5XODG+Q7Z5ZUcXu62ID/Hst3S0c2dlSXVZLw8WOLE2rGzQ==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "o+HefwtPZBqyuUHEnKF+qb/ctCAlNc2BYIw3ULEsZ93zweHt5wOMvOeuPxIXR0Gvj3fg6yNlY2nUcdFEduIXYA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -307,14 +307,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.5.2"
+          "Speckle.Sdk.Dependencies": "3.5.3"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "EsNd0OIbubhjFptextM6DeiN74hqb+s8J+HwfAmIFU9XOlmZPfznqjPMJnK9B+8sCpcM2pFsWZys0g/g00m1aw=="
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "kC15SE4yZoVTasgywCm0SpY9yjBsQeUIDt4qoscYAgbn9pe0jj3uM0hZeJUCxn9Fdoj64OfQBpCKzR7VqhkwHQ=="
       }
     },
     "net8.0-windows7.0/win-x64": {

--- a/Connectors/Autocad/Speckle.Connectors.Autocad2026/packages.lock.json
+++ b/Connectors/Autocad/Speckle.Connectors.Autocad2026/packages.lock.json
@@ -210,9 +210,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.5.2, )",
-          "Speckle.Sdk": "[3.5.2, )",
-          "Speckle.Sdk.Dependencies": "[3.5.2, )"
+          "Speckle.Objects": "[3.5.3, )",
+          "Speckle.Sdk": "[3.5.3, )",
+          "Speckle.Sdk.Dependencies": "[3.5.3, )"
         }
       },
       "speckle.connectors.dui": {
@@ -244,7 +244,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.5.2, )"
+          "Speckle.Objects": "[3.5.3, )"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -288,18 +288,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "4OlvSSV1cxPeIs3gK4GRvq9X0Su3NE/TBxE6uA/rBS4tCCUdRRiF8wJMFSOxj8K6CRuJcdCxAqD6TIB0cwJ/9Q==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "T3xwwoALVGmhIuEjlDrTdDXZ9haFILT32r8OACWrRUItU3xMkOWGyob51Ca1MHPmo8B5gvbk2Gnm8AgReGnxWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.5.2"
+          "Speckle.Sdk": "3.5.3"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "6WUC7nbLOQURVb12eONGewhNdJHJb03jJ74QO8Tc5XODG+Q7Z5ZUcXu62ID/Hst3S0c2dlSXVZLw8WOLE2rGzQ==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "o+HefwtPZBqyuUHEnKF+qb/ctCAlNc2BYIw3ULEsZ93zweHt5wOMvOeuPxIXR0Gvj3fg6yNlY2nUcdFEduIXYA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -307,14 +307,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.5.2"
+          "Speckle.Sdk.Dependencies": "3.5.3"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "EsNd0OIbubhjFptextM6DeiN74hqb+s8J+HwfAmIFU9XOlmZPfznqjPMJnK9B+8sCpcM2pFsWZys0g/g00m1aw=="
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "kC15SE4yZoVTasgywCm0SpY9yjBsQeUIDt4qoscYAgbn9pe0jj3uM0hZeJUCxn9Fdoj64OfQBpCKzR7VqhkwHQ=="
       }
     },
     "net8.0-windows7.0/win-x64": {

--- a/Connectors/Autocad/Speckle.Connectors.Civil3d2022/packages.lock.json
+++ b/Connectors/Autocad/Speckle.Connectors.Civil3d2022/packages.lock.json
@@ -268,9 +268,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.5.2, )",
-          "Speckle.Sdk": "[3.5.2, )",
-          "Speckle.Sdk.Dependencies": "[3.5.2, )"
+          "Speckle.Objects": "[3.5.3, )",
+          "Speckle.Sdk": "[3.5.3, )",
+          "Speckle.Sdk.Dependencies": "[3.5.3, )"
         }
       },
       "speckle.connectors.dui": {
@@ -302,7 +302,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.5.2, )"
+          "Speckle.Objects": "[3.5.3, )"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -346,18 +346,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "4OlvSSV1cxPeIs3gK4GRvq9X0Su3NE/TBxE6uA/rBS4tCCUdRRiF8wJMFSOxj8K6CRuJcdCxAqD6TIB0cwJ/9Q==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "T3xwwoALVGmhIuEjlDrTdDXZ9haFILT32r8OACWrRUItU3xMkOWGyob51Ca1MHPmo8B5gvbk2Gnm8AgReGnxWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.5.2"
+          "Speckle.Sdk": "3.5.3"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "6WUC7nbLOQURVb12eONGewhNdJHJb03jJ74QO8Tc5XODG+Q7Z5ZUcXu62ID/Hst3S0c2dlSXVZLw8WOLE2rGzQ==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "o+HefwtPZBqyuUHEnKF+qb/ctCAlNc2BYIw3ULEsZ93zweHt5wOMvOeuPxIXR0Gvj3fg6yNlY2nUcdFEduIXYA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -367,14 +367,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.5.2"
+          "Speckle.Sdk.Dependencies": "3.5.3"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "EsNd0OIbubhjFptextM6DeiN74hqb+s8J+HwfAmIFU9XOlmZPfznqjPMJnK9B+8sCpcM2pFsWZys0g/g00m1aw=="
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "kC15SE4yZoVTasgywCm0SpY9yjBsQeUIDt4qoscYAgbn9pe0jj3uM0hZeJUCxn9Fdoj64OfQBpCKzR7VqhkwHQ=="
       }
     }
   }

--- a/Connectors/Autocad/Speckle.Connectors.Civil3d2023/packages.lock.json
+++ b/Connectors/Autocad/Speckle.Connectors.Civil3d2023/packages.lock.json
@@ -268,9 +268,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.5.2, )",
-          "Speckle.Sdk": "[3.5.2, )",
-          "Speckle.Sdk.Dependencies": "[3.5.2, )"
+          "Speckle.Objects": "[3.5.3, )",
+          "Speckle.Sdk": "[3.5.3, )",
+          "Speckle.Sdk.Dependencies": "[3.5.3, )"
         }
       },
       "speckle.connectors.dui": {
@@ -302,7 +302,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.5.2, )"
+          "Speckle.Objects": "[3.5.3, )"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -346,18 +346,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "4OlvSSV1cxPeIs3gK4GRvq9X0Su3NE/TBxE6uA/rBS4tCCUdRRiF8wJMFSOxj8K6CRuJcdCxAqD6TIB0cwJ/9Q==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "T3xwwoALVGmhIuEjlDrTdDXZ9haFILT32r8OACWrRUItU3xMkOWGyob51Ca1MHPmo8B5gvbk2Gnm8AgReGnxWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.5.2"
+          "Speckle.Sdk": "3.5.3"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "6WUC7nbLOQURVb12eONGewhNdJHJb03jJ74QO8Tc5XODG+Q7Z5ZUcXu62ID/Hst3S0c2dlSXVZLw8WOLE2rGzQ==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "o+HefwtPZBqyuUHEnKF+qb/ctCAlNc2BYIw3ULEsZ93zweHt5wOMvOeuPxIXR0Gvj3fg6yNlY2nUcdFEduIXYA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -367,14 +367,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.5.2"
+          "Speckle.Sdk.Dependencies": "3.5.3"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "EsNd0OIbubhjFptextM6DeiN74hqb+s8J+HwfAmIFU9XOlmZPfznqjPMJnK9B+8sCpcM2pFsWZys0g/g00m1aw=="
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "kC15SE4yZoVTasgywCm0SpY9yjBsQeUIDt4qoscYAgbn9pe0jj3uM0hZeJUCxn9Fdoj64OfQBpCKzR7VqhkwHQ=="
       }
     }
   }

--- a/Connectors/Autocad/Speckle.Connectors.Civil3d2024/packages.lock.json
+++ b/Connectors/Autocad/Speckle.Connectors.Civil3d2024/packages.lock.json
@@ -268,9 +268,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.5.2, )",
-          "Speckle.Sdk": "[3.5.2, )",
-          "Speckle.Sdk.Dependencies": "[3.5.2, )"
+          "Speckle.Objects": "[3.5.3, )",
+          "Speckle.Sdk": "[3.5.3, )",
+          "Speckle.Sdk.Dependencies": "[3.5.3, )"
         }
       },
       "speckle.connectors.dui": {
@@ -302,7 +302,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.5.2, )"
+          "Speckle.Objects": "[3.5.3, )"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -346,18 +346,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "4OlvSSV1cxPeIs3gK4GRvq9X0Su3NE/TBxE6uA/rBS4tCCUdRRiF8wJMFSOxj8K6CRuJcdCxAqD6TIB0cwJ/9Q==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "T3xwwoALVGmhIuEjlDrTdDXZ9haFILT32r8OACWrRUItU3xMkOWGyob51Ca1MHPmo8B5gvbk2Gnm8AgReGnxWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.5.2"
+          "Speckle.Sdk": "3.5.3"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "6WUC7nbLOQURVb12eONGewhNdJHJb03jJ74QO8Tc5XODG+Q7Z5ZUcXu62ID/Hst3S0c2dlSXVZLw8WOLE2rGzQ==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "o+HefwtPZBqyuUHEnKF+qb/ctCAlNc2BYIw3ULEsZ93zweHt5wOMvOeuPxIXR0Gvj3fg6yNlY2nUcdFEduIXYA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -367,14 +367,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.5.2"
+          "Speckle.Sdk.Dependencies": "3.5.3"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "EsNd0OIbubhjFptextM6DeiN74hqb+s8J+HwfAmIFU9XOlmZPfznqjPMJnK9B+8sCpcM2pFsWZys0g/g00m1aw=="
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "kC15SE4yZoVTasgywCm0SpY9yjBsQeUIDt4qoscYAgbn9pe0jj3uM0hZeJUCxn9Fdoj64OfQBpCKzR7VqhkwHQ=="
       }
     }
   }

--- a/Connectors/Autocad/Speckle.Connectors.Civil3d2025/packages.lock.json
+++ b/Connectors/Autocad/Speckle.Connectors.Civil3d2025/packages.lock.json
@@ -219,9 +219,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.5.2, )",
-          "Speckle.Sdk": "[3.5.2, )",
-          "Speckle.Sdk.Dependencies": "[3.5.2, )"
+          "Speckle.Objects": "[3.5.3, )",
+          "Speckle.Sdk": "[3.5.3, )",
+          "Speckle.Sdk.Dependencies": "[3.5.3, )"
         }
       },
       "speckle.connectors.dui": {
@@ -254,7 +254,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.5.2, )"
+          "Speckle.Objects": "[3.5.3, )"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -298,18 +298,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "4OlvSSV1cxPeIs3gK4GRvq9X0Su3NE/TBxE6uA/rBS4tCCUdRRiF8wJMFSOxj8K6CRuJcdCxAqD6TIB0cwJ/9Q==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "T3xwwoALVGmhIuEjlDrTdDXZ9haFILT32r8OACWrRUItU3xMkOWGyob51Ca1MHPmo8B5gvbk2Gnm8AgReGnxWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.5.2"
+          "Speckle.Sdk": "3.5.3"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "6WUC7nbLOQURVb12eONGewhNdJHJb03jJ74QO8Tc5XODG+Q7Z5ZUcXu62ID/Hst3S0c2dlSXVZLw8WOLE2rGzQ==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "o+HefwtPZBqyuUHEnKF+qb/ctCAlNc2BYIw3ULEsZ93zweHt5wOMvOeuPxIXR0Gvj3fg6yNlY2nUcdFEduIXYA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -317,14 +317,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.5.2"
+          "Speckle.Sdk.Dependencies": "3.5.3"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "EsNd0OIbubhjFptextM6DeiN74hqb+s8J+HwfAmIFU9XOlmZPfznqjPMJnK9B+8sCpcM2pFsWZys0g/g00m1aw=="
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "kC15SE4yZoVTasgywCm0SpY9yjBsQeUIDt4qoscYAgbn9pe0jj3uM0hZeJUCxn9Fdoj64OfQBpCKzR7VqhkwHQ=="
       }
     },
     "net8.0-windows7.0/win-x64": {

--- a/Connectors/Autocad/Speckle.Connectors.Civil3d2026/packages.lock.json
+++ b/Connectors/Autocad/Speckle.Connectors.Civil3d2026/packages.lock.json
@@ -219,9 +219,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.5.2, )",
-          "Speckle.Sdk": "[3.5.2, )",
-          "Speckle.Sdk.Dependencies": "[3.5.2, )"
+          "Speckle.Objects": "[3.5.3, )",
+          "Speckle.Sdk": "[3.5.3, )",
+          "Speckle.Sdk.Dependencies": "[3.5.3, )"
         }
       },
       "speckle.connectors.dui": {
@@ -254,7 +254,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.5.2, )"
+          "Speckle.Objects": "[3.5.3, )"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -298,18 +298,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "4OlvSSV1cxPeIs3gK4GRvq9X0Su3NE/TBxE6uA/rBS4tCCUdRRiF8wJMFSOxj8K6CRuJcdCxAqD6TIB0cwJ/9Q==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "T3xwwoALVGmhIuEjlDrTdDXZ9haFILT32r8OACWrRUItU3xMkOWGyob51Ca1MHPmo8B5gvbk2Gnm8AgReGnxWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.5.2"
+          "Speckle.Sdk": "3.5.3"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "6WUC7nbLOQURVb12eONGewhNdJHJb03jJ74QO8Tc5XODG+Q7Z5ZUcXu62ID/Hst3S0c2dlSXVZLw8WOLE2rGzQ==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "o+HefwtPZBqyuUHEnKF+qb/ctCAlNc2BYIw3ULEsZ93zweHt5wOMvOeuPxIXR0Gvj3fg6yNlY2nUcdFEduIXYA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -317,14 +317,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.5.2"
+          "Speckle.Sdk.Dependencies": "3.5.3"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "EsNd0OIbubhjFptextM6DeiN74hqb+s8J+HwfAmIFU9XOlmZPfznqjPMJnK9B+8sCpcM2pFsWZys0g/g00m1aw=="
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "kC15SE4yZoVTasgywCm0SpY9yjBsQeUIDt4qoscYAgbn9pe0jj3uM0hZeJUCxn9Fdoj64OfQBpCKzR7VqhkwHQ=="
       }
     },
     "net8.0-windows7.0/win-x64": {

--- a/Connectors/CSi/Speckle.Connectors.ETABS21/packages.lock.json
+++ b/Connectors/CSi/Speckle.Connectors.ETABS21/packages.lock.json
@@ -259,9 +259,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.5.2, )",
-          "Speckle.Sdk": "[3.5.2, )",
-          "Speckle.Sdk.Dependencies": "[3.5.2, )"
+          "Speckle.Objects": "[3.5.3, )",
+          "Speckle.Sdk": "[3.5.3, )",
+          "Speckle.Sdk.Dependencies": "[3.5.3, )"
         }
       },
       "speckle.connectors.dui": {
@@ -285,7 +285,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.5.2, )"
+          "Speckle.Objects": "[3.5.3, )"
         }
       },
       "speckle.converters.etabs21": {
@@ -335,18 +335,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "4OlvSSV1cxPeIs3gK4GRvq9X0Su3NE/TBxE6uA/rBS4tCCUdRRiF8wJMFSOxj8K6CRuJcdCxAqD6TIB0cwJ/9Q==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "T3xwwoALVGmhIuEjlDrTdDXZ9haFILT32r8OACWrRUItU3xMkOWGyob51Ca1MHPmo8B5gvbk2Gnm8AgReGnxWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.5.2"
+          "Speckle.Sdk": "3.5.3"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "6WUC7nbLOQURVb12eONGewhNdJHJb03jJ74QO8Tc5XODG+Q7Z5ZUcXu62ID/Hst3S0c2dlSXVZLw8WOLE2rGzQ==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "o+HefwtPZBqyuUHEnKF+qb/ctCAlNc2BYIw3ULEsZ93zweHt5wOMvOeuPxIXR0Gvj3fg6yNlY2nUcdFEduIXYA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -356,14 +356,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.5.2"
+          "Speckle.Sdk.Dependencies": "3.5.3"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "EsNd0OIbubhjFptextM6DeiN74hqb+s8J+HwfAmIFU9XOlmZPfznqjPMJnK9B+8sCpcM2pFsWZys0g/g00m1aw=="
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "kC15SE4yZoVTasgywCm0SpY9yjBsQeUIDt4qoscYAgbn9pe0jj3uM0hZeJUCxn9Fdoj64OfQBpCKzR7VqhkwHQ=="
       }
     }
   }

--- a/Connectors/CSi/Speckle.Connectors.ETABS22/packages.lock.json
+++ b/Connectors/CSi/Speckle.Connectors.ETABS22/packages.lock.json
@@ -210,9 +210,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.5.2, )",
-          "Speckle.Sdk": "[3.5.2, )",
-          "Speckle.Sdk.Dependencies": "[3.5.2, )"
+          "Speckle.Objects": "[3.5.3, )",
+          "Speckle.Sdk": "[3.5.3, )",
+          "Speckle.Sdk.Dependencies": "[3.5.3, )"
         }
       },
       "speckle.connectors.dui": {
@@ -236,7 +236,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.5.2, )"
+          "Speckle.Objects": "[3.5.3, )"
         }
       },
       "speckle.converters.etabs22": {
@@ -286,18 +286,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "4OlvSSV1cxPeIs3gK4GRvq9X0Su3NE/TBxE6uA/rBS4tCCUdRRiF8wJMFSOxj8K6CRuJcdCxAqD6TIB0cwJ/9Q==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "T3xwwoALVGmhIuEjlDrTdDXZ9haFILT32r8OACWrRUItU3xMkOWGyob51Ca1MHPmo8B5gvbk2Gnm8AgReGnxWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.5.2"
+          "Speckle.Sdk": "3.5.3"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "6WUC7nbLOQURVb12eONGewhNdJHJb03jJ74QO8Tc5XODG+Q7Z5ZUcXu62ID/Hst3S0c2dlSXVZLw8WOLE2rGzQ==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "o+HefwtPZBqyuUHEnKF+qb/ctCAlNc2BYIw3ULEsZ93zweHt5wOMvOeuPxIXR0Gvj3fg6yNlY2nUcdFEduIXYA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -305,14 +305,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.5.2"
+          "Speckle.Sdk.Dependencies": "3.5.3"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "EsNd0OIbubhjFptextM6DeiN74hqb+s8J+HwfAmIFU9XOlmZPfznqjPMJnK9B+8sCpcM2pFsWZys0g/g00m1aw=="
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "kC15SE4yZoVTasgywCm0SpY9yjBsQeUIDt4qoscYAgbn9pe0jj3uM0hZeJUCxn9Fdoj64OfQBpCKzR7VqhkwHQ=="
       }
     }
   }

--- a/Connectors/Navisworks/Speckle.Connectors.Navisworks2020/packages.lock.json
+++ b/Connectors/Navisworks/Speckle.Connectors.Navisworks2020/packages.lock.json
@@ -259,9 +259,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.5.2, )",
-          "Speckle.Sdk": "[3.5.2, )",
-          "Speckle.Sdk.Dependencies": "[3.5.2, )"
+          "Speckle.Objects": "[3.5.3, )",
+          "Speckle.Sdk": "[3.5.3, )",
+          "Speckle.Sdk.Dependencies": "[3.5.3, )"
         }
       },
       "speckle.connectors.dui": {
@@ -285,7 +285,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.5.2, )"
+          "Speckle.Objects": "[3.5.3, )"
         }
       },
       "speckle.converters.navisworks2020": {
@@ -337,18 +337,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "4OlvSSV1cxPeIs3gK4GRvq9X0Su3NE/TBxE6uA/rBS4tCCUdRRiF8wJMFSOxj8K6CRuJcdCxAqD6TIB0cwJ/9Q==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "T3xwwoALVGmhIuEjlDrTdDXZ9haFILT32r8OACWrRUItU3xMkOWGyob51Ca1MHPmo8B5gvbk2Gnm8AgReGnxWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.5.2"
+          "Speckle.Sdk": "3.5.3"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "6WUC7nbLOQURVb12eONGewhNdJHJb03jJ74QO8Tc5XODG+Q7Z5ZUcXu62ID/Hst3S0c2dlSXVZLw8WOLE2rGzQ==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "o+HefwtPZBqyuUHEnKF+qb/ctCAlNc2BYIw3ULEsZ93zweHt5wOMvOeuPxIXR0Gvj3fg6yNlY2nUcdFEduIXYA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -358,14 +358,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.5.2"
+          "Speckle.Sdk.Dependencies": "3.5.3"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "EsNd0OIbubhjFptextM6DeiN74hqb+s8J+HwfAmIFU9XOlmZPfznqjPMJnK9B+8sCpcM2pFsWZys0g/g00m1aw=="
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "kC15SE4yZoVTasgywCm0SpY9yjBsQeUIDt4qoscYAgbn9pe0jj3uM0hZeJUCxn9Fdoj64OfQBpCKzR7VqhkwHQ=="
       }
     },
     ".NETFramework,Version=v4.8/win-x64": {

--- a/Connectors/Navisworks/Speckle.Connectors.Navisworks2021/packages.lock.json
+++ b/Connectors/Navisworks/Speckle.Connectors.Navisworks2021/packages.lock.json
@@ -259,9 +259,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.5.2, )",
-          "Speckle.Sdk": "[3.5.2, )",
-          "Speckle.Sdk.Dependencies": "[3.5.2, )"
+          "Speckle.Objects": "[3.5.3, )",
+          "Speckle.Sdk": "[3.5.3, )",
+          "Speckle.Sdk.Dependencies": "[3.5.3, )"
         }
       },
       "speckle.connectors.dui": {
@@ -285,7 +285,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.5.2, )"
+          "Speckle.Objects": "[3.5.3, )"
         }
       },
       "speckle.converters.navisworks2021": {
@@ -337,18 +337,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "4OlvSSV1cxPeIs3gK4GRvq9X0Su3NE/TBxE6uA/rBS4tCCUdRRiF8wJMFSOxj8K6CRuJcdCxAqD6TIB0cwJ/9Q==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "T3xwwoALVGmhIuEjlDrTdDXZ9haFILT32r8OACWrRUItU3xMkOWGyob51Ca1MHPmo8B5gvbk2Gnm8AgReGnxWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.5.2"
+          "Speckle.Sdk": "3.5.3"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "6WUC7nbLOQURVb12eONGewhNdJHJb03jJ74QO8Tc5XODG+Q7Z5ZUcXu62ID/Hst3S0c2dlSXVZLw8WOLE2rGzQ==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "o+HefwtPZBqyuUHEnKF+qb/ctCAlNc2BYIw3ULEsZ93zweHt5wOMvOeuPxIXR0Gvj3fg6yNlY2nUcdFEduIXYA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -358,14 +358,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.5.2"
+          "Speckle.Sdk.Dependencies": "3.5.3"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "EsNd0OIbubhjFptextM6DeiN74hqb+s8J+HwfAmIFU9XOlmZPfznqjPMJnK9B+8sCpcM2pFsWZys0g/g00m1aw=="
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "kC15SE4yZoVTasgywCm0SpY9yjBsQeUIDt4qoscYAgbn9pe0jj3uM0hZeJUCxn9Fdoj64OfQBpCKzR7VqhkwHQ=="
       }
     },
     ".NETFramework,Version=v4.8/win-x64": {

--- a/Connectors/Navisworks/Speckle.Connectors.Navisworks2022/packages.lock.json
+++ b/Connectors/Navisworks/Speckle.Connectors.Navisworks2022/packages.lock.json
@@ -259,9 +259,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.5.2, )",
-          "Speckle.Sdk": "[3.5.2, )",
-          "Speckle.Sdk.Dependencies": "[3.5.2, )"
+          "Speckle.Objects": "[3.5.3, )",
+          "Speckle.Sdk": "[3.5.3, )",
+          "Speckle.Sdk.Dependencies": "[3.5.3, )"
         }
       },
       "speckle.connectors.dui": {
@@ -285,7 +285,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.5.2, )"
+          "Speckle.Objects": "[3.5.3, )"
         }
       },
       "speckle.converters.navisworks2022": {
@@ -337,18 +337,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "4OlvSSV1cxPeIs3gK4GRvq9X0Su3NE/TBxE6uA/rBS4tCCUdRRiF8wJMFSOxj8K6CRuJcdCxAqD6TIB0cwJ/9Q==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "T3xwwoALVGmhIuEjlDrTdDXZ9haFILT32r8OACWrRUItU3xMkOWGyob51Ca1MHPmo8B5gvbk2Gnm8AgReGnxWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.5.2"
+          "Speckle.Sdk": "3.5.3"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "6WUC7nbLOQURVb12eONGewhNdJHJb03jJ74QO8Tc5XODG+Q7Z5ZUcXu62ID/Hst3S0c2dlSXVZLw8WOLE2rGzQ==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "o+HefwtPZBqyuUHEnKF+qb/ctCAlNc2BYIw3ULEsZ93zweHt5wOMvOeuPxIXR0Gvj3fg6yNlY2nUcdFEduIXYA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -358,14 +358,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.5.2"
+          "Speckle.Sdk.Dependencies": "3.5.3"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "EsNd0OIbubhjFptextM6DeiN74hqb+s8J+HwfAmIFU9XOlmZPfznqjPMJnK9B+8sCpcM2pFsWZys0g/g00m1aw=="
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "kC15SE4yZoVTasgywCm0SpY9yjBsQeUIDt4qoscYAgbn9pe0jj3uM0hZeJUCxn9Fdoj64OfQBpCKzR7VqhkwHQ=="
       }
     },
     ".NETFramework,Version=v4.8/win-x64": {

--- a/Connectors/Navisworks/Speckle.Connectors.Navisworks2023/packages.lock.json
+++ b/Connectors/Navisworks/Speckle.Connectors.Navisworks2023/packages.lock.json
@@ -259,9 +259,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.5.2, )",
-          "Speckle.Sdk": "[3.5.2, )",
-          "Speckle.Sdk.Dependencies": "[3.5.2, )"
+          "Speckle.Objects": "[3.5.3, )",
+          "Speckle.Sdk": "[3.5.3, )",
+          "Speckle.Sdk.Dependencies": "[3.5.3, )"
         }
       },
       "speckle.connectors.dui": {
@@ -285,7 +285,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.5.2, )"
+          "Speckle.Objects": "[3.5.3, )"
         }
       },
       "speckle.converters.navisworks2023": {
@@ -337,18 +337,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "4OlvSSV1cxPeIs3gK4GRvq9X0Su3NE/TBxE6uA/rBS4tCCUdRRiF8wJMFSOxj8K6CRuJcdCxAqD6TIB0cwJ/9Q==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "T3xwwoALVGmhIuEjlDrTdDXZ9haFILT32r8OACWrRUItU3xMkOWGyob51Ca1MHPmo8B5gvbk2Gnm8AgReGnxWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.5.2"
+          "Speckle.Sdk": "3.5.3"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "6WUC7nbLOQURVb12eONGewhNdJHJb03jJ74QO8Tc5XODG+Q7Z5ZUcXu62ID/Hst3S0c2dlSXVZLw8WOLE2rGzQ==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "o+HefwtPZBqyuUHEnKF+qb/ctCAlNc2BYIw3ULEsZ93zweHt5wOMvOeuPxIXR0Gvj3fg6yNlY2nUcdFEduIXYA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -358,14 +358,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.5.2"
+          "Speckle.Sdk.Dependencies": "3.5.3"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "EsNd0OIbubhjFptextM6DeiN74hqb+s8J+HwfAmIFU9XOlmZPfznqjPMJnK9B+8sCpcM2pFsWZys0g/g00m1aw=="
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "kC15SE4yZoVTasgywCm0SpY9yjBsQeUIDt4qoscYAgbn9pe0jj3uM0hZeJUCxn9Fdoj64OfQBpCKzR7VqhkwHQ=="
       }
     },
     ".NETFramework,Version=v4.8/win-x64": {

--- a/Connectors/Navisworks/Speckle.Connectors.Navisworks2024/packages.lock.json
+++ b/Connectors/Navisworks/Speckle.Connectors.Navisworks2024/packages.lock.json
@@ -259,9 +259,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.5.2, )",
-          "Speckle.Sdk": "[3.5.2, )",
-          "Speckle.Sdk.Dependencies": "[3.5.2, )"
+          "Speckle.Objects": "[3.5.3, )",
+          "Speckle.Sdk": "[3.5.3, )",
+          "Speckle.Sdk.Dependencies": "[3.5.3, )"
         }
       },
       "speckle.connectors.dui": {
@@ -285,7 +285,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.5.2, )"
+          "Speckle.Objects": "[3.5.3, )"
         }
       },
       "speckle.converters.navisworks2024": {
@@ -337,18 +337,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "4OlvSSV1cxPeIs3gK4GRvq9X0Su3NE/TBxE6uA/rBS4tCCUdRRiF8wJMFSOxj8K6CRuJcdCxAqD6TIB0cwJ/9Q==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "T3xwwoALVGmhIuEjlDrTdDXZ9haFILT32r8OACWrRUItU3xMkOWGyob51Ca1MHPmo8B5gvbk2Gnm8AgReGnxWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.5.2"
+          "Speckle.Sdk": "3.5.3"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "6WUC7nbLOQURVb12eONGewhNdJHJb03jJ74QO8Tc5XODG+Q7Z5ZUcXu62ID/Hst3S0c2dlSXVZLw8WOLE2rGzQ==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "o+HefwtPZBqyuUHEnKF+qb/ctCAlNc2BYIw3ULEsZ93zweHt5wOMvOeuPxIXR0Gvj3fg6yNlY2nUcdFEduIXYA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -358,14 +358,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.5.2"
+          "Speckle.Sdk.Dependencies": "3.5.3"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "EsNd0OIbubhjFptextM6DeiN74hqb+s8J+HwfAmIFU9XOlmZPfznqjPMJnK9B+8sCpcM2pFsWZys0g/g00m1aw=="
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "kC15SE4yZoVTasgywCm0SpY9yjBsQeUIDt4qoscYAgbn9pe0jj3uM0hZeJUCxn9Fdoj64OfQBpCKzR7VqhkwHQ=="
       }
     },
     ".NETFramework,Version=v4.8/win-x64": {

--- a/Connectors/Navisworks/Speckle.Connectors.Navisworks2025/packages.lock.json
+++ b/Connectors/Navisworks/Speckle.Connectors.Navisworks2025/packages.lock.json
@@ -265,9 +265,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.5.2, )",
-          "Speckle.Sdk": "[3.5.2, )",
-          "Speckle.Sdk.Dependencies": "[3.5.2, )"
+          "Speckle.Objects": "[3.5.3, )",
+          "Speckle.Sdk": "[3.5.3, )",
+          "Speckle.Sdk.Dependencies": "[3.5.3, )"
         }
       },
       "speckle.connectors.dui": {
@@ -291,7 +291,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.5.2, )"
+          "Speckle.Objects": "[3.5.3, )"
         }
       },
       "speckle.converters.navisworks2025": {
@@ -337,18 +337,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "4OlvSSV1cxPeIs3gK4GRvq9X0Su3NE/TBxE6uA/rBS4tCCUdRRiF8wJMFSOxj8K6CRuJcdCxAqD6TIB0cwJ/9Q==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "T3xwwoALVGmhIuEjlDrTdDXZ9haFILT32r8OACWrRUItU3xMkOWGyob51Ca1MHPmo8B5gvbk2Gnm8AgReGnxWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.5.2"
+          "Speckle.Sdk": "3.5.3"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "6WUC7nbLOQURVb12eONGewhNdJHJb03jJ74QO8Tc5XODG+Q7Z5ZUcXu62ID/Hst3S0c2dlSXVZLw8WOLE2rGzQ==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "o+HefwtPZBqyuUHEnKF+qb/ctCAlNc2BYIw3ULEsZ93zweHt5wOMvOeuPxIXR0Gvj3fg6yNlY2nUcdFEduIXYA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -358,14 +358,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.5.2"
+          "Speckle.Sdk.Dependencies": "3.5.3"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "EsNd0OIbubhjFptextM6DeiN74hqb+s8J+HwfAmIFU9XOlmZPfznqjPMJnK9B+8sCpcM2pFsWZys0g/g00m1aw=="
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "kC15SE4yZoVTasgywCm0SpY9yjBsQeUIDt4qoscYAgbn9pe0jj3uM0hZeJUCxn9Fdoj64OfQBpCKzR7VqhkwHQ=="
       }
     },
     ".NETFramework,Version=v4.8/win-x64": {

--- a/Connectors/Navisworks/Speckle.Connectors.Navisworks2026/packages.lock.json
+++ b/Connectors/Navisworks/Speckle.Connectors.Navisworks2026/packages.lock.json
@@ -266,9 +266,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.5.2, )",
-          "Speckle.Sdk": "[3.5.2, )",
-          "Speckle.Sdk.Dependencies": "[3.5.2, )"
+          "Speckle.Objects": "[3.5.3, )",
+          "Speckle.Sdk": "[3.5.3, )",
+          "Speckle.Sdk.Dependencies": "[3.5.3, )"
         }
       },
       "speckle.connectors.dui": {
@@ -292,7 +292,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.5.2, )"
+          "Speckle.Objects": "[3.5.3, )"
         }
       },
       "speckle.converters.navisworks2026": {
@@ -339,18 +339,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "4OlvSSV1cxPeIs3gK4GRvq9X0Su3NE/TBxE6uA/rBS4tCCUdRRiF8wJMFSOxj8K6CRuJcdCxAqD6TIB0cwJ/9Q==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "T3xwwoALVGmhIuEjlDrTdDXZ9haFILT32r8OACWrRUItU3xMkOWGyob51Ca1MHPmo8B5gvbk2Gnm8AgReGnxWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.5.2"
+          "Speckle.Sdk": "3.5.3"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "6WUC7nbLOQURVb12eONGewhNdJHJb03jJ74QO8Tc5XODG+Q7Z5ZUcXu62ID/Hst3S0c2dlSXVZLw8WOLE2rGzQ==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "o+HefwtPZBqyuUHEnKF+qb/ctCAlNc2BYIw3ULEsZ93zweHt5wOMvOeuPxIXR0Gvj3fg6yNlY2nUcdFEduIXYA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -360,14 +360,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.5.2"
+          "Speckle.Sdk.Dependencies": "3.5.3"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "EsNd0OIbubhjFptextM6DeiN74hqb+s8J+HwfAmIFU9XOlmZPfznqjPMJnK9B+8sCpcM2pFsWZys0g/g00m1aw=="
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "kC15SE4yZoVTasgywCm0SpY9yjBsQeUIDt4qoscYAgbn9pe0jj3uM0hZeJUCxn9Fdoj64OfQBpCKzR7VqhkwHQ=="
       }
     },
     ".NETFramework,Version=v4.8/win-x64": {

--- a/Connectors/Revit/Speckle.Connectors.Revit2022/packages.lock.json
+++ b/Connectors/Revit/Speckle.Connectors.Revit2022/packages.lock.json
@@ -281,9 +281,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.5.2, )",
-          "Speckle.Sdk": "[3.5.2, )",
-          "Speckle.Sdk.Dependencies": "[3.5.2, )"
+          "Speckle.Objects": "[3.5.3, )",
+          "Speckle.Sdk": "[3.5.3, )",
+          "Speckle.Sdk.Dependencies": "[3.5.3, )"
         }
       },
       "speckle.connectors.dui": {
@@ -306,7 +306,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.5.2, )"
+          "Speckle.Objects": "[3.5.3, )"
         }
       },
       "speckle.converters.revit2022": {
@@ -351,11 +351,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "4OlvSSV1cxPeIs3gK4GRvq9X0Su3NE/TBxE6uA/rBS4tCCUdRRiF8wJMFSOxj8K6CRuJcdCxAqD6TIB0cwJ/9Q==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "T3xwwoALVGmhIuEjlDrTdDXZ9haFILT32r8OACWrRUItU3xMkOWGyob51Ca1MHPmo8B5gvbk2Gnm8AgReGnxWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.5.2"
+          "Speckle.Sdk": "3.5.3"
         }
       },
       "Speckle.Revit.API": {
@@ -366,9 +366,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "6WUC7nbLOQURVb12eONGewhNdJHJb03jJ74QO8Tc5XODG+Q7Z5ZUcXu62ID/Hst3S0c2dlSXVZLw8WOLE2rGzQ==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "o+HefwtPZBqyuUHEnKF+qb/ctCAlNc2BYIw3ULEsZ93zweHt5wOMvOeuPxIXR0Gvj3fg6yNlY2nUcdFEduIXYA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -378,14 +378,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.5.2"
+          "Speckle.Sdk.Dependencies": "3.5.3"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "EsNd0OIbubhjFptextM6DeiN74hqb+s8J+HwfAmIFU9XOlmZPfznqjPMJnK9B+8sCpcM2pFsWZys0g/g00m1aw=="
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "kC15SE4yZoVTasgywCm0SpY9yjBsQeUIDt4qoscYAgbn9pe0jj3uM0hZeJUCxn9Fdoj64OfQBpCKzR7VqhkwHQ=="
       }
     }
   }

--- a/Connectors/Revit/Speckle.Connectors.Revit2023/packages.lock.json
+++ b/Connectors/Revit/Speckle.Connectors.Revit2023/packages.lock.json
@@ -281,9 +281,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.5.2, )",
-          "Speckle.Sdk": "[3.5.2, )",
-          "Speckle.Sdk.Dependencies": "[3.5.2, )"
+          "Speckle.Objects": "[3.5.3, )",
+          "Speckle.Sdk": "[3.5.3, )",
+          "Speckle.Sdk.Dependencies": "[3.5.3, )"
         }
       },
       "speckle.connectors.dui": {
@@ -306,7 +306,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.5.2, )"
+          "Speckle.Objects": "[3.5.3, )"
         }
       },
       "speckle.converters.revit2023": {
@@ -351,11 +351,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "4OlvSSV1cxPeIs3gK4GRvq9X0Su3NE/TBxE6uA/rBS4tCCUdRRiF8wJMFSOxj8K6CRuJcdCxAqD6TIB0cwJ/9Q==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "T3xwwoALVGmhIuEjlDrTdDXZ9haFILT32r8OACWrRUItU3xMkOWGyob51Ca1MHPmo8B5gvbk2Gnm8AgReGnxWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.5.2"
+          "Speckle.Sdk": "3.5.3"
         }
       },
       "Speckle.Revit.API": {
@@ -366,9 +366,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "6WUC7nbLOQURVb12eONGewhNdJHJb03jJ74QO8Tc5XODG+Q7Z5ZUcXu62ID/Hst3S0c2dlSXVZLw8WOLE2rGzQ==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "o+HefwtPZBqyuUHEnKF+qb/ctCAlNc2BYIw3ULEsZ93zweHt5wOMvOeuPxIXR0Gvj3fg6yNlY2nUcdFEduIXYA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -378,14 +378,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.5.2"
+          "Speckle.Sdk.Dependencies": "3.5.3"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "EsNd0OIbubhjFptextM6DeiN74hqb+s8J+HwfAmIFU9XOlmZPfznqjPMJnK9B+8sCpcM2pFsWZys0g/g00m1aw=="
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "kC15SE4yZoVTasgywCm0SpY9yjBsQeUIDt4qoscYAgbn9pe0jj3uM0hZeJUCxn9Fdoj64OfQBpCKzR7VqhkwHQ=="
       }
     }
   }

--- a/Connectors/Revit/Speckle.Connectors.Revit2024/packages.lock.json
+++ b/Connectors/Revit/Speckle.Connectors.Revit2024/packages.lock.json
@@ -281,9 +281,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.5.2, )",
-          "Speckle.Sdk": "[3.5.2, )",
-          "Speckle.Sdk.Dependencies": "[3.5.2, )"
+          "Speckle.Objects": "[3.5.3, )",
+          "Speckle.Sdk": "[3.5.3, )",
+          "Speckle.Sdk.Dependencies": "[3.5.3, )"
         }
       },
       "speckle.connectors.dui": {
@@ -306,7 +306,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.5.2, )"
+          "Speckle.Objects": "[3.5.3, )"
         }
       },
       "speckle.converters.revit2024": {
@@ -351,11 +351,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "4OlvSSV1cxPeIs3gK4GRvq9X0Su3NE/TBxE6uA/rBS4tCCUdRRiF8wJMFSOxj8K6CRuJcdCxAqD6TIB0cwJ/9Q==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "T3xwwoALVGmhIuEjlDrTdDXZ9haFILT32r8OACWrRUItU3xMkOWGyob51Ca1MHPmo8B5gvbk2Gnm8AgReGnxWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.5.2"
+          "Speckle.Sdk": "3.5.3"
         }
       },
       "Speckle.Revit.API": {
@@ -366,9 +366,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "6WUC7nbLOQURVb12eONGewhNdJHJb03jJ74QO8Tc5XODG+Q7Z5ZUcXu62ID/Hst3S0c2dlSXVZLw8WOLE2rGzQ==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "o+HefwtPZBqyuUHEnKF+qb/ctCAlNc2BYIw3ULEsZ93zweHt5wOMvOeuPxIXR0Gvj3fg6yNlY2nUcdFEduIXYA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -378,14 +378,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.5.2"
+          "Speckle.Sdk.Dependencies": "3.5.3"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "EsNd0OIbubhjFptextM6DeiN74hqb+s8J+HwfAmIFU9XOlmZPfznqjPMJnK9B+8sCpcM2pFsWZys0g/g00m1aw=="
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "kC15SE4yZoVTasgywCm0SpY9yjBsQeUIDt4qoscYAgbn9pe0jj3uM0hZeJUCxn9Fdoj64OfQBpCKzR7VqhkwHQ=="
       }
     }
   }

--- a/Connectors/Revit/Speckle.Connectors.Revit2025/packages.lock.json
+++ b/Connectors/Revit/Speckle.Connectors.Revit2025/packages.lock.json
@@ -226,9 +226,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.5.2, )",
-          "Speckle.Sdk": "[3.5.2, )",
-          "Speckle.Sdk.Dependencies": "[3.5.2, )"
+          "Speckle.Objects": "[3.5.3, )",
+          "Speckle.Sdk": "[3.5.3, )",
+          "Speckle.Sdk.Dependencies": "[3.5.3, )"
         }
       },
       "speckle.connectors.dui": {
@@ -251,7 +251,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.5.2, )"
+          "Speckle.Objects": "[3.5.3, )"
         }
       },
       "speckle.converters.revit2025": {
@@ -296,11 +296,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "4OlvSSV1cxPeIs3gK4GRvq9X0Su3NE/TBxE6uA/rBS4tCCUdRRiF8wJMFSOxj8K6CRuJcdCxAqD6TIB0cwJ/9Q==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "T3xwwoALVGmhIuEjlDrTdDXZ9haFILT32r8OACWrRUItU3xMkOWGyob51Ca1MHPmo8B5gvbk2Gnm8AgReGnxWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.5.2"
+          "Speckle.Sdk": "3.5.3"
         }
       },
       "Speckle.Revit.API": {
@@ -311,9 +311,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "6WUC7nbLOQURVb12eONGewhNdJHJb03jJ74QO8Tc5XODG+Q7Z5ZUcXu62ID/Hst3S0c2dlSXVZLw8WOLE2rGzQ==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "o+HefwtPZBqyuUHEnKF+qb/ctCAlNc2BYIw3ULEsZ93zweHt5wOMvOeuPxIXR0Gvj3fg6yNlY2nUcdFEduIXYA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -321,14 +321,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.5.2"
+          "Speckle.Sdk.Dependencies": "3.5.3"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "EsNd0OIbubhjFptextM6DeiN74hqb+s8J+HwfAmIFU9XOlmZPfznqjPMJnK9B+8sCpcM2pFsWZys0g/g00m1aw=="
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "kC15SE4yZoVTasgywCm0SpY9yjBsQeUIDt4qoscYAgbn9pe0jj3uM0hZeJUCxn9Fdoj64OfQBpCKzR7VqhkwHQ=="
       }
     },
     "net8.0-windows7.0/win-x64": {

--- a/Connectors/Revit/Speckle.Connectors.Revit2026/packages.lock.json
+++ b/Connectors/Revit/Speckle.Connectors.Revit2026/packages.lock.json
@@ -219,9 +219,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.5.2, )",
-          "Speckle.Sdk": "[3.5.2, )",
-          "Speckle.Sdk.Dependencies": "[3.5.2, )"
+          "Speckle.Objects": "[3.5.3, )",
+          "Speckle.Sdk": "[3.5.3, )",
+          "Speckle.Sdk.Dependencies": "[3.5.3, )"
         }
       },
       "speckle.connectors.dui": {
@@ -244,7 +244,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.5.2, )"
+          "Speckle.Objects": "[3.5.3, )"
         }
       },
       "speckle.converters.revit2026": {
@@ -280,11 +280,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "4OlvSSV1cxPeIs3gK4GRvq9X0Su3NE/TBxE6uA/rBS4tCCUdRRiF8wJMFSOxj8K6CRuJcdCxAqD6TIB0cwJ/9Q==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "T3xwwoALVGmhIuEjlDrTdDXZ9haFILT32r8OACWrRUItU3xMkOWGyob51Ca1MHPmo8B5gvbk2Gnm8AgReGnxWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.5.2"
+          "Speckle.Sdk": "3.5.3"
         }
       },
       "Speckle.Revit.API": {
@@ -295,9 +295,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "6WUC7nbLOQURVb12eONGewhNdJHJb03jJ74QO8Tc5XODG+Q7Z5ZUcXu62ID/Hst3S0c2dlSXVZLw8WOLE2rGzQ==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "o+HefwtPZBqyuUHEnKF+qb/ctCAlNc2BYIw3ULEsZ93zweHt5wOMvOeuPxIXR0Gvj3fg6yNlY2nUcdFEduIXYA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -305,14 +305,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.5.2"
+          "Speckle.Sdk.Dependencies": "3.5.3"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "EsNd0OIbubhjFptextM6DeiN74hqb+s8J+HwfAmIFU9XOlmZPfznqjPMJnK9B+8sCpcM2pFsWZys0g/g00m1aw=="
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "kC15SE4yZoVTasgywCm0SpY9yjBsQeUIDt4qoscYAgbn9pe0jj3uM0hZeJUCxn9Fdoj64OfQBpCKzR7VqhkwHQ=="
       }
     },
     "net8.0-windows7.0/win-x64": {

--- a/Connectors/Rhino/Speckle.Connectors.Grasshopper7/packages.lock.json
+++ b/Connectors/Rhino/Speckle.Connectors.Grasshopper7/packages.lock.json
@@ -325,9 +325,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.5.2, )",
-          "Speckle.Sdk": "[3.5.2, )",
-          "Speckle.Sdk.Dependencies": "[3.5.2, )"
+          "Speckle.Objects": "[3.5.3, )",
+          "Speckle.Sdk": "[3.5.3, )",
+          "Speckle.Sdk.Dependencies": "[3.5.3, )"
         }
       },
       "speckle.connectors.logging": {
@@ -337,7 +337,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.5.2, )"
+          "Speckle.Objects": "[3.5.3, )"
         }
       },
       "speckle.converters.rhino7": {
@@ -382,18 +382,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "4OlvSSV1cxPeIs3gK4GRvq9X0Su3NE/TBxE6uA/rBS4tCCUdRRiF8wJMFSOxj8K6CRuJcdCxAqD6TIB0cwJ/9Q==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "T3xwwoALVGmhIuEjlDrTdDXZ9haFILT32r8OACWrRUItU3xMkOWGyob51Ca1MHPmo8B5gvbk2Gnm8AgReGnxWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.5.2"
+          "Speckle.Sdk": "3.5.3"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "6WUC7nbLOQURVb12eONGewhNdJHJb03jJ74QO8Tc5XODG+Q7Z5ZUcXu62ID/Hst3S0c2dlSXVZLw8WOLE2rGzQ==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "o+HefwtPZBqyuUHEnKF+qb/ctCAlNc2BYIw3ULEsZ93zweHt5wOMvOeuPxIXR0Gvj3fg6yNlY2nUcdFEduIXYA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -403,14 +403,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.5.2"
+          "Speckle.Sdk.Dependencies": "3.5.3"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "EsNd0OIbubhjFptextM6DeiN74hqb+s8J+HwfAmIFU9XOlmZPfznqjPMJnK9B+8sCpcM2pFsWZys0g/g00m1aw=="
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "kC15SE4yZoVTasgywCm0SpY9yjBsQeUIDt4qoscYAgbn9pe0jj3uM0hZeJUCxn9Fdoj64OfQBpCKzR7VqhkwHQ=="
       }
     }
   }

--- a/Connectors/Rhino/Speckle.Connectors.Grasshopper8/packages.lock.json
+++ b/Connectors/Rhino/Speckle.Connectors.Grasshopper8/packages.lock.json
@@ -325,9 +325,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.5.2, )",
-          "Speckle.Sdk": "[3.5.2, )",
-          "Speckle.Sdk.Dependencies": "[3.5.2, )"
+          "Speckle.Objects": "[3.5.3, )",
+          "Speckle.Sdk": "[3.5.3, )",
+          "Speckle.Sdk.Dependencies": "[3.5.3, )"
         }
       },
       "speckle.connectors.logging": {
@@ -337,7 +337,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.5.2, )"
+          "Speckle.Objects": "[3.5.3, )"
         }
       },
       "speckle.converters.rhino8": {
@@ -381,18 +381,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "4OlvSSV1cxPeIs3gK4GRvq9X0Su3NE/TBxE6uA/rBS4tCCUdRRiF8wJMFSOxj8K6CRuJcdCxAqD6TIB0cwJ/9Q==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "T3xwwoALVGmhIuEjlDrTdDXZ9haFILT32r8OACWrRUItU3xMkOWGyob51Ca1MHPmo8B5gvbk2Gnm8AgReGnxWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.5.2"
+          "Speckle.Sdk": "3.5.3"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "6WUC7nbLOQURVb12eONGewhNdJHJb03jJ74QO8Tc5XODG+Q7Z5ZUcXu62ID/Hst3S0c2dlSXVZLw8WOLE2rGzQ==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "o+HefwtPZBqyuUHEnKF+qb/ctCAlNc2BYIw3ULEsZ93zweHt5wOMvOeuPxIXR0Gvj3fg6yNlY2nUcdFEduIXYA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -402,14 +402,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.5.2"
+          "Speckle.Sdk.Dependencies": "3.5.3"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "EsNd0OIbubhjFptextM6DeiN74hqb+s8J+HwfAmIFU9XOlmZPfznqjPMJnK9B+8sCpcM2pFsWZys0g/g00m1aw=="
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "kC15SE4yZoVTasgywCm0SpY9yjBsQeUIDt4qoscYAgbn9pe0jj3uM0hZeJUCxn9Fdoj64OfQBpCKzR7VqhkwHQ=="
       }
     }
   }

--- a/Connectors/Rhino/Speckle.Connectors.Rhino7/packages.lock.json
+++ b/Connectors/Rhino/Speckle.Connectors.Rhino7/packages.lock.json
@@ -306,9 +306,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.5.2, )",
-          "Speckle.Sdk": "[3.5.2, )",
-          "Speckle.Sdk.Dependencies": "[3.5.2, )"
+          "Speckle.Objects": "[3.5.3, )",
+          "Speckle.Sdk": "[3.5.3, )",
+          "Speckle.Sdk.Dependencies": "[3.5.3, )"
         }
       },
       "speckle.connectors.dui": {
@@ -341,7 +341,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.5.2, )"
+          "Speckle.Objects": "[3.5.3, )"
         }
       },
       "speckle.converters.rhino7": {
@@ -401,18 +401,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "4OlvSSV1cxPeIs3gK4GRvq9X0Su3NE/TBxE6uA/rBS4tCCUdRRiF8wJMFSOxj8K6CRuJcdCxAqD6TIB0cwJ/9Q==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "T3xwwoALVGmhIuEjlDrTdDXZ9haFILT32r8OACWrRUItU3xMkOWGyob51Ca1MHPmo8B5gvbk2Gnm8AgReGnxWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.5.2"
+          "Speckle.Sdk": "3.5.3"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "6WUC7nbLOQURVb12eONGewhNdJHJb03jJ74QO8Tc5XODG+Q7Z5ZUcXu62ID/Hst3S0c2dlSXVZLw8WOLE2rGzQ==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "o+HefwtPZBqyuUHEnKF+qb/ctCAlNc2BYIw3ULEsZ93zweHt5wOMvOeuPxIXR0Gvj3fg6yNlY2nUcdFEduIXYA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -422,14 +422,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.5.2"
+          "Speckle.Sdk.Dependencies": "3.5.3"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "EsNd0OIbubhjFptextM6DeiN74hqb+s8J+HwfAmIFU9XOlmZPfznqjPMJnK9B+8sCpcM2pFsWZys0g/g00m1aw=="
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "kC15SE4yZoVTasgywCm0SpY9yjBsQeUIDt4qoscYAgbn9pe0jj3uM0hZeJUCxn9Fdoj64OfQBpCKzR7VqhkwHQ=="
       },
       "System.Resources.Extensions": {
         "type": "CentralTransitive",

--- a/Connectors/Rhino/Speckle.Connectors.Rhino8/packages.lock.json
+++ b/Connectors/Rhino/Speckle.Connectors.Rhino8/packages.lock.json
@@ -306,9 +306,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.5.2, )",
-          "Speckle.Sdk": "[3.5.2, )",
-          "Speckle.Sdk.Dependencies": "[3.5.2, )"
+          "Speckle.Objects": "[3.5.3, )",
+          "Speckle.Sdk": "[3.5.3, )",
+          "Speckle.Sdk.Dependencies": "[3.5.3, )"
         }
       },
       "speckle.connectors.dui": {
@@ -341,7 +341,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.5.2, )"
+          "Speckle.Objects": "[3.5.3, )"
         }
       },
       "speckle.converters.rhino8": {
@@ -400,18 +400,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "4OlvSSV1cxPeIs3gK4GRvq9X0Su3NE/TBxE6uA/rBS4tCCUdRRiF8wJMFSOxj8K6CRuJcdCxAqD6TIB0cwJ/9Q==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "T3xwwoALVGmhIuEjlDrTdDXZ9haFILT32r8OACWrRUItU3xMkOWGyob51Ca1MHPmo8B5gvbk2Gnm8AgReGnxWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.5.2"
+          "Speckle.Sdk": "3.5.3"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "6WUC7nbLOQURVb12eONGewhNdJHJb03jJ74QO8Tc5XODG+Q7Z5ZUcXu62ID/Hst3S0c2dlSXVZLw8WOLE2rGzQ==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "o+HefwtPZBqyuUHEnKF+qb/ctCAlNc2BYIw3ULEsZ93zweHt5wOMvOeuPxIXR0Gvj3fg6yNlY2nUcdFEduIXYA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -421,14 +421,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.5.2"
+          "Speckle.Sdk.Dependencies": "3.5.3"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "EsNd0OIbubhjFptextM6DeiN74hqb+s8J+HwfAmIFU9XOlmZPfznqjPMJnK9B+8sCpcM2pFsWZys0g/g00m1aw=="
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "kC15SE4yZoVTasgywCm0SpY9yjBsQeUIDt4qoscYAgbn9pe0jj3uM0hZeJUCxn9Fdoj64OfQBpCKzR7VqhkwHQ=="
       },
       "System.Resources.Extensions": {
         "type": "CentralTransitive",

--- a/Connectors/Rhino/Speckle.Connectors.RhinoImporter/packages.lock.json
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoImporter/packages.lock.json
@@ -235,9 +235,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.5.2, )",
-          "Speckle.Sdk": "[3.5.2, )",
-          "Speckle.Sdk.Dependencies": "[3.5.2, )"
+          "Speckle.Objects": "[3.5.3, )",
+          "Speckle.Sdk": "[3.5.3, )",
+          "Speckle.Sdk.Dependencies": "[3.5.3, )"
         }
       },
       "speckle.connectors.dui": {
@@ -261,7 +261,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.5.2, )"
+          "Speckle.Objects": "[3.5.3, )"
         }
       },
       "speckle.converters.rhino8": {
@@ -311,18 +311,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "4OlvSSV1cxPeIs3gK4GRvq9X0Su3NE/TBxE6uA/rBS4tCCUdRRiF8wJMFSOxj8K6CRuJcdCxAqD6TIB0cwJ/9Q==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "T3xwwoALVGmhIuEjlDrTdDXZ9haFILT32r8OACWrRUItU3xMkOWGyob51Ca1MHPmo8B5gvbk2Gnm8AgReGnxWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.5.2"
+          "Speckle.Sdk": "3.5.3"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "6WUC7nbLOQURVb12eONGewhNdJHJb03jJ74QO8Tc5XODG+Q7Z5ZUcXu62ID/Hst3S0c2dlSXVZLw8WOLE2rGzQ==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "o+HefwtPZBqyuUHEnKF+qb/ctCAlNc2BYIw3ULEsZ93zweHt5wOMvOeuPxIXR0Gvj3fg6yNlY2nUcdFEduIXYA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -330,14 +330,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.5.2"
+          "Speckle.Sdk.Dependencies": "3.5.3"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "EsNd0OIbubhjFptextM6DeiN74hqb+s8J+HwfAmIFU9XOlmZPfznqjPMJnK9B+8sCpcM2pFsWZys0g/g00m1aw=="
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "kC15SE4yZoVTasgywCm0SpY9yjBsQeUIDt4qoscYAgbn9pe0jj3uM0hZeJUCxn9Fdoj64OfQBpCKzR7VqhkwHQ=="
       }
     },
     "net8.0-windows7.0/win-x64": {

--- a/Connectors/Tekla/Speckle.Connector.Tekla2023/packages.lock.json
+++ b/Connectors/Tekla/Speckle.Connector.Tekla2023/packages.lock.json
@@ -325,9 +325,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.5.2, )",
-          "Speckle.Sdk": "[3.5.2, )",
-          "Speckle.Sdk.Dependencies": "[3.5.2, )"
+          "Speckle.Objects": "[3.5.3, )",
+          "Speckle.Sdk": "[3.5.3, )",
+          "Speckle.Sdk.Dependencies": "[3.5.3, )"
         }
       },
       "speckle.connectors.dui": {
@@ -360,7 +360,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.5.2, )"
+          "Speckle.Objects": "[3.5.3, )"
         }
       },
       "LibTessDotNet": {
@@ -410,18 +410,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "4OlvSSV1cxPeIs3gK4GRvq9X0Su3NE/TBxE6uA/rBS4tCCUdRRiF8wJMFSOxj8K6CRuJcdCxAqD6TIB0cwJ/9Q==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "T3xwwoALVGmhIuEjlDrTdDXZ9haFILT32r8OACWrRUItU3xMkOWGyob51Ca1MHPmo8B5gvbk2Gnm8AgReGnxWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.5.2"
+          "Speckle.Sdk": "3.5.3"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "6WUC7nbLOQURVb12eONGewhNdJHJb03jJ74QO8Tc5XODG+Q7Z5ZUcXu62ID/Hst3S0c2dlSXVZLw8WOLE2rGzQ==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "o+HefwtPZBqyuUHEnKF+qb/ctCAlNc2BYIw3ULEsZ93zweHt5wOMvOeuPxIXR0Gvj3fg6yNlY2nUcdFEduIXYA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -431,14 +431,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.5.2"
+          "Speckle.Sdk.Dependencies": "3.5.3"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "EsNd0OIbubhjFptextM6DeiN74hqb+s8J+HwfAmIFU9XOlmZPfznqjPMJnK9B+8sCpcM2pFsWZys0g/g00m1aw=="
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "kC15SE4yZoVTasgywCm0SpY9yjBsQeUIDt4qoscYAgbn9pe0jj3uM0hZeJUCxn9Fdoj64OfQBpCKzR7VqhkwHQ=="
       }
     }
   }

--- a/Connectors/Tekla/Speckle.Connector.Tekla2024/packages.lock.json
+++ b/Connectors/Tekla/Speckle.Connector.Tekla2024/packages.lock.json
@@ -406,9 +406,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.5.2, )",
-          "Speckle.Sdk": "[3.5.2, )",
-          "Speckle.Sdk.Dependencies": "[3.5.2, )"
+          "Speckle.Objects": "[3.5.3, )",
+          "Speckle.Sdk": "[3.5.3, )",
+          "Speckle.Sdk.Dependencies": "[3.5.3, )"
         }
       },
       "speckle.connectors.dui": {
@@ -441,7 +441,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.5.2, )"
+          "Speckle.Objects": "[3.5.3, )"
         }
       },
       "LibTessDotNet": {
@@ -491,18 +491,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "4OlvSSV1cxPeIs3gK4GRvq9X0Su3NE/TBxE6uA/rBS4tCCUdRRiF8wJMFSOxj8K6CRuJcdCxAqD6TIB0cwJ/9Q==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "T3xwwoALVGmhIuEjlDrTdDXZ9haFILT32r8OACWrRUItU3xMkOWGyob51Ca1MHPmo8B5gvbk2Gnm8AgReGnxWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.5.2"
+          "Speckle.Sdk": "3.5.3"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "6WUC7nbLOQURVb12eONGewhNdJHJb03jJ74QO8Tc5XODG+Q7Z5ZUcXu62ID/Hst3S0c2dlSXVZLw8WOLE2rGzQ==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "o+HefwtPZBqyuUHEnKF+qb/ctCAlNc2BYIw3ULEsZ93zweHt5wOMvOeuPxIXR0Gvj3fg6yNlY2nUcdFEduIXYA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -512,14 +512,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.5.2"
+          "Speckle.Sdk.Dependencies": "3.5.3"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "EsNd0OIbubhjFptextM6DeiN74hqb+s8J+HwfAmIFU9XOlmZPfznqjPMJnK9B+8sCpcM2pFsWZys0g/g00m1aw=="
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "kC15SE4yZoVTasgywCm0SpY9yjBsQeUIDt4qoscYAgbn9pe0jj3uM0hZeJUCxn9Fdoj64OfQBpCKzR7VqhkwHQ=="
       }
     }
   }

--- a/Connectors/Tekla/Speckle.Connector.Tekla2025/packages.lock.json
+++ b/Connectors/Tekla/Speckle.Connector.Tekla2025/packages.lock.json
@@ -406,9 +406,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.5.2, )",
-          "Speckle.Sdk": "[3.5.2, )",
-          "Speckle.Sdk.Dependencies": "[3.5.2, )"
+          "Speckle.Objects": "[3.5.3, )",
+          "Speckle.Sdk": "[3.5.3, )",
+          "Speckle.Sdk.Dependencies": "[3.5.3, )"
         }
       },
       "speckle.connectors.dui": {
@@ -441,7 +441,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.5.2, )"
+          "Speckle.Objects": "[3.5.3, )"
         }
       },
       "LibTessDotNet": {
@@ -491,18 +491,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "4OlvSSV1cxPeIs3gK4GRvq9X0Su3NE/TBxE6uA/rBS4tCCUdRRiF8wJMFSOxj8K6CRuJcdCxAqD6TIB0cwJ/9Q==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "T3xwwoALVGmhIuEjlDrTdDXZ9haFILT32r8OACWrRUItU3xMkOWGyob51Ca1MHPmo8B5gvbk2Gnm8AgReGnxWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.5.2"
+          "Speckle.Sdk": "3.5.3"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "6WUC7nbLOQURVb12eONGewhNdJHJb03jJ74QO8Tc5XODG+Q7Z5ZUcXu62ID/Hst3S0c2dlSXVZLw8WOLE2rGzQ==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "o+HefwtPZBqyuUHEnKF+qb/ctCAlNc2BYIw3ULEsZ93zweHt5wOMvOeuPxIXR0Gvj3fg6yNlY2nUcdFEduIXYA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -512,14 +512,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.5.2"
+          "Speckle.Sdk.Dependencies": "3.5.3"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "EsNd0OIbubhjFptextM6DeiN74hqb+s8J+HwfAmIFU9XOlmZPfznqjPMJnK9B+8sCpcM2pFsWZys0g/g00m1aw=="
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "kC15SE4yZoVTasgywCm0SpY9yjBsQeUIDt4qoscYAgbn9pe0jj3uM0hZeJUCxn9Fdoj64OfQBpCKzR7VqhkwHQ=="
       }
     }
   }

--- a/Converters/Autocad/Speckle.Converters.Autocad2022/packages.lock.json
+++ b/Converters/Autocad/Speckle.Converters.Autocad2022/packages.lock.json
@@ -258,7 +258,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.5.2, )"
+          "Speckle.Objects": "[3.5.3, )"
         }
       },
       "Microsoft.Extensions.Logging": {
@@ -287,18 +287,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "4OlvSSV1cxPeIs3gK4GRvq9X0Su3NE/TBxE6uA/rBS4tCCUdRRiF8wJMFSOxj8K6CRuJcdCxAqD6TIB0cwJ/9Q==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "T3xwwoALVGmhIuEjlDrTdDXZ9haFILT32r8OACWrRUItU3xMkOWGyob51Ca1MHPmo8B5gvbk2Gnm8AgReGnxWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.5.2"
+          "Speckle.Sdk": "3.5.3"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "6WUC7nbLOQURVb12eONGewhNdJHJb03jJ74QO8Tc5XODG+Q7Z5ZUcXu62ID/Hst3S0c2dlSXVZLw8WOLE2rGzQ==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "o+HefwtPZBqyuUHEnKF+qb/ctCAlNc2BYIw3ULEsZ93zweHt5wOMvOeuPxIXR0Gvj3fg6yNlY2nUcdFEduIXYA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -308,14 +308,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.5.2"
+          "Speckle.Sdk.Dependencies": "3.5.3"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "EsNd0OIbubhjFptextM6DeiN74hqb+s8J+HwfAmIFU9XOlmZPfznqjPMJnK9B+8sCpcM2pFsWZys0g/g00m1aw=="
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "kC15SE4yZoVTasgywCm0SpY9yjBsQeUIDt4qoscYAgbn9pe0jj3uM0hZeJUCxn9Fdoj64OfQBpCKzR7VqhkwHQ=="
       }
     }
   }

--- a/Converters/Autocad/Speckle.Converters.Autocad2023/packages.lock.json
+++ b/Converters/Autocad/Speckle.Converters.Autocad2023/packages.lock.json
@@ -258,7 +258,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.5.2, )"
+          "Speckle.Objects": "[3.5.3, )"
         }
       },
       "Microsoft.Extensions.Logging": {
@@ -287,18 +287,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "4OlvSSV1cxPeIs3gK4GRvq9X0Su3NE/TBxE6uA/rBS4tCCUdRRiF8wJMFSOxj8K6CRuJcdCxAqD6TIB0cwJ/9Q==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "T3xwwoALVGmhIuEjlDrTdDXZ9haFILT32r8OACWrRUItU3xMkOWGyob51Ca1MHPmo8B5gvbk2Gnm8AgReGnxWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.5.2"
+          "Speckle.Sdk": "3.5.3"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "6WUC7nbLOQURVb12eONGewhNdJHJb03jJ74QO8Tc5XODG+Q7Z5ZUcXu62ID/Hst3S0c2dlSXVZLw8WOLE2rGzQ==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "o+HefwtPZBqyuUHEnKF+qb/ctCAlNc2BYIw3ULEsZ93zweHt5wOMvOeuPxIXR0Gvj3fg6yNlY2nUcdFEduIXYA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -308,14 +308,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.5.2"
+          "Speckle.Sdk.Dependencies": "3.5.3"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "EsNd0OIbubhjFptextM6DeiN74hqb+s8J+HwfAmIFU9XOlmZPfznqjPMJnK9B+8sCpcM2pFsWZys0g/g00m1aw=="
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "kC15SE4yZoVTasgywCm0SpY9yjBsQeUIDt4qoscYAgbn9pe0jj3uM0hZeJUCxn9Fdoj64OfQBpCKzR7VqhkwHQ=="
       }
     }
   }

--- a/Converters/Autocad/Speckle.Converters.Autocad2024/packages.lock.json
+++ b/Converters/Autocad/Speckle.Converters.Autocad2024/packages.lock.json
@@ -259,9 +259,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.5.2, )",
-          "Speckle.Sdk": "[3.5.2, )",
-          "Speckle.Sdk.Dependencies": "[3.5.2, )"
+          "Speckle.Objects": "[3.5.3, )",
+          "Speckle.Sdk": "[3.5.3, )",
+          "Speckle.Sdk.Dependencies": "[3.5.3, )"
         }
       },
       "speckle.connectors.dui": {
@@ -285,7 +285,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.5.2, )"
+          "Speckle.Objects": "[3.5.3, )"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -329,18 +329,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "4OlvSSV1cxPeIs3gK4GRvq9X0Su3NE/TBxE6uA/rBS4tCCUdRRiF8wJMFSOxj8K6CRuJcdCxAqD6TIB0cwJ/9Q==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "T3xwwoALVGmhIuEjlDrTdDXZ9haFILT32r8OACWrRUItU3xMkOWGyob51Ca1MHPmo8B5gvbk2Gnm8AgReGnxWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.5.2"
+          "Speckle.Sdk": "3.5.3"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "6WUC7nbLOQURVb12eONGewhNdJHJb03jJ74QO8Tc5XODG+Q7Z5ZUcXu62ID/Hst3S0c2dlSXVZLw8WOLE2rGzQ==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "o+HefwtPZBqyuUHEnKF+qb/ctCAlNc2BYIw3ULEsZ93zweHt5wOMvOeuPxIXR0Gvj3fg6yNlY2nUcdFEduIXYA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -350,14 +350,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.5.2"
+          "Speckle.Sdk.Dependencies": "3.5.3"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "EsNd0OIbubhjFptextM6DeiN74hqb+s8J+HwfAmIFU9XOlmZPfznqjPMJnK9B+8sCpcM2pFsWZys0g/g00m1aw=="
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "kC15SE4yZoVTasgywCm0SpY9yjBsQeUIDt4qoscYAgbn9pe0jj3uM0hZeJUCxn9Fdoj64OfQBpCKzR7VqhkwHQ=="
       }
     }
   }

--- a/Converters/Autocad/Speckle.Converters.Autocad2025/packages.lock.json
+++ b/Converters/Autocad/Speckle.Converters.Autocad2025/packages.lock.json
@@ -210,9 +210,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.5.2, )",
-          "Speckle.Sdk": "[3.5.2, )",
-          "Speckle.Sdk.Dependencies": "[3.5.2, )"
+          "Speckle.Objects": "[3.5.3, )",
+          "Speckle.Sdk": "[3.5.3, )",
+          "Speckle.Sdk.Dependencies": "[3.5.3, )"
         }
       },
       "speckle.connectors.dui": {
@@ -236,7 +236,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.5.2, )"
+          "Speckle.Objects": "[3.5.3, )"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -280,18 +280,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "4OlvSSV1cxPeIs3gK4GRvq9X0Su3NE/TBxE6uA/rBS4tCCUdRRiF8wJMFSOxj8K6CRuJcdCxAqD6TIB0cwJ/9Q==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "T3xwwoALVGmhIuEjlDrTdDXZ9haFILT32r8OACWrRUItU3xMkOWGyob51Ca1MHPmo8B5gvbk2Gnm8AgReGnxWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.5.2"
+          "Speckle.Sdk": "3.5.3"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "6WUC7nbLOQURVb12eONGewhNdJHJb03jJ74QO8Tc5XODG+Q7Z5ZUcXu62ID/Hst3S0c2dlSXVZLw8WOLE2rGzQ==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "o+HefwtPZBqyuUHEnKF+qb/ctCAlNc2BYIw3ULEsZ93zweHt5wOMvOeuPxIXR0Gvj3fg6yNlY2nUcdFEduIXYA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -299,14 +299,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.5.2"
+          "Speckle.Sdk.Dependencies": "3.5.3"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "EsNd0OIbubhjFptextM6DeiN74hqb+s8J+HwfAmIFU9XOlmZPfznqjPMJnK9B+8sCpcM2pFsWZys0g/g00m1aw=="
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "kC15SE4yZoVTasgywCm0SpY9yjBsQeUIDt4qoscYAgbn9pe0jj3uM0hZeJUCxn9Fdoj64OfQBpCKzR7VqhkwHQ=="
       }
     }
   }

--- a/Converters/Autocad/Speckle.Converters.Autocad2026/packages.lock.json
+++ b/Converters/Autocad/Speckle.Converters.Autocad2026/packages.lock.json
@@ -210,9 +210,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.5.2, )",
-          "Speckle.Sdk": "[3.5.2, )",
-          "Speckle.Sdk.Dependencies": "[3.5.2, )"
+          "Speckle.Objects": "[3.5.3, )",
+          "Speckle.Sdk": "[3.5.3, )",
+          "Speckle.Sdk.Dependencies": "[3.5.3, )"
         }
       },
       "speckle.connectors.dui": {
@@ -236,7 +236,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.5.2, )"
+          "Speckle.Objects": "[3.5.3, )"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -280,18 +280,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "4OlvSSV1cxPeIs3gK4GRvq9X0Su3NE/TBxE6uA/rBS4tCCUdRRiF8wJMFSOxj8K6CRuJcdCxAqD6TIB0cwJ/9Q==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "T3xwwoALVGmhIuEjlDrTdDXZ9haFILT32r8OACWrRUItU3xMkOWGyob51Ca1MHPmo8B5gvbk2Gnm8AgReGnxWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.5.2"
+          "Speckle.Sdk": "3.5.3"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "6WUC7nbLOQURVb12eONGewhNdJHJb03jJ74QO8Tc5XODG+Q7Z5ZUcXu62ID/Hst3S0c2dlSXVZLw8WOLE2rGzQ==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "o+HefwtPZBqyuUHEnKF+qb/ctCAlNc2BYIw3ULEsZ93zweHt5wOMvOeuPxIXR0Gvj3fg6yNlY2nUcdFEduIXYA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -299,14 +299,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.5.2"
+          "Speckle.Sdk.Dependencies": "3.5.3"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "EsNd0OIbubhjFptextM6DeiN74hqb+s8J+HwfAmIFU9XOlmZPfznqjPMJnK9B+8sCpcM2pFsWZys0g/g00m1aw=="
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "kC15SE4yZoVTasgywCm0SpY9yjBsQeUIDt4qoscYAgbn9pe0jj3uM0hZeJUCxn9Fdoj64OfQBpCKzR7VqhkwHQ=="
       }
     }
   }

--- a/Converters/CSi/Speckle.Converters.ETABS21/packages.lock.json
+++ b/Converters/CSi/Speckle.Converters.ETABS21/packages.lock.json
@@ -258,7 +258,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.5.2, )"
+          "Speckle.Objects": "[3.5.3, )"
         }
       },
       "Microsoft.Extensions.Logging": {
@@ -287,18 +287,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "4OlvSSV1cxPeIs3gK4GRvq9X0Su3NE/TBxE6uA/rBS4tCCUdRRiF8wJMFSOxj8K6CRuJcdCxAqD6TIB0cwJ/9Q==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "T3xwwoALVGmhIuEjlDrTdDXZ9haFILT32r8OACWrRUItU3xMkOWGyob51Ca1MHPmo8B5gvbk2Gnm8AgReGnxWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.5.2"
+          "Speckle.Sdk": "3.5.3"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "6WUC7nbLOQURVb12eONGewhNdJHJb03jJ74QO8Tc5XODG+Q7Z5ZUcXu62ID/Hst3S0c2dlSXVZLw8WOLE2rGzQ==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "o+HefwtPZBqyuUHEnKF+qb/ctCAlNc2BYIw3ULEsZ93zweHt5wOMvOeuPxIXR0Gvj3fg6yNlY2nUcdFEduIXYA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -308,14 +308,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.5.2"
+          "Speckle.Sdk.Dependencies": "3.5.3"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "EsNd0OIbubhjFptextM6DeiN74hqb+s8J+HwfAmIFU9XOlmZPfznqjPMJnK9B+8sCpcM2pFsWZys0g/g00m1aw=="
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "kC15SE4yZoVTasgywCm0SpY9yjBsQeUIDt4qoscYAgbn9pe0jj3uM0hZeJUCxn9Fdoj64OfQBpCKzR7VqhkwHQ=="
       }
     }
   }

--- a/Converters/CSi/Speckle.Converters.ETABS22/packages.lock.json
+++ b/Converters/CSi/Speckle.Converters.ETABS22/packages.lock.json
@@ -209,7 +209,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.5.2, )"
+          "Speckle.Objects": "[3.5.3, )"
         }
       },
       "Microsoft.Extensions.Logging": {
@@ -238,18 +238,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "4OlvSSV1cxPeIs3gK4GRvq9X0Su3NE/TBxE6uA/rBS4tCCUdRRiF8wJMFSOxj8K6CRuJcdCxAqD6TIB0cwJ/9Q==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "T3xwwoALVGmhIuEjlDrTdDXZ9haFILT32r8OACWrRUItU3xMkOWGyob51Ca1MHPmo8B5gvbk2Gnm8AgReGnxWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.5.2"
+          "Speckle.Sdk": "3.5.3"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "6WUC7nbLOQURVb12eONGewhNdJHJb03jJ74QO8Tc5XODG+Q7Z5ZUcXu62ID/Hst3S0c2dlSXVZLw8WOLE2rGzQ==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "o+HefwtPZBqyuUHEnKF+qb/ctCAlNc2BYIw3ULEsZ93zweHt5wOMvOeuPxIXR0Gvj3fg6yNlY2nUcdFEduIXYA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -257,14 +257,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.5.2"
+          "Speckle.Sdk.Dependencies": "3.5.3"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "EsNd0OIbubhjFptextM6DeiN74hqb+s8J+HwfAmIFU9XOlmZPfznqjPMJnK9B+8sCpcM2pFsWZys0g/g00m1aw=="
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "kC15SE4yZoVTasgywCm0SpY9yjBsQeUIDt4qoscYAgbn9pe0jj3uM0hZeJUCxn9Fdoj64OfQBpCKzR7VqhkwHQ=="
       }
     }
   }

--- a/Converters/Civil3d/Speckle.Converters.Civil3d2022/packages.lock.json
+++ b/Converters/Civil3d/Speckle.Converters.Civil3d2022/packages.lock.json
@@ -267,7 +267,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.5.2, )"
+          "Speckle.Objects": "[3.5.3, )"
         }
       },
       "Microsoft.Extensions.Logging": {
@@ -296,18 +296,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "4OlvSSV1cxPeIs3gK4GRvq9X0Su3NE/TBxE6uA/rBS4tCCUdRRiF8wJMFSOxj8K6CRuJcdCxAqD6TIB0cwJ/9Q==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "T3xwwoALVGmhIuEjlDrTdDXZ9haFILT32r8OACWrRUItU3xMkOWGyob51Ca1MHPmo8B5gvbk2Gnm8AgReGnxWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.5.2"
+          "Speckle.Sdk": "3.5.3"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "6WUC7nbLOQURVb12eONGewhNdJHJb03jJ74QO8Tc5XODG+Q7Z5ZUcXu62ID/Hst3S0c2dlSXVZLw8WOLE2rGzQ==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "o+HefwtPZBqyuUHEnKF+qb/ctCAlNc2BYIw3ULEsZ93zweHt5wOMvOeuPxIXR0Gvj3fg6yNlY2nUcdFEduIXYA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -317,14 +317,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.5.2"
+          "Speckle.Sdk.Dependencies": "3.5.3"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "EsNd0OIbubhjFptextM6DeiN74hqb+s8J+HwfAmIFU9XOlmZPfznqjPMJnK9B+8sCpcM2pFsWZys0g/g00m1aw=="
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "kC15SE4yZoVTasgywCm0SpY9yjBsQeUIDt4qoscYAgbn9pe0jj3uM0hZeJUCxn9Fdoj64OfQBpCKzR7VqhkwHQ=="
       }
     }
   }

--- a/Converters/Civil3d/Speckle.Converters.Civil3d2023/packages.lock.json
+++ b/Converters/Civil3d/Speckle.Converters.Civil3d2023/packages.lock.json
@@ -267,7 +267,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.5.2, )"
+          "Speckle.Objects": "[3.5.3, )"
         }
       },
       "Microsoft.Extensions.Logging": {
@@ -296,18 +296,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "4OlvSSV1cxPeIs3gK4GRvq9X0Su3NE/TBxE6uA/rBS4tCCUdRRiF8wJMFSOxj8K6CRuJcdCxAqD6TIB0cwJ/9Q==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "T3xwwoALVGmhIuEjlDrTdDXZ9haFILT32r8OACWrRUItU3xMkOWGyob51Ca1MHPmo8B5gvbk2Gnm8AgReGnxWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.5.2"
+          "Speckle.Sdk": "3.5.3"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "6WUC7nbLOQURVb12eONGewhNdJHJb03jJ74QO8Tc5XODG+Q7Z5ZUcXu62ID/Hst3S0c2dlSXVZLw8WOLE2rGzQ==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "o+HefwtPZBqyuUHEnKF+qb/ctCAlNc2BYIw3ULEsZ93zweHt5wOMvOeuPxIXR0Gvj3fg6yNlY2nUcdFEduIXYA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -317,14 +317,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.5.2"
+          "Speckle.Sdk.Dependencies": "3.5.3"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "EsNd0OIbubhjFptextM6DeiN74hqb+s8J+HwfAmIFU9XOlmZPfznqjPMJnK9B+8sCpcM2pFsWZys0g/g00m1aw=="
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "kC15SE4yZoVTasgywCm0SpY9yjBsQeUIDt4qoscYAgbn9pe0jj3uM0hZeJUCxn9Fdoj64OfQBpCKzR7VqhkwHQ=="
       }
     }
   }

--- a/Converters/Civil3d/Speckle.Converters.Civil3d2024/packages.lock.json
+++ b/Converters/Civil3d/Speckle.Converters.Civil3d2024/packages.lock.json
@@ -267,7 +267,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.5.2, )"
+          "Speckle.Objects": "[3.5.3, )"
         }
       },
       "Microsoft.Extensions.Logging": {
@@ -296,18 +296,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "4OlvSSV1cxPeIs3gK4GRvq9X0Su3NE/TBxE6uA/rBS4tCCUdRRiF8wJMFSOxj8K6CRuJcdCxAqD6TIB0cwJ/9Q==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "T3xwwoALVGmhIuEjlDrTdDXZ9haFILT32r8OACWrRUItU3xMkOWGyob51Ca1MHPmo8B5gvbk2Gnm8AgReGnxWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.5.2"
+          "Speckle.Sdk": "3.5.3"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "6WUC7nbLOQURVb12eONGewhNdJHJb03jJ74QO8Tc5XODG+Q7Z5ZUcXu62ID/Hst3S0c2dlSXVZLw8WOLE2rGzQ==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "o+HefwtPZBqyuUHEnKF+qb/ctCAlNc2BYIw3ULEsZ93zweHt5wOMvOeuPxIXR0Gvj3fg6yNlY2nUcdFEduIXYA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -317,14 +317,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.5.2"
+          "Speckle.Sdk.Dependencies": "3.5.3"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "EsNd0OIbubhjFptextM6DeiN74hqb+s8J+HwfAmIFU9XOlmZPfznqjPMJnK9B+8sCpcM2pFsWZys0g/g00m1aw=="
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "kC15SE4yZoVTasgywCm0SpY9yjBsQeUIDt4qoscYAgbn9pe0jj3uM0hZeJUCxn9Fdoj64OfQBpCKzR7VqhkwHQ=="
       }
     }
   }

--- a/Converters/Civil3d/Speckle.Converters.Civil3d2025/packages.lock.json
+++ b/Converters/Civil3d/Speckle.Converters.Civil3d2025/packages.lock.json
@@ -219,9 +219,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.5.2, )",
-          "Speckle.Sdk": "[3.5.2, )",
-          "Speckle.Sdk.Dependencies": "[3.5.2, )"
+          "Speckle.Objects": "[3.5.3, )",
+          "Speckle.Sdk": "[3.5.3, )",
+          "Speckle.Sdk.Dependencies": "[3.5.3, )"
         }
       },
       "speckle.connectors.dui": {
@@ -245,7 +245,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.5.2, )"
+          "Speckle.Objects": "[3.5.3, )"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -289,18 +289,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "4OlvSSV1cxPeIs3gK4GRvq9X0Su3NE/TBxE6uA/rBS4tCCUdRRiF8wJMFSOxj8K6CRuJcdCxAqD6TIB0cwJ/9Q==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "T3xwwoALVGmhIuEjlDrTdDXZ9haFILT32r8OACWrRUItU3xMkOWGyob51Ca1MHPmo8B5gvbk2Gnm8AgReGnxWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.5.2"
+          "Speckle.Sdk": "3.5.3"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "6WUC7nbLOQURVb12eONGewhNdJHJb03jJ74QO8Tc5XODG+Q7Z5ZUcXu62ID/Hst3S0c2dlSXVZLw8WOLE2rGzQ==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "o+HefwtPZBqyuUHEnKF+qb/ctCAlNc2BYIw3ULEsZ93zweHt5wOMvOeuPxIXR0Gvj3fg6yNlY2nUcdFEduIXYA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -308,14 +308,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.5.2"
+          "Speckle.Sdk.Dependencies": "3.5.3"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "EsNd0OIbubhjFptextM6DeiN74hqb+s8J+HwfAmIFU9XOlmZPfznqjPMJnK9B+8sCpcM2pFsWZys0g/g00m1aw=="
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "kC15SE4yZoVTasgywCm0SpY9yjBsQeUIDt4qoscYAgbn9pe0jj3uM0hZeJUCxn9Fdoj64OfQBpCKzR7VqhkwHQ=="
       }
     }
   }

--- a/Converters/Civil3d/Speckle.Converters.Civil3d2026/packages.lock.json
+++ b/Converters/Civil3d/Speckle.Converters.Civil3d2026/packages.lock.json
@@ -219,9 +219,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.5.2, )",
-          "Speckle.Sdk": "[3.5.2, )",
-          "Speckle.Sdk.Dependencies": "[3.5.2, )"
+          "Speckle.Objects": "[3.5.3, )",
+          "Speckle.Sdk": "[3.5.3, )",
+          "Speckle.Sdk.Dependencies": "[3.5.3, )"
         }
       },
       "speckle.connectors.dui": {
@@ -245,7 +245,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.5.2, )"
+          "Speckle.Objects": "[3.5.3, )"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -289,18 +289,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "4OlvSSV1cxPeIs3gK4GRvq9X0Su3NE/TBxE6uA/rBS4tCCUdRRiF8wJMFSOxj8K6CRuJcdCxAqD6TIB0cwJ/9Q==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "T3xwwoALVGmhIuEjlDrTdDXZ9haFILT32r8OACWrRUItU3xMkOWGyob51Ca1MHPmo8B5gvbk2Gnm8AgReGnxWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.5.2"
+          "Speckle.Sdk": "3.5.3"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "6WUC7nbLOQURVb12eONGewhNdJHJb03jJ74QO8Tc5XODG+Q7Z5ZUcXu62ID/Hst3S0c2dlSXVZLw8WOLE2rGzQ==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "o+HefwtPZBqyuUHEnKF+qb/ctCAlNc2BYIw3ULEsZ93zweHt5wOMvOeuPxIXR0Gvj3fg6yNlY2nUcdFEduIXYA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -308,14 +308,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.5.2"
+          "Speckle.Sdk.Dependencies": "3.5.3"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "EsNd0OIbubhjFptextM6DeiN74hqb+s8J+HwfAmIFU9XOlmZPfznqjPMJnK9B+8sCpcM2pFsWZys0g/g00m1aw=="
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "kC15SE4yZoVTasgywCm0SpY9yjBsQeUIDt4qoscYAgbn9pe0jj3uM0hZeJUCxn9Fdoj64OfQBpCKzR7VqhkwHQ=="
       }
     }
   }

--- a/Converters/Navisworks/Speckle.Converters.Navisworks2020/packages.lock.json
+++ b/Converters/Navisworks/Speckle.Converters.Navisworks2020/packages.lock.json
@@ -259,9 +259,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.5.2, )",
-          "Speckle.Sdk": "[3.5.2, )",
-          "Speckle.Sdk.Dependencies": "[3.5.2, )"
+          "Speckle.Objects": "[3.5.3, )",
+          "Speckle.Sdk": "[3.5.3, )",
+          "Speckle.Sdk.Dependencies": "[3.5.3, )"
         }
       },
       "speckle.connectors.dui": {
@@ -278,7 +278,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.5.2, )"
+          "Speckle.Objects": "[3.5.3, )"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -316,18 +316,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "4OlvSSV1cxPeIs3gK4GRvq9X0Su3NE/TBxE6uA/rBS4tCCUdRRiF8wJMFSOxj8K6CRuJcdCxAqD6TIB0cwJ/9Q==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "T3xwwoALVGmhIuEjlDrTdDXZ9haFILT32r8OACWrRUItU3xMkOWGyob51Ca1MHPmo8B5gvbk2Gnm8AgReGnxWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.5.2"
+          "Speckle.Sdk": "3.5.3"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "6WUC7nbLOQURVb12eONGewhNdJHJb03jJ74QO8Tc5XODG+Q7Z5ZUcXu62ID/Hst3S0c2dlSXVZLw8WOLE2rGzQ==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "o+HefwtPZBqyuUHEnKF+qb/ctCAlNc2BYIw3ULEsZ93zweHt5wOMvOeuPxIXR0Gvj3fg6yNlY2nUcdFEduIXYA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -337,14 +337,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.5.2"
+          "Speckle.Sdk.Dependencies": "3.5.3"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "EsNd0OIbubhjFptextM6DeiN74hqb+s8J+HwfAmIFU9XOlmZPfznqjPMJnK9B+8sCpcM2pFsWZys0g/g00m1aw=="
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "kC15SE4yZoVTasgywCm0SpY9yjBsQeUIDt4qoscYAgbn9pe0jj3uM0hZeJUCxn9Fdoj64OfQBpCKzR7VqhkwHQ=="
       }
     }
   }

--- a/Converters/Navisworks/Speckle.Converters.Navisworks2021/packages.lock.json
+++ b/Converters/Navisworks/Speckle.Converters.Navisworks2021/packages.lock.json
@@ -259,9 +259,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.5.2, )",
-          "Speckle.Sdk": "[3.5.2, )",
-          "Speckle.Sdk.Dependencies": "[3.5.2, )"
+          "Speckle.Objects": "[3.5.3, )",
+          "Speckle.Sdk": "[3.5.3, )",
+          "Speckle.Sdk.Dependencies": "[3.5.3, )"
         }
       },
       "speckle.connectors.dui": {
@@ -278,7 +278,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.5.2, )"
+          "Speckle.Objects": "[3.5.3, )"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -316,18 +316,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "4OlvSSV1cxPeIs3gK4GRvq9X0Su3NE/TBxE6uA/rBS4tCCUdRRiF8wJMFSOxj8K6CRuJcdCxAqD6TIB0cwJ/9Q==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "T3xwwoALVGmhIuEjlDrTdDXZ9haFILT32r8OACWrRUItU3xMkOWGyob51Ca1MHPmo8B5gvbk2Gnm8AgReGnxWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.5.2"
+          "Speckle.Sdk": "3.5.3"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "6WUC7nbLOQURVb12eONGewhNdJHJb03jJ74QO8Tc5XODG+Q7Z5ZUcXu62ID/Hst3S0c2dlSXVZLw8WOLE2rGzQ==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "o+HefwtPZBqyuUHEnKF+qb/ctCAlNc2BYIw3ULEsZ93zweHt5wOMvOeuPxIXR0Gvj3fg6yNlY2nUcdFEduIXYA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -337,14 +337,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.5.2"
+          "Speckle.Sdk.Dependencies": "3.5.3"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "EsNd0OIbubhjFptextM6DeiN74hqb+s8J+HwfAmIFU9XOlmZPfznqjPMJnK9B+8sCpcM2pFsWZys0g/g00m1aw=="
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "kC15SE4yZoVTasgywCm0SpY9yjBsQeUIDt4qoscYAgbn9pe0jj3uM0hZeJUCxn9Fdoj64OfQBpCKzR7VqhkwHQ=="
       }
     }
   }

--- a/Converters/Navisworks/Speckle.Converters.Navisworks2022/packages.lock.json
+++ b/Converters/Navisworks/Speckle.Converters.Navisworks2022/packages.lock.json
@@ -259,9 +259,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.5.2, )",
-          "Speckle.Sdk": "[3.5.2, )",
-          "Speckle.Sdk.Dependencies": "[3.5.2, )"
+          "Speckle.Objects": "[3.5.3, )",
+          "Speckle.Sdk": "[3.5.3, )",
+          "Speckle.Sdk.Dependencies": "[3.5.3, )"
         }
       },
       "speckle.connectors.dui": {
@@ -278,7 +278,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.5.2, )"
+          "Speckle.Objects": "[3.5.3, )"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -316,18 +316,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "4OlvSSV1cxPeIs3gK4GRvq9X0Su3NE/TBxE6uA/rBS4tCCUdRRiF8wJMFSOxj8K6CRuJcdCxAqD6TIB0cwJ/9Q==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "T3xwwoALVGmhIuEjlDrTdDXZ9haFILT32r8OACWrRUItU3xMkOWGyob51Ca1MHPmo8B5gvbk2Gnm8AgReGnxWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.5.2"
+          "Speckle.Sdk": "3.5.3"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "6WUC7nbLOQURVb12eONGewhNdJHJb03jJ74QO8Tc5XODG+Q7Z5ZUcXu62ID/Hst3S0c2dlSXVZLw8WOLE2rGzQ==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "o+HefwtPZBqyuUHEnKF+qb/ctCAlNc2BYIw3ULEsZ93zweHt5wOMvOeuPxIXR0Gvj3fg6yNlY2nUcdFEduIXYA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -337,14 +337,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.5.2"
+          "Speckle.Sdk.Dependencies": "3.5.3"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "EsNd0OIbubhjFptextM6DeiN74hqb+s8J+HwfAmIFU9XOlmZPfznqjPMJnK9B+8sCpcM2pFsWZys0g/g00m1aw=="
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "kC15SE4yZoVTasgywCm0SpY9yjBsQeUIDt4qoscYAgbn9pe0jj3uM0hZeJUCxn9Fdoj64OfQBpCKzR7VqhkwHQ=="
       }
     }
   }

--- a/Converters/Navisworks/Speckle.Converters.Navisworks2023/packages.lock.json
+++ b/Converters/Navisworks/Speckle.Converters.Navisworks2023/packages.lock.json
@@ -259,9 +259,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.5.2, )",
-          "Speckle.Sdk": "[3.5.2, )",
-          "Speckle.Sdk.Dependencies": "[3.5.2, )"
+          "Speckle.Objects": "[3.5.3, )",
+          "Speckle.Sdk": "[3.5.3, )",
+          "Speckle.Sdk.Dependencies": "[3.5.3, )"
         }
       },
       "speckle.connectors.dui": {
@@ -278,7 +278,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.5.2, )"
+          "Speckle.Objects": "[3.5.3, )"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -316,18 +316,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "4OlvSSV1cxPeIs3gK4GRvq9X0Su3NE/TBxE6uA/rBS4tCCUdRRiF8wJMFSOxj8K6CRuJcdCxAqD6TIB0cwJ/9Q==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "T3xwwoALVGmhIuEjlDrTdDXZ9haFILT32r8OACWrRUItU3xMkOWGyob51Ca1MHPmo8B5gvbk2Gnm8AgReGnxWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.5.2"
+          "Speckle.Sdk": "3.5.3"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "6WUC7nbLOQURVb12eONGewhNdJHJb03jJ74QO8Tc5XODG+Q7Z5ZUcXu62ID/Hst3S0c2dlSXVZLw8WOLE2rGzQ==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "o+HefwtPZBqyuUHEnKF+qb/ctCAlNc2BYIw3ULEsZ93zweHt5wOMvOeuPxIXR0Gvj3fg6yNlY2nUcdFEduIXYA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -337,14 +337,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.5.2"
+          "Speckle.Sdk.Dependencies": "3.5.3"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "EsNd0OIbubhjFptextM6DeiN74hqb+s8J+HwfAmIFU9XOlmZPfznqjPMJnK9B+8sCpcM2pFsWZys0g/g00m1aw=="
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "kC15SE4yZoVTasgywCm0SpY9yjBsQeUIDt4qoscYAgbn9pe0jj3uM0hZeJUCxn9Fdoj64OfQBpCKzR7VqhkwHQ=="
       }
     }
   }

--- a/Converters/Navisworks/Speckle.Converters.Navisworks2024/packages.lock.json
+++ b/Converters/Navisworks/Speckle.Converters.Navisworks2024/packages.lock.json
@@ -259,9 +259,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.5.2, )",
-          "Speckle.Sdk": "[3.5.2, )",
-          "Speckle.Sdk.Dependencies": "[3.5.2, )"
+          "Speckle.Objects": "[3.5.3, )",
+          "Speckle.Sdk": "[3.5.3, )",
+          "Speckle.Sdk.Dependencies": "[3.5.3, )"
         }
       },
       "speckle.connectors.dui": {
@@ -278,7 +278,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.5.2, )"
+          "Speckle.Objects": "[3.5.3, )"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -316,18 +316,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "4OlvSSV1cxPeIs3gK4GRvq9X0Su3NE/TBxE6uA/rBS4tCCUdRRiF8wJMFSOxj8K6CRuJcdCxAqD6TIB0cwJ/9Q==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "T3xwwoALVGmhIuEjlDrTdDXZ9haFILT32r8OACWrRUItU3xMkOWGyob51Ca1MHPmo8B5gvbk2Gnm8AgReGnxWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.5.2"
+          "Speckle.Sdk": "3.5.3"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "6WUC7nbLOQURVb12eONGewhNdJHJb03jJ74QO8Tc5XODG+Q7Z5ZUcXu62ID/Hst3S0c2dlSXVZLw8WOLE2rGzQ==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "o+HefwtPZBqyuUHEnKF+qb/ctCAlNc2BYIw3ULEsZ93zweHt5wOMvOeuPxIXR0Gvj3fg6yNlY2nUcdFEduIXYA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -337,14 +337,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.5.2"
+          "Speckle.Sdk.Dependencies": "3.5.3"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "EsNd0OIbubhjFptextM6DeiN74hqb+s8J+HwfAmIFU9XOlmZPfznqjPMJnK9B+8sCpcM2pFsWZys0g/g00m1aw=="
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "kC15SE4yZoVTasgywCm0SpY9yjBsQeUIDt4qoscYAgbn9pe0jj3uM0hZeJUCxn9Fdoj64OfQBpCKzR7VqhkwHQ=="
       }
     }
   }

--- a/Converters/Navisworks/Speckle.Converters.Navisworks2025/packages.lock.json
+++ b/Converters/Navisworks/Speckle.Converters.Navisworks2025/packages.lock.json
@@ -259,9 +259,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.5.2, )",
-          "Speckle.Sdk": "[3.5.2, )",
-          "Speckle.Sdk.Dependencies": "[3.5.2, )"
+          "Speckle.Objects": "[3.5.3, )",
+          "Speckle.Sdk": "[3.5.3, )",
+          "Speckle.Sdk.Dependencies": "[3.5.3, )"
         }
       },
       "speckle.connectors.dui": {
@@ -278,7 +278,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.5.2, )"
+          "Speckle.Objects": "[3.5.3, )"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -316,18 +316,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "4OlvSSV1cxPeIs3gK4GRvq9X0Su3NE/TBxE6uA/rBS4tCCUdRRiF8wJMFSOxj8K6CRuJcdCxAqD6TIB0cwJ/9Q==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "T3xwwoALVGmhIuEjlDrTdDXZ9haFILT32r8OACWrRUItU3xMkOWGyob51Ca1MHPmo8B5gvbk2Gnm8AgReGnxWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.5.2"
+          "Speckle.Sdk": "3.5.3"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "6WUC7nbLOQURVb12eONGewhNdJHJb03jJ74QO8Tc5XODG+Q7Z5ZUcXu62ID/Hst3S0c2dlSXVZLw8WOLE2rGzQ==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "o+HefwtPZBqyuUHEnKF+qb/ctCAlNc2BYIw3ULEsZ93zweHt5wOMvOeuPxIXR0Gvj3fg6yNlY2nUcdFEduIXYA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -337,14 +337,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.5.2"
+          "Speckle.Sdk.Dependencies": "3.5.3"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "EsNd0OIbubhjFptextM6DeiN74hqb+s8J+HwfAmIFU9XOlmZPfznqjPMJnK9B+8sCpcM2pFsWZys0g/g00m1aw=="
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "kC15SE4yZoVTasgywCm0SpY9yjBsQeUIDt4qoscYAgbn9pe0jj3uM0hZeJUCxn9Fdoj64OfQBpCKzR7VqhkwHQ=="
       }
     }
   }

--- a/Converters/Navisworks/Speckle.Converters.Navisworks2026/packages.lock.json
+++ b/Converters/Navisworks/Speckle.Converters.Navisworks2026/packages.lock.json
@@ -260,9 +260,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.5.2, )",
-          "Speckle.Sdk": "[3.5.2, )",
-          "Speckle.Sdk.Dependencies": "[3.5.2, )"
+          "Speckle.Objects": "[3.5.3, )",
+          "Speckle.Sdk": "[3.5.3, )",
+          "Speckle.Sdk.Dependencies": "[3.5.3, )"
         }
       },
       "speckle.connectors.dui": {
@@ -279,7 +279,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.5.2, )"
+          "Speckle.Objects": "[3.5.3, )"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -317,18 +317,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "4OlvSSV1cxPeIs3gK4GRvq9X0Su3NE/TBxE6uA/rBS4tCCUdRRiF8wJMFSOxj8K6CRuJcdCxAqD6TIB0cwJ/9Q==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "T3xwwoALVGmhIuEjlDrTdDXZ9haFILT32r8OACWrRUItU3xMkOWGyob51Ca1MHPmo8B5gvbk2Gnm8AgReGnxWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.5.2"
+          "Speckle.Sdk": "3.5.3"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "6WUC7nbLOQURVb12eONGewhNdJHJb03jJ74QO8Tc5XODG+Q7Z5ZUcXu62ID/Hst3S0c2dlSXVZLw8WOLE2rGzQ==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "o+HefwtPZBqyuUHEnKF+qb/ctCAlNc2BYIw3ULEsZ93zweHt5wOMvOeuPxIXR0Gvj3fg6yNlY2nUcdFEduIXYA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -338,14 +338,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.5.2"
+          "Speckle.Sdk.Dependencies": "3.5.3"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "EsNd0OIbubhjFptextM6DeiN74hqb+s8J+HwfAmIFU9XOlmZPfznqjPMJnK9B+8sCpcM2pFsWZys0g/g00m1aw=="
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "kC15SE4yZoVTasgywCm0SpY9yjBsQeUIDt4qoscYAgbn9pe0jj3uM0hZeJUCxn9Fdoj64OfQBpCKzR7VqhkwHQ=="
       }
     }
   }

--- a/Converters/Revit/Speckle.Converters.Revit2022/packages.lock.json
+++ b/Converters/Revit/Speckle.Converters.Revit2022/packages.lock.json
@@ -258,7 +258,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.5.2, )"
+          "Speckle.Objects": "[3.5.3, )"
         }
       },
       "Microsoft.Extensions.Logging": {
@@ -287,18 +287,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "4OlvSSV1cxPeIs3gK4GRvq9X0Su3NE/TBxE6uA/rBS4tCCUdRRiF8wJMFSOxj8K6CRuJcdCxAqD6TIB0cwJ/9Q==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "T3xwwoALVGmhIuEjlDrTdDXZ9haFILT32r8OACWrRUItU3xMkOWGyob51Ca1MHPmo8B5gvbk2Gnm8AgReGnxWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.5.2"
+          "Speckle.Sdk": "3.5.3"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "6WUC7nbLOQURVb12eONGewhNdJHJb03jJ74QO8Tc5XODG+Q7Z5ZUcXu62ID/Hst3S0c2dlSXVZLw8WOLE2rGzQ==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "o+HefwtPZBqyuUHEnKF+qb/ctCAlNc2BYIw3ULEsZ93zweHt5wOMvOeuPxIXR0Gvj3fg6yNlY2nUcdFEduIXYA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -308,14 +308,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.5.2"
+          "Speckle.Sdk.Dependencies": "3.5.3"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "EsNd0OIbubhjFptextM6DeiN74hqb+s8J+HwfAmIFU9XOlmZPfznqjPMJnK9B+8sCpcM2pFsWZys0g/g00m1aw=="
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "kC15SE4yZoVTasgywCm0SpY9yjBsQeUIDt4qoscYAgbn9pe0jj3uM0hZeJUCxn9Fdoj64OfQBpCKzR7VqhkwHQ=="
       }
     }
   }

--- a/Converters/Revit/Speckle.Converters.Revit2023/packages.lock.json
+++ b/Converters/Revit/Speckle.Converters.Revit2023/packages.lock.json
@@ -258,7 +258,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.5.2, )"
+          "Speckle.Objects": "[3.5.3, )"
         }
       },
       "Microsoft.Extensions.Logging": {
@@ -287,18 +287,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "4OlvSSV1cxPeIs3gK4GRvq9X0Su3NE/TBxE6uA/rBS4tCCUdRRiF8wJMFSOxj8K6CRuJcdCxAqD6TIB0cwJ/9Q==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "T3xwwoALVGmhIuEjlDrTdDXZ9haFILT32r8OACWrRUItU3xMkOWGyob51Ca1MHPmo8B5gvbk2Gnm8AgReGnxWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.5.2"
+          "Speckle.Sdk": "3.5.3"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "6WUC7nbLOQURVb12eONGewhNdJHJb03jJ74QO8Tc5XODG+Q7Z5ZUcXu62ID/Hst3S0c2dlSXVZLw8WOLE2rGzQ==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "o+HefwtPZBqyuUHEnKF+qb/ctCAlNc2BYIw3ULEsZ93zweHt5wOMvOeuPxIXR0Gvj3fg6yNlY2nUcdFEduIXYA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -308,14 +308,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.5.2"
+          "Speckle.Sdk.Dependencies": "3.5.3"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "EsNd0OIbubhjFptextM6DeiN74hqb+s8J+HwfAmIFU9XOlmZPfznqjPMJnK9B+8sCpcM2pFsWZys0g/g00m1aw=="
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "kC15SE4yZoVTasgywCm0SpY9yjBsQeUIDt4qoscYAgbn9pe0jj3uM0hZeJUCxn9Fdoj64OfQBpCKzR7VqhkwHQ=="
       }
     }
   }

--- a/Converters/Revit/Speckle.Converters.Revit2024/packages.lock.json
+++ b/Converters/Revit/Speckle.Converters.Revit2024/packages.lock.json
@@ -258,7 +258,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.5.2, )"
+          "Speckle.Objects": "[3.5.3, )"
         }
       },
       "Microsoft.Extensions.Logging": {
@@ -287,18 +287,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "4OlvSSV1cxPeIs3gK4GRvq9X0Su3NE/TBxE6uA/rBS4tCCUdRRiF8wJMFSOxj8K6CRuJcdCxAqD6TIB0cwJ/9Q==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "T3xwwoALVGmhIuEjlDrTdDXZ9haFILT32r8OACWrRUItU3xMkOWGyob51Ca1MHPmo8B5gvbk2Gnm8AgReGnxWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.5.2"
+          "Speckle.Sdk": "3.5.3"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "6WUC7nbLOQURVb12eONGewhNdJHJb03jJ74QO8Tc5XODG+Q7Z5ZUcXu62ID/Hst3S0c2dlSXVZLw8WOLE2rGzQ==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "o+HefwtPZBqyuUHEnKF+qb/ctCAlNc2BYIw3ULEsZ93zweHt5wOMvOeuPxIXR0Gvj3fg6yNlY2nUcdFEduIXYA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -308,14 +308,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.5.2"
+          "Speckle.Sdk.Dependencies": "3.5.3"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "EsNd0OIbubhjFptextM6DeiN74hqb+s8J+HwfAmIFU9XOlmZPfznqjPMJnK9B+8sCpcM2pFsWZys0g/g00m1aw=="
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "kC15SE4yZoVTasgywCm0SpY9yjBsQeUIDt4qoscYAgbn9pe0jj3uM0hZeJUCxn9Fdoj64OfQBpCKzR7VqhkwHQ=="
       }
     }
   }

--- a/Converters/Revit/Speckle.Converters.Revit2025/packages.lock.json
+++ b/Converters/Revit/Speckle.Converters.Revit2025/packages.lock.json
@@ -209,7 +209,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.5.2, )"
+          "Speckle.Objects": "[3.5.3, )"
         }
       },
       "Microsoft.Extensions.Logging": {
@@ -238,18 +238,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "4OlvSSV1cxPeIs3gK4GRvq9X0Su3NE/TBxE6uA/rBS4tCCUdRRiF8wJMFSOxj8K6CRuJcdCxAqD6TIB0cwJ/9Q==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "T3xwwoALVGmhIuEjlDrTdDXZ9haFILT32r8OACWrRUItU3xMkOWGyob51Ca1MHPmo8B5gvbk2Gnm8AgReGnxWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.5.2"
+          "Speckle.Sdk": "3.5.3"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "6WUC7nbLOQURVb12eONGewhNdJHJb03jJ74QO8Tc5XODG+Q7Z5ZUcXu62ID/Hst3S0c2dlSXVZLw8WOLE2rGzQ==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "o+HefwtPZBqyuUHEnKF+qb/ctCAlNc2BYIw3ULEsZ93zweHt5wOMvOeuPxIXR0Gvj3fg6yNlY2nUcdFEduIXYA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -257,14 +257,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.5.2"
+          "Speckle.Sdk.Dependencies": "3.5.3"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "EsNd0OIbubhjFptextM6DeiN74hqb+s8J+HwfAmIFU9XOlmZPfznqjPMJnK9B+8sCpcM2pFsWZys0g/g00m1aw=="
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "kC15SE4yZoVTasgywCm0SpY9yjBsQeUIDt4qoscYAgbn9pe0jj3uM0hZeJUCxn9Fdoj64OfQBpCKzR7VqhkwHQ=="
       }
     }
   }

--- a/Converters/Revit/Speckle.Converters.Revit2026/packages.lock.json
+++ b/Converters/Revit/Speckle.Converters.Revit2026/packages.lock.json
@@ -209,7 +209,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.5.2, )"
+          "Speckle.Objects": "[3.5.3, )"
         }
       },
       "Microsoft.Extensions.Logging": {
@@ -238,18 +238,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "4OlvSSV1cxPeIs3gK4GRvq9X0Su3NE/TBxE6uA/rBS4tCCUdRRiF8wJMFSOxj8K6CRuJcdCxAqD6TIB0cwJ/9Q==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "T3xwwoALVGmhIuEjlDrTdDXZ9haFILT32r8OACWrRUItU3xMkOWGyob51Ca1MHPmo8B5gvbk2Gnm8AgReGnxWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.5.2"
+          "Speckle.Sdk": "3.5.3"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "6WUC7nbLOQURVb12eONGewhNdJHJb03jJ74QO8Tc5XODG+Q7Z5ZUcXu62ID/Hst3S0c2dlSXVZLw8WOLE2rGzQ==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "o+HefwtPZBqyuUHEnKF+qb/ctCAlNc2BYIw3ULEsZ93zweHt5wOMvOeuPxIXR0Gvj3fg6yNlY2nUcdFEduIXYA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -257,14 +257,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.5.2"
+          "Speckle.Sdk.Dependencies": "3.5.3"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "EsNd0OIbubhjFptextM6DeiN74hqb+s8J+HwfAmIFU9XOlmZPfznqjPMJnK9B+8sCpcM2pFsWZys0g/g00m1aw=="
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "kC15SE4yZoVTasgywCm0SpY9yjBsQeUIDt4qoscYAgbn9pe0jj3uM0hZeJUCxn9Fdoj64OfQBpCKzR7VqhkwHQ=="
       }
     }
   }

--- a/Converters/Rhino/Speckle.Converters.Rhino7/packages.lock.json
+++ b/Converters/Rhino/Speckle.Converters.Rhino7/packages.lock.json
@@ -258,7 +258,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.5.2, )"
+          "Speckle.Objects": "[3.5.3, )"
         }
       },
       "Microsoft.Extensions.Logging": {
@@ -287,18 +287,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "4OlvSSV1cxPeIs3gK4GRvq9X0Su3NE/TBxE6uA/rBS4tCCUdRRiF8wJMFSOxj8K6CRuJcdCxAqD6TIB0cwJ/9Q==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "T3xwwoALVGmhIuEjlDrTdDXZ9haFILT32r8OACWrRUItU3xMkOWGyob51Ca1MHPmo8B5gvbk2Gnm8AgReGnxWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.5.2"
+          "Speckle.Sdk": "3.5.3"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "6WUC7nbLOQURVb12eONGewhNdJHJb03jJ74QO8Tc5XODG+Q7Z5ZUcXu62ID/Hst3S0c2dlSXVZLw8WOLE2rGzQ==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "o+HefwtPZBqyuUHEnKF+qb/ctCAlNc2BYIw3ULEsZ93zweHt5wOMvOeuPxIXR0Gvj3fg6yNlY2nUcdFEduIXYA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -308,14 +308,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.5.2"
+          "Speckle.Sdk.Dependencies": "3.5.3"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "EsNd0OIbubhjFptextM6DeiN74hqb+s8J+HwfAmIFU9XOlmZPfznqjPMJnK9B+8sCpcM2pFsWZys0g/g00m1aw=="
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "kC15SE4yZoVTasgywCm0SpY9yjBsQeUIDt4qoscYAgbn9pe0jj3uM0hZeJUCxn9Fdoj64OfQBpCKzR7VqhkwHQ=="
       }
     }
   }

--- a/Converters/Rhino/Speckle.Converters.Rhino8/packages.lock.json
+++ b/Converters/Rhino/Speckle.Converters.Rhino8/packages.lock.json
@@ -258,7 +258,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.5.2, )"
+          "Speckle.Objects": "[3.5.3, )"
         }
       },
       "Microsoft.Extensions.Logging": {
@@ -287,18 +287,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "4OlvSSV1cxPeIs3gK4GRvq9X0Su3NE/TBxE6uA/rBS4tCCUdRRiF8wJMFSOxj8K6CRuJcdCxAqD6TIB0cwJ/9Q==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "T3xwwoALVGmhIuEjlDrTdDXZ9haFILT32r8OACWrRUItU3xMkOWGyob51Ca1MHPmo8B5gvbk2Gnm8AgReGnxWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.5.2"
+          "Speckle.Sdk": "3.5.3"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "6WUC7nbLOQURVb12eONGewhNdJHJb03jJ74QO8Tc5XODG+Q7Z5ZUcXu62ID/Hst3S0c2dlSXVZLw8WOLE2rGzQ==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "o+HefwtPZBqyuUHEnKF+qb/ctCAlNc2BYIw3ULEsZ93zweHt5wOMvOeuPxIXR0Gvj3fg6yNlY2nUcdFEduIXYA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -308,14 +308,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.5.2"
+          "Speckle.Sdk.Dependencies": "3.5.3"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "EsNd0OIbubhjFptextM6DeiN74hqb+s8J+HwfAmIFU9XOlmZPfznqjPMJnK9B+8sCpcM2pFsWZys0g/g00m1aw=="
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "kC15SE4yZoVTasgywCm0SpY9yjBsQeUIDt4qoscYAgbn9pe0jj3uM0hZeJUCxn9Fdoj64OfQBpCKzR7VqhkwHQ=="
       }
     },
     "net8.0": {
@@ -542,7 +542,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.5.2, )"
+          "Speckle.Objects": "[3.5.3, )"
         }
       },
       "Microsoft.Extensions.Logging": {
@@ -571,18 +571,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "4OlvSSV1cxPeIs3gK4GRvq9X0Su3NE/TBxE6uA/rBS4tCCUdRRiF8wJMFSOxj8K6CRuJcdCxAqD6TIB0cwJ/9Q==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "T3xwwoALVGmhIuEjlDrTdDXZ9haFILT32r8OACWrRUItU3xMkOWGyob51Ca1MHPmo8B5gvbk2Gnm8AgReGnxWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.5.2"
+          "Speckle.Sdk": "3.5.3"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "6WUC7nbLOQURVb12eONGewhNdJHJb03jJ74QO8Tc5XODG+Q7Z5ZUcXu62ID/Hst3S0c2dlSXVZLw8WOLE2rGzQ==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "o+HefwtPZBqyuUHEnKF+qb/ctCAlNc2BYIw3ULEsZ93zweHt5wOMvOeuPxIXR0Gvj3fg6yNlY2nUcdFEduIXYA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -590,14 +590,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.5.2"
+          "Speckle.Sdk.Dependencies": "3.5.3"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "EsNd0OIbubhjFptextM6DeiN74hqb+s8J+HwfAmIFU9XOlmZPfznqjPMJnK9B+8sCpcM2pFsWZys0g/g00m1aw=="
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "kC15SE4yZoVTasgywCm0SpY9yjBsQeUIDt4qoscYAgbn9pe0jj3uM0hZeJUCxn9Fdoj64OfQBpCKzR7VqhkwHQ=="
       }
     }
   }

--- a/Converters/Tekla/Speckle.Converter.Tekla2023/packages.lock.json
+++ b/Converters/Tekla/Speckle.Converter.Tekla2023/packages.lock.json
@@ -302,7 +302,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.5.2, )"
+          "Speckle.Objects": "[3.5.3, )"
         }
       },
       "LibTessDotNet": {
@@ -337,18 +337,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "4OlvSSV1cxPeIs3gK4GRvq9X0Su3NE/TBxE6uA/rBS4tCCUdRRiF8wJMFSOxj8K6CRuJcdCxAqD6TIB0cwJ/9Q==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "T3xwwoALVGmhIuEjlDrTdDXZ9haFILT32r8OACWrRUItU3xMkOWGyob51Ca1MHPmo8B5gvbk2Gnm8AgReGnxWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.5.2"
+          "Speckle.Sdk": "3.5.3"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "6WUC7nbLOQURVb12eONGewhNdJHJb03jJ74QO8Tc5XODG+Q7Z5ZUcXu62ID/Hst3S0c2dlSXVZLw8WOLE2rGzQ==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "o+HefwtPZBqyuUHEnKF+qb/ctCAlNc2BYIw3ULEsZ93zweHt5wOMvOeuPxIXR0Gvj3fg6yNlY2nUcdFEduIXYA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -358,14 +358,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.5.2"
+          "Speckle.Sdk.Dependencies": "3.5.3"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "EsNd0OIbubhjFptextM6DeiN74hqb+s8J+HwfAmIFU9XOlmZPfznqjPMJnK9B+8sCpcM2pFsWZys0g/g00m1aw=="
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "kC15SE4yZoVTasgywCm0SpY9yjBsQeUIDt4qoscYAgbn9pe0jj3uM0hZeJUCxn9Fdoj64OfQBpCKzR7VqhkwHQ=="
       },
       "Tekla.Structures.Dialog": {
         "type": "CentralTransitive",

--- a/Converters/Tekla/Speckle.Converter.Tekla2024/packages.lock.json
+++ b/Converters/Tekla/Speckle.Converter.Tekla2024/packages.lock.json
@@ -343,7 +343,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.5.2, )"
+          "Speckle.Objects": "[3.5.3, )"
         }
       },
       "LibTessDotNet": {
@@ -378,18 +378,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "4OlvSSV1cxPeIs3gK4GRvq9X0Su3NE/TBxE6uA/rBS4tCCUdRRiF8wJMFSOxj8K6CRuJcdCxAqD6TIB0cwJ/9Q==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "T3xwwoALVGmhIuEjlDrTdDXZ9haFILT32r8OACWrRUItU3xMkOWGyob51Ca1MHPmo8B5gvbk2Gnm8AgReGnxWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.5.2"
+          "Speckle.Sdk": "3.5.3"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "6WUC7nbLOQURVb12eONGewhNdJHJb03jJ74QO8Tc5XODG+Q7Z5ZUcXu62ID/Hst3S0c2dlSXVZLw8WOLE2rGzQ==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "o+HefwtPZBqyuUHEnKF+qb/ctCAlNc2BYIw3ULEsZ93zweHt5wOMvOeuPxIXR0Gvj3fg6yNlY2nUcdFEduIXYA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -399,14 +399,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.5.2"
+          "Speckle.Sdk.Dependencies": "3.5.3"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "EsNd0OIbubhjFptextM6DeiN74hqb+s8J+HwfAmIFU9XOlmZPfznqjPMJnK9B+8sCpcM2pFsWZys0g/g00m1aw=="
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "kC15SE4yZoVTasgywCm0SpY9yjBsQeUIDt4qoscYAgbn9pe0jj3uM0hZeJUCxn9Fdoj64OfQBpCKzR7VqhkwHQ=="
       },
       "Tekla.Structures.Plugins": {
         "type": "CentralTransitive",

--- a/Converters/Tekla/Speckle.Converter.Tekla2025/packages.lock.json
+++ b/Converters/Tekla/Speckle.Converter.Tekla2025/packages.lock.json
@@ -343,7 +343,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.5.2, )"
+          "Speckle.Objects": "[3.5.3, )"
         }
       },
       "LibTessDotNet": {
@@ -378,18 +378,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "4OlvSSV1cxPeIs3gK4GRvq9X0Su3NE/TBxE6uA/rBS4tCCUdRRiF8wJMFSOxj8K6CRuJcdCxAqD6TIB0cwJ/9Q==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "T3xwwoALVGmhIuEjlDrTdDXZ9haFILT32r8OACWrRUItU3xMkOWGyob51Ca1MHPmo8B5gvbk2Gnm8AgReGnxWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.5.2"
+          "Speckle.Sdk": "3.5.3"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "6WUC7nbLOQURVb12eONGewhNdJHJb03jJ74QO8Tc5XODG+Q7Z5ZUcXu62ID/Hst3S0c2dlSXVZLw8WOLE2rGzQ==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "o+HefwtPZBqyuUHEnKF+qb/ctCAlNc2BYIw3ULEsZ93zweHt5wOMvOeuPxIXR0Gvj3fg6yNlY2nUcdFEduIXYA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -399,14 +399,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.5.2"
+          "Speckle.Sdk.Dependencies": "3.5.3"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "EsNd0OIbubhjFptextM6DeiN74hqb+s8J+HwfAmIFU9XOlmZPfznqjPMJnK9B+8sCpcM2pFsWZys0g/g00m1aw=="
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "kC15SE4yZoVTasgywCm0SpY9yjBsQeUIDt4qoscYAgbn9pe0jj3uM0hZeJUCxn9Fdoj64OfQBpCKzR7VqhkwHQ=="
       },
       "Tekla.Structures.Plugins": {
         "type": "CentralTransitive",

--- a/DUI3/Speckle.Connectors.DUI.Tests/packages.lock.json
+++ b/DUI3/Speckle.Connectors.DUI.Tests/packages.lock.json
@@ -314,9 +314,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.5.2, )",
-          "Speckle.Sdk": "[3.5.2, )",
-          "Speckle.Sdk.Dependencies": "[3.5.2, )"
+          "Speckle.Objects": "[3.5.3, )",
+          "Speckle.Sdk": "[3.5.3, )",
+          "Speckle.Sdk.Dependencies": "[3.5.3, )"
         }
       },
       "speckle.connectors.dui": {
@@ -335,7 +335,7 @@
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Moq": "[4.20.70, )",
           "NUnit": "[4.1.0, )",
-          "Speckle.Sdk": "[3.5.2, )"
+          "Speckle.Sdk": "[3.5.3, )"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -373,18 +373,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "4OlvSSV1cxPeIs3gK4GRvq9X0Su3NE/TBxE6uA/rBS4tCCUdRRiF8wJMFSOxj8K6CRuJcdCxAqD6TIB0cwJ/9Q==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "T3xwwoALVGmhIuEjlDrTdDXZ9haFILT32r8OACWrRUItU3xMkOWGyob51Ca1MHPmo8B5gvbk2Gnm8AgReGnxWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.5.2"
+          "Speckle.Sdk": "3.5.3"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "6WUC7nbLOQURVb12eONGewhNdJHJb03jJ74QO8Tc5XODG+Q7Z5ZUcXu62ID/Hst3S0c2dlSXVZLw8WOLE2rGzQ==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "o+HefwtPZBqyuUHEnKF+qb/ctCAlNc2BYIw3ULEsZ93zweHt5wOMvOeuPxIXR0Gvj3fg6yNlY2nUcdFEduIXYA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -392,14 +392,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.5.2"
+          "Speckle.Sdk.Dependencies": "3.5.3"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "EsNd0OIbubhjFptextM6DeiN74hqb+s8J+HwfAmIFU9XOlmZPfznqjPMJnK9B+8sCpcM2pFsWZys0g/g00m1aw=="
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "kC15SE4yZoVTasgywCm0SpY9yjBsQeUIDt4qoscYAgbn9pe0jj3uM0hZeJUCxn9Fdoj64OfQBpCKzR7VqhkwHQ=="
       }
     }
   }

--- a/DUI3/Speckle.Connectors.DUI.WebView/packages.lock.json
+++ b/DUI3/Speckle.Connectors.DUI.WebView/packages.lock.json
@@ -259,9 +259,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.5.2, )",
-          "Speckle.Sdk": "[3.5.2, )",
-          "Speckle.Sdk.Dependencies": "[3.5.2, )"
+          "Speckle.Objects": "[3.5.3, )",
+          "Speckle.Sdk": "[3.5.3, )",
+          "Speckle.Sdk.Dependencies": "[3.5.3, )"
         }
       },
       "speckle.connectors.dui": {
@@ -309,18 +309,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "4OlvSSV1cxPeIs3gK4GRvq9X0Su3NE/TBxE6uA/rBS4tCCUdRRiF8wJMFSOxj8K6CRuJcdCxAqD6TIB0cwJ/9Q==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "T3xwwoALVGmhIuEjlDrTdDXZ9haFILT32r8OACWrRUItU3xMkOWGyob51Ca1MHPmo8B5gvbk2Gnm8AgReGnxWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.5.2"
+          "Speckle.Sdk": "3.5.3"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "6WUC7nbLOQURVb12eONGewhNdJHJb03jJ74QO8Tc5XODG+Q7Z5ZUcXu62ID/Hst3S0c2dlSXVZLw8WOLE2rGzQ==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "o+HefwtPZBqyuUHEnKF+qb/ctCAlNc2BYIw3ULEsZ93zweHt5wOMvOeuPxIXR0Gvj3fg6yNlY2nUcdFEduIXYA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -330,14 +330,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.5.2"
+          "Speckle.Sdk.Dependencies": "3.5.3"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "EsNd0OIbubhjFptextM6DeiN74hqb+s8J+HwfAmIFU9XOlmZPfznqjPMJnK9B+8sCpcM2pFsWZys0g/g00m1aw=="
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "kC15SE4yZoVTasgywCm0SpY9yjBsQeUIDt4qoscYAgbn9pe0jj3uM0hZeJUCxn9Fdoj64OfQBpCKzR7VqhkwHQ=="
       }
     },
     "net8.0-windows7.0": {
@@ -549,9 +549,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.5.2, )",
-          "Speckle.Sdk": "[3.5.2, )",
-          "Speckle.Sdk.Dependencies": "[3.5.2, )"
+          "Speckle.Objects": "[3.5.3, )",
+          "Speckle.Sdk": "[3.5.3, )",
+          "Speckle.Sdk.Dependencies": "[3.5.3, )"
         }
       },
       "speckle.connectors.dui": {
@@ -599,18 +599,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "4OlvSSV1cxPeIs3gK4GRvq9X0Su3NE/TBxE6uA/rBS4tCCUdRRiF8wJMFSOxj8K6CRuJcdCxAqD6TIB0cwJ/9Q==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "T3xwwoALVGmhIuEjlDrTdDXZ9haFILT32r8OACWrRUItU3xMkOWGyob51Ca1MHPmo8B5gvbk2Gnm8AgReGnxWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.5.2"
+          "Speckle.Sdk": "3.5.3"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "6WUC7nbLOQURVb12eONGewhNdJHJb03jJ74QO8Tc5XODG+Q7Z5ZUcXu62ID/Hst3S0c2dlSXVZLw8WOLE2rGzQ==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "o+HefwtPZBqyuUHEnKF+qb/ctCAlNc2BYIw3ULEsZ93zweHt5wOMvOeuPxIXR0Gvj3fg6yNlY2nUcdFEduIXYA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -618,14 +618,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.5.2"
+          "Speckle.Sdk.Dependencies": "3.5.3"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "EsNd0OIbubhjFptextM6DeiN74hqb+s8J+HwfAmIFU9XOlmZPfznqjPMJnK9B+8sCpcM2pFsWZys0g/g00m1aw=="
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "kC15SE4yZoVTasgywCm0SpY9yjBsQeUIDt4qoscYAgbn9pe0jj3uM0hZeJUCxn9Fdoj64OfQBpCKzR7VqhkwHQ=="
       }
     }
   }

--- a/DUI3/Speckle.Connectors.DUI/packages.lock.json
+++ b/DUI3/Speckle.Connectors.DUI/packages.lock.json
@@ -259,9 +259,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.5.2, )",
-          "Speckle.Sdk": "[3.5.2, )",
-          "Speckle.Sdk.Dependencies": "[3.5.2, )"
+          "Speckle.Objects": "[3.5.3, )",
+          "Speckle.Sdk": "[3.5.3, )",
+          "Speckle.Sdk.Dependencies": "[3.5.3, )"
         }
       },
       "speckle.connectors.logging": {
@@ -296,18 +296,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "4OlvSSV1cxPeIs3gK4GRvq9X0Su3NE/TBxE6uA/rBS4tCCUdRRiF8wJMFSOxj8K6CRuJcdCxAqD6TIB0cwJ/9Q==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "T3xwwoALVGmhIuEjlDrTdDXZ9haFILT32r8OACWrRUItU3xMkOWGyob51Ca1MHPmo8B5gvbk2Gnm8AgReGnxWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.5.2"
+          "Speckle.Sdk": "3.5.3"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "6WUC7nbLOQURVb12eONGewhNdJHJb03jJ74QO8Tc5XODG+Q7Z5ZUcXu62ID/Hst3S0c2dlSXVZLw8WOLE2rGzQ==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "o+HefwtPZBqyuUHEnKF+qb/ctCAlNc2BYIw3ULEsZ93zweHt5wOMvOeuPxIXR0Gvj3fg6yNlY2nUcdFEduIXYA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -317,14 +317,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.5.2"
+          "Speckle.Sdk.Dependencies": "3.5.3"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "EsNd0OIbubhjFptextM6DeiN74hqb+s8J+HwfAmIFU9XOlmZPfznqjPMJnK9B+8sCpcM2pFsWZys0g/g00m1aw=="
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "kC15SE4yZoVTasgywCm0SpY9yjBsQeUIDt4qoscYAgbn9pe0jj3uM0hZeJUCxn9Fdoj64OfQBpCKzR7VqhkwHQ=="
       }
     },
     "net8.0": {
@@ -536,9 +536,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.5.2, )",
-          "Speckle.Sdk": "[3.5.2, )",
-          "Speckle.Sdk.Dependencies": "[3.5.2, )"
+          "Speckle.Objects": "[3.5.3, )",
+          "Speckle.Sdk": "[3.5.3, )",
+          "Speckle.Sdk.Dependencies": "[3.5.3, )"
         }
       },
       "speckle.connectors.logging": {
@@ -573,18 +573,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "4OlvSSV1cxPeIs3gK4GRvq9X0Su3NE/TBxE6uA/rBS4tCCUdRRiF8wJMFSOxj8K6CRuJcdCxAqD6TIB0cwJ/9Q==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "T3xwwoALVGmhIuEjlDrTdDXZ9haFILT32r8OACWrRUItU3xMkOWGyob51Ca1MHPmo8B5gvbk2Gnm8AgReGnxWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.5.2"
+          "Speckle.Sdk": "3.5.3"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "6WUC7nbLOQURVb12eONGewhNdJHJb03jJ74QO8Tc5XODG+Q7Z5ZUcXu62ID/Hst3S0c2dlSXVZLw8WOLE2rGzQ==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "o+HefwtPZBqyuUHEnKF+qb/ctCAlNc2BYIw3ULEsZ93zweHt5wOMvOeuPxIXR0Gvj3fg6yNlY2nUcdFEduIXYA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -592,14 +592,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.5.2"
+          "Speckle.Sdk.Dependencies": "3.5.3"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "EsNd0OIbubhjFptextM6DeiN74hqb+s8J+HwfAmIFU9XOlmZPfznqjPMJnK9B+8sCpcM2pFsWZys0g/g00m1aw=="
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "kC15SE4yZoVTasgywCm0SpY9yjBsQeUIDt4qoscYAgbn9pe0jj3uM0hZeJUCxn9Fdoj64OfQBpCKzR7VqhkwHQ=="
       }
     }
   }

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -53,9 +53,9 @@
     <PackageVersion Include="Speckle.Civil3D.API" Version="2022.0.2" />
     <PackageVersion Include="Speckle.Revit.API" Version="2023.0.0" />
     <PackageVersion Include="Speckle.Navisworks.API" Version="2024.0.0" />
-    <PackageVersion Include="Speckle.Objects" Version="3.5.2" />
-    <PackageVersion Include="Speckle.Sdk" Version="3.5.2" />
-    <PackageVersion Include="Speckle.Sdk.Dependencies" Version="3.5.2" />
+    <PackageVersion Include="Speckle.Objects" Version="3.5.3" />
+    <PackageVersion Include="Speckle.Sdk" Version="3.5.3" />
+    <PackageVersion Include="Speckle.Sdk.Dependencies" Version="3.5.3" />
     <PackageVersion Include="SimpleExec" Version="12.0.0" />
     <GlobalPackageReference Include="PolySharp" Version="1.14.1" />
     <GlobalPackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />

--- a/Importers/Ifc/Speckle.Importers.Ifc.Tester/packages.lock.json
+++ b/Importers/Ifc/Speckle.Importers.Ifc.Tester/packages.lock.json
@@ -204,9 +204,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.5.2, )",
-          "Speckle.Sdk": "[3.5.2, )",
-          "Speckle.Sdk.Dependencies": "[3.5.2, )"
+          "Speckle.Objects": "[3.5.3, )",
+          "Speckle.Sdk": "[3.5.3, )",
+          "Speckle.Sdk.Dependencies": "[3.5.3, )"
         }
       },
       "speckle.connectors.logging": {
@@ -220,8 +220,8 @@
           "Ara3D.Utils": "[1.4.5, )",
           "Microsoft.Extensions.DependencyInjection": "[8.0.0, )",
           "Speckle.Connectors.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.5.2, )",
-          "Speckle.Sdk": "[3.5.2, )"
+          "Speckle.Objects": "[3.5.3, )",
+          "Speckle.Sdk": "[3.5.3, )"
         }
       },
       "Ara3D.Buffers": {
@@ -283,18 +283,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "4OlvSSV1cxPeIs3gK4GRvq9X0Su3NE/TBxE6uA/rBS4tCCUdRRiF8wJMFSOxj8K6CRuJcdCxAqD6TIB0cwJ/9Q==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "T3xwwoALVGmhIuEjlDrTdDXZ9haFILT32r8OACWrRUItU3xMkOWGyob51Ca1MHPmo8B5gvbk2Gnm8AgReGnxWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.5.2"
+          "Speckle.Sdk": "3.5.3"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "6WUC7nbLOQURVb12eONGewhNdJHJb03jJ74QO8Tc5XODG+Q7Z5ZUcXu62ID/Hst3S0c2dlSXVZLw8WOLE2rGzQ==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "o+HefwtPZBqyuUHEnKF+qb/ctCAlNc2BYIw3ULEsZ93zweHt5wOMvOeuPxIXR0Gvj3fg6yNlY2nUcdFEduIXYA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -302,14 +302,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.5.2"
+          "Speckle.Sdk.Dependencies": "3.5.3"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "EsNd0OIbubhjFptextM6DeiN74hqb+s8J+HwfAmIFU9XOlmZPfznqjPMJnK9B+8sCpcM2pFsWZys0g/g00m1aw=="
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "kC15SE4yZoVTasgywCm0SpY9yjBsQeUIDt4qoscYAgbn9pe0jj3uM0hZeJUCxn9Fdoj64OfQBpCKzR7VqhkwHQ=="
       }
     }
   }

--- a/Importers/Ifc/Speckle.Importers.Ifc.Tester2/packages.lock.json
+++ b/Importers/Ifc/Speckle.Importers.Ifc.Tester2/packages.lock.json
@@ -204,9 +204,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.5.2, )",
-          "Speckle.Sdk": "[3.5.2, )",
-          "Speckle.Sdk.Dependencies": "[3.5.2, )"
+          "Speckle.Objects": "[3.5.3, )",
+          "Speckle.Sdk": "[3.5.3, )",
+          "Speckle.Sdk.Dependencies": "[3.5.3, )"
         }
       },
       "speckle.connectors.logging": {
@@ -220,8 +220,8 @@
           "Ara3D.Utils": "[1.4.5, )",
           "Microsoft.Extensions.DependencyInjection": "[8.0.0, )",
           "Speckle.Connectors.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.5.2, )",
-          "Speckle.Sdk": "[3.5.2, )"
+          "Speckle.Objects": "[3.5.3, )",
+          "Speckle.Sdk": "[3.5.3, )"
         }
       },
       "Ara3D.Buffers": {
@@ -283,18 +283,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "4OlvSSV1cxPeIs3gK4GRvq9X0Su3NE/TBxE6uA/rBS4tCCUdRRiF8wJMFSOxj8K6CRuJcdCxAqD6TIB0cwJ/9Q==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "T3xwwoALVGmhIuEjlDrTdDXZ9haFILT32r8OACWrRUItU3xMkOWGyob51Ca1MHPmo8B5gvbk2Gnm8AgReGnxWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.5.2"
+          "Speckle.Sdk": "3.5.3"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "6WUC7nbLOQURVb12eONGewhNdJHJb03jJ74QO8Tc5XODG+Q7Z5ZUcXu62ID/Hst3S0c2dlSXVZLw8WOLE2rGzQ==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "o+HefwtPZBqyuUHEnKF+qb/ctCAlNc2BYIw3ULEsZ93zweHt5wOMvOeuPxIXR0Gvj3fg6yNlY2nUcdFEduIXYA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -302,14 +302,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.5.2"
+          "Speckle.Sdk.Dependencies": "3.5.3"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "EsNd0OIbubhjFptextM6DeiN74hqb+s8J+HwfAmIFU9XOlmZPfznqjPMJnK9B+8sCpcM2pFsWZys0g/g00m1aw=="
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "kC15SE4yZoVTasgywCm0SpY9yjBsQeUIDt4qoscYAgbn9pe0jj3uM0hZeJUCxn9Fdoj64OfQBpCKzR7VqhkwHQ=="
       }
     }
   }

--- a/Importers/Ifc/Speckle.Importers.Ifc/packages.lock.json
+++ b/Importers/Ifc/Speckle.Importers.Ifc/packages.lock.json
@@ -68,18 +68,18 @@
       },
       "Speckle.Objects": {
         "type": "Direct",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "4OlvSSV1cxPeIs3gK4GRvq9X0Su3NE/TBxE6uA/rBS4tCCUdRRiF8wJMFSOxj8K6CRuJcdCxAqD6TIB0cwJ/9Q==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "T3xwwoALVGmhIuEjlDrTdDXZ9haFILT32r8OACWrRUItU3xMkOWGyob51Ca1MHPmo8B5gvbk2Gnm8AgReGnxWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.5.2"
+          "Speckle.Sdk": "3.5.3"
         }
       },
       "Speckle.Sdk": {
         "type": "Direct",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "6WUC7nbLOQURVb12eONGewhNdJHJb03jJ74QO8Tc5XODG+Q7Z5ZUcXu62ID/Hst3S0c2dlSXVZLw8WOLE2rGzQ==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "o+HefwtPZBqyuUHEnKF+qb/ctCAlNc2BYIw3ULEsZ93zweHt5wOMvOeuPxIXR0Gvj3fg6yNlY2nUcdFEduIXYA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -87,7 +87,7 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.5.2"
+          "Speckle.Sdk.Dependencies": "3.5.3"
         }
       },
       "GraphQL.Client": {
@@ -261,9 +261,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.5.2, )",
-          "Speckle.Sdk": "[3.5.2, )",
-          "Speckle.Sdk.Dependencies": "[3.5.2, )"
+          "Speckle.Objects": "[3.5.3, )",
+          "Speckle.Sdk": "[3.5.3, )",
+          "Speckle.Sdk.Dependencies": "[3.5.3, )"
         }
       },
       "speckle.connectors.logging": {
@@ -295,9 +295,9 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "EsNd0OIbubhjFptextM6DeiN74hqb+s8J+HwfAmIFU9XOlmZPfznqjPMJnK9B+8sCpcM2pFsWZys0g/g00m1aw=="
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "kC15SE4yZoVTasgywCm0SpY9yjBsQeUIDt4qoscYAgbn9pe0jj3uM0hZeJUCxn9Fdoj64OfQBpCKzR7VqhkwHQ=="
       }
     }
   }

--- a/Importers/Rhino/Speckle.Importers.JobProcessor/packages.lock.json
+++ b/Importers/Rhino/Speckle.Importers.JobProcessor/packages.lock.json
@@ -208,9 +208,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.5.2, )",
-          "Speckle.Sdk": "[3.5.2, )",
-          "Speckle.Sdk.Dependencies": "[3.5.2, )"
+          "Speckle.Objects": "[3.5.3, )",
+          "Speckle.Sdk": "[3.5.3, )",
+          "Speckle.Sdk.Dependencies": "[3.5.3, )"
         }
       },
       "speckle.connectors.dui": {
@@ -242,7 +242,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.5.2, )"
+          "Speckle.Objects": "[3.5.3, )"
         }
       },
       "speckle.converters.rhino8": {
@@ -257,15 +257,6 @@
           "Rhino.Inside": "[8.0.7-beta, )",
           "Speckle.Connectors.RhinoImporter": "[1.0.0, )",
           "Speckle.Converters.Rhino8": "[1.0.0, )"
-        }
-      },
-      "Grasshopper": {
-        "type": "CentralTransitive",
-        "requested": "[8.9.24194.18121, )",
-        "resolved": "8.0.23304.9001",
-        "contentHash": "L1Cse6nAxryzcZ7jsu3WzBiG9BYtgYsaNbRV+p55N+THKTFGmXx1PdBbiWtuxK9kB4jyuLVpeV8XBiYlSGA1Vw==",
-        "dependencies": {
-          "RhinoCommon": "[8.0.23304.9001]"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -327,18 +318,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "4OlvSSV1cxPeIs3gK4GRvq9X0Su3NE/TBxE6uA/rBS4tCCUdRRiF8wJMFSOxj8K6CRuJcdCxAqD6TIB0cwJ/9Q==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "T3xwwoALVGmhIuEjlDrTdDXZ9haFILT32r8OACWrRUItU3xMkOWGyob51Ca1MHPmo8B5gvbk2Gnm8AgReGnxWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.5.2"
+          "Speckle.Sdk": "3.5.3"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "6WUC7nbLOQURVb12eONGewhNdJHJb03jJ74QO8Tc5XODG+Q7Z5ZUcXu62ID/Hst3S0c2dlSXVZLw8WOLE2rGzQ==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "o+HefwtPZBqyuUHEnKF+qb/ctCAlNc2BYIw3ULEsZ93zweHt5wOMvOeuPxIXR0Gvj3fg6yNlY2nUcdFEduIXYA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -346,14 +337,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.5.2"
+          "Speckle.Sdk.Dependencies": "3.5.3"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "EsNd0OIbubhjFptextM6DeiN74hqb+s8J+HwfAmIFU9XOlmZPfznqjPMJnK9B+8sCpcM2pFsWZys0g/g00m1aw=="
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "kC15SE4yZoVTasgywCm0SpY9yjBsQeUIDt4qoscYAgbn9pe0jj3uM0hZeJUCxn9Fdoj64OfQBpCKzR7VqhkwHQ=="
       }
     }
   }

--- a/Importers/Rhino/Speckle.Importers.Rhino/packages.lock.json
+++ b/Importers/Rhino/Speckle.Importers.Rhino/packages.lock.json
@@ -254,9 +254,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.5.2, )",
-          "Speckle.Sdk": "[3.5.2, )",
-          "Speckle.Sdk.Dependencies": "[3.5.2, )"
+          "Speckle.Objects": "[3.5.3, )",
+          "Speckle.Sdk": "[3.5.3, )",
+          "Speckle.Sdk.Dependencies": "[3.5.3, )"
         }
       },
       "speckle.connectors.dui": {
@@ -288,7 +288,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.5.2, )"
+          "Speckle.Objects": "[3.5.3, )"
         }
       },
       "speckle.converters.rhino8": {
@@ -338,18 +338,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "4OlvSSV1cxPeIs3gK4GRvq9X0Su3NE/TBxE6uA/rBS4tCCUdRRiF8wJMFSOxj8K6CRuJcdCxAqD6TIB0cwJ/9Q==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "T3xwwoALVGmhIuEjlDrTdDXZ9haFILT32r8OACWrRUItU3xMkOWGyob51Ca1MHPmo8B5gvbk2Gnm8AgReGnxWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.5.2"
+          "Speckle.Sdk": "3.5.3"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "6WUC7nbLOQURVb12eONGewhNdJHJb03jJ74QO8Tc5XODG+Q7Z5ZUcXu62ID/Hst3S0c2dlSXVZLw8WOLE2rGzQ==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "o+HefwtPZBqyuUHEnKF+qb/ctCAlNc2BYIw3ULEsZ93zweHt5wOMvOeuPxIXR0Gvj3fg6yNlY2nUcdFEduIXYA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -357,14 +357,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.5.2"
+          "Speckle.Sdk.Dependencies": "3.5.3"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "EsNd0OIbubhjFptextM6DeiN74hqb+s8J+HwfAmIFU9XOlmZPfznqjPMJnK9B+8sCpcM2pFsWZys0g/g00m1aw=="
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "kC15SE4yZoVTasgywCm0SpY9yjBsQeUIDt4qoscYAgbn9pe0jj3uM0hZeJUCxn9Fdoj64OfQBpCKzR7VqhkwHQ=="
       }
     }
   }

--- a/Sdk/Speckle.Connectors.Common.Tests/packages.lock.json
+++ b/Sdk/Speckle.Connectors.Common.Tests/packages.lock.json
@@ -308,9 +308,9 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
-          "Speckle.Objects": "[3.5.2, )",
-          "Speckle.Sdk": "[3.5.2, )",
-          "Speckle.Sdk.Dependencies": "[3.5.2, )"
+          "Speckle.Objects": "[3.5.3, )",
+          "Speckle.Sdk": "[3.5.3, )",
+          "Speckle.Sdk.Dependencies": "[3.5.3, )"
         }
       },
       "speckle.connectors.logging": {
@@ -322,7 +322,7 @@
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Moq": "[4.20.70, )",
           "NUnit": "[4.1.0, )",
-          "Speckle.Sdk": "[3.5.2, )"
+          "Speckle.Sdk": "[3.5.3, )"
         }
       },
       "Microsoft.Extensions.Logging": {
@@ -366,18 +366,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "4OlvSSV1cxPeIs3gK4GRvq9X0Su3NE/TBxE6uA/rBS4tCCUdRRiF8wJMFSOxj8K6CRuJcdCxAqD6TIB0cwJ/9Q==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "T3xwwoALVGmhIuEjlDrTdDXZ9haFILT32r8OACWrRUItU3xMkOWGyob51Ca1MHPmo8B5gvbk2Gnm8AgReGnxWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.5.2"
+          "Speckle.Sdk": "3.5.3"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "6WUC7nbLOQURVb12eONGewhNdJHJb03jJ74QO8Tc5XODG+Q7Z5ZUcXu62ID/Hst3S0c2dlSXVZLw8WOLE2rGzQ==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "o+HefwtPZBqyuUHEnKF+qb/ctCAlNc2BYIw3ULEsZ93zweHt5wOMvOeuPxIXR0Gvj3fg6yNlY2nUcdFEduIXYA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -385,14 +385,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.5.2"
+          "Speckle.Sdk.Dependencies": "3.5.3"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "EsNd0OIbubhjFptextM6DeiN74hqb+s8J+HwfAmIFU9XOlmZPfznqjPMJnK9B+8sCpcM2pFsWZys0g/g00m1aw=="
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "kC15SE4yZoVTasgywCm0SpY9yjBsQeUIDt4qoscYAgbn9pe0jj3uM0hZeJUCxn9Fdoj64OfQBpCKzR7VqhkwHQ=="
       }
     }
   }

--- a/Sdk/Speckle.Connectors.Common/Operations/Receive/RootObjectUnpacker.cs
+++ b/Sdk/Speckle.Connectors.Common/Operations/Receive/RootObjectUnpacker.cs
@@ -52,8 +52,8 @@ public class RootObjectUnpacker
     IReadOnlyCollection<TraversalContext> instanceComponents
   ) SplitAtomicObjectsAndInstances(IEnumerable<TraversalContext> objectsToSplit)
   {
-    HashSet<TraversalContext> atomicObjects = [];
-    HashSet<TraversalContext> instanceComponents = [];
+    List<TraversalContext> atomicObjects = [];
+    List<TraversalContext> instanceComponents = [];
     foreach (TraversalContext tc in objectsToSplit)
     {
       if (tc.Current is IInstanceComponent)

--- a/Sdk/Speckle.Connectors.Common/Operations/Receive/RootObjectUnpacker.cs
+++ b/Sdk/Speckle.Connectors.Common/Operations/Receive/RootObjectUnpacker.cs
@@ -1,5 +1,4 @@
 ﻿using Speckle.Objects.Other;
-using Speckle.Sdk.Dependencies;
 using Speckle.Sdk.Models;
 using Speckle.Sdk.Models.Collections;
 using Speckle.Sdk.Models.GraphTraversal;
@@ -31,7 +30,7 @@ public class RootObjectUnpacker
     );
 
   public IReadOnlyCollection<TraversalContext> GetObjectsToConvert(Base root) =>
-    _traverseFunction.Traverse(root).Where(obj => obj.Current is not Collection).Freeze();
+    _traverseFunction.Traverse(root).Where(obj => obj.Current is not Collection).Reverse().ToArray();
 
   public IReadOnlyCollection<ColorProxy>? TryGetColorProxies(Base root) =>
     TryGetProxies<ColorProxy>(root, ProxyKeys.COLOR);
@@ -53,8 +52,8 @@ public class RootObjectUnpacker
     IReadOnlyCollection<TraversalContext> instanceComponents
   ) SplitAtomicObjectsAndInstances(IEnumerable<TraversalContext> objectsToSplit)
   {
-    HashSet<TraversalContext> atomicObjects = new();
-    HashSet<TraversalContext> instanceComponents = new();
+    HashSet<TraversalContext> atomicObjects = [];
+    HashSet<TraversalContext> instanceComponents = [];
     foreach (TraversalContext tc in objectsToSplit)
     {
       if (tc.Current is IInstanceComponent)
@@ -66,7 +65,7 @@ public class RootObjectUnpacker
         atomicObjects.Add(tc);
       }
     }
-    return (atomicObjects.Freeze(), instanceComponents.Freeze());
+    return (atomicObjects.ToArray(), instanceComponents.ToArray());
   }
 
   private IReadOnlyCollection<T>? TryGetProxies<T>(Base root, string key) =>

--- a/Sdk/Speckle.Connectors.Common/Operations/Receive/RootObjectUnpacker.cs
+++ b/Sdk/Speckle.Connectors.Common/Operations/Receive/RootObjectUnpacker.cs
@@ -30,7 +30,7 @@ public class RootObjectUnpacker
     );
 
   public IReadOnlyCollection<TraversalContext> GetObjectsToConvert(Base root) =>
-    _traverseFunction.Traverse(root).Where(obj => obj.Current is not Collection).Reverse().ToArray();
+    _traverseFunction.Traverse(root).Where(obj => obj.Current is not Collection).ToArray();
 
   public IReadOnlyCollection<ColorProxy>? TryGetColorProxies(Base root) =>
     TryGetProxies<ColorProxy>(root, ProxyKeys.COLOR);

--- a/Sdk/Speckle.Connectors.Common/Operations/Receive/RootObjectUnpacker.cs
+++ b/Sdk/Speckle.Connectors.Common/Operations/Receive/RootObjectUnpacker.cs
@@ -65,7 +65,7 @@ public class RootObjectUnpacker
         atomicObjects.Add(tc);
       }
     }
-    return (atomicObjects.ToArray(), instanceComponents.ToArray());
+    return (atomicObjects, instanceComponents);
   }
 
   private IReadOnlyCollection<T>? TryGetProxies<T>(Base root, string key) =>

--- a/Sdk/Speckle.Connectors.Common/packages.lock.json
+++ b/Sdk/Speckle.Connectors.Common/packages.lock.json
@@ -44,18 +44,18 @@
       },
       "Speckle.Objects": {
         "type": "Direct",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "4OlvSSV1cxPeIs3gK4GRvq9X0Su3NE/TBxE6uA/rBS4tCCUdRRiF8wJMFSOxj8K6CRuJcdCxAqD6TIB0cwJ/9Q==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "T3xwwoALVGmhIuEjlDrTdDXZ9haFILT32r8OACWrRUItU3xMkOWGyob51Ca1MHPmo8B5gvbk2Gnm8AgReGnxWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.5.2"
+          "Speckle.Sdk": "3.5.3"
         }
       },
       "Speckle.Sdk": {
         "type": "Direct",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "6WUC7nbLOQURVb12eONGewhNdJHJb03jJ74QO8Tc5XODG+Q7Z5ZUcXu62ID/Hst3S0c2dlSXVZLw8WOLE2rGzQ==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "o+HefwtPZBqyuUHEnKF+qb/ctCAlNc2BYIw3ULEsZ93zweHt5wOMvOeuPxIXR0Gvj3fg6yNlY2nUcdFEduIXYA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -65,14 +65,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.5.2"
+          "Speckle.Sdk.Dependencies": "3.5.3"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Direct",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "EsNd0OIbubhjFptextM6DeiN74hqb+s8J+HwfAmIFU9XOlmZPfznqjPMJnK9B+8sCpcM2pFsWZys0g/g00m1aw=="
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "kC15SE4yZoVTasgywCm0SpY9yjBsQeUIDt4qoscYAgbn9pe0jj3uM0hZeJUCxn9Fdoj64OfQBpCKzR7VqhkwHQ=="
       },
       "GraphQL.Client": {
         "type": "Transitive",
@@ -360,18 +360,18 @@
       },
       "Speckle.Objects": {
         "type": "Direct",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "4OlvSSV1cxPeIs3gK4GRvq9X0Su3NE/TBxE6uA/rBS4tCCUdRRiF8wJMFSOxj8K6CRuJcdCxAqD6TIB0cwJ/9Q==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "T3xwwoALVGmhIuEjlDrTdDXZ9haFILT32r8OACWrRUItU3xMkOWGyob51Ca1MHPmo8B5gvbk2Gnm8AgReGnxWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.5.2"
+          "Speckle.Sdk": "3.5.3"
         }
       },
       "Speckle.Sdk": {
         "type": "Direct",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "6WUC7nbLOQURVb12eONGewhNdJHJb03jJ74QO8Tc5XODG+Q7Z5ZUcXu62ID/Hst3S0c2dlSXVZLw8WOLE2rGzQ==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "o+HefwtPZBqyuUHEnKF+qb/ctCAlNc2BYIw3ULEsZ93zweHt5wOMvOeuPxIXR0Gvj3fg6yNlY2nUcdFEduIXYA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -379,14 +379,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.5.2"
+          "Speckle.Sdk.Dependencies": "3.5.3"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Direct",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "EsNd0OIbubhjFptextM6DeiN74hqb+s8J+HwfAmIFU9XOlmZPfznqjPMJnK9B+8sCpcM2pFsWZys0g/g00m1aw=="
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "kC15SE4yZoVTasgywCm0SpY9yjBsQeUIDt4qoscYAgbn9pe0jj3uM0hZeJUCxn9Fdoj64OfQBpCKzR7VqhkwHQ=="
       },
       "GraphQL.Client": {
         "type": "Transitive",

--- a/Sdk/Speckle.Converters.Common.Tests/packages.lock.json
+++ b/Sdk/Speckle.Converters.Common.Tests/packages.lock.json
@@ -322,7 +322,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.5.2, )"
+          "Speckle.Objects": "[3.5.3, )"
         }
       },
       "speckle.testing": {
@@ -331,7 +331,7 @@
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Moq": "[4.20.70, )",
           "NUnit": "[4.1.0, )",
-          "Speckle.Sdk": "[3.5.2, )"
+          "Speckle.Sdk": "[3.5.3, )"
         }
       },
       "Microsoft.Extensions.Logging": {
@@ -360,18 +360,18 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "4OlvSSV1cxPeIs3gK4GRvq9X0Su3NE/TBxE6uA/rBS4tCCUdRRiF8wJMFSOxj8K6CRuJcdCxAqD6TIB0cwJ/9Q==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "T3xwwoALVGmhIuEjlDrTdDXZ9haFILT32r8OACWrRUItU3xMkOWGyob51Ca1MHPmo8B5gvbk2Gnm8AgReGnxWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.5.2"
+          "Speckle.Sdk": "3.5.3"
         }
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "6WUC7nbLOQURVb12eONGewhNdJHJb03jJ74QO8Tc5XODG+Q7Z5ZUcXu62ID/Hst3S0c2dlSXVZLw8WOLE2rGzQ==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "o+HefwtPZBqyuUHEnKF+qb/ctCAlNc2BYIw3ULEsZ93zweHt5wOMvOeuPxIXR0Gvj3fg6yNlY2nUcdFEduIXYA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -379,14 +379,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.5.2"
+          "Speckle.Sdk.Dependencies": "3.5.3"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "EsNd0OIbubhjFptextM6DeiN74hqb+s8J+HwfAmIFU9XOlmZPfznqjPMJnK9B+8sCpcM2pFsWZys0g/g00m1aw=="
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "kC15SE4yZoVTasgywCm0SpY9yjBsQeUIDt4qoscYAgbn9pe0jj3uM0hZeJUCxn9Fdoj64OfQBpCKzR7VqhkwHQ=="
       }
     }
   }

--- a/Sdk/Speckle.Converters.Common/packages.lock.json
+++ b/Sdk/Speckle.Converters.Common/packages.lock.json
@@ -41,11 +41,11 @@
       },
       "Speckle.Objects": {
         "type": "Direct",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "4OlvSSV1cxPeIs3gK4GRvq9X0Su3NE/TBxE6uA/rBS4tCCUdRRiF8wJMFSOxj8K6CRuJcdCxAqD6TIB0cwJ/9Q==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "T3xwwoALVGmhIuEjlDrTdDXZ9haFILT32r8OACWrRUItU3xMkOWGyob51Ca1MHPmo8B5gvbk2Gnm8AgReGnxWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.5.2"
+          "Speckle.Sdk": "3.5.3"
         }
       },
       "GraphQL.Client": {
@@ -283,9 +283,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "6WUC7nbLOQURVb12eONGewhNdJHJb03jJ74QO8Tc5XODG+Q7Z5ZUcXu62ID/Hst3S0c2dlSXVZLw8WOLE2rGzQ==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "o+HefwtPZBqyuUHEnKF+qb/ctCAlNc2BYIw3ULEsZ93zweHt5wOMvOeuPxIXR0Gvj3fg6yNlY2nUcdFEduIXYA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
@@ -295,14 +295,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.5.2"
+          "Speckle.Sdk.Dependencies": "3.5.3"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "EsNd0OIbubhjFptextM6DeiN74hqb+s8J+HwfAmIFU9XOlmZPfznqjPMJnK9B+8sCpcM2pFsWZys0g/g00m1aw=="
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "kC15SE4yZoVTasgywCm0SpY9yjBsQeUIDt4qoscYAgbn9pe0jj3uM0hZeJUCxn9Fdoj64OfQBpCKzR7VqhkwHQ=="
       }
     },
     "net8.0": {
@@ -345,11 +345,11 @@
       },
       "Speckle.Objects": {
         "type": "Direct",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "4OlvSSV1cxPeIs3gK4GRvq9X0Su3NE/TBxE6uA/rBS4tCCUdRRiF8wJMFSOxj8K6CRuJcdCxAqD6TIB0cwJ/9Q==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "T3xwwoALVGmhIuEjlDrTdDXZ9haFILT32r8OACWrRUItU3xMkOWGyob51Ca1MHPmo8B5gvbk2Gnm8AgReGnxWg==",
         "dependencies": {
-          "Speckle.Sdk": "3.5.2"
+          "Speckle.Sdk": "3.5.3"
         }
       },
       "GraphQL.Client": {
@@ -538,9 +538,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "6WUC7nbLOQURVb12eONGewhNdJHJb03jJ74QO8Tc5XODG+Q7Z5ZUcXu62ID/Hst3S0c2dlSXVZLw8WOLE2rGzQ==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "o+HefwtPZBqyuUHEnKF+qb/ctCAlNc2BYIw3ULEsZ93zweHt5wOMvOeuPxIXR0Gvj3fg6yNlY2nUcdFEduIXYA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -548,14 +548,14 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.5.2"
+          "Speckle.Sdk.Dependencies": "3.5.3"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "EsNd0OIbubhjFptextM6DeiN74hqb+s8J+HwfAmIFU9XOlmZPfznqjPMJnK9B+8sCpcM2pFsWZys0g/g00m1aw=="
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "kC15SE4yZoVTasgywCm0SpY9yjBsQeUIDt4qoscYAgbn9pe0jj3uM0hZeJUCxn9Fdoj64OfQBpCKzR7VqhkwHQ=="
       }
     }
   }

--- a/Sdk/Speckle.Testing/packages.lock.json
+++ b/Sdk/Speckle.Testing/packages.lock.json
@@ -59,9 +59,9 @@
       },
       "Speckle.Sdk": {
         "type": "Direct",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "6WUC7nbLOQURVb12eONGewhNdJHJb03jJ74QO8Tc5XODG+Q7Z5ZUcXu62ID/Hst3S0c2dlSXVZLw8WOLE2rGzQ==",
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "o+HefwtPZBqyuUHEnKF+qb/ctCAlNc2BYIw3ULEsZ93zweHt5wOMvOeuPxIXR0Gvj3fg6yNlY2nUcdFEduIXYA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -69,7 +69,7 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.5.2"
+          "Speckle.Sdk.Dependencies": "3.5.3"
         }
       },
       "Castle.Core": {
@@ -277,9 +277,9 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "CentralTransitive",
-        "requested": "[3.5.2, )",
-        "resolved": "3.5.2",
-        "contentHash": "EsNd0OIbubhjFptextM6DeiN74hqb+s8J+HwfAmIFU9XOlmZPfznqjPMJnK9B+8sCpcM2pFsWZys0g/g00m1aw=="
+        "requested": "[3.5.3, )",
+        "resolved": "3.5.3",
+        "contentHash": "kC15SE4yZoVTasgywCm0SpY9yjBsQeUIDt4qoscYAgbn9pe0jj3uM0hZeJUCxn9Fdoj64OfQBpCKzR7VqhkwHQ=="
       }
     }
   }


### PR DESCRIPTION
## Description
Fixed collection order getting mixed up during receive operations.

## User Value
Collections now keep their original order consistently across receive operations - no more random shuffling organized data.

## Changes:
- **RootObjectUnpacker.GetObjectsToConvert()**: Changed `.Freeze()` to `.ToArray()` to fix make results predictable
- **RootObjectUnpacker.SplitAtomicObjectsAndInstances()**: Changed `.Freeze()` to `.ToArray()` to stop the random reordering between versions

## To-Do Before Merge

- [x] Merge [fix: collection order #380](https://github.com/specklesystems/speckle-sharp-sdk/pull/380)
- [ ] Update packages to latest SDK release

## Screenshots & Validation of changes:

### Before

https://github.com/user-attachments/assets/6d28aae5-0ea8-44d1-a3e5-b6df001211ac

### After

https://github.com/user-attachments/assets/1d64c774-e35e-49b8-a7a9-706b9fbd21eb

## Checklist:
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] I have added appropriate tests.
- [x] I have updated or added relevant documentation.