### PR TITLE
chore(rhino-importer): remove obsolete obsolete warning

### DIFF
--- a/Importers/Rhino/Speckle.Importers.Rhino/Internal/FileTypeConfig/Rhino3dmConfig.cs
+++ b/Importers/Rhino/Speckle.Importers.Rhino/Internal/FileTypeConfig/Rhino3dmConfig.cs
@@ -11,7 +11,6 @@ namespace Speckle.Importers.Rhino.Internal.FileTypeConfig;
 /// </remarks>
 public sealed class Rhino3dmConfig : IFileTypeConfig
 {
-  [Obsolete("Bugged, don't use until fixed")]
   public RhinoDoc OpenInHeadlessDocument(string filePath)
   {
     RhinoDoc? doc = RhinoDoc.OpenHeadless(filePath);


### PR DESCRIPTION
The bug was fixed by https://github.com/specklesystems/speckle-sharp-connectors/pull/1088
but the comment about there being a bug was left in erroniously.