### PR TITLE
fix(grasshopper): clear `Base.id` to force serializer recomputation of mutations

### DIFF
--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Objects/SpeckleBlockDefinitionPassthrough.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Objects/SpeckleBlockDefinitionPassthrough.cs
@@ -84,7 +84,12 @@ public class SpeckleBlockDefinitionPassthrough()
 
     // process the definition
     // deep copy so we don't mutate the object
-    SpeckleBlockDefinitionWrapperGoo result = inputDefinition != null ? new(inputDefinition.Value.DeepCopy()) : new();
+    SpeckleBlockDefinitionWrapperGoo result = new();
+    if (inputDefinition != null)
+    {
+      result = new SpeckleBlockDefinitionWrapperGoo(inputDefinition.Value.DeepCopy());
+      result.Value.Base.id = null; // ⚠️ TODO: Co-ordinate with SDK. We're having to do this otherwise the serializer won't recompute mutated objects
+    }
 
     // process geometry
     if (inputObjects.Count > 0)

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Objects/SpeckleBlockInstancePassthrough.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Objects/SpeckleBlockInstancePassthrough.cs
@@ -151,8 +151,12 @@ public class SpeckleBlockInstancePassthrough()
 
     // process the instance
     // deep copy so we don't mutate the incoming object
-    SpeckleBlockInstanceWrapperGoo result =
-      inputInstance != null ? new((SpeckleBlockInstanceWrapper)inputInstance.Value.DeepCopy()) : new();
+    SpeckleBlockInstanceWrapperGoo result = new();
+    if (inputInstance != null)
+    {
+      result = new SpeckleBlockInstanceWrapperGoo((SpeckleBlockInstanceWrapper)inputInstance.Value.DeepCopy());
+      result.Value.Base.id = null; // ⚠️ TODO: Co-ordinate with SDK. We're having to do this otherwise the serializer won't recompute mutated objects
+    }
 
     // process definition
     if (inputDefinition != null)

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Objects/SpeckleDataObjectPassthrough.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Objects/SpeckleDataObjectPassthrough.cs
@@ -98,6 +98,7 @@ public class SpeckleDataObjectPassthrough()
     if (da.GetData(0, ref inputObject))
     {
       result = inputObject.Value.DeepCopy();
+      result.Base.id = null; // ⚠️ TODO: Co-ordinate with SDK. We're having to do this otherwise the serializer won't recompute mutated objects
     }
 
     List<SpeckleGeometryWrapperGoo> inputGeometry = new();

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Objects/SpeckleGeometryPassthrough.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Objects/SpeckleGeometryPassthrough.cs
@@ -125,6 +125,7 @@ public class SpeckleGeometryPassthrough()
       if (inputObject?.ToSpeckleGeometryWrapper() is SpeckleGeometryWrapper gooWrapper)
       {
         result = gooWrapper.DeepCopy();
+        result.Base.id = null; // ⚠️ TODO: Co-ordinate with SDK. We're having to do this otherwise the serializer won't recompute mutated objects
       }
       else
       {


### PR DESCRIPTION
## Description
Temporary fix for bug where mutations on objects with preserved IDs (from `DeepCopy`) are ignored. The serializer caches `ObjectReferences` by `Base.id` and returns stale data instead of recomputing mutated objects.

This was exposed in `SpeckleGeometryPassthrough` where `Name`/`Properties` mutations weren't appearing in the viewer.

**This is a temporary workaround until the proper SDK fix is implemented [CNX-2527](https://linear.app/speckle/issue/CNX-2527/sdk-serializer-ignores-mutations-on-objects-with-preserved-ids-after). PR linked here: [Remove the cache that avoids recalculating IDs from JSON #384](https://github.com/specklesystems/speckle-sharp-sdk/pull/384)**

Fixes [CNX-2233](https://linear.app/speckle/issue/CNX-2233/grasshopper-data-object-mutated-geometry-does-not-get-published) and [CNX-2417](https://linear.app/speckle/issue/CNX-2417/cant-tag-properties-to-and-block-instance-with-grasshopper)

## User Value
Users can now mutate existing Speckle objects.

## Changes:
- Clear `Base.id` on deep copied objects in `SpeckleGeometryPassthrough` to force serializer recomputation
- Add TODO comment noting this is a temporary fix pending SDK changes

## Screenshots & Validation of changes

### `SpeckleGeometry`
#### Before

![before-fix](https://github.com/user-attachments/assets/dbeb24f0-802a-4e76-9089-e0314e9e89b0)
### After

![after-fix](https://github.com/user-attachments/assets/33e39723-90cd-494f-98ed-3dd483409917)

### `SpeckleDataObject`
Fixes this report too: [Gen 3 Grasshopper - Modifying geometry](https://speckle.community/t/gen-3-grasshopper-modifying-geometry/19819/2).

https://github.com/user-attachments/assets/ad1f6594-05b2-4386-b3f5-0d3c9dfd69d6

## Checklist:
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] I have added appropriate tests.
- [x] I have updated or added relevant documentation.