### PR TITLE
CSI conversion exceptions should be speckle ones

### DIFF
--- a/Connectors/CSi/Speckle.Connectors.CSiShared/Operations/Send/CsiRootObjectBuilder.cs
+++ b/Connectors/CSi/Speckle.Connectors.CSiShared/Operations/Send/CsiRootObjectBuilder.cs
@@ -138,13 +138,21 @@ public class CsiRootObjectBuilder : IRootObjectBuilder<ICsiWrapper>
         throw new SpeckleException("Model unlocked. No access to analysis results.");
       }
 
-      var analysisResults = _analysisResultsExtractor.ExtractAnalysisResults(
-        selectedCasesAndCombinations,
-        requestedResultTypes,
-        objectSelectionSummary
-      );
-      rootObjectCollection["analysisResults"] = analysisResults;
+      try
+      {
+        var analysisResults = _analysisResultsExtractor.ExtractAnalysisResults(
+          selectedCasesAndCombinations,
+          requestedResultTypes,
+          objectSelectionSummary
+        );
+        rootObjectCollection["analysisResults"] = analysisResults;
+      }
+      catch (Exception e)
+      {
+        throw new SpeckleException("Analysis failed.", e);
+      }
     }
+
     return new RootObjectBuilderResult(rootObjectCollection, results);
   }
 


### PR DESCRIPTION
Trying to stop
<img width="626" height="636" alt="image" src="https://github.com/user-attachments/assets/7cc03a0b-88f8-4f99-867a-c2f04e1c287c" />
