### PR TITLE
fix(grasshopper): add auto-load persistence and reactive behavior to sync receive component

### DIFF
--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Receive/ReceiveAsyncComponent.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Receive/ReceiveAsyncComponent.cs
@@ -1,4 +1,5 @@
 using System.Runtime.InteropServices;
+using GH_IO.Serialization;
 using Grasshopper.GUI;
 using Grasshopper.GUI.Canvas;
 using Grasshopper.Kernel;
@@ -296,6 +297,32 @@ public class ReceiveAsyncComponent : GH_AsyncComponent<ReceiveAsyncComponent>
     {
       AddRuntimeMessage(GH_RuntimeMessageLevel.Error, e.ToFormattedString());
     }
+  }
+
+  public override bool Write(GH_IWriter writer)
+  {
+    // call base implementation first
+    var result = base.Write(writer);
+
+    // persist AutoReceive setting
+    writer.SetBoolean("AutoReceive", AutoReceive);
+
+    return result;
+  }
+
+  public override bool Read(GH_IReader reader)
+  {
+    // call base implementation first
+    var result = base.Read(reader);
+
+    // restore AutoReceive setting
+    bool autoReceive = false;
+    if (reader.TryGetBoolean("AutoReceive", ref autoReceive))
+    {
+      AutoReceive = autoReceive;
+    }
+
+    return result;
   }
 }
 

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Receive/ReceiveComponent.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Receive/ReceiveComponent.cs
@@ -33,6 +33,9 @@ public class ReceiveComponentInput
 
 public class ReceiveComponentOutput
 {
+  /// <remarks>
+  /// Made nullable as output can be null when Run = false or on error
+  /// </remarks>
   public SpeckleCollectionWrapperGoo? RootObject { get; set; }
 }
 
@@ -121,7 +124,7 @@ public class ReceiveComponent : SpeckleTaskCapableComponent<ReceiveComponentInpu
         GH_RuntimeMessageLevel.Error,
         "Only one model can be loaded at a time. To load to multiple models, please use different load components."
       );
