### PR TITLE
fix(grasshopper): optimize `CreateSpeckleProperties` for large data trees

### DIFF
--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Objects/CreateSpeckleProperties.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Objects/CreateSpeckleProperties.cs
@@ -34,8 +34,7 @@ public class CreateSpeckleProperties : VariableParameterComponentBase
     pManager.AddParameter(param);
   }
 
-  protected override void RegisterOutputParams(GH_OutputParamManager pManager)
-  {
+  protected override void RegisterOutputParams(GH_OutputParamManager pManager) =>
     pManager.AddParameter(
       new SpecklePropertyGroupParam(),
       "Properties",
@@ -43,7 +42,6 @@ public class CreateSpeckleProperties : VariableParameterComponentBase
       "Properties for Speckle Objects",
       GH_ParamAccess.item
     );
-  }
 
   protected override void SolveInstance(IGH_DataAccess da)
   {
@@ -167,10 +165,8 @@ public class CreateSpeckleProperties : VariableParameterComponentBase
     ExpireSolution(true);
   }
 
-  protected override void WriteComponentSpecificData(GH_IWriter writer)
-  {
+  protected override void WriteComponentSpecificData(GH_IWriter writer) =>
     writer.SetBoolean("CreateEmptyProperties", CreateEmptyProperties);
-  }
 
   protected override void ReadComponentSpecificData(GH_IReader reader)
   {

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Objects/CreateSpeckleProperties.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Objects/CreateSpeckleProperties.cs
@@ -67,8 +67,7 @@ public class CreateSpeckleProperties : VariableParameterComponentBase
     {
       var paramName = Params.Input[i].NickName;
 
-      var data = Params.Input[i].VolatileData.AllData(true).ToList();
-      if (data.Count == 0)
+      if (Params.Input[i].VolatileDataCount == 0)
       {
         continue;
       }


### PR DESCRIPTION
## Description
Replaced expensive tree flattening operation with lightweight count check in `CreateSpeckleProperties` component.

Previously used `AllData(true).ToList()` to check if parameters were empty, which flattened entire data trees unnecessarily. Now using `VolatileDataCount` property for O(1) empty check.

Fixes: [CNX-2599](https://linear.app/speckle/issue/CNX-2599/speed-issues-on-nested-property-creations)

## User Value
Reduces solve time from ~11 seconds to ~1 second when creating properties with large same-sized trees (e.g., 904 × 62 × 15 = 840K items).

## Changes:
- Changed empty parameter check from `Params.Input[i].VolatileData.AllData(true).ToList()` to `Params.Input[i].VolatileDataCount == 0`
- Eliminates unnecessary tree flattening for all input parameters

## Screenshots:
**Before:** 
- Component 1: 10.7s
- Component 2: 10.8s  
- Component 3: 10.7s

<img width="960" height="650" alt="Screenshot 2025-10-03 203822" src="https://github.com/user-attachments/assets/9702cfb1-c873-4147-a32f-691c14c7f0d5" />

**After:**
- Component 1: 1s
- Component 2: 975ms
- Component 3: 992ms

<img width="960" height="748" alt="Screenshot 2025-10-03 203435" src="https://github.com/user-attachments/assets/df15dcbb-c2c4-45f6-80b0-3b38f6a6b0fc" />

## Validation of changes:
Manually tested in Grasshopper with:
- Disconnected inputs (skipped correctly)
- Empty lists/panels (same behavior)
- Single values (works as expected)
- Large lists (performance improvement)

## Checklist:
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] I have added appropriate tests.
- [x] I have updated or added relevant documentation.