### PR TITLE
fix(grasshopper): hide internal parameter classes from component panel

### DIFF
--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/SpeckleOutputParam.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/SpeckleOutputParam.cs
@@ -11,6 +11,7 @@ namespace Speckle.Connectors.GrasshopperShared.Parameters;
 /// </summary>
 public class SpeckleOutputParam : Param_GenericObject
 {
+  public override GH_Exposure Exposure => GH_Exposure.hidden;
   public override Guid ComponentGuid => new("D2B4713D-FE8B-4EF0-8445-B6096DB15B24");
 
   public override void AppendAdditionalMenuItems(ToolStripDropDown menu)

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/SpeckleVariableParam.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/SpeckleVariableParam.cs
@@ -52,6 +52,7 @@ public class SpeckleVariableParam : Param_GenericObject
     }
   }
 
+  public override GH_Exposure Exposure => GH_Exposure.hidden;
   public override Guid ComponentGuid => new("A1B2C3D4-E5F6-7890-ABCD-123456789ABC");
 
   public override void AppendAdditionalMenuItems(ToolStripDropDown menu)


### PR DESCRIPTION
## Description
`SpeckleVariableParam` and `SpeckleOutputParam` were showing up as duplicate "Data" components under `Params/Primitives`. These are foundational classes used internally by variable parameter components and shouldn't be user-facing. Added `GH_Exposure.hidden` to both.

## User Value
Cleans up the Grasshopper UI by removing two confusing duplicate "Data" parameters that users shouldn't interact with directly.

## Changes:
- Added `GH_Exposure.hidden` to `SpeckleVariableParam`
- Added `GH_Exposure.hidden` to `SpeckleOutputParam`

## Validation of changes:
Build and install the plugin - the duplicate Data components no longer appear under Params/Primitives tab.

### Before

<img width="960" height="650" alt="Screenshot 2025-10-02 195429" src="https://github.com/user-attachments/assets/5f5570b8-326a-47f9-bd86-94d4669cc2f5" />

### After

<img width="960" height="650" alt="Screenshot 2025-10-02 195501" src="https://github.com/user-attachments/assets/b094a1fd-8f70-4aec-a734-6e6aeb5a97a4" />

## Checklist:
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] I have added appropriate tests.
- [x] I have updated or added relevant documentation.