### PR TITLE
Chore(build): Enforce CA2254

### DIFF
--- a/Connectors/CSi/Speckle.Connectors.CSiShared/HostApp/CsiDocumentModelStore.cs
+++ b/Connectors/CSi/Speckle.Connectors.CSiShared/HostApp/CsiDocumentModelStore.cs
@@ -89,7 +89,11 @@ public class CsiDocumentModelStore : DocumentModelStore, IDisposable
         _speckleApplication.Slug
       );
       DocumentStateFile = Path.Combine(HostAppUserDataPath, $"{ModelPathHash}.json");
-      _logger.LogDebug("Paths set - Hash: {ModelPathHash}, File: {DocumentStateFile}", ModelPathHash, DocumentStateFile);
+      _logger.LogDebug(
+        "Paths set - Hash: {ModelPathHash}, File: {DocumentStateFile}",
+        ModelPathHash,
+        DocumentStateFile
+      );
     }
     catch (Exception ex) when (!ex.IsFatal())
     {

--- a/Connectors/CSi/Speckle.Connectors.CSiShared/HostApp/CsiDocumentModelStore.cs
+++ b/Connectors/CSi/Speckle.Connectors.CSiShared/HostApp/CsiDocumentModelStore.cs
@@ -89,7 +89,7 @@ public class CsiDocumentModelStore : DocumentModelStore, IDisposable
         _speckleApplication.Slug
       );
       DocumentStateFile = Path.Combine(HostAppUserDataPath, $"{ModelPathHash}.json");
-      _logger.LogDebug($"Paths set - Hash: {ModelPathHash}, File: {DocumentStateFile}");
+      _logger.LogDebug("Paths set - Hash: {ModelPathHash}, File: {DocumentStateFile}", ModelPathHash, DocumentStateFile);
     }
     catch (Exception ex) when (!ex.IsFatal())
     {

--- a/Connectors/CSi/Speckle.Connectors.CSiShared/Operations/Send/CsiRootObjectBuilder.cs
+++ b/Connectors/CSi/Speckle.Connectors.CSiShared/Operations/Send/CsiRootObjectBuilder.cs
@@ -182,12 +182,12 @@ public class CsiRootObjectBuilder : IRootObjectBuilder<ICsiWrapper>
     // NOTE: CsiTendonWrapper - not typically modelled in ETABS, rather SAFE
     catch (NotImplementedException ex)
     {
-      _logger.LogError(ex, sourceType);
+      _logger.LogError(ex, "Failed to convert object {sourceType}", sourceType);
       return new(Status.WARNING, applicationId, sourceType, null, ex);
     }
     catch (Exception ex) when (!ex.IsFatal())
     {
-      _logger.LogError(ex, sourceType);
+      _logger.LogError(ex, "Failed to convert object {sourceType}", sourceType);
       return new(Status.ERROR, applicationId, sourceType, null, ex);
     }
   }

--- a/Connectors/Tekla/Speckle.Connector.TeklaShared/HostApp/TeklaDocumentModelStore.cs
+++ b/Connectors/Tekla/Speckle.Connector.TeklaShared/HostApp/TeklaDocumentModelStore.cs
@@ -56,7 +56,7 @@ public class TeklaDocumentModelStore : DocumentModelStore
     }
     catch (Exception ex) when (!ex.IsFatal())
     {
-      _logger.LogError(ex.Message);
+      _logger.LogError(ex, "Failed to Save Host App State");
     }
   }
 

--- a/Connectors/Tekla/Speckle.Connector.TeklaShared/Operations/Send/TeklaRootObjectBuilder.cs
+++ b/Connectors/Tekla/Speckle.Connector.TeklaShared/Operations/Send/TeklaRootObjectBuilder.cs
@@ -119,7 +119,7 @@ public class TeklaRootObjectBuilder : IRootObjectBuilder<TSM.ModelObject>
     }
     catch (Exception ex) when (!ex.IsFatal())
     {
-      _logger.LogError(ex, sourceType);
+      _logger.LogError(ex, "Failed to convert object {SourceType}", sourceType);
       return new(Status.ERROR, applicationId, sourceType, null, ex);
     }
   }

--- a/Converters/Civil3d/Speckle.Converters.Civil3dShared/ToSpeckle/Properties/PropertySetExtractor.cs
+++ b/Converters/Civil3d/Speckle.Converters.Civil3dShared/ToSpeckle/Properties/PropertySetExtractor.cs
@@ -39,9 +39,9 @@ public class PropertySetExtractor
     {
       propertySetIds = AAECPDB.PropertyDataServices.GetPropertySets(dbObject);
     }
-    catch (Exception e) when (!e.IsFatal())
+    catch (Exception ex) when (!ex.IsFatal())
     {
-      _logger.LogWarning(e, $"Failed to retrieve property sets on object {dbObject.Handle.Value}");
+      _logger.LogWarning(ex, "Failed to retrieve property sets on object {HandleValue}", dbObject.Handle.Value);
     }
 
     if (propertySetIds is null || propertySetIds.Count == 0)
@@ -102,9 +102,9 @@ public class PropertySetExtractor
 
       return (name, propertySetData);
     }
-    catch (Exception e) when (!e.IsFatal())
+    catch (Exception ex) when (!ex.IsFatal())
     {
-      _logger.LogWarning(e, $"Failed to convert property set {propertySet.Name}");
+      _logger.LogWarning(ex, "Failed to convert property set {propertySetName}", propertySet.Name);
     }
 
     return null;

