### PR TITLE
fix(rhino): match cleaned block names when purging instance definitions

### DIFF
--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/HostApp/RhinoInstanceBaker.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/HostApp/RhinoInstanceBaker.cs
@@ -169,7 +169,7 @@ public class RhinoInstanceBaker : IInstanceBaker<IReadOnlyCollection<string>>
 
   public void PurgeInstances(string namePrefix)
   {
-    var currentDoc = RhinoDoc.ActiveDoc;
+    var currentDoc = RhinoDoc.ActiveDoc; // POC: too much right now to interface around
 
     // clean name prefix to match how block names are created
     var cleanedPrefix = RhinoUtils.CleanBlockDefinitionName(namePrefix);


### PR DESCRIPTION
## Description

Fixes the issue where receiving a model (from a **nested** Speckle model) in Rhino would succeed on the first receive, but fail on subsequent receives with a "One or more errors occured" error. 

When block definitions are created, their names are cleaned via `CleanBlockDefinitionName` which replaces `/` with `_` (e.g., `"tickets/cnx-2678"` becomes `"tickets_cnx-2678"`). 

`PurgeInstances` was searching for definitions using the original uncleaned `baseLayerName`, so it never found matches and definitions were never deleted. These orphaned definitions held references to the `revitInstancedObjects` layer, preventing it from being purged. On the next receive, attempting to recreate this layer would fail.

Fixes [CNX-2678](https://linear.app/speckle/issue/CNX-2678/warning-displayed-when-reloading-same-model-in-rhino).

After trying to re-receive in Rhino, inspecting the "remaining" layers, `revitInstancedObjects` always remained. Right-click delete layer would expose the following error:

<img width="644" height="389" alt="image" src="https://github.com/user-attachments/assets/05a8a951-10cc-439c-81f8-444632001dc7" />

## User Value

Users can re-receive nested speckle models with instanced geometry multiple times in Rhino without manual cleanup between receives.

## Change:
- Updated `RhinoInstanceBaker.PurgeInstances` to clean the `namePrefix` using `CleanBlockDefinitionName` before searching for definitions

## Validation of changes:

1. Publish Revit model with instanced family geometry
2. Receive in Rhino
3. Receive same model again using model card

## Checklist:
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] I have added appropriate tests.
- [x] I have updated or added relevant documentation.