### PR TITLE
fix(revit): handle null SelectedObjectIds in view filters on send

### DIFF
--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/Filters/RevitViewsFilter.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/Filters/RevitViewsFilter.cs
@@ -17,7 +17,7 @@ public class RevitViewsFilter : DiscriminatedObject, ISendFilter, IRevitSendFilt
   public string? Summary { get; set; }
   public bool IsDefault { get; set; }
   public string? SelectedView { get; set; }
-  public List<string> SelectedObjectIds { get; set; }
+  public List<string> SelectedObjectIds { get; set; } = new();
   public Dictionary<string, string>? IdMap { get; set; } = new();
   public List<string>? AvailableViews { get; set; }
 

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/Settings/ToSpeckleSettingsManager.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/Settings/ToSpeckleSettingsManager.cs
@@ -173,7 +173,7 @@ public class ToSpeckleSettingsManager(
 
   private void EvictCacheForModelCard(Document document, SenderModelCard modelCard)
   {
-    var objectIds = modelCard.SendFilter != null ? modelCard.SendFilter.NotNull().SelectedObjectIds : [];
+    var objectIds = modelCard.SendFilter?.SelectedObjectIds ?? [];
     var unpackedObjectIds = elementUnpacker.GetUnpackedElementIds(objectIds, document);
     sendConversionCache.EvictObjects(unpackedObjectIds);
   }


### PR DESCRIPTION
## Description

### TL;DR
Sparked by an intercom ping (logs in linear ticket). Seems we have an oversight where `SelectedObjectIds` prop in `RevitViewsFilter` was uninitialized (other filters had this in). Should fix the null reference exception when publishing via `RevitViewsFilter`.

### Root Cause
`RevitViewsFilter.SelectedObjectIds` was uninitialized when the send operation started. Race condition? The cache eviction logic in `ToSpeckleSettingsManager.EvictCacheForModelCard()` tried to use `SelectedObjectIds` before `RefreshObjectIds()` populated it.

### Ticket
Fixes [CNX-2655](https://linear.app/speckle/issue/CNX-2655/revit-v390-view-filter-crashes-on-send-due-to-null-selectedobjectids)

## User Value

Avoiding this error:

<img width="408" height="135" alt="image" src="https://github.com/user-attachments/assets/ad114d7d-916e-4e8c-a7fb-9888e1467274" />

## Changes:
- Initialize `SelectedObjectIds` property in `RevitViewsFilter` to match `RevitCategoriesFilter` and `DirectSelectionSendFilter`. This was perhaps an oversight?
- Replace ternary null check with null-coalescing operators in `ToSpeckleSettingsManager.EvictCacheForModelCard()` to check the two layers of nullability (filter AND `SelectedObjectIds`

## Validation of changes:

### Before:
Below exception:

```
System.ArgumentNullException: Value cannot be null. (Parameter 'source')
   at System.Linq.ThrowHelper.ThrowArgumentNullException(ExceptionArgument argument)
   at System.Linq.Enumerable.Select[TSource,TResult](IEnumerable`1 source, Func`2 selector)
   at Speckle.Connectors.Revit.HostApp.Elements.GetElements(Document doc, IEnumerable`1 objectIds) in /_/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/Elements.cs:line 10
   at Speckle.Connectors.Revit.HostApp.ElementUnpacker.GetUnpackedElementIds(IEnumerable`1 objectIds, Document doc) in /_/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/ElementUnpacker.cs:line 43
   at Speckle.Connectors.Revit.Operations.Send.Settings.ToSpeckleSettingsManager.EvictCacheForModelCard(SenderModelCard modelCard) in /_/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/Settings/ToSpeckleSettingsManager.cs:line 195
   at Speckle.Connectors.Revit.Operations.Send.Settings.ToSpeckleSettingsManager.GetReferencePointSetting(ModelCard modelCard) in /_/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/Settings/ToSpeckleSettingsManager.cs:line 98
   at Speckle.Connectors.Revit.Bindings.RevitSendBinding.<Send>b__23_0(IServiceProvider sp, SenderModelCard card) in /_/Connectors/Revit/Speckle.Connectors.RevitShared/Bindings/RevitSendBinding.cs:line 120
   at Speckle.Connectors.DUI.Bindings.SendOperationManager.Process[T](ISendBindingUICommands commands, String modelCardId, Action`2 initializeScope, Func`3 gatherObjects) in /_/DUI3/Speckle.Connectors.DUI/Bindings/SendOperationManager.cs:line 69
```

### After:
Tricky. I can't reproduce this on my end, but understand how this could occur?

## Checklist:

- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [ ] I have added appropriate tests.
- [x] I have updated or added relevant documentation.