--- a/Converters/Revit/Speckle.Converters.RevitShared/ToSpeckle/Properties/ParameterExtractor.cs
+++ b/Converters/Revit/Speckle.Converters.RevitShared/ToSpeckle/Properties/ParameterExtractor.cs
@@ -231,9 +231,9 @@ public class ParameterExtractor
 
         paramGroup[targetKey] = param;
       }
-      catch (Exception e) when (!e.IsFatal())
+      catch (Exception ex) when (!ex.IsFatal())
       {
-        _logger.LogWarning(e, $"Failed to convert parameter {parameter.Definition.Name}");
+        _logger.LogWarning(ex, "Failed to convert parameter {parameterDefinitionName}", parameter.Definition.Name);
       }
     }
 

--- a/DUI3/Speckle.Connectors.DUI/Models/DocumentModelStore.cs
+++ b/DUI3/Speckle.Connectors.DUI/Models/DocumentModelStore.cs
@@ -51,7 +51,7 @@ public abstract class DocumentModelStore(ILogger<DocumentModelStore> logger, IJs
       var model = _models.FirstOrDefault(model => model.ModelCardId == id);
       if (model is null)
       {
-        logger.LogWarning($"Model with id {id} not found.");
+        logger.LogWarning("Model with id {id} not found", id);
         return null;
       }
       return model;
@@ -83,7 +83,7 @@ public abstract class DocumentModelStore(ILogger<DocumentModelStore> logger, IJs
       var index = _models.FindIndex(m => m.ModelCardId == model.ModelCardId);
       if (index == -1)
       {
-        logger.LogWarning($"Model card not found to update. Model card ID: {model.ModelCardId}");
+        logger.LogWarning("Model card not found to update. Model card ID: {ModelCardId}", model.ModelCardId);
         return;
       }
       _models[index] = model;
@@ -98,7 +98,7 @@ public abstract class DocumentModelStore(ILogger<DocumentModelStore> logger, IJs
       var index = _models.FindIndex(m => m.ModelCardId == model.ModelCardId);
       if (index == -1)
       {
-        logger.LogWarning($"Model card not found to update. Model card ID: {model.ModelCardId}");
+        logger.LogWarning("Model card not found to update. Model card ID: {ModelCardId}", model.ModelCardId);
         return;
       }
       _models.RemoveAt(index);
@@ -123,7 +123,7 @@ public abstract class DocumentModelStore(ILogger<DocumentModelStore> logger, IJs
       SaveState();
       if (listForMissingModelCards.Count > 0)
       {
-        logger.LogWarning($"Model cards with IDs {listForMissingModelCards} not found to remove.");
+        logger.LogWarning("Model cards with IDs {ListForMissingModelCards} not found to remove", listForMissingModelCards);
       }
     }
   }

--- a/DUI3/Speckle.Connectors.DUI/Models/DocumentModelStore.cs
+++ b/DUI3/Speckle.Connectors.DUI/Models/DocumentModelStore.cs
@@ -123,7 +123,10 @@ public abstract class DocumentModelStore(ILogger<DocumentModelStore> logger, IJs
       SaveState();
       if (listForMissingModelCards.Count > 0)
       {
-        logger.LogWarning("Model cards with IDs {ListForMissingModelCards} not found to remove", listForMissingModelCards);
+        logger.LogWarning(
+          "Model cards with IDs {ListForMissingModelCards} not found to remove",
+          listForMissingModelCards
+        );
       }
     }
   }

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -29,7 +29,7 @@
       <!-- Globalization rules -->
       CA1303;CA1304;CA1305;CA1307;CA1308;CA1309;CA1310;CA1311;
       <!-- Logging -->
-      CA1848;CA2254;CA1727;
+      CA1848;CA1727;
       <!-- Others we don't want -->
       CA1815;CA1725;CA1501;
       <!-- Package using wrong RIDs (Net8 changed them). Usually fixable by updating.  -->

--- a/Importers/Rhino/Speckle.Importers.Rhino/Internal/Progress.cs
+++ b/Importers/Rhino/Speckle.Importers.Rhino/Internal/Progress.cs
@@ -13,7 +13,7 @@ internal sealed class Progress(ILogger<Progress> logger) : IProgress<CardProgres
     var now = DateTime.UtcNow;
     if (now - _lastTime >= _debounce)
     {
-      logger.LogInformation(value.Status + " p " + value.Progress);
+      logger.LogInformation("{Status} p {Progress}", value.Status, value.Progress);
       _lastTime = now;
     }
   }

--- a/Importers/Rhino/Speckle.Importers.Rhino/Internal/Sender.cs
+++ b/Importers/Rhino/Speckle.Importers.Rhino/Internal/Sender.cs
@@ -64,7 +64,7 @@ internal sealed class Sender(
     }
 
     await mixpanel.TrackEvent(MixPanelEvents.Send, account, customProperties);
-    logger.LogInformation($"Root: {results.RootId}");
+    logger.LogInformation("Root: {RootId}", results.RootId);
 
     return version;
   }


### PR DESCRIPTION
I noticed several places where we were incorrectly logging interpolated strings.

The standard with structural logging is to use a compile time constant message template, and pass args in to as params

The reason for this is it allows for logs to be easily grouped in seq by template, and parameter values to be searched. It also allows for non-stringified values such as numbers and basic json style structures.

I'll also probably fix CA1727 at some point, but in another PR