### PR TITLE
fix(grasshopper): prevent parameter index error in `ExpandSpeckleProperties` during parameter creation

### DIFF
--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Objects/ExpandSpeckleProperties.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Objects/ExpandSpeckleProperties.cs
@@ -77,8 +77,10 @@ public class ExpandSpeckleProperties : GH_Component, IGH_VariableParameterCompon
     if (da.Iteration == 0 && OutputMismatch(outputParams))
     {
       OnPingDocument()?.ScheduleSolution(5, _ => CreateOutputs(outputParams));
+      return; // exit early
     }
-    else
+    // only set data if we have the correct parameter structure
+    if (Params.Output.Count == outputParams.Count)
     {
       for (int i = 0; i < outputParams.Count; i++)
       {


### PR DESCRIPTION
## Description
Fixed a bug in the ExpandSpeckleProperties component where using properties from SpeckleGeometryPassthrough would cause a "parameter index too high/too low" error popup. The component was trying to access output parameters before they were properly created during the dynamic parameter recreation process.

## User Value
Users can now connect `SpeckleGeometryPassthrough` (and others) properties to `ExpandProperties` without getting error popups (component still works correctly, just no more annoying dialogs).

## Changes:
- Added early return after scheduling parameter creation in `ExpandSpeckleProperties`
- Added parameter count validation before attempting data access
- Prevents accessing non-existent parameters during the recreation cycle

## Validation of changes:
### Before
![before-fix](https://github.com/user-attachments/assets/3c58a53c-82de-4bbc-abcf-f253fd694d5d)
### After
![after-fix](https://github.com/user-attachments/assets/1c41514b-9632-49a1-b048-97242abe7e7e)
## Checklist:
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] I have added appropriate tests.
- [x] I have updated or added relevant documentation.