### PR TITLE
fix (revit) Eager deep copy to avoid multi-enum while saving

### DIFF
--- a/DUI3/Speckle.Connectors.DUI/Models/Card/ModelCard.cs
+++ b/DUI3/Speckle.Connectors.DUI/Models/Card/ModelCard.cs
@@ -53,9 +53,6 @@ public class ModelCard : DiscriminatedObject
       WorkspaceSlug = WorkspaceSlug,
       AccountId = AccountId,
       ServerUrl = ServerUrl,
-      Settings = Settings?.Select(x => x with
-      {
-        Enum = x.Enum?.ToList()
-      }).ToList(),
+      Settings = Settings?.Select(x => x with { Enum = x.Enum?.ToList() }).ToList(),
     };
 }

--- a/DUI3/Speckle.Connectors.DUI/Models/Card/ModelCard.cs
+++ b/DUI3/Speckle.Connectors.DUI/Models/Card/ModelCard.cs
@@ -42,4 +42,20 @@ public class ModelCard : DiscriminatedObject
   public string? ServerUrl { get; set; }
 
   public List<CardSetting>? Settings { get; set; }
+
+  public ModelCard Clone() =>
+    new()
+    {
+      ModelCardId = ModelCardId,
+      ModelId = ModelId,
+      ProjectId = ProjectId,
+      WorkspaceId = WorkspaceId,
+      WorkspaceSlug = WorkspaceSlug,
+      AccountId = AccountId,
+      ServerUrl = ServerUrl,
+      Settings = Settings?.Select(x => x with
+      {
+        Enum = x.Enum?.ToList()
+      }).ToList(),
+    };
 }

--- a/DUI3/Speckle.Connectors.DUI/Models/DocumentModelStore.cs
+++ b/DUI3/Speckle.Connectors.DUI/Models/DocumentModelStore.cs
@@ -141,8 +141,6 @@ public abstract class DocumentModelStore(ILogger<DocumentModelStore> logger, IJs
     }
   }
 
-  protected string Serialize() => serializer.Serialize(Models.ToList());
-
   // POC: this seemms more like a IModelsDeserializer?, seems disconnected from this class
   protected List<ModelCard> Deserialize(string models) => serializer.Deserialize<List<ModelCard>>(models).NotNull();
 
@@ -150,7 +148,8 @@ public abstract class DocumentModelStore(ILogger<DocumentModelStore> logger, IJs
   {
     lock (_models)
     {
-      var state = Serialize();
+      //eager clone to avoid multi concurrency issues with settings?
+      var state = serializer.Serialize(_models.Select(x => x.Clone()).ToList());
       HostAppSaveState(state);
     }
   }

--- a/DUI3/Speckle.Connectors.DUI/Settings/CardSetting.cs
+++ b/DUI3/Speckle.Connectors.DUI/Settings/CardSetting.cs
@@ -3,7 +3,7 @@ using Speckle.InterfaceGenerator;
 namespace Speckle.Connectors.DUI.Settings;
 
 [GenerateAutoInterface]
-public class CardSetting : ICardSetting
+public record CardSetting : ICardSetting
 {
   public string? Id { get; set; }
   public string? Title { get; set; }


### PR DESCRIPTION
This happens often: 
<img width="1414" height="898" alt="image" src="https://github.com/user-attachments/assets/7aa9a07a-5fd1-474b-9481-1709351e644a" />

The models collection itself is locked so there must be a problem with all the model collections.  I'm doing a deep clone (I should probably lock all those too) to avoid issues but since this is directly exposed to the Revit DUI, locking is probably impossible.