### PR TITLE
ci: Update Actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
         run: |
           echo "semver=${{ env.SEMVER }}" >> "$Env:GITHUB_OUTPUT"
           echo "file_version=${{ env.FILE_VERSION }}" >> "$Env:GITHUB_OUTPUT"
-          
+
   deploy-installers:
     runs-on: ubuntu-latest
     needs: build-connectors
@@ -56,7 +56,7 @@ jobs:
       IS_PUBLIC_RELEASE: ${{ github.ref_type == 'tag' }}
     steps:
       - name: 🔫 Trigger Build Installers
-        uses: the-actions-org/workflow-dispatch@v4.0.0
+        uses: benc-uk/workflow-dispatch@v1
         with:
           workflow: Build Installers
           repo: specklesystems/connector-installers
@@ -70,11 +70,9 @@ jobs:
             }'
           ref: main
           wait-for-completion: true
-          wait-for-completion-interval: 10s
-          wait-for-completion-timeout: 10m
-          display-workflow-run-url: true
-          display-workflow-run-url-interval: 10s
-      
+          sync-status: true
+          wait-timeout-seconds: 10m
+
       # Allows us to inspect the artifacts of failed builds, since this below step will be skipped if the above step fails
       - uses: geekyeggo/delete-artifact@v6
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,7 +71,7 @@ jobs:
           ref: main
           wait-for-completion: true
           sync-status: true
-        timeout-minutes: 1
+        timeout-minutes: 15
 
       # Allows us to inspect the artifacts of failed builds, since this below step will be skipped if the above step fails
       - uses: geekyeggo/delete-artifact@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,7 +71,7 @@ jobs:
           ref: main
           wait-for-completion: true
           sync-status: true
-          wait-timeout-seconds: 10m
+        timeout-minutes: 1
 
       # Allows us to inspect the artifacts of failed builds, since this below step will be skipped if the above step fails
       - uses: geekyeggo/delete-artifact@v6


### PR DESCRIPTION
We're using several Actions that are using Node 20 which will soon become EOL...

This PR, along with https://github.com/specklesystems/speckle-sharp-connectors/pull/1321 updates actions in this repo to supported node versions.

Importantly, [benc-uk/workflow-dispatch](https://github.com/benc-uk/workflow-dispatch) action has now been updated to have the features from the (now unmaintained, and Node 20 based) [the-actions-org/workflow-dispatch](https://github.com/the-actions-org/workflow-dispatch). So we can use it.

<img width="3175" height="486" alt="image" src="https://github.com/user-attachments/assets/fb73a8c0-c892-4240-8a6c-198a801a455a" />

---

I'll need to make this same change over in many repos (blender, sketchup, desktop services, archicad, powerbi)
