### PR TITLE
feat(revit)!: Use Hash function for mesh geometry instance ids

### DIFF
--- a/Converters/Revit/Speckle.Converters.RevitShared/ToSpeckle/TopLevel/RevitElementTopLevelConverterToSpeckle.cs
+++ b/Converters/Revit/Speckle.Converters.RevitShared/ToSpeckle/TopLevel/RevitElementTopLevelConverterToSpeckle.cs
@@ -1,5 +1,6 @@
 using Speckle.Converters.Common;
 using Speckle.Converters.Common.Objects;
+using Speckle.Converters.Common.ToSpeckle;
 using Speckle.Converters.RevitShared.Extensions;
 using Speckle.Converters.RevitShared.Helpers;
 using Speckle.Converters.RevitShared.Settings;
@@ -110,10 +111,9 @@ public class ElementTopLevelConverterToSpeckle : IToSpeckleTopLevelConverter
       if (displayValueWithTransform.Item1 is SOG.Mesh && displayValueWithTransform.Item2 is not null)
       {
         // potential instances scenario here
-        var unbakedMesh = displayValueWithTransform.Item1 as SOG.Mesh;
-        if (unbakedMesh is not null)
+        if (displayValueWithTransform.Item1 is SOG.Mesh unbakedMesh)
         {
-          var instanceDefinitionId = GenerateUntransformedMeshId(unbakedMesh);
+          var instanceDefinitionId = MeshInstanceIdGenerator.GenerateUntransformedMeshId(unbakedMesh);
           if (
             _revitToSpeckleCacheSingleton.InstanceDefinitionProxiesMap.TryGetValue(
               instanceDefinitionId,
@@ -250,8 +250,4 @@ public class ElementTopLevelConverterToSpeckle : IToSpeckleTopLevelConverter
       yield return Convert(_converterSettings.Current.Document.GetElement(childId));
     }
   }
-
-  // ewwwww ...
-  private string GenerateUntransformedMeshId(SOG.Mesh mesh) =>
-    (mesh.vertices.Average() / mesh.VerticesCount).ToString();
 }

--- a/Sdk/Speckle.Converters.Common.Tests/ToSpeckle/MeshInstanceIdGeneratorTests.cs
+++ b/Sdk/Speckle.Converters.Common.Tests/ToSpeckle/MeshInstanceIdGeneratorTests.cs
@@ -1,0 +1,29 @@
+﻿using NUnit.Framework;
+using Speckle.Converters.Common.ToSpeckle;
+
+namespace Speckle.Converters.Common.Tests.ToSpeckle;
+
+public class MeshInstanceIdGeneratorTests
+{
+  private static IEnumerable<List<double>> TestCases()
+  {
+    int[] testCases = [0, 1, 100, 1_000_000];
+    foreach (int testLength in testCases)
+    {
+      yield return Enumerable
+        .Range(0, testLength)
+        .Select(_ => TestContext.CurrentContext.Random.NextDouble(float.MinValue, float.MaxValue))
+        .ToList();
+    }
+  }
+
+  [Test]
+  [TestCaseSource(nameof(TestCases))]
+  public void TestEquivalentImplementations(List<double> vertices)
+  {
+    var result = MeshInstanceIdGenerator.GenerateUntransformedMeshId(vertices);
+    var resultSpan = MeshInstanceIdGenerator.GenerateUntransformedMeshId_Span(vertices);
+
+    Assert.That(result, Is.EqualTo(resultSpan));
+  }
+}

--- a/Sdk/Speckle.Converters.Common/Speckle.Converters.Common.csproj
+++ b/Sdk/Speckle.Converters.Common/Speckle.Converters.Common.csproj
@@ -4,6 +4,10 @@
     <TargetFrameworks>net48;net8.0</TargetFrameworks>
     <Configurations>Debug;Release;Local</Configurations>
   </PropertyGroup>
+  
+  <ItemGroup>
+    <InternalsVisibleTo Include="Speckle.Converters.Common.Tests"/>
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />

--- a/Sdk/Speckle.Converters.Common/ToSpeckle/MeshInstanceIdGenerator.cs
+++ b/Sdk/Speckle.Converters.Common/ToSpeckle/MeshInstanceIdGenerator.cs
@@ -1,0 +1,87 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.Contracts;
+using System.Reflection;
+using System.Security.Cryptography;
+using System.Text;
+using Speckle.InterfaceGenerator;
+using Speckle.Objects.Geometry;
+using Speckle.Sdk.Common;
+#if NET6_0_OR_GREATER
+using System.Runtime.InteropServices;
+#endif
+
+namespace Speckle.Converters.Common.ToSpeckle;
+
+[GenerateAutoInterface]
+public static class MeshInstanceIdGenerator
+{
+  /// <summary>
+  ///
+  /// </summary>
+  /// <remarks>
+  /// There are two implementations of this function because NET Framework lacks some of the Marshall and Span based functions.
+  /// However, their external behaviour is the same.
+  /// </remarks>
+  /// <param name="mesh"></param>
+  /// <returns></returns>
+  [Pure]
+  public static string GenerateUntransformedMeshId(Mesh mesh)
+  {
+#if NET6_0_OR_GREATER
+    return GenerateUntransformedMeshId_Span(mesh.vertices);
+#else
+    return GenerateUntransformedMeshId(mesh.vertices);
+#endif
+  }
+
+#if NET6_0_OR_GREATER
+
+  [Pure]
+  internal static string GenerateUntransformedMeshId_Span(List<double> vertices)
+  {
+    ReadOnlySpan<double> span = CollectionsMarshal.AsSpan(vertices);
+    ReadOnlySpan<byte> inputBytes = MemoryMarshal.AsBytes(span);
+
+    Span<byte> hash = stackalloc byte[SHA256.HashSizeInBytes];
+    SHA256.HashData(inputBytes, hash);
+
+    return Convert.ToHexString(hash);
+  }
+#endif
+
+  [Pure]
+  [SuppressMessage(
+    "Performance",
+    "CA1850:Prefer static \'HashData\' method over \'ComputeHash\'",
+    Justification = "Already another overload for .NET Core"
+  )]
+  internal static string GenerateUntransformedMeshId(List<double> vertices)
+  {
+    double[] verts = (double[])s_listItemsField.GetValue(vertices).NotNull();
+    int byteCount = verts.Length * sizeof(double);
+    byte[] inputBytes = new byte[byteCount];
+    Buffer.BlockCopy(verts, 0, inputBytes, 0, byteCount);
+
+    // Compute the SHA256 hash
+    using (SHA256 sha256 = SHA256.Create())
+    {
+      byte[] hashBytes = sha256.ComputeHash(inputBytes);
+
+      // Convert hash to hex string (uppercase, similar to Convert.ToHexString)
+      StringBuilder sb = new(hashBytes.Length * 2);
+      foreach (byte b in hashBytes)
+      {
+        sb.AppendFormat("{0:X2}", b);
+      }
+
+      return sb.ToString();
+    }
+  }
+
+  private static readonly FieldInfo s_listItemsField = typeof(List<double>).GetField(
+    "_items",
+    BindingFlags.NonPublic | BindingFlags.Instance
+  )!;
+  //TODO: check if a null check would be bad here. if so, include this message
+  //do not replace with a null check, I don't want to interrupt the compile time optimisation of reflection
+}


### PR DESCRIPTION
WIP there's some issues here we need to solve.

The way we're getting the instance geometry appears to not always be deterministic.
In v2, we've identified we had some different logic that uses the Symbol geometry for `GeometryInstance`s.

 