### PR TITLE
feat(grasshopper): accept a mix of data objects and collections

### DIFF
--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Collections/CreateCollection.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Collections/CreateCollection.cs
@@ -4,7 +4,6 @@ using Speckle.Connectors.GrasshopperShared.Components.BaseComponents;
 using Speckle.Connectors.GrasshopperShared.HostApp;
 using Speckle.Connectors.GrasshopperShared.Parameters;
 using Speckle.Connectors.GrasshopperShared.Properties;
-using Speckle.Sdk.Common;
 using Speckle.Sdk.Models.Collections;
 
 namespace Speckle.Connectors.GrasshopperShared.Components.Collections;
@@ -92,44 +91,8 @@ public class CreateCollection : VariableParameterComponentBase
     dataAccess.SetData(0, new SpeckleCollectionWrapperGoo(rootCollection));
   }
 
-  /// <summary>
-  /// Recursively checks if collection or any descendants contain valid geometry/data objects
-  /// </summary>
-  private bool HasAnyValidContent(ISpeckleCollectionObject? element) =>
-    element switch
-    {
-      SpeckleGeometryWrapper => true,
-      SpeckleDataObjectWrapper => true,
-      SpeckleCollectionWrapper collection => collection.Elements.Any(HasAnyValidContent),
-      _ => false
-    };
-
-  private SpeckleCollectionWrapper CreateRootCollection() =>
-    new()
-    {
-      Base = new Collection(),
-      Name = "Unnamed",
-      Path = new List<string> { "Unnamed" },
-      Color = null,
-      Material = null,
-      ApplicationId = InstanceGuid.ToString()
-    };
-
   private SpeckleCollectionWrapper? ProcessInputParameter(IGH_Param inputParam, List<IGH_Goo> data, string rootName)
   {
-    var collections = data.OfType<SpeckleCollectionWrapperGoo>().Empty().ToList();
-    var nonCollections = data.Where(t => t is not SpeckleCollectionWrapperGoo).Empty().ToList();
-
-    // Validate input - cannot mix collections and objects
-    if (collections.Count > 0 && nonCollections.Count > 0)
-    {
-      AddRuntimeMessage(
-        GH_RuntimeMessageLevel.Error,
-        $"Parameter {inputParam.NickName} cannot contain both objects and collections."
-      );
-      return null;
-    }
-
     var childPath = new List<string> { rootName, inputParam.NickName };
     var childCollection = new SpeckleCollectionWrapper
     {
@@ -142,83 +105,57 @@ public class CreateCollection : VariableParameterComponentBase
       ApplicationId = inputParam.InstanceGuid.ToString()
     };
 
-    if (collections.Count > 0)
-    {
-      ProcessCollectionInputs(collections, childCollection, childPath);
-    }
-    else
-    {
-      ProcessObjectInputs(nonCollections, childCollection, childPath);
-    }
-
-    return childCollection;
-  }
-
-  private void ProcessCollectionInputs(
-    List<SpeckleCollectionWrapperGoo> collections,
-    SpeckleCollectionWrapper parentCollection,
-    List<string> childPath
-  )
-  {
     var duplicateNames = new HashSet<string>();
-
-    foreach (var collectionGoo in collections.Select(c => (SpeckleCollectionWrapperGoo)c.Duplicate()))
-    {
-      collectionGoo.Value.Path = childPath;
-
-      // Check for duplicate names within this collection
-      foreach (
-        var subCollectionName in collectionGoo
-          .Value.Elements.Where(e => e != null) // skip nulls (CNX-2855)
-          .OfType<SpeckleCollectionWrapper>()
-          .Select(c => c.Name)
-      )
-      {
-        if (!duplicateNames.Add(subCollectionName))
-        {
-          AddRuntimeMessage(
-            GH_RuntimeMessageLevel.Error,
-            $"Duplicate collection name '{subCollectionName}' found. Collection names must be unique per level."
-          );
-          return;
-        }
-      }
-
-      parentCollection.Elements.AddRange(collectionGoo.Value.Elements);
-    }
-  }
-
-  private void ProcessObjectInputs(
-    List<IGH_Goo> objects,
-    SpeckleCollectionWrapper parentCollection,
-    List<string> childPath
-  )
-  {
     int skippedCount = 0;
 
-    foreach (var obj in objects)
+    foreach (var obj in data)
     {
+      if (obj is SpeckleCollectionWrapperGoo collectionGoo)
+      {
+        var colClone = (SpeckleCollectionWrapperGoo)collectionGoo.Duplicate();
+        colClone.Value.Path = childPath;
+
+        // Check for duplicate names within this collection
+        foreach (
+          var subCollectionName in colClone
+            .Value.Elements.Where(e => e != null) // skip nulls (CNX-2855)
+            .OfType<SpeckleCollectionWrapper>()
+            .Select(c => c.Name)
+        )
+        {
+          if (!duplicateNames.Add(subCollectionName))
+          {
+            AddRuntimeMessage(
+              GH_RuntimeMessageLevel.Error,
+              $"Duplicate collection name '{subCollectionName}' found. Collection names must be unique per level."
+            );
+            return null;
+          }
+        }
+
+        childCollection.Elements.AddRange(colClone.Value.Elements);
+      }
       // handle data objects directly (deep copy to avoid mutations)
       // NOTE: DataObject first, since a DataObject with one geo is castable to speckle geometry
-      if (obj is SpeckleDataObjectWrapperGoo dataObjectWrapperGoo)
+      else if (obj is SpeckleDataObjectWrapperGoo dataObjectWrapperGoo)
       {
         var dataObjectWrapper = dataObjectWrapperGoo.Value.DeepCopy();
         dataObjectWrapper.Path = childPath;
-        dataObjectWrapper.Parent = parentCollection;
-        parentCollection.Elements.Add(dataObjectWrapper);
+        dataObjectWrapper.Parent = childCollection;
+        childCollection.Elements.Add(dataObjectWrapper);
       }
       // handle geometry objects (deep copy to avoid mutations)
       else if (obj?.ToSpeckleGeometryWrapper() is SpeckleGeometryWrapper objWrapper)
       {
         SpeckleGeometryWrapper wrapper = objWrapper.DeepCopy();
         wrapper.Path = childPath;
-        wrapper.Parent = parentCollection;
-        parentCollection.Elements.Add(wrapper);
+        wrapper.Parent = childCollection;
+        childCollection.Elements.Add(wrapper);
       }
       else
       {
         // add null placeholder to preserve topology (CNX-2855)
-        parentCollection.Elements.Add(null);
+        childCollection.Elements.Add(null);
         skippedCount++;
       }
     }
@@ -231,6 +168,8 @@ public class CreateCollection : VariableParameterComponentBase
         $"Skipped {skippedCount} unsupported object(s) (Leaders, TextDots, Dimensions, etc.)"
       );
     }
