### PR TITLE
Only call `IsConnected` on Physical connectors

### DIFF
--- a/Converters/Revit/Speckle.Converters.RevitShared/ToSpeckle/Properties/ParameterExtractor.cs
+++ b/Converters/Revit/Speckle.Converters.RevitShared/ToSpeckle/Properties/ParameterExtractor.cs
@@ -148,7 +148,7 @@ public class ParameterExtractor
       {
         foreach (DB.Connector conn in cm.Connectors)
         {
-          if (conn.IsConnected && conn.MEPSystem != null)
+          if (conn.ConnectorType == DB.ConnectorType.Physical && conn.IsConnected && conn.MEPSystem != null)
           {
             return conn.MEPSystem;
           }


### PR DESCRIPTION
`IsConnected` can only be called on physical connectors. Otherwise they throw an `InvalidOperationException`
<img width="587" height="206" alt="image" src="https://github.com/user-attachments/assets/bbbca053-9f09-4c97-9a3e-71038870064f" />