### PR TITLE
fix(rhino-importer): Return non-zero exit code on fault

### DIFF
--- a/Importers/Rhino/Speckle.Importers.Rhino/Internal/ImporterInstance.cs
+++ b/Importers/Rhino/Speckle.Importers.Rhino/Internal/ImporterInstance.cs
@@ -52,6 +52,8 @@ internal sealed class ImporterInstance(Sender sender, ILogger<ImporterInstance> 
     try
     {
       using var config = GetConfig(Path.GetExtension(args.FilePath));
+      logger.LogInformation("Opening file {FilePath}", args.FilePath);
+
       _rhinoDoc = config.OpenInHeadlessDocument(args.FilePath);
       RhinoDoc.ActiveDoc = _rhinoDoc;
 


### PR DESCRIPTION
Exceptions that occur during the execution of a background service to not surface to the apphost `RunAsync` which would allow them to terminate the process with a non-zero exit code.
See related discussion https://github.com/dotnet/runtime/issues/67146