+
+    return childCollection;
   }
 
   // IGH_VariableParameterComponent implementation

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Send/SendAsyncComponent.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Send/SendAsyncComponent.cs
@@ -66,8 +66,8 @@ public class SendAsyncComponent : GH_AsyncComponent<SendAsyncComponent>
 
     // collection / data
     pManager.AddGenericParameter(
-      "Data",
-      "D",
+      "Collection",
+      "collection",
       "The collections, data objects, or geometries to publish",
       GH_ParamAccess.list
     );

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Send/SendAsyncComponent.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Send/SendAsyncComponent.cs
@@ -5,6 +5,7 @@ using Grasshopper.GUI;
 using Grasshopper.GUI.Canvas;
 using Grasshopper.Kernel;
 using Grasshopper.Kernel.Attributes;
+using Grasshopper.Kernel.Types;
 using GrasshopperAsyncComponent;
 using Microsoft.Extensions.DependencyInjection;
 using Rhino;
@@ -63,14 +64,15 @@ public class SendAsyncComponent : GH_AsyncComponent<SendAsyncComponent>
     // speckle model
     pManager.AddParameter(new SpeckleUrlModelResourceParam());
 
-    // collection
-    pManager.AddParameter(
-      new SpeckleCollectionParam(GH_ParamAccess.item),
-      "Collection",
-      "collection",
-      "The collection model object to send",
-      GH_ParamAccess.item
+    // collection / data
+    pManager.AddGenericParameter(
+      "Data",
+      "D",
+      "The collections, data objects, or geometries to publish",
+      GH_ParamAccess.list
     );
+
+    // version message
     pManager.AddTextParameter("Version Message", "versionMessage", "The version message", GH_ParamAccess.item);
     pManager[2].Optional = true;
 
@@ -149,27 +151,15 @@ public class SendAsyncComponent : GH_AsyncComponent<SendAsyncComponent>
   protected override void SolveInstance(IGH_DataAccess da)
   {
     var multipleResources = Params.Input[0].VolatileData.HasInputCountGreaterThan(1);
-    var multipleCollections = Params.Input[1].VolatileData.HasInputCountGreaterThan(1);
 
-    HasMultipleInputs = multipleCollections || multipleResources;
+    HasMultipleInputs = multipleResources;
 
     if (HasMultipleInputs)
     {
-      var mCollErrText =
-        "Only one single collection supported. Please group your input collections into one single one before sending.";
-      var mLinksErrText =
-        "Only one single model can be published to from this node. To send to multiple models, please use different publish components.";
-
-      if (multipleCollections)
-      {
-        AddRuntimeMessage(GH_RuntimeMessageLevel.Error, mCollErrText);
-      }
-
-      if (multipleResources)
-      {
-        AddRuntimeMessage(GH_RuntimeMessageLevel.Error, mLinksErrText);
-      }
-
+      AddRuntimeMessage(
+        GH_RuntimeMessageLevel.Error,
+        "Only one single model can be published to from this node. To send to multiple models, please use different publish components."
+      );
       return;
     }
 
@@ -194,7 +184,6 @@ public class SendAsyncComponent : GH_AsyncComponent<SendAsyncComponent>
     {
       // Set output data in a "first run" event. Note: we are not persisting the actual "sent" object as it can be very big.
       base.SolveInstance(da);
-      return;
     }
     else
     {
@@ -283,15 +272,84 @@ public class SendAsyncComponent : GH_AsyncComponent<SendAsyncComponent>
       AddRuntimeMessage(GH_RuntimeMessageLevel.Error, e.ToFormattedString());
     }
 
-    SpeckleCollectionWrapperGoo rootCollectionWrapper = new();
-    da.GetData(1, ref rootCollectionWrapper);
-    if (rootCollectionWrapper is null)
+    List<IGH_Goo> inputGoos = new();
+    da.GetDataList(1, inputGoos);
+
+    if (inputGoos.Count == 0)
     {
       RootCollectionWrapper = null;
       TriggerAutoSave();
       return;
     }
-    RootCollectionWrapper = rootCollectionWrapper;
+
+    SpeckleCollectionWrapper? rootBase;
+
+    // filter out nulls just to check if we can use the fast path
+    var nonNullGoos = inputGoos.Where(x => x != null).ToList();
+
+    // fast path: if there's exactly one valid item and it's a collection, use it directly
+    if (nonNullGoos.Count == 1 && nonNullGoos[0] is SpeckleCollectionWrapperGoo singleCollection)
+    {
+      rootBase = singleCollection.Value.DeepCopy();
+    }
+    else
+    {
+      // mixed inputs: construct a root collection using the document name (CNX-3175)
+      var docName = SendComponent.GetGrasshopperFileInfo().fileName ?? "Unnamed Document";
+      if (
+        docName.EndsWith(".gh", StringComparison.OrdinalIgnoreCase)
+        || docName.EndsWith(".ghx", StringComparison.OrdinalIgnoreCase)
+      )
+      {
+        docName = Path.GetFileNameWithoutExtension(docName);
+      }
+
+      rootBase = new SpeckleCollectionWrapper
+      {
+        Base = new Speckle.Sdk.Models.Collections.Collection(),
+        Path = [docName],
+        Color = null,
+        Material = null,
+        Name = docName
+      };
+
+      int skippedCount = 0;
+      foreach (var obj in inputGoos)
+      {
+        if (obj is SpeckleCollectionWrapperGoo collectionGoo)
+        {
+          var colClone = (SpeckleCollectionWrapperGoo)collectionGoo.Duplicate();
+          colClone.Value.Path = rootBase.Path;
+          rootBase.Elements.AddRange(colClone.Value.Elements);
+        }
+        else if (obj is SpeckleDataObjectWrapperGoo dataObjectWrapperGoo)
+        {
+          var dataObjectWrapper = dataObjectWrapperGoo.Value.DeepCopy();
+          dataObjectWrapper.Path = rootBase.Path;
+          dataObjectWrapper.Parent = rootBase;
+          rootBase.Elements.Add(dataObjectWrapper);
+        }
+        else if (obj?.ToSpeckleGeometryWrapper() is SpeckleGeometryWrapper objWrapper)
+        {
+          SpeckleGeometryWrapper wrapper = objWrapper.DeepCopy();
+          wrapper.Path = rootBase.Path;
+          wrapper.Parent = rootBase;
+          rootBase.Elements.Add(wrapper);
+        }
+        else
+        {
+          rootBase.Elements.Add(null);
+          skippedCount++;
+        }
+      }
+
+      if (skippedCount > 0)
+      {
+        AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, $"Skipped {skippedCount} unsupported object(s).");
+      }
+    }
+
+    RootCollectionWrapper = new SpeckleCollectionWrapperGoo(rootBase);
 
     string? versionMessage = null;
     da.GetData(2, ref versionMessage);
@@ -301,7 +359,6 @@ public class SendAsyncComponent : GH_AsyncComponent<SendAsyncComponent>
     da.GetData(3, ref rootPropsGoo);
 
     // validate single properties group
-    // we can't support a list input here, what does that even mean? grafting the collection to each props entry?? scary.
     if (Params.Input[3].VolatileData.DataCount > 1)
     {
       AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Only one Model Properties group is allowed");

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Send/SendComponent.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Send/SendComponent.cs
@@ -68,8 +68,8 @@ public class SendComponent : SpeckleTaskCapableComponent<SendComponentInput, Sen
 
     // collection / data (Refactored to accept lists of mixed data)
     pManager.AddGenericParameter(
-      "Data",
-      "D",
+      "Collection",
+      "collection",
       "The collections, data objects, or geometries to publish",
       GH_ParamAccess.list
     );

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Send/SendComponent.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Send/SendComponent.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using Grasshopper;
 using Grasshopper.Kernel;
+using Grasshopper.Kernel.Types;
 using Microsoft.Extensions.DependencyInjection;
 using Speckle.Connectors.Common.Analytics;
 using Speckle.Connectors.Common.Operations;
@@ -13,6 +14,7 @@ using Speckle.Sdk;
 using Speckle.Sdk.Api;
 using Speckle.Sdk.Common;
 using Speckle.Sdk.Credentials;
+using Speckle.Sdk.Models.Collections;
 
 namespace Speckle.Connectors.GrasshopperShared.Components.Operations.Send;
 
@@ -64,14 +66,15 @@ public class SendComponent : SpeckleTaskCapableComponent<SendComponentInput, Sen
     // speckle model
     pManager.AddParameter(new SpeckleUrlModelResourceParam());
 
-    // collection
-    pManager.AddParameter(
-      new SpeckleCollectionParam(GH_ParamAccess.item),
-      "Collection",
-      "collection",
-      "The model collection to publish",
-      GH_ParamAccess.item
+    // collection / data (Refactored to accept lists of mixed data)
+    pManager.AddGenericParameter(
+      "Data",
+      "D",
+      "The collections, data objects, or geometries to publish",
+      GH_ParamAccess.list
     );
+
+    // version message
     pManager.AddTextParameter("Version Message", "versionMessage", "The version message", GH_ParamAccess.item);
     pManager[2].Optional = true;
 
@@ -107,8 +110,78 @@ public class SendComponent : SpeckleTaskCapableComponent<SendComponentInput, Sen
       throw new SpeckleException("Failed to get resource");
     }
 
-    SpeckleCollectionWrapperGoo rootCollectionWrapper = new();
-    da.GetData(1, ref rootCollectionWrapper);
+    // read as generic list of Goos
+    List<IGH_Goo> inputGoos = new();
+    da.GetDataList(1, inputGoos);
+
+    SpeckleCollectionWrapper? rootBase;
+
+    // filter out nulls just to check if we can use the fast path
+    var nonNullGoos = inputGoos.Where(x => x != null).ToList();
+
+    // fast path: if there's exactly one valid item and it's a collection, use it directly
+    if (nonNullGoos.Count == 1 && nonNullGoos[0] is SpeckleCollectionWrapperGoo singleCollection)
+    {
+      rootBase = singleCollection.Value.DeepCopy();
+    }
+    else
+    {
+      // mixed inputs: construct a root collection using the document name  (CNX-3175)
+      var docName = GetGrasshopperFileInfo().fileName ?? "Unnamed Document";
+      if (
+        docName.EndsWith(".gh", StringComparison.OrdinalIgnoreCase)
+        || docName.EndsWith(".ghx", StringComparison.OrdinalIgnoreCase)
+      )
+      {
+        docName = Path.GetFileNameWithoutExtension(docName);
+      }
+
+      rootBase = new SpeckleCollectionWrapper
+      {
+        Base = new Collection(),
+        Name = docName,
+        Path = [docName],
+        Color = null,
+        Material = null
+      };
+
+      int skippedCount = 0;
+      foreach (var obj in inputGoos)
+      {
+        if (obj is SpeckleCollectionWrapperGoo collectionGoo)
+        {
+          var colClone = (SpeckleCollectionWrapperGoo)collectionGoo.Duplicate();
+          colClone.Value.Path = rootBase.Path;
+          rootBase.Elements.AddRange(colClone.Value.Elements);
+        }
+        else if (obj is SpeckleDataObjectWrapperGoo dataObjectWrapperGoo)
+        {
+          var dataObjectWrapper = dataObjectWrapperGoo.Value.DeepCopy();
+          dataObjectWrapper.Path = rootBase.Path;
+          dataObjectWrapper.Parent = rootBase;
+          rootBase.Elements.Add(dataObjectWrapper);
+        }
+        else if (obj?.ToSpeckleGeometryWrapper() is SpeckleGeometryWrapper objWrapper)
+        {
+          SpeckleGeometryWrapper wrapper = objWrapper.DeepCopy();
+          wrapper.Path = rootBase.Path;
+          wrapper.Parent = rootBase;
+          rootBase.Elements.Add(wrapper);
+        }
+        else
+        {
+          rootBase.Elements.Add(null);
+          skippedCount++;
+        }
+      }
+
+      if (skippedCount > 0)
+      {
+        AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, $"Skipped {skippedCount} unsupported object(s).");
+      }
+    }
+
+    SpeckleCollectionWrapperGoo rootCollectionWrapper = new(rootBase);
 
     string? versionMessage = null;
     da.GetData(2, ref versionMessage);
@@ -169,27 +242,13 @@ public class SendComponent : SpeckleTaskCapableComponent<SendComponentInput, Sen
   )
   {
     var multipleResources = Params.Input[0].VolatileData.HasInputCountGreaterThan(1);
-    var multipleCollections = Params.Input[1].VolatileData.HasInputCountGreaterThan(1);
 
-    var hasMultipleInputs = multipleCollections || multipleResources;
-
-    if (hasMultipleInputs)
+    if (multipleResources)
     {
-      var mCollErrText =
-        "Only one single collection supported. Please group your input collections into one single one before sending.";
-      var mLinksErrText =
-        "Only one single model can be published to from this node. To send to multiple models, please use multiple publish components.";
-
-      if (multipleCollections)
-      {
-        AddRuntimeMessage(GH_RuntimeMessageLevel.Error, mCollErrText);
-      }
-
-      if (multipleResources)
-      {
-        AddRuntimeMessage(GH_RuntimeMessageLevel.Error, mLinksErrText);
-      }
-
+      AddRuntimeMessage(
+        GH_RuntimeMessageLevel.Error,
+        "Only one single model can be published to from this node. To send to multiple models, please use multiple publish components."
+      );
       return new(null);
     }
 
@@ -198,9 +257,7 @@ public class SendComponent : SpeckleTaskCapableComponent<SendComponentInput, Sen
       return new(null);
     }
 
