### PR TITLE
Stop exceptions we can't do anything about

### DIFF
--- a/Connectors/Revit/Speckle.Connectors.RevitShared.Cef/CefSharpPanel.xaml.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared.Cef/CefSharpPanel.xaml.cs
@@ -1,3 +1,4 @@
+using System.Runtime.InteropServices;
 using System.Windows.Controls;
 using System.Windows.Threading;
 using Autodesk.Revit.UI;
@@ -30,6 +31,10 @@ public partial class CefSharpPanel : Page, Autodesk.Revit.UI.IDockablePaneProvid
         },
         DispatcherPriority.Background
       );
+    }
+    catch (SEHException)
+    {
+      //do nothing as we can't control external components
     }
     catch (OperationCanceledException)
     {


### PR DESCRIPTION
This probably is a random Revit issue we can't do anything about

stops

<img width="1189" height="651" alt="image" src="https://github.com/user-attachments/assets/db784bd0-07e9-4108-a745-9f7ca45c8953" />
