### PR TITLE
Key for docs should fallback correctly and load when not found.

### DIFF
--- a/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/RevitDocumentStore.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/RevitDocumentStore.cs
@@ -97,10 +97,7 @@ internal sealed class RevitDocumentStore : DocumentModelStore
     try
     {
       var key = GetKeyForDocument(document);
-      if (key != null)
-      {
-        _jsonCacheManager.UpdateObject(key, modelCardState);
-      }
+      _jsonCacheManager.UpdateObject(key, modelCardState);
     }
     catch (Exception ex) when (!ex.IsFatal())
     {
@@ -109,13 +106,9 @@ internal sealed class RevitDocumentStore : DocumentModelStore
     }
   }
 
-  private string? GetKeyForDocument(Document doc)
+  private string GetKeyForDocument(Document doc)
   {
-    string? id = doc?.ProjectInformation?.UniqueId; //ProjectInformation Should only be null for family docs
-#if REVIT_2024_OR_GREATER
-    id ??= doc.CreationGUID.ToString(); //fallback for family docs
-#endif
-    return id;
+    return  doc.CreationGUID.ToString();
   }
 
   protected override void LoadState()
@@ -128,14 +121,7 @@ internal sealed class RevitDocumentStore : DocumentModelStore
     }
 
     var key = GetKeyForDocument(document);
-    if (key != null)
-    {
-      var state = _jsonCacheManager.GetObject(key);
-      if (state == null)
-      {
-        return;
-      }
-      LoadFromString(state);
-    }
+    var state = _jsonCacheManager.GetObject(key);
+    LoadFromString(state);
   }
 }


### PR DESCRIPTION
Revit 24+ properly uses creation guid which is unique per doc instance.
Revit 22/23 uses path (if it exists) for a best effort for cards.

A null key or null state will clear out the current cards.