-    // safe to always create new wrapper since users cannot create SpeckleRootCollectionWrapper directly - it's only
-    // constructed here from the Collection + Model Properties inputs.
-    // if this changes, then we need to update below!
+    // safe to always create new wrapper since users cannot create SpeckleRootCollectionWrapper directly
     var rootWrapper = new SpeckleRootCollectionWrapper(input.Input.Value, input.RootProperties?.Unwrap());
     var collectionToSend = new SpeckleRootCollectionWrapperGoo(rootWrapper);
 


### PR DESCRIPTION
## Description

The data structure we publish often has a mixture of `SpeckleDataObject` (and/or `SpeckleGeometry`) and `Collection`. GH invalidates it. So this strict validation was just an artificial blocker. 

This PR removes that constraint so users can pipe in a mixture of data objects, speckle geometries, and collections. We also updated the Send components so if you pipe a mixed list directly into them, it auto-wraps everything into a root collection.

Completes [CNX-3175](https://linear.app/speckle/issue/CNX-3175/collections-node-should-accept-a-mix-of-data-objects-collections).

## User Value

Users can now combine data objects and collections using standard GH merge components without hitting errors, and can even skip the `Create Collection` node entirely for simple scripts.

## Changes:

- Reworked `CreateCollection.cs` to process mixed inputs in a single loop
- Updated `SendComponent.cs` and `SendAsyncComponent.cs` inputs to accept generic lists instead of a single collection item.
- Added an root builder in the Send components to auto-wrap mixed inputs 

## Screenshots & Validation of changes:

- **Green**: shows piping data objects straight in to publish component. Wrapped in root and published
- **Red**: shows collection containing mixture of `DataObject` and child `Collection`.
- **Blue**: shows expanding preserving inputs.
 
<img width="1920" height="1098" alt="Screenshot 2026-03-23 160539" src="https://github.com/user-attachments/assets/9bdcff7a-1c09-4f4c-84d9-4c7241a18630" />

No changes were needed on the receive/expand workflows as the core `Base` and Grasshopper unpackers already supported mixed elements.

## Before Merge:
- [ ] @bimgeek I renamed `Collections` on the publish component to `Data`. What do you think? Probably silly as this would be breaking. If I keep to `Collections` then no auto-updating needed. 

## Checklist:

- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] I have added appropriate tests.
- [x] I have updated or added relevant documentation.