### PR TITLE
fix(grasshopper): sync SpeckleGeometryWrapper Properties with Base

### DIFF
--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/Wrappers/SpeckleGeometryWrapper.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/Wrappers/SpeckleGeometryWrapper.cs
@@ -4,6 +4,7 @@ using Rhino;
 using Rhino.Display;
 using Rhino.DocObjects;
 using Rhino.Geometry;
+using Speckle.Connectors.GrasshopperShared.HostApp;
 using Speckle.Sdk.Models;
 
 namespace Speckle.Connectors.GrasshopperShared.Parameters;
@@ -27,7 +28,25 @@ public class SpeckleGeometryWrapper : SpeckleWrapper, ISpeckleCollectionObject
   // The list of layer/collection names that forms the full path to this object
   public List<string> Path { get; set; } = new();
   public SpeckleCollectionWrapper? Parent { get; set; }
-  public SpecklePropertyGroupGoo Properties { get; set; } = new();
+
+  /// <summary>
+  /// Properties that stay synchronized with Base["properties"]
+  /// </summary>
+  public SpecklePropertyGroupGoo Properties
+  {
+    get
+    {
+      // always create from Base["properties"] like SpeckleDataObjectWrapper does
+      if (Base[Constants.PROPERTIES_PROP] is Dictionary<string, object?> baseProps)
+      {
+        return new SpecklePropertyGroupGoo(baseProps);
+      }
+      return new SpecklePropertyGroupGoo(); // return empty if no properties
+    }
+    set =>
+      // unwrap and store in Base["properties"] like SpeckleDataObjectWrapper does
+      Base[Constants.PROPERTIES_PROP] = value.Unwrap();
+  }
 
   /// <summary>
   /// The color of the <see cref="Base"/>


### PR DESCRIPTION
## Description
Fixed `SpeckleBlockInstancePassthrough` outputting empty properties by syncing with the Base object. The issue was that `wrapper.Properties` wasn't kept in sync with `Base["properties"]`.

Fixes bjorn/cnx-2597-block-properties-not-working.

## User Value
SpeckleBlockInstancePassthrough now correctly outputs properties instead of empty property groups.

## Changes:
- Changed `SpeckleGeometryWrapper.Properties` from a field to a computed property that reads/writes directly from `Base[Constants.PROPERTIES_PROP]`
- Follows the pattern already used in `SpeckleDataObjectWrapper`

## Screenshots:
### Before
Problem was localised to `SpeckleBlockInstance`.

<img width="1128" height="716" alt="image" src="https://github.com/user-attachments/assets/688f06fa-2a64-4aec-b241-a17eb71d05e1" />


### After
<img width="1128" height="716" alt="image" src="https://github.com/user-attachments/assets/81161ebb-b6b1-48d2-91e1-fd03deada322" />


## Validation of changes:
- Tested `SpeckleBlockInstancePassthrough` as well as `SpeckleGeometryWrapper` and `SpeckleDataObjectWrapper` for good measure
- Received objects with props, used the passthrough components to then expand properties and make sure that they were present
- Also mutated existing objects to make sure the mutated property only reflected on intended object

## Checklist:
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] I have added appropriate tests.
- [x] I have updated or added relevant documentation.