-      return new();
+      return new ReceiveComponentOutput();
     }
     if (!input.Run)
     {

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Receive/ReceiveComponent.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Receive/ReceiveComponent.cs
@@ -1,5 +1,6 @@
 using Grasshopper.Kernel;
 using Microsoft.Extensions.DependencyInjection;
+using Rhino;
 using Speckle.Connectors.Common;
 using Speckle.Connectors.Common.Analytics;
 using Speckle.Connectors.Common.Operations;
@@ -12,6 +13,7 @@ using Speckle.Connectors.GrasshopperShared.Properties;
 using Speckle.Connectors.GrasshopperShared.Registration;
 using Speckle.Sdk;
 using Speckle.Sdk.Api;
+using Speckle.Sdk.Api.GraphQL.Models;
 using Speckle.Sdk.Credentials;
 using Speckle.Sdk.Models.Collections;
 
@@ -31,11 +33,17 @@ public class ReceiveComponentInput
 
 public class ReceiveComponentOutput
 {
-  public SpeckleCollectionWrapperGoo RootObject { get; set; }
+  public SpeckleCollectionWrapperGoo? RootObject { get; set; }
 }
 
 public class ReceiveComponent : SpeckleTaskCapableComponent<ReceiveComponentInput, ReceiveComponentOutput>
 {
+  private IClient? _apiClient;
+  private string? _lastVersionId;
+  private SpeckleUrlModelResource? _lastResource;
+  public override Guid ComponentGuid => new("74954F59-B1B7-41FD-97DE-4C6B005F2801");
+  protected override Bitmap Icon => Resources.speckle_operations_syncload;
+
   public ReceiveComponent()
     : base(
       "(Sync) Load",
@@ -44,9 +52,6 @@ public class ReceiveComponent : SpeckleTaskCapableComponent<ReceiveComponentInpu
       ComponentCategories.PRIMARY_RIBBON,
       ComponentCategories.DEVELOPER
     ) { }
-
-  public override Guid ComponentGuid => new("74954F59-B1B7-41FD-97DE-4C6B005F2801");
-  protected override Bitmap Icon => Resources.speckle_operations_syncload;
 
   protected override void RegisterInputParams(GH_InputParamManager pManager)
   {
@@ -77,19 +82,28 @@ public class ReceiveComponent : SpeckleTaskCapableComponent<ReceiveComponentInpu
     bool run = false;
     da.GetData(1, ref run);
 
-    return new(url, run);
+    if (run)
+    {
+      SetupSubscription(url);
+    }
+    else
+    {
+      CleanupSubscription();
+    }
+
+    return new ReceiveComponentInput(url, run);
   }
 
   protected override void SetOutput(IGH_DataAccess da, ReceiveComponentOutput result)
   {
     if (result.RootObject is null)
     {
-      Message = "Not Loaded";
+      Message = _apiClient != null ? "Monitoring" : "Not Loaded";
     }
     else
     {
       da.SetData(0, result.RootObject);
-      Message = "Done";
+      Message = _apiClient != null ? "Loaded" : "Done";
     }
   }
 
@@ -111,7 +125,7 @@ public class ReceiveComponent : SpeckleTaskCapableComponent<ReceiveComponentInpu
     }
     if (!input.Run)
     {
-      return new();
+      return new ReceiveComponentOutput();
     }
 
     using var scope = PriorityLoader.CreateScopeForActiveDocument();
@@ -128,6 +142,9 @@ public class ReceiveComponent : SpeckleTaskCapableComponent<ReceiveComponentInpu
 
     using var client = clientFactory.Create(account);
     var receiveInfo = await input.Resource.GetReceiveInfo(client, cancellationToken).ConfigureAwait(false);
+
+    // store version id for tracking
+    _lastVersionId = receiveInfo.SelectedVersionId;
 
     var progress = new Progress<CardProgress>(_ =>
     {
@@ -194,5 +211,117 @@ public class ReceiveComponent : SpeckleTaskCapableComponent<ReceiveComponentInpu
     // var x = new SpeckleCollectionGoo { Value = collGen.RootCollection };
     var goo = new SpeckleCollectionWrapperGoo(collectionRebuilder.RootCollectionWrapper);
     return new ReceiveComponentOutput { RootObject = goo };
+  }
+
+  private void SetupSubscription(SpeckleUrlModelResource resource)
+  {
+    // skip if already subscribed to this resource
+    if (_apiClient != null && _lastResource != null && _lastResource.Equals(resource))
+    {
+      return;
+    }
+
+    // only subscribe for Model URLs (not specific versions)
+    if (resource is SpeckleUrlModelVersionResource)
+    {
+      CleanupSubscription();
+      _lastResource = resource;
+      return;
+    }
+
+    try
+    {
+      CleanupSubscription(); // clean up old subscription first
+
+      using var scope = PriorityLoader.CreateScopeForActiveDocument();
+      var account = resource.Account.GetAccount(scope);
+      if (account == null)
+      {
+        return;
+      }
+
+      _apiClient = scope.Get<IClientFactory>().Create(account);
+      _apiClient.Subscription.CreateProjectVersionsUpdatedSubscription(resource.ProjectId).Listeners +=
+        OnVersionCreated;
+
+      _lastResource = resource;
+      Message = "Monitoring";
+    }
+    catch (Exception ex) when (!ex.IsFatal())
+    {
+      AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, $"Could not setup monitoring: {ex.Message}");
+    }
+  }
+
+  private void OnVersionCreated(object? sender, ProjectVersionsUpdatedMessage e) =>
+    // new version detected - trigger reload
+    RhinoApp.InvokeOnUiThread(
+      (Action)
+        delegate
+        {
+          ExpireSolution(true);
+        }
+    );
+
+  private void CleanupSubscription()
+  {
+    if (_apiClient != null && _lastResource != null)
+    {
+      try
+      {
+        _apiClient.Subscription.CreateProjectVersionsUpdatedSubscription(_lastResource.ProjectId).Listeners -=
+          OnVersionCreated;
+      }
+      catch (Exception ex) when (!ex.IsFatal())
+      {
+        // ignore cleanup errors
+      }
+
+      _apiClient.Dispose();
+      _apiClient = null;
+    }
+  }
+
+  // Cleanup on removal
+  public override void RemovedFromDocument(GH_Document document)
+  {
+    CleanupSubscription();
+    base.RemovedFromDocument(document);
+  }
+
+  // Handle document context changes
+  public override void DocumentContextChanged(GH_Document document, GH_DocumentContext context)
+  {
+    if (context == GH_DocumentContext.Unloaded)
+    {
+      CleanupSubscription();
+    }
+    else if (context == GH_DocumentContext.Loaded && _lastResource != null && _apiClient != null)
+    {
+      // Check for version changes when document reopens
+      Task.Run(async () =>
+      {
+        try
+        {
+          var receiveInfo = await _lastResource.GetReceiveInfo(_apiClient);
+          if (receiveInfo.SelectedVersionId != _lastVersionId)
+          {
+            RhinoApp.InvokeOnUiThread(
+              (Action)
+                delegate
+                {
+                  ExpireSolution(true);
+                }
+            );
+          }
+        }
+        catch (Exception ex) when (!ex.IsFatal())
+        {
+          // ignore errors during background check
+        }
+      });
+    }
+
+    base.DocumentContextChanged(document, context);
   }
 }


### PR DESCRIPTION
## Description

Fixed the `ReceiveComponent` (sync load) to properly detect and react to new Speckle model versions when `Run = true`. Previously, it would only load once when the boolean was toggled, losing reactivity. Now it subscribes to version updates from the server and automatically reloads when new versions are published.

Also added persistence for the `AutoReceive` setting in `ReceiveAsyncComponent` so "Load automatically" state persists between sessions.

## User Value

Users can now keep `Run = true` on the sync load component and it will automatically pull new versions as they're published, matching the expected reactive behavior. The async component remembers if you had auto-load enabled when you reopen your file.

## Changes:

- Component now automatically expires and reloads when new versions are detected on the server
- Added `Write()` and `Read()` methods to `ReceiveAsyncComponent` to persist `AutoReceive` setting

## Validation of changes:
Test:
- Simulataneously testing `ReceiveComponent` and `ReceiveAsyncComponent`
- Set Run to True for `ReceiveComponent` and enable "Load Automatically" for `ReceiveAsyncComponent`
- Close script, reopen.
   - Setting for  `ReceiveAsyncComponent` should persist ✅ 
   - Both components should automatically load open document open ✅ 
- Publish new version to respective source models (from Rhino)
   - Should trigger both components to fetch new versions ✅  

https://github.com/user-attachments/assets/8c681c90-a427-46ba-b3c1-99e4d70bd919

## Checklist:

- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] I have added appropriate tests.
- [x] I have updated or added relevant documentation.