### PR TITLE
fix(revit): handle level extraction for face-based family instances

### DIFF
--- a/Converters/Revit/Speckle.Converters.RevitShared/Helpers/LevelExtractor.cs
+++ b/Converters/Revit/Speckle.Converters.RevitShared/Helpers/LevelExtractor.cs
@@ -15,7 +15,7 @@ public sealed class LevelExtractor
       return null;
     }
 
-    return level?.Name;
+    return level.Name;
   }
 
   /// <summary>


### PR DESCRIPTION
## Description
Fixes level extraction for face-based family instances that don't have a valid `LevelId` property. 

The Revit API stores level info for these elements in `INSTANCE_SCHEDULE_ONLY_LEVEL_PARAM` or via their host element, which wasn't being checked. See article [here](https://forums.autodesk.com/t5/revit-api-forum/newfamilyinstance-not-setting-level-of-family-instance/td-p/11405934).

**Root Cause:**
1. `LevelExtractor.GetLevel()` wasn't checking face-based family instance parameters or host elements
2. `LevelUnpacker` used `element.LevelId` as the dictionary key, which returns `InvalidElementId` for face-based instances

**Solution:**
Refactored the `GetLevel` method to:
1. Check direct `LevelId` first
2. Fall back to parameter-based level for family instances
3. Recurse to host element if needed

Updated `LevelUnpacker` to:
- Use `level.UniqueId` (from the `Level` object itself) as the dictionary key instead of `element.LevelId`
- Call `GetLevel()` before dictionary lookup to ensure we have the correct level for key generation
- This ensures face-based instances are grouped by their actual level rather than all sharing the same invalid key

Fixes [CNX-2697](https://linear.app/speckle/issue/CNX-2697/level-proxies-are-empty)

## User Value
Proper level proxies.

## Changes:
- Added `TryGetFamilyInstanceLevelId` helper method to check `INSTANCE_SCHEDULE_ONLY_LEVEL_PARAM` and host-based levels
- `GetLevel` now goes through all fallback checks
- **`LevelUnpacker` now uses `level.UniqueId` as the dictionary key instead of `element.LevelId.ToString()`**
- Moved `GetLevel()` call before dictionary lookup in `Unpack()` to ensure correct key generation

## Technical Notes
- `LevelUnpacker` now calls `GetLevel()` for every element instead of only on cache misses
- Performance regression negligible due to `LevelExtractor`'s internal `_levelCache`

## Validation of changes:

### Before

<img width="1260" height="938" alt="image" src="https://github.com/user-attachments/assets/80d70abd-4638-4023-a897-630525a25bf6" />

### After

<img width="1014" height="830" alt="image" src="https://github.com/user-attachments/assets/43051149-03fe-4708-8e15-cb70fec84c14" />

## Checklist:
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] I have added appropriate tests.
- [x] I have updated or added relevant documentation.