### PR TITLE
fix(navis): fix for navis change tracking

### DIFF
--- a/Sdk/Speckle.Connectors.Common/Caching/ISendConversionCache.cs
+++ b/Sdk/Speckle.Connectors.Common/Caching/ISendConversionCache.cs
@@ -15,7 +15,7 @@ public interface ISendConversionCache
 {
   void StoreSendResult(string projectId, IReadOnlyDictionary<Id, ObjectReference> convertedReferences);
 
-  void AppendSendResult(string projectId, string applicationId, ObjectReference convertedReference);
+  void StoreSendResult(string projectId, string applicationId, ObjectReference convertedReference);
 
   /// <summary>
   /// <para>Call this method whenever you need to invalidate a set of objects that have changed in the host app.</para>

--- a/Sdk/Speckle.Connectors.Common/Caching/NullSendConversionCache.cs
+++ b/Sdk/Speckle.Connectors.Common/Caching/NullSendConversionCache.cs
@@ -13,7 +13,7 @@ public class NullSendConversionCache : ISendConversionCache
 
   public void EvictObjects(IEnumerable<string> objectIds) { }
 
-  public void AppendSendResult(string projectId, string applicationId, ObjectReference convertedReference) { }
+  public void StoreSendResult(string projectId, string applicationId, ObjectReference convertedReference) { }
 
   public void ClearCache() { }
 

--- a/Sdk/Speckle.Connectors.Common/Caching/SendConversionCache.cs
+++ b/Sdk/Speckle.Connectors.Common/Caching/SendConversionCache.cs
@@ -17,7 +17,7 @@ public class SendConversionCache : ISendConversionCache
     }
   }
 
-  public void AppendSendResult(string projectId, string applicationId, ObjectReference convertedReference)
+  public void StoreSendResult(string projectId, string applicationId, ObjectReference convertedReference)
   {
     Cache[(applicationId, projectId)] = convertedReference;
   }

--- a/Sdk/Speckle.Connectors.Common/Operations/SendOperation.cs
+++ b/Sdk/Speckle.Connectors.Common/Operations/SendOperation.cs
@@ -381,10 +381,6 @@ public sealed class SendOperation<T>(
     return false;
   }
 
-  /// <remarks>
-  /// Assuming that <paramref name="conversionResults"/> are either <see langword="null"/> or <see cref="ObjectReference"/>
-  /// Which will be true only for the packfile based builders.
-  /// </remarks>
   /// <param name="conversionResults"></param>
   /// <param name="projectId"></param>
   private void WriteReferencesToCache(IReadOnlyList<SendConversionResult> conversionResults, string projectId)
@@ -396,17 +392,26 @@ public sealed class SendOperation<T>(
     // This would leave this send cache out-of-sync with the server, and lead to bad commits that contain references to objects the server doesn't have.
     // For now, we've taken the decision that it's unlikely to happen...
 
-    var references = new Dictionary<Id, ObjectReference>();
     foreach (var x in conversionResults)
     {
-      if (x.Result is not null)
+      switch (x.Result)
       {
-        // NOTE: why not ToDictionary -> we might end up reoccurring object references for any reason. instancing, linked models etc.
-        // ToDictionary throws 'item already exists' errors. but safe to override items in references dictionary since they are unique
-        references[new Id(x.SourceId)] = (ObjectReference)x.Result.NotNull();
+        case ObjectReference r:
+          // NOTE: we may end up reoccurring applicationId multiple times e.g. instancing, linked models etc.
+          // It's safe to let StoreSendResult override references since they are equivalent
+          sendConversionCache.StoreSendResult(projectId, x.SourceId, r);
+          break;
+        case { } b:
+          // All other connectores report ObjectReferences as results
+          // Navisworks works a bit differently because it's not converting depth first
+          sendConversionCache.StoreSendResult(
+            projectId,
+            x.SourceId,
+            new ObjectReference { referencedId = b.id.NotNull(), applicationId = b.applicationId }
+          );
+          break;
       }
     }
-    sendConversionCache.StoreSendResult(projectId, references);
   }
 }
 


### PR DESCRIPTION
Navisworks connector returns 1 send result per atomic object.
But unlike all other connectors, it "builds" the commit tree post conversion (since navisworks objects can be deeply nested.
This means we cannot use the serializer's returned references for the send results since there's not a 1-1 relationship.

The quickest solution I could find was to simply have the `SendOperation` re-create a `ObjectReference` for any send result that isn't already a reference.

This will lead to a slightly different behaviour (since the ObjectReference I'm creating lacks closure table and an id) however, it in my testing it doesn't look like any of that is needed. Since change tracking appears to still work, and the resulting commit is identical json (but a different order)