### PR TITLE
feat(deps): Update connectors to 3.15.0 sdk with logging changes

### DIFF
--- a/Connectors/Autocad/Speckle.Connectors.Autocad2022/packages.lock.json
+++ b/Connectors/Autocad/Speckle.Connectors.Autocad2022/packages.lock.json
@@ -73,8 +73,8 @@
       },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
-        "resolved": "5.0.0",
-        "contentHash": "W8DPQjkMScOMTtJbPwmPyj9c3zYSFGawDW3jwlBOOsnY+EzZFLgNQ/UMkK35JmkNOVPdCyPr2Tw7Vv9N+KA3ZQ==",
+        "resolved": "9.0.4",
+        "contentHash": "9VGI5kxIvrNG2mqLQZnUR6y/3fcnygD8eNpHR+CqfbnIXvea6nehnYknDKQTxZVPMpzpNca+7DxLBmpdB3q0Bw==",
         "dependencies": {
           "System.Threading.Tasks.Extensions": "4.5.4"
         }
@@ -171,24 +171,26 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "qCKCPT4HeSCJ7S+wnnjF+N+9Sd6lj5+Ra9DfxDHHrFli9rtXdnQRU5UOObyfcbiWQidVXhc2n0kbo3LPCEcvNw==",
+        "resolved": "3.15.0",
+        "contentHash": "/Qc1ESqxzLulN2c8vR0rEk+SjEHRUzdzKWvcF5i1H2ipWBzxYNi+QdZ2yc7kE+he+LmW6rdALEfAGW6b0hQbig==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
-          "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
           "Microsoft.CSharp": "4.7.0",
           "Microsoft.Data.Sqlite": "7.0.5",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "2.2.0",
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.13.1"
+          "Speckle.Sdk.Dependencies": "3.15.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "McLXS+Hd/bW+AdJifxGUIQi+ftofGY5r6i/X00HmlnbOvHJKZAR6fzJ12E8otMhMd78He8tcyjBD3R2jOR9ctA=="
+        "resolved": "3.15.0",
+        "contentHash": "q7CL5P25PXoya5QhfieD4b56HgsM/6nAPsmcitHCURxj6nHrIVECpOeptbnN0T5KaA5SL6RAB5WIj7YYepkXzQ==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
+        }
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -281,7 +283,7 @@
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -312,7 +314,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -356,11 +358,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.13.1, )",
-        "resolved": "3.13.1",
-        "contentHash": "VRG8SApTbAYA0YmgWTw0Eb+/AHeE0yOxDuKBTvFj3VipuSnwF29fV479BehnZdg3d8OBh4aP/YEx3vPAafybVw==",
+        "requested": "[3.15.0, )",
+        "resolved": "3.15.0",
+        "contentHash": "7/40NmAVbQS+fm4y8J2Y8U7G7oFHTbI8C03HO2dig1tICdCO2EXcv9wpDM9WRfD+vKx/vfx8WwpT+/HUP4DlcQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.13.1"
+          "Speckle.Sdk": "3.15.0"
         }
       }
     }

--- a/Connectors/Autocad/Speckle.Connectors.Autocad2023/packages.lock.json
+++ b/Connectors/Autocad/Speckle.Connectors.Autocad2023/packages.lock.json
@@ -73,8 +73,8 @@
       },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
-        "resolved": "5.0.0",
-        "contentHash": "W8DPQjkMScOMTtJbPwmPyj9c3zYSFGawDW3jwlBOOsnY+EzZFLgNQ/UMkK35JmkNOVPdCyPr2Tw7Vv9N+KA3ZQ==",
+        "resolved": "9.0.4",
+        "contentHash": "9VGI5kxIvrNG2mqLQZnUR6y/3fcnygD8eNpHR+CqfbnIXvea6nehnYknDKQTxZVPMpzpNca+7DxLBmpdB3q0Bw==",
         "dependencies": {
           "System.Threading.Tasks.Extensions": "4.5.4"
         }
@@ -171,24 +171,26 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "qCKCPT4HeSCJ7S+wnnjF+N+9Sd6lj5+Ra9DfxDHHrFli9rtXdnQRU5UOObyfcbiWQidVXhc2n0kbo3LPCEcvNw==",
+        "resolved": "3.15.0",
+        "contentHash": "/Qc1ESqxzLulN2c8vR0rEk+SjEHRUzdzKWvcF5i1H2ipWBzxYNi+QdZ2yc7kE+he+LmW6rdALEfAGW6b0hQbig==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
-          "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
           "Microsoft.CSharp": "4.7.0",
           "Microsoft.Data.Sqlite": "7.0.5",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "2.2.0",
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.13.1"
+          "Speckle.Sdk.Dependencies": "3.15.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "McLXS+Hd/bW+AdJifxGUIQi+ftofGY5r6i/X00HmlnbOvHJKZAR6fzJ12E8otMhMd78He8tcyjBD3R2jOR9ctA=="
+        "resolved": "3.15.0",
+        "contentHash": "q7CL5P25PXoya5QhfieD4b56HgsM/6nAPsmcitHCURxj6nHrIVECpOeptbnN0T5KaA5SL6RAB5WIj7YYepkXzQ==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
+        }
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -281,7 +283,7 @@
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -312,7 +314,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -356,11 +358,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.13.1, )",
-        "resolved": "3.13.1",
-        "contentHash": "VRG8SApTbAYA0YmgWTw0Eb+/AHeE0yOxDuKBTvFj3VipuSnwF29fV479BehnZdg3d8OBh4aP/YEx3vPAafybVw==",
+        "requested": "[3.15.0, )",
+        "resolved": "3.15.0",
+        "contentHash": "7/40NmAVbQS+fm4y8J2Y8U7G7oFHTbI8C03HO2dig1tICdCO2EXcv9wpDM9WRfD+vKx/vfx8WwpT+/HUP4DlcQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.13.1"
+          "Speckle.Sdk": "3.15.0"
         }
       }
     }

--- a/Connectors/Autocad/Speckle.Connectors.Autocad2024/packages.lock.json
+++ b/Connectors/Autocad/Speckle.Connectors.Autocad2024/packages.lock.json
@@ -73,8 +73,8 @@
       },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
-        "resolved": "5.0.0",
-        "contentHash": "W8DPQjkMScOMTtJbPwmPyj9c3zYSFGawDW3jwlBOOsnY+EzZFLgNQ/UMkK35JmkNOVPdCyPr2Tw7Vv9N+KA3ZQ==",
+        "resolved": "9.0.4",
+        "contentHash": "9VGI5kxIvrNG2mqLQZnUR6y/3fcnygD8eNpHR+CqfbnIXvea6nehnYknDKQTxZVPMpzpNca+7DxLBmpdB3q0Bw==",
         "dependencies": {
           "System.Threading.Tasks.Extensions": "4.5.4"
         }
@@ -171,24 +171,26 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "qCKCPT4HeSCJ7S+wnnjF+N+9Sd6lj5+Ra9DfxDHHrFli9rtXdnQRU5UOObyfcbiWQidVXhc2n0kbo3LPCEcvNw==",
+        "resolved": "3.15.0",
+        "contentHash": "/Qc1ESqxzLulN2c8vR0rEk+SjEHRUzdzKWvcF5i1H2ipWBzxYNi+QdZ2yc7kE+he+LmW6rdALEfAGW6b0hQbig==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
-          "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
           "Microsoft.CSharp": "4.7.0",
           "Microsoft.Data.Sqlite": "7.0.5",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "2.2.0",
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.13.1"
+          "Speckle.Sdk.Dependencies": "3.15.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "McLXS+Hd/bW+AdJifxGUIQi+ftofGY5r6i/X00HmlnbOvHJKZAR6fzJ12E8otMhMd78He8tcyjBD3R2jOR9ctA=="
+        "resolved": "3.15.0",
+        "contentHash": "q7CL5P25PXoya5QhfieD4b56HgsM/6nAPsmcitHCURxj6nHrIVECpOeptbnN0T5KaA5SL6RAB5WIj7YYepkXzQ==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
+        }
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -281,7 +283,7 @@
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -313,7 +315,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -357,11 +359,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.13.1, )",
-        "resolved": "3.13.1",
-        "contentHash": "VRG8SApTbAYA0YmgWTw0Eb+/AHeE0yOxDuKBTvFj3VipuSnwF29fV479BehnZdg3d8OBh4aP/YEx3vPAafybVw==",
+        "requested": "[3.15.0, )",
+        "resolved": "3.15.0",
+        "contentHash": "7/40NmAVbQS+fm4y8J2Y8U7G7oFHTbI8C03HO2dig1tICdCO2EXcv9wpDM9WRfD+vKx/vfx8WwpT+/HUP4DlcQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.13.1"
+          "Speckle.Sdk": "3.15.0"
         }
       }
     }

--- a/Connectors/Autocad/Speckle.Connectors.Autocad2025/packages.lock.json
+++ b/Connectors/Autocad/Speckle.Connectors.Autocad2025/packages.lock.json
@@ -157,8 +157,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "qCKCPT4HeSCJ7S+wnnjF+N+9Sd6lj5+Ra9DfxDHHrFli9rtXdnQRU5UOObyfcbiWQidVXhc2n0kbo3LPCEcvNw==",
+        "resolved": "3.15.0",
+        "contentHash": "/Qc1ESqxzLulN2c8vR0rEk+SjEHRUzdzKWvcF5i1H2ipWBzxYNi+QdZ2yc7kE+he+LmW6rdALEfAGW6b0hQbig==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -166,13 +166,13 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.13.1"
+          "Speckle.Sdk.Dependencies": "3.15.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "McLXS+Hd/bW+AdJifxGUIQi+ftofGY5r6i/X00HmlnbOvHJKZAR6fzJ12E8otMhMd78He8tcyjBD3R2jOR9ctA=="
+        "resolved": "3.15.0",
+        "contentHash": "q7CL5P25PXoya5QhfieD4b56HgsM/6nAPsmcitHCURxj6nHrIVECpOeptbnN0T5KaA5SL6RAB5WIj7YYepkXzQ=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -230,7 +230,7 @@
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -262,7 +262,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -306,11 +306,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.13.1, )",
-        "resolved": "3.13.1",
-        "contentHash": "VRG8SApTbAYA0YmgWTw0Eb+/AHeE0yOxDuKBTvFj3VipuSnwF29fV479BehnZdg3d8OBh4aP/YEx3vPAafybVw==",
+        "requested": "[3.15.0, )",
+        "resolved": "3.15.0",
+        "contentHash": "7/40NmAVbQS+fm4y8J2Y8U7G7oFHTbI8C03HO2dig1tICdCO2EXcv9wpDM9WRfD+vKx/vfx8WwpT+/HUP4DlcQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.13.1"
+          "Speckle.Sdk": "3.15.0"
         }
       }
     },

--- a/Connectors/Autocad/Speckle.Connectors.Autocad2026/packages.lock.json
+++ b/Connectors/Autocad/Speckle.Connectors.Autocad2026/packages.lock.json
@@ -157,8 +157,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "qCKCPT4HeSCJ7S+wnnjF+N+9Sd6lj5+Ra9DfxDHHrFli9rtXdnQRU5UOObyfcbiWQidVXhc2n0kbo3LPCEcvNw==",
+        "resolved": "3.15.0",
+        "contentHash": "/Qc1ESqxzLulN2c8vR0rEk+SjEHRUzdzKWvcF5i1H2ipWBzxYNi+QdZ2yc7kE+he+LmW6rdALEfAGW6b0hQbig==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -166,13 +166,13 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.13.1"
+          "Speckle.Sdk.Dependencies": "3.15.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "McLXS+Hd/bW+AdJifxGUIQi+ftofGY5r6i/X00HmlnbOvHJKZAR6fzJ12E8otMhMd78He8tcyjBD3R2jOR9ctA=="
+        "resolved": "3.15.0",
+        "contentHash": "q7CL5P25PXoya5QhfieD4b56HgsM/6nAPsmcitHCURxj6nHrIVECpOeptbnN0T5KaA5SL6RAB5WIj7YYepkXzQ=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -230,7 +230,7 @@
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -262,7 +262,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -306,11 +306,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.13.1, )",
-        "resolved": "3.13.1",
-        "contentHash": "VRG8SApTbAYA0YmgWTw0Eb+/AHeE0yOxDuKBTvFj3VipuSnwF29fV479BehnZdg3d8OBh4aP/YEx3vPAafybVw==",
+        "requested": "[3.15.0, )",
+        "resolved": "3.15.0",
+        "contentHash": "7/40NmAVbQS+fm4y8J2Y8U7G7oFHTbI8C03HO2dig1tICdCO2EXcv9wpDM9WRfD+vKx/vfx8WwpT+/HUP4DlcQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.13.1"
+          "Speckle.Sdk": "3.15.0"
         }
       }
     },

--- a/Connectors/Autocad/Speckle.Connectors.Civil3d2022/packages.lock.json
+++ b/Connectors/Autocad/Speckle.Connectors.Civil3d2022/packages.lock.json
@@ -82,8 +82,8 @@
       },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
-        "resolved": "5.0.0",
-        "contentHash": "W8DPQjkMScOMTtJbPwmPyj9c3zYSFGawDW3jwlBOOsnY+EzZFLgNQ/UMkK35JmkNOVPdCyPr2Tw7Vv9N+KA3ZQ==",
+        "resolved": "9.0.4",
+        "contentHash": "9VGI5kxIvrNG2mqLQZnUR6y/3fcnygD8eNpHR+CqfbnIXvea6nehnYknDKQTxZVPMpzpNca+7DxLBmpdB3q0Bw==",
         "dependencies": {
           "System.Threading.Tasks.Extensions": "4.5.4"
         }
@@ -180,24 +180,26 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "qCKCPT4HeSCJ7S+wnnjF+N+9Sd6lj5+Ra9DfxDHHrFli9rtXdnQRU5UOObyfcbiWQidVXhc2n0kbo3LPCEcvNw==",
+        "resolved": "3.15.0",
+        "contentHash": "/Qc1ESqxzLulN2c8vR0rEk+SjEHRUzdzKWvcF5i1H2ipWBzxYNi+QdZ2yc7kE+he+LmW6rdALEfAGW6b0hQbig==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
-          "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
           "Microsoft.CSharp": "4.7.0",
           "Microsoft.Data.Sqlite": "7.0.5",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "2.2.0",
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.13.1"
+          "Speckle.Sdk.Dependencies": "3.15.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "McLXS+Hd/bW+AdJifxGUIQi+ftofGY5r6i/X00HmlnbOvHJKZAR6fzJ12E8otMhMd78He8tcyjBD3R2jOR9ctA=="
+        "resolved": "3.15.0",
+        "contentHash": "q7CL5P25PXoya5QhfieD4b56HgsM/6nAPsmcitHCURxj6nHrIVECpOeptbnN0T5KaA5SL6RAB5WIj7YYepkXzQ==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
+        }
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -290,7 +292,7 @@
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -322,7 +324,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -366,11 +368,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.13.1, )",
-        "resolved": "3.13.1",
-        "contentHash": "VRG8SApTbAYA0YmgWTw0Eb+/AHeE0yOxDuKBTvFj3VipuSnwF29fV479BehnZdg3d8OBh4aP/YEx3vPAafybVw==",
+        "requested": "[3.15.0, )",
+        "resolved": "3.15.0",
+        "contentHash": "7/40NmAVbQS+fm4y8J2Y8U7G7oFHTbI8C03HO2dig1tICdCO2EXcv9wpDM9WRfD+vKx/vfx8WwpT+/HUP4DlcQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.13.1"
+          "Speckle.Sdk": "3.15.0"
         }
       }
     }

--- a/Connectors/Autocad/Speckle.Connectors.Civil3d2023/packages.lock.json
+++ b/Connectors/Autocad/Speckle.Connectors.Civil3d2023/packages.lock.json
@@ -82,8 +82,8 @@
       },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
-        "resolved": "5.0.0",
-        "contentHash": "W8DPQjkMScOMTtJbPwmPyj9c3zYSFGawDW3jwlBOOsnY+EzZFLgNQ/UMkK35JmkNOVPdCyPr2Tw7Vv9N+KA3ZQ==",
+        "resolved": "9.0.4",
+        "contentHash": "9VGI5kxIvrNG2mqLQZnUR6y/3fcnygD8eNpHR+CqfbnIXvea6nehnYknDKQTxZVPMpzpNca+7DxLBmpdB3q0Bw==",
         "dependencies": {
           "System.Threading.Tasks.Extensions": "4.5.4"
         }
@@ -180,24 +180,26 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "qCKCPT4HeSCJ7S+wnnjF+N+9Sd6lj5+Ra9DfxDHHrFli9rtXdnQRU5UOObyfcbiWQidVXhc2n0kbo3LPCEcvNw==",
+        "resolved": "3.15.0",
+        "contentHash": "/Qc1ESqxzLulN2c8vR0rEk+SjEHRUzdzKWvcF5i1H2ipWBzxYNi+QdZ2yc7kE+he+LmW6rdALEfAGW6b0hQbig==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
-          "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
           "Microsoft.CSharp": "4.7.0",
           "Microsoft.Data.Sqlite": "7.0.5",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "2.2.0",
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.13.1"
+          "Speckle.Sdk.Dependencies": "3.15.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "McLXS+Hd/bW+AdJifxGUIQi+ftofGY5r6i/X00HmlnbOvHJKZAR6fzJ12E8otMhMd78He8tcyjBD3R2jOR9ctA=="
+        "resolved": "3.15.0",
+        "contentHash": "q7CL5P25PXoya5QhfieD4b56HgsM/6nAPsmcitHCURxj6nHrIVECpOeptbnN0T5KaA5SL6RAB5WIj7YYepkXzQ==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
+        }
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -290,7 +292,7 @@
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -322,7 +324,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -366,11 +368,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.13.1, )",
-        "resolved": "3.13.1",
-        "contentHash": "VRG8SApTbAYA0YmgWTw0Eb+/AHeE0yOxDuKBTvFj3VipuSnwF29fV479BehnZdg3d8OBh4aP/YEx3vPAafybVw==",
+        "requested": "[3.15.0, )",
+        "resolved": "3.15.0",
+        "contentHash": "7/40NmAVbQS+fm4y8J2Y8U7G7oFHTbI8C03HO2dig1tICdCO2EXcv9wpDM9WRfD+vKx/vfx8WwpT+/HUP4DlcQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.13.1"
+          "Speckle.Sdk": "3.15.0"
         }
       }
     }

--- a/Connectors/Autocad/Speckle.Connectors.Civil3d2024/packages.lock.json
+++ b/Connectors/Autocad/Speckle.Connectors.Civil3d2024/packages.lock.json
@@ -82,8 +82,8 @@
       },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
-        "resolved": "5.0.0",
-        "contentHash": "W8DPQjkMScOMTtJbPwmPyj9c3zYSFGawDW3jwlBOOsnY+EzZFLgNQ/UMkK35JmkNOVPdCyPr2Tw7Vv9N+KA3ZQ==",
+        "resolved": "9.0.4",
+        "contentHash": "9VGI5kxIvrNG2mqLQZnUR6y/3fcnygD8eNpHR+CqfbnIXvea6nehnYknDKQTxZVPMpzpNca+7DxLBmpdB3q0Bw==",
         "dependencies": {
           "System.Threading.Tasks.Extensions": "4.5.4"
         }
@@ -180,24 +180,26 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "qCKCPT4HeSCJ7S+wnnjF+N+9Sd6lj5+Ra9DfxDHHrFli9rtXdnQRU5UOObyfcbiWQidVXhc2n0kbo3LPCEcvNw==",
+        "resolved": "3.15.0",
+        "contentHash": "/Qc1ESqxzLulN2c8vR0rEk+SjEHRUzdzKWvcF5i1H2ipWBzxYNi+QdZ2yc7kE+he+LmW6rdALEfAGW6b0hQbig==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
-          "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
           "Microsoft.CSharp": "4.7.0",
           "Microsoft.Data.Sqlite": "7.0.5",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "2.2.0",
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.13.1"
+          "Speckle.Sdk.Dependencies": "3.15.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "McLXS+Hd/bW+AdJifxGUIQi+ftofGY5r6i/X00HmlnbOvHJKZAR6fzJ12E8otMhMd78He8tcyjBD3R2jOR9ctA=="
+        "resolved": "3.15.0",
+        "contentHash": "q7CL5P25PXoya5QhfieD4b56HgsM/6nAPsmcitHCURxj6nHrIVECpOeptbnN0T5KaA5SL6RAB5WIj7YYepkXzQ==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
+        }
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -290,7 +292,7 @@
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -322,7 +324,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -366,11 +368,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.13.1, )",
-        "resolved": "3.13.1",
-        "contentHash": "VRG8SApTbAYA0YmgWTw0Eb+/AHeE0yOxDuKBTvFj3VipuSnwF29fV479BehnZdg3d8OBh4aP/YEx3vPAafybVw==",
+        "requested": "[3.15.0, )",
+        "resolved": "3.15.0",
+        "contentHash": "7/40NmAVbQS+fm4y8J2Y8U7G7oFHTbI8C03HO2dig1tICdCO2EXcv9wpDM9WRfD+vKx/vfx8WwpT+/HUP4DlcQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.13.1"
+          "Speckle.Sdk": "3.15.0"
         }
       }
     }

--- a/Connectors/Autocad/Speckle.Connectors.Civil3d2025/packages.lock.json
+++ b/Connectors/Autocad/Speckle.Connectors.Civil3d2025/packages.lock.json
@@ -166,8 +166,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "qCKCPT4HeSCJ7S+wnnjF+N+9Sd6lj5+Ra9DfxDHHrFli9rtXdnQRU5UOObyfcbiWQidVXhc2n0kbo3LPCEcvNw==",
+        "resolved": "3.15.0",
+        "contentHash": "/Qc1ESqxzLulN2c8vR0rEk+SjEHRUzdzKWvcF5i1H2ipWBzxYNi+QdZ2yc7kE+he+LmW6rdALEfAGW6b0hQbig==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -175,13 +175,13 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.13.1"
+          "Speckle.Sdk.Dependencies": "3.15.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "McLXS+Hd/bW+AdJifxGUIQi+ftofGY5r6i/X00HmlnbOvHJKZAR6fzJ12E8otMhMd78He8tcyjBD3R2jOR9ctA=="
+        "resolved": "3.15.0",
+        "contentHash": "q7CL5P25PXoya5QhfieD4b56HgsM/6nAPsmcitHCURxj6nHrIVECpOeptbnN0T5KaA5SL6RAB5WIj7YYepkXzQ=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -239,7 +239,7 @@
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -272,7 +272,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -316,11 +316,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.13.1, )",
-        "resolved": "3.13.1",
-        "contentHash": "VRG8SApTbAYA0YmgWTw0Eb+/AHeE0yOxDuKBTvFj3VipuSnwF29fV479BehnZdg3d8OBh4aP/YEx3vPAafybVw==",
+        "requested": "[3.15.0, )",
+        "resolved": "3.15.0",
+        "contentHash": "7/40NmAVbQS+fm4y8J2Y8U7G7oFHTbI8C03HO2dig1tICdCO2EXcv9wpDM9WRfD+vKx/vfx8WwpT+/HUP4DlcQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.13.1"
+          "Speckle.Sdk": "3.15.0"
         }
       }
     },

--- a/Connectors/Autocad/Speckle.Connectors.Civil3d2026/packages.lock.json
+++ b/Connectors/Autocad/Speckle.Connectors.Civil3d2026/packages.lock.json
@@ -166,8 +166,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "qCKCPT4HeSCJ7S+wnnjF+N+9Sd6lj5+Ra9DfxDHHrFli9rtXdnQRU5UOObyfcbiWQidVXhc2n0kbo3LPCEcvNw==",
+        "resolved": "3.15.0",
+        "contentHash": "/Qc1ESqxzLulN2c8vR0rEk+SjEHRUzdzKWvcF5i1H2ipWBzxYNi+QdZ2yc7kE+he+LmW6rdALEfAGW6b0hQbig==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -175,13 +175,13 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.13.1"
+          "Speckle.Sdk.Dependencies": "3.15.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "McLXS+Hd/bW+AdJifxGUIQi+ftofGY5r6i/X00HmlnbOvHJKZAR6fzJ12E8otMhMd78He8tcyjBD3R2jOR9ctA=="
+        "resolved": "3.15.0",
+        "contentHash": "q7CL5P25PXoya5QhfieD4b56HgsM/6nAPsmcitHCURxj6nHrIVECpOeptbnN0T5KaA5SL6RAB5WIj7YYepkXzQ=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -239,7 +239,7 @@
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -272,7 +272,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -316,11 +316,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.13.1, )",
-        "resolved": "3.13.1",
-        "contentHash": "VRG8SApTbAYA0YmgWTw0Eb+/AHeE0yOxDuKBTvFj3VipuSnwF29fV479BehnZdg3d8OBh4aP/YEx3vPAafybVw==",
+        "requested": "[3.15.0, )",
+        "resolved": "3.15.0",
+        "contentHash": "7/40NmAVbQS+fm4y8J2Y8U7G7oFHTbI8C03HO2dig1tICdCO2EXcv9wpDM9WRfD+vKx/vfx8WwpT+/HUP4DlcQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.13.1"
+          "Speckle.Sdk": "3.15.0"
         }
       }
     },

--- a/Connectors/CSi/Speckle.Connectors.ETABS21/packages.lock.json
+++ b/Connectors/CSi/Speckle.Connectors.ETABS21/packages.lock.json
@@ -73,8 +73,8 @@
       },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
-        "resolved": "5.0.0",
-        "contentHash": "W8DPQjkMScOMTtJbPwmPyj9c3zYSFGawDW3jwlBOOsnY+EzZFLgNQ/UMkK35JmkNOVPdCyPr2Tw7Vv9N+KA3ZQ==",
+        "resolved": "9.0.4",
+        "contentHash": "9VGI5kxIvrNG2mqLQZnUR6y/3fcnygD8eNpHR+CqfbnIXvea6nehnYknDKQTxZVPMpzpNca+7DxLBmpdB3q0Bw==",
         "dependencies": {
           "System.Threading.Tasks.Extensions": "4.5.4"
         }
@@ -171,24 +171,26 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "qCKCPT4HeSCJ7S+wnnjF+N+9Sd6lj5+Ra9DfxDHHrFli9rtXdnQRU5UOObyfcbiWQidVXhc2n0kbo3LPCEcvNw==",
+        "resolved": "3.15.0",
+        "contentHash": "/Qc1ESqxzLulN2c8vR0rEk+SjEHRUzdzKWvcF5i1H2ipWBzxYNi+QdZ2yc7kE+he+LmW6rdALEfAGW6b0hQbig==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
-          "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
           "Microsoft.CSharp": "4.7.0",
           "Microsoft.Data.Sqlite": "7.0.5",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "2.2.0",
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.13.1"
+          "Speckle.Sdk.Dependencies": "3.15.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "McLXS+Hd/bW+AdJifxGUIQi+ftofGY5r6i/X00HmlnbOvHJKZAR6fzJ12E8otMhMd78He8tcyjBD3R2jOR9ctA=="
+        "resolved": "3.15.0",
+        "contentHash": "q7CL5P25PXoya5QhfieD4b56HgsM/6nAPsmcitHCURxj6nHrIVECpOeptbnN0T5KaA5SL6RAB5WIj7YYepkXzQ==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
+        }
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -281,7 +283,7 @@
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -305,7 +307,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "speckle.converters.etabs21": {
@@ -355,11 +357,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.13.1, )",
-        "resolved": "3.13.1",
-        "contentHash": "VRG8SApTbAYA0YmgWTw0Eb+/AHeE0yOxDuKBTvFj3VipuSnwF29fV479BehnZdg3d8OBh4aP/YEx3vPAafybVw==",
+        "requested": "[3.15.0, )",
+        "resolved": "3.15.0",
+        "contentHash": "7/40NmAVbQS+fm4y8J2Y8U7G7oFHTbI8C03HO2dig1tICdCO2EXcv9wpDM9WRfD+vKx/vfx8WwpT+/HUP4DlcQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.13.1"
+          "Speckle.Sdk": "3.15.0"
         }
       }
     }

--- a/Connectors/CSi/Speckle.Connectors.ETABS22/packages.lock.json
+++ b/Connectors/CSi/Speckle.Connectors.ETABS22/packages.lock.json
@@ -157,8 +157,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "qCKCPT4HeSCJ7S+wnnjF+N+9Sd6lj5+Ra9DfxDHHrFli9rtXdnQRU5UOObyfcbiWQidVXhc2n0kbo3LPCEcvNw==",
+        "resolved": "3.15.0",
+        "contentHash": "/Qc1ESqxzLulN2c8vR0rEk+SjEHRUzdzKWvcF5i1H2ipWBzxYNi+QdZ2yc7kE+he+LmW6rdALEfAGW6b0hQbig==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -166,13 +166,13 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.13.1"
+          "Speckle.Sdk.Dependencies": "3.15.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "McLXS+Hd/bW+AdJifxGUIQi+ftofGY5r6i/X00HmlnbOvHJKZAR6fzJ12E8otMhMd78He8tcyjBD3R2jOR9ctA=="
+        "resolved": "3.15.0",
+        "contentHash": "q7CL5P25PXoya5QhfieD4b56HgsM/6nAPsmcitHCURxj6nHrIVECpOeptbnN0T5KaA5SL6RAB5WIj7YYepkXzQ=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -230,7 +230,7 @@
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -254,7 +254,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "speckle.converters.etabs22": {
@@ -304,11 +304,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.13.1, )",
-        "resolved": "3.13.1",
-        "contentHash": "VRG8SApTbAYA0YmgWTw0Eb+/AHeE0yOxDuKBTvFj3VipuSnwF29fV479BehnZdg3d8OBh4aP/YEx3vPAafybVw==",
+        "requested": "[3.15.0, )",
+        "resolved": "3.15.0",
+        "contentHash": "7/40NmAVbQS+fm4y8J2Y8U7G7oFHTbI8C03HO2dig1tICdCO2EXcv9wpDM9WRfD+vKx/vfx8WwpT+/HUP4DlcQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.13.1"
+          "Speckle.Sdk": "3.15.0"
         }
       }
     }

--- a/Connectors/Navisworks/Speckle.Connectors.Navisworks2020/packages.lock.json
+++ b/Connectors/Navisworks/Speckle.Connectors.Navisworks2020/packages.lock.json
@@ -73,8 +73,8 @@
       },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
-        "resolved": "5.0.0",
-        "contentHash": "W8DPQjkMScOMTtJbPwmPyj9c3zYSFGawDW3jwlBOOsnY+EzZFLgNQ/UMkK35JmkNOVPdCyPr2Tw7Vv9N+KA3ZQ==",
+        "resolved": "9.0.4",
+        "contentHash": "9VGI5kxIvrNG2mqLQZnUR6y/3fcnygD8eNpHR+CqfbnIXvea6nehnYknDKQTxZVPMpzpNca+7DxLBmpdB3q0Bw==",
         "dependencies": {
           "System.Threading.Tasks.Extensions": "4.5.4"
         }
@@ -171,24 +171,26 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "qCKCPT4HeSCJ7S+wnnjF+N+9Sd6lj5+Ra9DfxDHHrFli9rtXdnQRU5UOObyfcbiWQidVXhc2n0kbo3LPCEcvNw==",
+        "resolved": "3.15.0",
+        "contentHash": "/Qc1ESqxzLulN2c8vR0rEk+SjEHRUzdzKWvcF5i1H2ipWBzxYNi+QdZ2yc7kE+he+LmW6rdALEfAGW6b0hQbig==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
-          "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
           "Microsoft.CSharp": "4.7.0",
           "Microsoft.Data.Sqlite": "7.0.5",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "2.2.0",
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.13.1"
+          "Speckle.Sdk.Dependencies": "3.15.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "McLXS+Hd/bW+AdJifxGUIQi+ftofGY5r6i/X00HmlnbOvHJKZAR6fzJ12E8otMhMd78He8tcyjBD3R2jOR9ctA=="
+        "resolved": "3.15.0",
+        "contentHash": "q7CL5P25PXoya5QhfieD4b56HgsM/6nAPsmcitHCURxj6nHrIVECpOeptbnN0T5KaA5SL6RAB5WIj7YYepkXzQ==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
+        }
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -281,7 +283,7 @@
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -305,7 +307,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "speckle.converters.navisworks2020": {
@@ -357,11 +359,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.13.1, )",
-        "resolved": "3.13.1",
-        "contentHash": "VRG8SApTbAYA0YmgWTw0Eb+/AHeE0yOxDuKBTvFj3VipuSnwF29fV479BehnZdg3d8OBh4aP/YEx3vPAafybVw==",
+        "requested": "[3.15.0, )",
+        "resolved": "3.15.0",
+        "contentHash": "7/40NmAVbQS+fm4y8J2Y8U7G7oFHTbI8C03HO2dig1tICdCO2EXcv9wpDM9WRfD+vKx/vfx8WwpT+/HUP4DlcQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.13.1"
+          "Speckle.Sdk": "3.15.0"
         }
       }
     },

--- a/Connectors/Navisworks/Speckle.Connectors.Navisworks2021/packages.lock.json
+++ b/Connectors/Navisworks/Speckle.Connectors.Navisworks2021/packages.lock.json
@@ -73,8 +73,8 @@
       },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
-        "resolved": "5.0.0",
-        "contentHash": "W8DPQjkMScOMTtJbPwmPyj9c3zYSFGawDW3jwlBOOsnY+EzZFLgNQ/UMkK35JmkNOVPdCyPr2Tw7Vv9N+KA3ZQ==",
+        "resolved": "9.0.4",
+        "contentHash": "9VGI5kxIvrNG2mqLQZnUR6y/3fcnygD8eNpHR+CqfbnIXvea6nehnYknDKQTxZVPMpzpNca+7DxLBmpdB3q0Bw==",
         "dependencies": {
           "System.Threading.Tasks.Extensions": "4.5.4"
         }
@@ -171,24 +171,26 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "qCKCPT4HeSCJ7S+wnnjF+N+9Sd6lj5+Ra9DfxDHHrFli9rtXdnQRU5UOObyfcbiWQidVXhc2n0kbo3LPCEcvNw==",
+        "resolved": "3.15.0",
+        "contentHash": "/Qc1ESqxzLulN2c8vR0rEk+SjEHRUzdzKWvcF5i1H2ipWBzxYNi+QdZ2yc7kE+he+LmW6rdALEfAGW6b0hQbig==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
-          "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
           "Microsoft.CSharp": "4.7.0",
           "Microsoft.Data.Sqlite": "7.0.5",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "2.2.0",
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.13.1"
+          "Speckle.Sdk.Dependencies": "3.15.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "McLXS+Hd/bW+AdJifxGUIQi+ftofGY5r6i/X00HmlnbOvHJKZAR6fzJ12E8otMhMd78He8tcyjBD3R2jOR9ctA=="
+        "resolved": "3.15.0",
+        "contentHash": "q7CL5P25PXoya5QhfieD4b56HgsM/6nAPsmcitHCURxj6nHrIVECpOeptbnN0T5KaA5SL6RAB5WIj7YYepkXzQ==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
+        }
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -281,7 +283,7 @@
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -305,7 +307,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "speckle.converters.navisworks2021": {
@@ -357,11 +359,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.13.1, )",
-        "resolved": "3.13.1",
-        "contentHash": "VRG8SApTbAYA0YmgWTw0Eb+/AHeE0yOxDuKBTvFj3VipuSnwF29fV479BehnZdg3d8OBh4aP/YEx3vPAafybVw==",
+        "requested": "[3.15.0, )",
+        "resolved": "3.15.0",
+        "contentHash": "7/40NmAVbQS+fm4y8J2Y8U7G7oFHTbI8C03HO2dig1tICdCO2EXcv9wpDM9WRfD+vKx/vfx8WwpT+/HUP4DlcQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.13.1"
+          "Speckle.Sdk": "3.15.0"
         }
       }
     },

--- a/Connectors/Navisworks/Speckle.Connectors.Navisworks2022/packages.lock.json
+++ b/Connectors/Navisworks/Speckle.Connectors.Navisworks2022/packages.lock.json
@@ -73,8 +73,8 @@
       },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
-        "resolved": "5.0.0",
-        "contentHash": "W8DPQjkMScOMTtJbPwmPyj9c3zYSFGawDW3jwlBOOsnY+EzZFLgNQ/UMkK35JmkNOVPdCyPr2Tw7Vv9N+KA3ZQ==",
+        "resolved": "9.0.4",
+        "contentHash": "9VGI5kxIvrNG2mqLQZnUR6y/3fcnygD8eNpHR+CqfbnIXvea6nehnYknDKQTxZVPMpzpNca+7DxLBmpdB3q0Bw==",
         "dependencies": {
           "System.Threading.Tasks.Extensions": "4.5.4"
         }
@@ -171,24 +171,26 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "qCKCPT4HeSCJ7S+wnnjF+N+9Sd6lj5+Ra9DfxDHHrFli9rtXdnQRU5UOObyfcbiWQidVXhc2n0kbo3LPCEcvNw==",
+        "resolved": "3.15.0",
+        "contentHash": "/Qc1ESqxzLulN2c8vR0rEk+SjEHRUzdzKWvcF5i1H2ipWBzxYNi+QdZ2yc7kE+he+LmW6rdALEfAGW6b0hQbig==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
-          "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
           "Microsoft.CSharp": "4.7.0",
           "Microsoft.Data.Sqlite": "7.0.5",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "2.2.0",
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.13.1"
+          "Speckle.Sdk.Dependencies": "3.15.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "McLXS+Hd/bW+AdJifxGUIQi+ftofGY5r6i/X00HmlnbOvHJKZAR6fzJ12E8otMhMd78He8tcyjBD3R2jOR9ctA=="
+        "resolved": "3.15.0",
+        "contentHash": "q7CL5P25PXoya5QhfieD4b56HgsM/6nAPsmcitHCURxj6nHrIVECpOeptbnN0T5KaA5SL6RAB5WIj7YYepkXzQ==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
+        }
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -281,7 +283,7 @@
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -305,7 +307,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "speckle.converters.navisworks2022": {
@@ -357,11 +359,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.13.1, )",
-        "resolved": "3.13.1",
-        "contentHash": "VRG8SApTbAYA0YmgWTw0Eb+/AHeE0yOxDuKBTvFj3VipuSnwF29fV479BehnZdg3d8OBh4aP/YEx3vPAafybVw==",
+        "requested": "[3.15.0, )",
+        "resolved": "3.15.0",
+        "contentHash": "7/40NmAVbQS+fm4y8J2Y8U7G7oFHTbI8C03HO2dig1tICdCO2EXcv9wpDM9WRfD+vKx/vfx8WwpT+/HUP4DlcQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.13.1"
+          "Speckle.Sdk": "3.15.0"
         }
       }
     },

--- a/Connectors/Navisworks/Speckle.Connectors.Navisworks2023/packages.lock.json
+++ b/Connectors/Navisworks/Speckle.Connectors.Navisworks2023/packages.lock.json
@@ -73,8 +73,8 @@
       },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
-        "resolved": "5.0.0",
-        "contentHash": "W8DPQjkMScOMTtJbPwmPyj9c3zYSFGawDW3jwlBOOsnY+EzZFLgNQ/UMkK35JmkNOVPdCyPr2Tw7Vv9N+KA3ZQ==",
+        "resolved": "9.0.4",
+        "contentHash": "9VGI5kxIvrNG2mqLQZnUR6y/3fcnygD8eNpHR+CqfbnIXvea6nehnYknDKQTxZVPMpzpNca+7DxLBmpdB3q0Bw==",
         "dependencies": {
           "System.Threading.Tasks.Extensions": "4.5.4"
         }
@@ -171,24 +171,26 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "qCKCPT4HeSCJ7S+wnnjF+N+9Sd6lj5+Ra9DfxDHHrFli9rtXdnQRU5UOObyfcbiWQidVXhc2n0kbo3LPCEcvNw==",
+        "resolved": "3.15.0",
+        "contentHash": "/Qc1ESqxzLulN2c8vR0rEk+SjEHRUzdzKWvcF5i1H2ipWBzxYNi+QdZ2yc7kE+he+LmW6rdALEfAGW6b0hQbig==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
-          "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
           "Microsoft.CSharp": "4.7.0",
           "Microsoft.Data.Sqlite": "7.0.5",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "2.2.0",
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.13.1"
+          "Speckle.Sdk.Dependencies": "3.15.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "McLXS+Hd/bW+AdJifxGUIQi+ftofGY5r6i/X00HmlnbOvHJKZAR6fzJ12E8otMhMd78He8tcyjBD3R2jOR9ctA=="
+        "resolved": "3.15.0",
+        "contentHash": "q7CL5P25PXoya5QhfieD4b56HgsM/6nAPsmcitHCURxj6nHrIVECpOeptbnN0T5KaA5SL6RAB5WIj7YYepkXzQ==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
+        }
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -281,7 +283,7 @@
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -305,7 +307,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "speckle.converters.navisworks2023": {
@@ -357,11 +359,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.13.1, )",
-        "resolved": "3.13.1",
-        "contentHash": "VRG8SApTbAYA0YmgWTw0Eb+/AHeE0yOxDuKBTvFj3VipuSnwF29fV479BehnZdg3d8OBh4aP/YEx3vPAafybVw==",
+        "requested": "[3.15.0, )",
+        "resolved": "3.15.0",
+        "contentHash": "7/40NmAVbQS+fm4y8J2Y8U7G7oFHTbI8C03HO2dig1tICdCO2EXcv9wpDM9WRfD+vKx/vfx8WwpT+/HUP4DlcQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.13.1"
+          "Speckle.Sdk": "3.15.0"
         }
       }
     },

--- a/Connectors/Navisworks/Speckle.Connectors.Navisworks2024/packages.lock.json
+++ b/Connectors/Navisworks/Speckle.Connectors.Navisworks2024/packages.lock.json
@@ -73,8 +73,8 @@
       },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
-        "resolved": "5.0.0",
-        "contentHash": "W8DPQjkMScOMTtJbPwmPyj9c3zYSFGawDW3jwlBOOsnY+EzZFLgNQ/UMkK35JmkNOVPdCyPr2Tw7Vv9N+KA3ZQ==",
+        "resolved": "9.0.4",
+        "contentHash": "9VGI5kxIvrNG2mqLQZnUR6y/3fcnygD8eNpHR+CqfbnIXvea6nehnYknDKQTxZVPMpzpNca+7DxLBmpdB3q0Bw==",
         "dependencies": {
           "System.Threading.Tasks.Extensions": "4.5.4"
         }
@@ -171,24 +171,26 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "qCKCPT4HeSCJ7S+wnnjF+N+9Sd6lj5+Ra9DfxDHHrFli9rtXdnQRU5UOObyfcbiWQidVXhc2n0kbo3LPCEcvNw==",
+        "resolved": "3.15.0",
+        "contentHash": "/Qc1ESqxzLulN2c8vR0rEk+SjEHRUzdzKWvcF5i1H2ipWBzxYNi+QdZ2yc7kE+he+LmW6rdALEfAGW6b0hQbig==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
-          "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
           "Microsoft.CSharp": "4.7.0",
           "Microsoft.Data.Sqlite": "7.0.5",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "2.2.0",
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.13.1"
+          "Speckle.Sdk.Dependencies": "3.15.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "McLXS+Hd/bW+AdJifxGUIQi+ftofGY5r6i/X00HmlnbOvHJKZAR6fzJ12E8otMhMd78He8tcyjBD3R2jOR9ctA=="
+        "resolved": "3.15.0",
+        "contentHash": "q7CL5P25PXoya5QhfieD4b56HgsM/6nAPsmcitHCURxj6nHrIVECpOeptbnN0T5KaA5SL6RAB5WIj7YYepkXzQ==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
+        }
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -281,7 +283,7 @@
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -305,7 +307,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "speckle.converters.navisworks2024": {
@@ -357,11 +359,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.13.1, )",
-        "resolved": "3.13.1",
-        "contentHash": "VRG8SApTbAYA0YmgWTw0Eb+/AHeE0yOxDuKBTvFj3VipuSnwF29fV479BehnZdg3d8OBh4aP/YEx3vPAafybVw==",
+        "requested": "[3.15.0, )",
+        "resolved": "3.15.0",
+        "contentHash": "7/40NmAVbQS+fm4y8J2Y8U7G7oFHTbI8C03HO2dig1tICdCO2EXcv9wpDM9WRfD+vKx/vfx8WwpT+/HUP4DlcQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.13.1"
+          "Speckle.Sdk": "3.15.0"
         }
       }
     },

--- a/Connectors/Navisworks/Speckle.Connectors.Navisworks2025/packages.lock.json
+++ b/Connectors/Navisworks/Speckle.Connectors.Navisworks2025/packages.lock.json
@@ -79,8 +79,8 @@
       },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
-        "resolved": "5.0.0",
-        "contentHash": "W8DPQjkMScOMTtJbPwmPyj9c3zYSFGawDW3jwlBOOsnY+EzZFLgNQ/UMkK35JmkNOVPdCyPr2Tw7Vv9N+KA3ZQ==",
+        "resolved": "9.0.4",
+        "contentHash": "9VGI5kxIvrNG2mqLQZnUR6y/3fcnygD8eNpHR+CqfbnIXvea6nehnYknDKQTxZVPMpzpNca+7DxLBmpdB3q0Bw==",
         "dependencies": {
           "System.Threading.Tasks.Extensions": "4.5.4"
         }
@@ -177,24 +177,26 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "qCKCPT4HeSCJ7S+wnnjF+N+9Sd6lj5+Ra9DfxDHHrFli9rtXdnQRU5UOObyfcbiWQidVXhc2n0kbo3LPCEcvNw==",
+        "resolved": "3.15.0",
+        "contentHash": "/Qc1ESqxzLulN2c8vR0rEk+SjEHRUzdzKWvcF5i1H2ipWBzxYNi+QdZ2yc7kE+he+LmW6rdALEfAGW6b0hQbig==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
-          "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
           "Microsoft.CSharp": "4.7.0",
           "Microsoft.Data.Sqlite": "7.0.5",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "2.2.0",
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.13.1"
+          "Speckle.Sdk.Dependencies": "3.15.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "McLXS+Hd/bW+AdJifxGUIQi+ftofGY5r6i/X00HmlnbOvHJKZAR6fzJ12E8otMhMd78He8tcyjBD3R2jOR9ctA=="
+        "resolved": "3.15.0",
+        "contentHash": "q7CL5P25PXoya5QhfieD4b56HgsM/6nAPsmcitHCURxj6nHrIVECpOeptbnN0T5KaA5SL6RAB5WIj7YYepkXzQ==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
+        }
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -287,7 +289,7 @@
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -311,7 +313,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "speckle.converters.navisworks2025": {
@@ -357,11 +359,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.13.1, )",
-        "resolved": "3.13.1",
-        "contentHash": "VRG8SApTbAYA0YmgWTw0Eb+/AHeE0yOxDuKBTvFj3VipuSnwF29fV479BehnZdg3d8OBh4aP/YEx3vPAafybVw==",
+        "requested": "[3.15.0, )",
+        "resolved": "3.15.0",
+        "contentHash": "7/40NmAVbQS+fm4y8J2Y8U7G7oFHTbI8C03HO2dig1tICdCO2EXcv9wpDM9WRfD+vKx/vfx8WwpT+/HUP4DlcQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.13.1"
+          "Speckle.Sdk": "3.15.0"
         }
       }
     },

--- a/Connectors/Navisworks/Speckle.Connectors.Navisworks2026/packages.lock.json
+++ b/Connectors/Navisworks/Speckle.Connectors.Navisworks2026/packages.lock.json
@@ -88,8 +88,8 @@
       },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
-        "resolved": "5.0.0",
-        "contentHash": "W8DPQjkMScOMTtJbPwmPyj9c3zYSFGawDW3jwlBOOsnY+EzZFLgNQ/UMkK35JmkNOVPdCyPr2Tw7Vv9N+KA3ZQ==",
+        "resolved": "9.0.4",
+        "contentHash": "9VGI5kxIvrNG2mqLQZnUR6y/3fcnygD8eNpHR+CqfbnIXvea6nehnYknDKQTxZVPMpzpNca+7DxLBmpdB3q0Bw==",
         "dependencies": {
           "System.Threading.Tasks.Extensions": "4.5.4"
         }
@@ -186,24 +186,26 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "qCKCPT4HeSCJ7S+wnnjF+N+9Sd6lj5+Ra9DfxDHHrFli9rtXdnQRU5UOObyfcbiWQidVXhc2n0kbo3LPCEcvNw==",
+        "resolved": "3.15.0",
+        "contentHash": "/Qc1ESqxzLulN2c8vR0rEk+SjEHRUzdzKWvcF5i1H2ipWBzxYNi+QdZ2yc7kE+he+LmW6rdALEfAGW6b0hQbig==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
-          "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
           "Microsoft.CSharp": "4.7.0",
           "Microsoft.Data.Sqlite": "7.0.5",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "2.2.0",
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.13.1"
+          "Speckle.Sdk.Dependencies": "3.15.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "McLXS+Hd/bW+AdJifxGUIQi+ftofGY5r6i/X00HmlnbOvHJKZAR6fzJ12E8otMhMd78He8tcyjBD3R2jOR9ctA=="
+        "resolved": "3.15.0",
+        "contentHash": "q7CL5P25PXoya5QhfieD4b56HgsM/6nAPsmcitHCURxj6nHrIVECpOeptbnN0T5KaA5SL6RAB5WIj7YYepkXzQ==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
+        }
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -288,7 +290,7 @@
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -312,7 +314,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "speckle.converters.navisworks2026": {
@@ -359,11 +361,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.13.1, )",
-        "resolved": "3.13.1",
-        "contentHash": "VRG8SApTbAYA0YmgWTw0Eb+/AHeE0yOxDuKBTvFj3VipuSnwF29fV479BehnZdg3d8OBh4aP/YEx3vPAafybVw==",
+        "requested": "[3.15.0, )",
+        "resolved": "3.15.0",
+        "contentHash": "7/40NmAVbQS+fm4y8J2Y8U7G7oFHTbI8C03HO2dig1tICdCO2EXcv9wpDM9WRfD+vKx/vfx8WwpT+/HUP4DlcQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.13.1"
+          "Speckle.Sdk": "3.15.0"
         }
       }
     },

--- a/Connectors/Revit/Speckle.Connectors.Revit2022/packages.lock.json
+++ b/Connectors/Revit/Speckle.Connectors.Revit2022/packages.lock.json
@@ -95,8 +95,8 @@
       },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
-        "resolved": "5.0.0",
-        "contentHash": "W8DPQjkMScOMTtJbPwmPyj9c3zYSFGawDW3jwlBOOsnY+EzZFLgNQ/UMkK35JmkNOVPdCyPr2Tw7Vv9N+KA3ZQ==",
+        "resolved": "9.0.4",
+        "contentHash": "9VGI5kxIvrNG2mqLQZnUR6y/3fcnygD8eNpHR+CqfbnIXvea6nehnYknDKQTxZVPMpzpNca+7DxLBmpdB3q0Bw==",
         "dependencies": {
           "System.Threading.Tasks.Extensions": "4.5.4"
         }
@@ -193,24 +193,26 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "qCKCPT4HeSCJ7S+wnnjF+N+9Sd6lj5+Ra9DfxDHHrFli9rtXdnQRU5UOObyfcbiWQidVXhc2n0kbo3LPCEcvNw==",
+        "resolved": "3.15.0",
+        "contentHash": "/Qc1ESqxzLulN2c8vR0rEk+SjEHRUzdzKWvcF5i1H2ipWBzxYNi+QdZ2yc7kE+he+LmW6rdALEfAGW6b0hQbig==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
-          "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
           "Microsoft.CSharp": "4.7.0",
           "Microsoft.Data.Sqlite": "7.0.5",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "2.2.0",
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.13.1"
+          "Speckle.Sdk.Dependencies": "3.15.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "McLXS+Hd/bW+AdJifxGUIQi+ftofGY5r6i/X00HmlnbOvHJKZAR6fzJ12E8otMhMd78He8tcyjBD3R2jOR9ctA=="
+        "resolved": "3.15.0",
+        "contentHash": "q7CL5P25PXoya5QhfieD4b56HgsM/6nAPsmcitHCURxj6nHrIVECpOeptbnN0T5KaA5SL6RAB5WIj7YYepkXzQ==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
+        }
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -310,7 +312,7 @@
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -333,7 +335,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "speckle.converters.revit2022": {
@@ -385,11 +387,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.13.1, )",
-        "resolved": "3.13.1",
-        "contentHash": "VRG8SApTbAYA0YmgWTw0Eb+/AHeE0yOxDuKBTvFj3VipuSnwF29fV479BehnZdg3d8OBh4aP/YEx3vPAafybVw==",
+        "requested": "[3.15.0, )",
+        "resolved": "3.15.0",
+        "contentHash": "7/40NmAVbQS+fm4y8J2Y8U7G7oFHTbI8C03HO2dig1tICdCO2EXcv9wpDM9WRfD+vKx/vfx8WwpT+/HUP4DlcQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.13.1"
+          "Speckle.Sdk": "3.15.0"
         }
       },
       "Speckle.Revit.API": {

--- a/Connectors/Revit/Speckle.Connectors.Revit2023/packages.lock.json
+++ b/Connectors/Revit/Speckle.Connectors.Revit2023/packages.lock.json
@@ -95,8 +95,8 @@
       },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
-        "resolved": "5.0.0",
-        "contentHash": "W8DPQjkMScOMTtJbPwmPyj9c3zYSFGawDW3jwlBOOsnY+EzZFLgNQ/UMkK35JmkNOVPdCyPr2Tw7Vv9N+KA3ZQ==",
+        "resolved": "9.0.4",
+        "contentHash": "9VGI5kxIvrNG2mqLQZnUR6y/3fcnygD8eNpHR+CqfbnIXvea6nehnYknDKQTxZVPMpzpNca+7DxLBmpdB3q0Bw==",
         "dependencies": {
           "System.Threading.Tasks.Extensions": "4.5.4"
         }
@@ -193,24 +193,26 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "qCKCPT4HeSCJ7S+wnnjF+N+9Sd6lj5+Ra9DfxDHHrFli9rtXdnQRU5UOObyfcbiWQidVXhc2n0kbo3LPCEcvNw==",
+        "resolved": "3.15.0",
+        "contentHash": "/Qc1ESqxzLulN2c8vR0rEk+SjEHRUzdzKWvcF5i1H2ipWBzxYNi+QdZ2yc7kE+he+LmW6rdALEfAGW6b0hQbig==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
-          "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
           "Microsoft.CSharp": "4.7.0",
           "Microsoft.Data.Sqlite": "7.0.5",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "2.2.0",
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.13.1"
+          "Speckle.Sdk.Dependencies": "3.15.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "McLXS+Hd/bW+AdJifxGUIQi+ftofGY5r6i/X00HmlnbOvHJKZAR6fzJ12E8otMhMd78He8tcyjBD3R2jOR9ctA=="
+        "resolved": "3.15.0",
+        "contentHash": "q7CL5P25PXoya5QhfieD4b56HgsM/6nAPsmcitHCURxj6nHrIVECpOeptbnN0T5KaA5SL6RAB5WIj7YYepkXzQ==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
+        }
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -310,7 +312,7 @@
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -333,7 +335,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "speckle.converters.revit2023": {
@@ -385,11 +387,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.13.1, )",
-        "resolved": "3.13.1",
-        "contentHash": "VRG8SApTbAYA0YmgWTw0Eb+/AHeE0yOxDuKBTvFj3VipuSnwF29fV479BehnZdg3d8OBh4aP/YEx3vPAafybVw==",
+        "requested": "[3.15.0, )",
+        "resolved": "3.15.0",
+        "contentHash": "7/40NmAVbQS+fm4y8J2Y8U7G7oFHTbI8C03HO2dig1tICdCO2EXcv9wpDM9WRfD+vKx/vfx8WwpT+/HUP4DlcQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.13.1"
+          "Speckle.Sdk": "3.15.0"
         }
       },
       "Speckle.Revit.API": {

--- a/Connectors/Revit/Speckle.Connectors.Revit2024/packages.lock.json
+++ b/Connectors/Revit/Speckle.Connectors.Revit2024/packages.lock.json
@@ -95,8 +95,8 @@
       },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
-        "resolved": "5.0.0",
-        "contentHash": "W8DPQjkMScOMTtJbPwmPyj9c3zYSFGawDW3jwlBOOsnY+EzZFLgNQ/UMkK35JmkNOVPdCyPr2Tw7Vv9N+KA3ZQ==",
+        "resolved": "9.0.4",
+        "contentHash": "9VGI5kxIvrNG2mqLQZnUR6y/3fcnygD8eNpHR+CqfbnIXvea6nehnYknDKQTxZVPMpzpNca+7DxLBmpdB3q0Bw==",
         "dependencies": {
           "System.Threading.Tasks.Extensions": "4.5.4"
         }
@@ -193,24 +193,26 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "qCKCPT4HeSCJ7S+wnnjF+N+9Sd6lj5+Ra9DfxDHHrFli9rtXdnQRU5UOObyfcbiWQidVXhc2n0kbo3LPCEcvNw==",
+        "resolved": "3.15.0",
+        "contentHash": "/Qc1ESqxzLulN2c8vR0rEk+SjEHRUzdzKWvcF5i1H2ipWBzxYNi+QdZ2yc7kE+he+LmW6rdALEfAGW6b0hQbig==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
-          "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
           "Microsoft.CSharp": "4.7.0",
           "Microsoft.Data.Sqlite": "7.0.5",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "2.2.0",
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.13.1"
+          "Speckle.Sdk.Dependencies": "3.15.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "McLXS+Hd/bW+AdJifxGUIQi+ftofGY5r6i/X00HmlnbOvHJKZAR6fzJ12E8otMhMd78He8tcyjBD3R2jOR9ctA=="
+        "resolved": "3.15.0",
+        "contentHash": "q7CL5P25PXoya5QhfieD4b56HgsM/6nAPsmcitHCURxj6nHrIVECpOeptbnN0T5KaA5SL6RAB5WIj7YYepkXzQ==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
+        }
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -310,7 +312,7 @@
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -333,7 +335,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "speckle.converters.revit2024": {
@@ -385,11 +387,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.13.1, )",
-        "resolved": "3.13.1",
-        "contentHash": "VRG8SApTbAYA0YmgWTw0Eb+/AHeE0yOxDuKBTvFj3VipuSnwF29fV479BehnZdg3d8OBh4aP/YEx3vPAafybVw==",
+        "requested": "[3.15.0, )",
+        "resolved": "3.15.0",
+        "contentHash": "7/40NmAVbQS+fm4y8J2Y8U7G7oFHTbI8C03HO2dig1tICdCO2EXcv9wpDM9WRfD+vKx/vfx8WwpT+/HUP4DlcQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.13.1"
+          "Speckle.Sdk": "3.15.0"
         }
       },
       "Speckle.Revit.API": {

--- a/Connectors/Revit/Speckle.Connectors.Revit2025/packages.lock.json
+++ b/Connectors/Revit/Speckle.Connectors.Revit2025/packages.lock.json
@@ -173,8 +173,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "qCKCPT4HeSCJ7S+wnnjF+N+9Sd6lj5+Ra9DfxDHHrFli9rtXdnQRU5UOObyfcbiWQidVXhc2n0kbo3LPCEcvNw==",
+        "resolved": "3.15.0",
+        "contentHash": "/Qc1ESqxzLulN2c8vR0rEk+SjEHRUzdzKWvcF5i1H2ipWBzxYNi+QdZ2yc7kE+he+LmW6rdALEfAGW6b0hQbig==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -182,13 +182,13 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.13.1"
+          "Speckle.Sdk.Dependencies": "3.15.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "McLXS+Hd/bW+AdJifxGUIQi+ftofGY5r6i/X00HmlnbOvHJKZAR6fzJ12E8otMhMd78He8tcyjBD3R2jOR9ctA=="
+        "resolved": "3.15.0",
+        "contentHash": "q7CL5P25PXoya5QhfieD4b56HgsM/6nAPsmcitHCURxj6nHrIVECpOeptbnN0T5KaA5SL6RAB5WIj7YYepkXzQ=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -253,7 +253,7 @@
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -276,7 +276,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "speckle.converters.revit2025": {
@@ -328,11 +328,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.13.1, )",
-        "resolved": "3.13.1",
-        "contentHash": "VRG8SApTbAYA0YmgWTw0Eb+/AHeE0yOxDuKBTvFj3VipuSnwF29fV479BehnZdg3d8OBh4aP/YEx3vPAafybVw==",
+        "requested": "[3.15.0, )",
+        "resolved": "3.15.0",
+        "contentHash": "7/40NmAVbQS+fm4y8J2Y8U7G7oFHTbI8C03HO2dig1tICdCO2EXcv9wpDM9WRfD+vKx/vfx8WwpT+/HUP4DlcQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.13.1"
+          "Speckle.Sdk": "3.15.0"
         }
       },
       "Speckle.Revit.API": {

--- a/Connectors/Revit/Speckle.Connectors.Revit2026/packages.lock.json
+++ b/Connectors/Revit/Speckle.Connectors.Revit2026/packages.lock.json
@@ -166,8 +166,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "qCKCPT4HeSCJ7S+wnnjF+N+9Sd6lj5+Ra9DfxDHHrFli9rtXdnQRU5UOObyfcbiWQidVXhc2n0kbo3LPCEcvNw==",
+        "resolved": "3.15.0",
+        "contentHash": "/Qc1ESqxzLulN2c8vR0rEk+SjEHRUzdzKWvcF5i1H2ipWBzxYNi+QdZ2yc7kE+he+LmW6rdALEfAGW6b0hQbig==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -175,13 +175,13 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.13.1"
+          "Speckle.Sdk.Dependencies": "3.15.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "McLXS+Hd/bW+AdJifxGUIQi+ftofGY5r6i/X00HmlnbOvHJKZAR6fzJ12E8otMhMd78He8tcyjBD3R2jOR9ctA=="
+        "resolved": "3.15.0",
+        "contentHash": "q7CL5P25PXoya5QhfieD4b56HgsM/6nAPsmcitHCURxj6nHrIVECpOeptbnN0T5KaA5SL6RAB5WIj7YYepkXzQ=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -246,7 +246,7 @@
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -269,7 +269,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "speckle.converters.revit2026": {
@@ -312,11 +312,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.13.1, )",
-        "resolved": "3.13.1",
-        "contentHash": "VRG8SApTbAYA0YmgWTw0Eb+/AHeE0yOxDuKBTvFj3VipuSnwF29fV479BehnZdg3d8OBh4aP/YEx3vPAafybVw==",
+        "requested": "[3.15.0, )",
+        "resolved": "3.15.0",
+        "contentHash": "7/40NmAVbQS+fm4y8J2Y8U7G7oFHTbI8C03HO2dig1tICdCO2EXcv9wpDM9WRfD+vKx/vfx8WwpT+/HUP4DlcQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.13.1"
+          "Speckle.Sdk": "3.15.0"
         }
       },
       "Speckle.Revit.API": {

--- a/Connectors/Rhino/Speckle.Connectors.Grasshopper7/packages.lock.json
+++ b/Connectors/Rhino/Speckle.Connectors.Grasshopper7/packages.lock.json
@@ -101,8 +101,8 @@
       },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
-        "resolved": "5.0.0",
-        "contentHash": "W8DPQjkMScOMTtJbPwmPyj9c3zYSFGawDW3jwlBOOsnY+EzZFLgNQ/UMkK35JmkNOVPdCyPr2Tw7Vv9N+KA3ZQ==",
+        "resolved": "9.0.4",
+        "contentHash": "9VGI5kxIvrNG2mqLQZnUR6y/3fcnygD8eNpHR+CqfbnIXvea6nehnYknDKQTxZVPMpzpNca+7DxLBmpdB3q0Bw==",
         "dependencies": {
           "System.Threading.Tasks.Extensions": "4.5.4"
         }
@@ -204,24 +204,26 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "qCKCPT4HeSCJ7S+wnnjF+N+9Sd6lj5+Ra9DfxDHHrFli9rtXdnQRU5UOObyfcbiWQidVXhc2n0kbo3LPCEcvNw==",
+        "resolved": "3.15.0",
+        "contentHash": "/Qc1ESqxzLulN2c8vR0rEk+SjEHRUzdzKWvcF5i1H2ipWBzxYNi+QdZ2yc7kE+he+LmW6rdALEfAGW6b0hQbig==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
-          "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
           "Microsoft.CSharp": "4.7.0",
           "Microsoft.Data.Sqlite": "7.0.5",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "2.2.0",
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.13.1"
+          "Speckle.Sdk.Dependencies": "3.15.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "McLXS+Hd/bW+AdJifxGUIQi+ftofGY5r6i/X00HmlnbOvHJKZAR6fzJ12E8otMhMd78He8tcyjBD3R2jOR9ctA=="
+        "resolved": "3.15.0",
+        "contentHash": "q7CL5P25PXoya5QhfieD4b56HgsM/6nAPsmcitHCURxj6nHrIVECpOeptbnN0T5KaA5SL6RAB5WIj7YYepkXzQ==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
+        }
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -347,7 +349,7 @@
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "speckle.connectors.logging": {
@@ -357,7 +359,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "speckle.converters.rhino7": {
@@ -402,11 +404,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.13.1, )",
-        "resolved": "3.13.1",
-        "contentHash": "VRG8SApTbAYA0YmgWTw0Eb+/AHeE0yOxDuKBTvFj3VipuSnwF29fV479BehnZdg3d8OBh4aP/YEx3vPAafybVw==",
+        "requested": "[3.15.0, )",
+        "resolved": "3.15.0",
+        "contentHash": "7/40NmAVbQS+fm4y8J2Y8U7G7oFHTbI8C03HO2dig1tICdCO2EXcv9wpDM9WRfD+vKx/vfx8WwpT+/HUP4DlcQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.13.1"
+          "Speckle.Sdk": "3.15.0"
         }
       }
     }

--- a/Connectors/Rhino/Speckle.Connectors.Grasshopper8/packages.lock.json
+++ b/Connectors/Rhino/Speckle.Connectors.Grasshopper8/packages.lock.json
@@ -101,8 +101,8 @@
       },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
-        "resolved": "5.0.0",
-        "contentHash": "W8DPQjkMScOMTtJbPwmPyj9c3zYSFGawDW3jwlBOOsnY+EzZFLgNQ/UMkK35JmkNOVPdCyPr2Tw7Vv9N+KA3ZQ==",
+        "resolved": "9.0.4",
+        "contentHash": "9VGI5kxIvrNG2mqLQZnUR6y/3fcnygD8eNpHR+CqfbnIXvea6nehnYknDKQTxZVPMpzpNca+7DxLBmpdB3q0Bw==",
         "dependencies": {
           "System.Threading.Tasks.Extensions": "4.5.4"
         }
@@ -204,24 +204,26 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "qCKCPT4HeSCJ7S+wnnjF+N+9Sd6lj5+Ra9DfxDHHrFli9rtXdnQRU5UOObyfcbiWQidVXhc2n0kbo3LPCEcvNw==",
+        "resolved": "3.15.0",
+        "contentHash": "/Qc1ESqxzLulN2c8vR0rEk+SjEHRUzdzKWvcF5i1H2ipWBzxYNi+QdZ2yc7kE+he+LmW6rdALEfAGW6b0hQbig==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
-          "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
           "Microsoft.CSharp": "4.7.0",
           "Microsoft.Data.Sqlite": "7.0.5",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "2.2.0",
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.13.1"
+          "Speckle.Sdk.Dependencies": "3.15.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "McLXS+Hd/bW+AdJifxGUIQi+ftofGY5r6i/X00HmlnbOvHJKZAR6fzJ12E8otMhMd78He8tcyjBD3R2jOR9ctA=="
+        "resolved": "3.15.0",
+        "contentHash": "q7CL5P25PXoya5QhfieD4b56HgsM/6nAPsmcitHCURxj6nHrIVECpOeptbnN0T5KaA5SL6RAB5WIj7YYepkXzQ==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
+        }
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -347,7 +349,7 @@
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "speckle.connectors.logging": {
@@ -357,7 +359,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "speckle.converters.rhino8": {
@@ -401,11 +403,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.13.1, )",
-        "resolved": "3.13.1",
-        "contentHash": "VRG8SApTbAYA0YmgWTw0Eb+/AHeE0yOxDuKBTvFj3VipuSnwF29fV479BehnZdg3d8OBh4aP/YEx3vPAafybVw==",
+        "requested": "[3.15.0, )",
+        "resolved": "3.15.0",
+        "contentHash": "7/40NmAVbQS+fm4y8J2Y8U7G7oFHTbI8C03HO2dig1tICdCO2EXcv9wpDM9WRfD+vKx/vfx8WwpT+/HUP4DlcQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.13.1"
+          "Speckle.Sdk": "3.15.0"
         }
       }
     }

--- a/Connectors/Rhino/Speckle.Connectors.Rhino7/packages.lock.json
+++ b/Connectors/Rhino/Speckle.Connectors.Rhino7/packages.lock.json
@@ -82,8 +82,8 @@
       },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
-        "resolved": "5.0.0",
-        "contentHash": "W8DPQjkMScOMTtJbPwmPyj9c3zYSFGawDW3jwlBOOsnY+EzZFLgNQ/UMkK35JmkNOVPdCyPr2Tw7Vv9N+KA3ZQ==",
+        "resolved": "9.0.4",
+        "contentHash": "9VGI5kxIvrNG2mqLQZnUR6y/3fcnygD8eNpHR+CqfbnIXvea6nehnYknDKQTxZVPMpzpNca+7DxLBmpdB3q0Bw==",
         "dependencies": {
           "System.Threading.Tasks.Extensions": "4.5.4"
         }
@@ -185,24 +185,26 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "qCKCPT4HeSCJ7S+wnnjF+N+9Sd6lj5+Ra9DfxDHHrFli9rtXdnQRU5UOObyfcbiWQidVXhc2n0kbo3LPCEcvNw==",
+        "resolved": "3.15.0",
+        "contentHash": "/Qc1ESqxzLulN2c8vR0rEk+SjEHRUzdzKWvcF5i1H2ipWBzxYNi+QdZ2yc7kE+he+LmW6rdALEfAGW6b0hQbig==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
-          "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
           "Microsoft.CSharp": "4.7.0",
           "Microsoft.Data.Sqlite": "7.0.5",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "2.2.0",
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.13.1"
+          "Speckle.Sdk.Dependencies": "3.15.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "McLXS+Hd/bW+AdJifxGUIQi+ftofGY5r6i/X00HmlnbOvHJKZAR6fzJ12E8otMhMd78He8tcyjBD3R2jOR9ctA=="
+        "resolved": "3.15.0",
+        "contentHash": "q7CL5P25PXoya5QhfieD4b56HgsM/6nAPsmcitHCURxj6nHrIVECpOeptbnN0T5KaA5SL6RAB5WIj7YYepkXzQ==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
+        }
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -328,7 +330,7 @@
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -361,7 +363,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "speckle.converters.rhino7": {
@@ -421,11 +423,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.13.1, )",
-        "resolved": "3.13.1",
-        "contentHash": "VRG8SApTbAYA0YmgWTw0Eb+/AHeE0yOxDuKBTvFj3VipuSnwF29fV479BehnZdg3d8OBh4aP/YEx3vPAafybVw==",
+        "requested": "[3.15.0, )",
+        "resolved": "3.15.0",
+        "contentHash": "7/40NmAVbQS+fm4y8J2Y8U7G7oFHTbI8C03HO2dig1tICdCO2EXcv9wpDM9WRfD+vKx/vfx8WwpT+/HUP4DlcQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.13.1"
+          "Speckle.Sdk": "3.15.0"
         }
       },
       "System.Resources.Extensions": {

--- a/Connectors/Rhino/Speckle.Connectors.Rhino8/packages.lock.json
+++ b/Connectors/Rhino/Speckle.Connectors.Rhino8/packages.lock.json
@@ -82,8 +82,8 @@
       },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
-        "resolved": "5.0.0",
-        "contentHash": "W8DPQjkMScOMTtJbPwmPyj9c3zYSFGawDW3jwlBOOsnY+EzZFLgNQ/UMkK35JmkNOVPdCyPr2Tw7Vv9N+KA3ZQ==",
+        "resolved": "9.0.4",
+        "contentHash": "9VGI5kxIvrNG2mqLQZnUR6y/3fcnygD8eNpHR+CqfbnIXvea6nehnYknDKQTxZVPMpzpNca+7DxLBmpdB3q0Bw==",
         "dependencies": {
           "System.Threading.Tasks.Extensions": "4.5.4"
         }
@@ -185,24 +185,26 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "qCKCPT4HeSCJ7S+wnnjF+N+9Sd6lj5+Ra9DfxDHHrFli9rtXdnQRU5UOObyfcbiWQidVXhc2n0kbo3LPCEcvNw==",
+        "resolved": "3.15.0",
+        "contentHash": "/Qc1ESqxzLulN2c8vR0rEk+SjEHRUzdzKWvcF5i1H2ipWBzxYNi+QdZ2yc7kE+he+LmW6rdALEfAGW6b0hQbig==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
-          "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
           "Microsoft.CSharp": "4.7.0",
           "Microsoft.Data.Sqlite": "7.0.5",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "2.2.0",
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.13.1"
+          "Speckle.Sdk.Dependencies": "3.15.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "McLXS+Hd/bW+AdJifxGUIQi+ftofGY5r6i/X00HmlnbOvHJKZAR6fzJ12E8otMhMd78He8tcyjBD3R2jOR9ctA=="
+        "resolved": "3.15.0",
+        "contentHash": "q7CL5P25PXoya5QhfieD4b56HgsM/6nAPsmcitHCURxj6nHrIVECpOeptbnN0T5KaA5SL6RAB5WIj7YYepkXzQ==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
+        }
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -328,7 +330,7 @@
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -361,7 +363,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "speckle.converters.rhino8": {
@@ -420,11 +422,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.13.1, )",
-        "resolved": "3.13.1",
-        "contentHash": "VRG8SApTbAYA0YmgWTw0Eb+/AHeE0yOxDuKBTvFj3VipuSnwF29fV479BehnZdg3d8OBh4aP/YEx3vPAafybVw==",
+        "requested": "[3.15.0, )",
+        "resolved": "3.15.0",
+        "contentHash": "7/40NmAVbQS+fm4y8J2Y8U7G7oFHTbI8C03HO2dig1tICdCO2EXcv9wpDM9WRfD+vKx/vfx8WwpT+/HUP4DlcQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.13.1"
+          "Speckle.Sdk": "3.15.0"
         }
       },
       "System.Resources.Extensions": {

--- a/Connectors/Rhino/Speckle.Connectors.RhinoImporter/packages.lock.json
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoImporter/packages.lock.json
@@ -174,8 +174,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "qCKCPT4HeSCJ7S+wnnjF+N+9Sd6lj5+Ra9DfxDHHrFli9rtXdnQRU5UOObyfcbiWQidVXhc2n0kbo3LPCEcvNw==",
+        "resolved": "3.15.0",
+        "contentHash": "/Qc1ESqxzLulN2c8vR0rEk+SjEHRUzdzKWvcF5i1H2ipWBzxYNi+QdZ2yc7kE+he+LmW6rdALEfAGW6b0hQbig==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -183,13 +183,13 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.13.1"
+          "Speckle.Sdk.Dependencies": "3.15.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "McLXS+Hd/bW+AdJifxGUIQi+ftofGY5r6i/X00HmlnbOvHJKZAR6fzJ12E8otMhMd78He8tcyjBD3R2jOR9ctA=="
+        "resolved": "3.15.0",
+        "contentHash": "q7CL5P25PXoya5QhfieD4b56HgsM/6nAPsmcitHCURxj6nHrIVECpOeptbnN0T5KaA5SL6RAB5WIj7YYepkXzQ=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -255,7 +255,7 @@
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -279,7 +279,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "speckle.converters.rhino8": {
@@ -329,11 +329,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.13.1, )",
-        "resolved": "3.13.1",
-        "contentHash": "VRG8SApTbAYA0YmgWTw0Eb+/AHeE0yOxDuKBTvFj3VipuSnwF29fV479BehnZdg3d8OBh4aP/YEx3vPAafybVw==",
+        "requested": "[3.15.0, )",
+        "resolved": "3.15.0",
+        "contentHash": "7/40NmAVbQS+fm4y8J2Y8U7G7oFHTbI8C03HO2dig1tICdCO2EXcv9wpDM9WRfD+vKx/vfx8WwpT+/HUP4DlcQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.13.1"
+          "Speckle.Sdk": "3.15.0"
         }
       }
     },

--- a/Connectors/Tekla/Speckle.Connector.Tekla2023/packages.lock.json
+++ b/Connectors/Tekla/Speckle.Connector.Tekla2023/packages.lock.json
@@ -112,8 +112,8 @@
       },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
-        "resolved": "5.0.0",
-        "contentHash": "W8DPQjkMScOMTtJbPwmPyj9c3zYSFGawDW3jwlBOOsnY+EzZFLgNQ/UMkK35JmkNOVPdCyPr2Tw7Vv9N+KA3ZQ==",
+        "resolved": "9.0.4",
+        "contentHash": "9VGI5kxIvrNG2mqLQZnUR6y/3fcnygD8eNpHR+CqfbnIXvea6nehnYknDKQTxZVPMpzpNca+7DxLBmpdB3q0Bw==",
         "dependencies": {
           "System.Threading.Tasks.Extensions": "4.5.4"
         }
@@ -210,24 +210,26 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "qCKCPT4HeSCJ7S+wnnjF+N+9Sd6lj5+Ra9DfxDHHrFli9rtXdnQRU5UOObyfcbiWQidVXhc2n0kbo3LPCEcvNw==",
+        "resolved": "3.15.0",
+        "contentHash": "/Qc1ESqxzLulN2c8vR0rEk+SjEHRUzdzKWvcF5i1H2ipWBzxYNi+QdZ2yc7kE+he+LmW6rdALEfAGW6b0hQbig==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
-          "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
           "Microsoft.CSharp": "4.7.0",
           "Microsoft.Data.Sqlite": "7.0.5",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "2.2.0",
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.13.1"
+          "Speckle.Sdk.Dependencies": "3.15.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "McLXS+Hd/bW+AdJifxGUIQi+ftofGY5r6i/X00HmlnbOvHJKZAR6fzJ12E8otMhMd78He8tcyjBD3R2jOR9ctA=="
+        "resolved": "3.15.0",
+        "contentHash": "q7CL5P25PXoya5QhfieD4b56HgsM/6nAPsmcitHCURxj6nHrIVECpOeptbnN0T5KaA5SL6RAB5WIj7YYepkXzQ==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
+        }
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -347,7 +349,7 @@
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -380,7 +382,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "LibTessDotNet": {
@@ -430,11 +432,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.13.1, )",
-        "resolved": "3.13.1",
-        "contentHash": "VRG8SApTbAYA0YmgWTw0Eb+/AHeE0yOxDuKBTvFj3VipuSnwF29fV479BehnZdg3d8OBh4aP/YEx3vPAafybVw==",
+        "requested": "[3.15.0, )",
+        "resolved": "3.15.0",
+        "contentHash": "7/40NmAVbQS+fm4y8J2Y8U7G7oFHTbI8C03HO2dig1tICdCO2EXcv9wpDM9WRfD+vKx/vfx8WwpT+/HUP4DlcQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.13.1"
+          "Speckle.Sdk": "3.15.0"
         }
       }
     }

--- a/Connectors/Tekla/Speckle.Connector.Tekla2024/packages.lock.json
+++ b/Connectors/Tekla/Speckle.Connector.Tekla2024/packages.lock.json
@@ -126,8 +126,8 @@
       },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
-        "resolved": "5.0.0",
-        "contentHash": "W8DPQjkMScOMTtJbPwmPyj9c3zYSFGawDW3jwlBOOsnY+EzZFLgNQ/UMkK35JmkNOVPdCyPr2Tw7Vv9N+KA3ZQ==",
+        "resolved": "9.0.4",
+        "contentHash": "9VGI5kxIvrNG2mqLQZnUR6y/3fcnygD8eNpHR+CqfbnIXvea6nehnYknDKQTxZVPMpzpNca+7DxLBmpdB3q0Bw==",
         "dependencies": {
           "System.Threading.Tasks.Extensions": "4.5.4"
         }
@@ -229,24 +229,26 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "qCKCPT4HeSCJ7S+wnnjF+N+9Sd6lj5+Ra9DfxDHHrFli9rtXdnQRU5UOObyfcbiWQidVXhc2n0kbo3LPCEcvNw==",
+        "resolved": "3.15.0",
+        "contentHash": "/Qc1ESqxzLulN2c8vR0rEk+SjEHRUzdzKWvcF5i1H2ipWBzxYNi+QdZ2yc7kE+he+LmW6rdALEfAGW6b0hQbig==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
-          "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
           "Microsoft.CSharp": "4.7.0",
           "Microsoft.Data.Sqlite": "7.0.5",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "2.2.0",
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.13.1"
+          "Speckle.Sdk.Dependencies": "3.15.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "McLXS+Hd/bW+AdJifxGUIQi+ftofGY5r6i/X00HmlnbOvHJKZAR6fzJ12E8otMhMd78He8tcyjBD3R2jOR9ctA=="
+        "resolved": "3.15.0",
+        "contentHash": "q7CL5P25PXoya5QhfieD4b56HgsM/6nAPsmcitHCURxj6nHrIVECpOeptbnN0T5KaA5SL6RAB5WIj7YYepkXzQ==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
+        }
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -428,7 +430,7 @@
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -461,7 +463,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "LibTessDotNet": {
@@ -511,11 +513,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.13.1, )",
-        "resolved": "3.13.1",
-        "contentHash": "VRG8SApTbAYA0YmgWTw0Eb+/AHeE0yOxDuKBTvFj3VipuSnwF29fV479BehnZdg3d8OBh4aP/YEx3vPAafybVw==",
+        "requested": "[3.15.0, )",
+        "resolved": "3.15.0",
+        "contentHash": "7/40NmAVbQS+fm4y8J2Y8U7G7oFHTbI8C03HO2dig1tICdCO2EXcv9wpDM9WRfD+vKx/vfx8WwpT+/HUP4DlcQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.13.1"
+          "Speckle.Sdk": "3.15.0"
         }
       }
     }

--- a/Connectors/Tekla/Speckle.Connector.Tekla2025/packages.lock.json
+++ b/Connectors/Tekla/Speckle.Connector.Tekla2025/packages.lock.json
@@ -126,8 +126,8 @@
       },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
-        "resolved": "5.0.0",
-        "contentHash": "W8DPQjkMScOMTtJbPwmPyj9c3zYSFGawDW3jwlBOOsnY+EzZFLgNQ/UMkK35JmkNOVPdCyPr2Tw7Vv9N+KA3ZQ==",
+        "resolved": "9.0.4",
+        "contentHash": "9VGI5kxIvrNG2mqLQZnUR6y/3fcnygD8eNpHR+CqfbnIXvea6nehnYknDKQTxZVPMpzpNca+7DxLBmpdB3q0Bw==",
         "dependencies": {
           "System.Threading.Tasks.Extensions": "4.5.4"
         }
@@ -229,24 +229,26 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "qCKCPT4HeSCJ7S+wnnjF+N+9Sd6lj5+Ra9DfxDHHrFli9rtXdnQRU5UOObyfcbiWQidVXhc2n0kbo3LPCEcvNw==",
+        "resolved": "3.15.0",
+        "contentHash": "/Qc1ESqxzLulN2c8vR0rEk+SjEHRUzdzKWvcF5i1H2ipWBzxYNi+QdZ2yc7kE+he+LmW6rdALEfAGW6b0hQbig==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
-          "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
           "Microsoft.CSharp": "4.7.0",
           "Microsoft.Data.Sqlite": "7.0.5",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "2.2.0",
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.13.1"
+          "Speckle.Sdk.Dependencies": "3.15.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "McLXS+Hd/bW+AdJifxGUIQi+ftofGY5r6i/X00HmlnbOvHJKZAR6fzJ12E8otMhMd78He8tcyjBD3R2jOR9ctA=="
+        "resolved": "3.15.0",
+        "contentHash": "q7CL5P25PXoya5QhfieD4b56HgsM/6nAPsmcitHCURxj6nHrIVECpOeptbnN0T5KaA5SL6RAB5WIj7YYepkXzQ==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
+        }
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -428,7 +430,7 @@
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -461,7 +463,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "LibTessDotNet": {
@@ -511,11 +513,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.13.1, )",
-        "resolved": "3.13.1",
-        "contentHash": "VRG8SApTbAYA0YmgWTw0Eb+/AHeE0yOxDuKBTvFj3VipuSnwF29fV479BehnZdg3d8OBh4aP/YEx3vPAafybVw==",
+        "requested": "[3.15.0, )",
+        "resolved": "3.15.0",
+        "contentHash": "7/40NmAVbQS+fm4y8J2Y8U7G7oFHTbI8C03HO2dig1tICdCO2EXcv9wpDM9WRfD+vKx/vfx8WwpT+/HUP4DlcQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.13.1"
+          "Speckle.Sdk": "3.15.0"
         }
       }
     }

--- a/Converters/Autocad/Speckle.Converters.Autocad2022/packages.lock.json
+++ b/Converters/Autocad/Speckle.Converters.Autocad2022/packages.lock.json
@@ -73,8 +73,8 @@
       },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
-        "resolved": "5.0.0",
-        "contentHash": "W8DPQjkMScOMTtJbPwmPyj9c3zYSFGawDW3jwlBOOsnY+EzZFLgNQ/UMkK35JmkNOVPdCyPr2Tw7Vv9N+KA3ZQ==",
+        "resolved": "9.0.4",
+        "contentHash": "9VGI5kxIvrNG2mqLQZnUR6y/3fcnygD8eNpHR+CqfbnIXvea6nehnYknDKQTxZVPMpzpNca+7DxLBmpdB3q0Bw==",
         "dependencies": {
           "System.Threading.Tasks.Extensions": "4.5.4"
         }
@@ -171,24 +171,26 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "qCKCPT4HeSCJ7S+wnnjF+N+9Sd6lj5+Ra9DfxDHHrFli9rtXdnQRU5UOObyfcbiWQidVXhc2n0kbo3LPCEcvNw==",
+        "resolved": "3.15.0",
+        "contentHash": "/Qc1ESqxzLulN2c8vR0rEk+SjEHRUzdzKWvcF5i1H2ipWBzxYNi+QdZ2yc7kE+he+LmW6rdALEfAGW6b0hQbig==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
-          "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
           "Microsoft.CSharp": "4.7.0",
           "Microsoft.Data.Sqlite": "7.0.5",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "2.2.0",
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.13.1"
+          "Speckle.Sdk.Dependencies": "3.15.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "McLXS+Hd/bW+AdJifxGUIQi+ftofGY5r6i/X00HmlnbOvHJKZAR6fzJ12E8otMhMd78He8tcyjBD3R2jOR9ctA=="
+        "resolved": "3.15.0",
+        "contentHash": "q7CL5P25PXoya5QhfieD4b56HgsM/6nAPsmcitHCURxj6nHrIVECpOeptbnN0T5KaA5SL6RAB5WIj7YYepkXzQ==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
+        }
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -279,7 +281,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "Microsoft.Extensions.Logging": {
@@ -308,11 +310,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.13.1, )",
-        "resolved": "3.13.1",
-        "contentHash": "VRG8SApTbAYA0YmgWTw0Eb+/AHeE0yOxDuKBTvFj3VipuSnwF29fV479BehnZdg3d8OBh4aP/YEx3vPAafybVw==",
+        "requested": "[3.15.0, )",
+        "resolved": "3.15.0",
+        "contentHash": "7/40NmAVbQS+fm4y8J2Y8U7G7oFHTbI8C03HO2dig1tICdCO2EXcv9wpDM9WRfD+vKx/vfx8WwpT+/HUP4DlcQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.13.1"
+          "Speckle.Sdk": "3.15.0"
         }
       }
     }

--- a/Converters/Autocad/Speckle.Converters.Autocad2023/packages.lock.json
+++ b/Converters/Autocad/Speckle.Converters.Autocad2023/packages.lock.json
@@ -73,8 +73,8 @@
       },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
-        "resolved": "5.0.0",
-        "contentHash": "W8DPQjkMScOMTtJbPwmPyj9c3zYSFGawDW3jwlBOOsnY+EzZFLgNQ/UMkK35JmkNOVPdCyPr2Tw7Vv9N+KA3ZQ==",
+        "resolved": "9.0.4",
+        "contentHash": "9VGI5kxIvrNG2mqLQZnUR6y/3fcnygD8eNpHR+CqfbnIXvea6nehnYknDKQTxZVPMpzpNca+7DxLBmpdB3q0Bw==",
         "dependencies": {
           "System.Threading.Tasks.Extensions": "4.5.4"
         }
@@ -171,24 +171,26 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "qCKCPT4HeSCJ7S+wnnjF+N+9Sd6lj5+Ra9DfxDHHrFli9rtXdnQRU5UOObyfcbiWQidVXhc2n0kbo3LPCEcvNw==",
+        "resolved": "3.15.0",
+        "contentHash": "/Qc1ESqxzLulN2c8vR0rEk+SjEHRUzdzKWvcF5i1H2ipWBzxYNi+QdZ2yc7kE+he+LmW6rdALEfAGW6b0hQbig==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
-          "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
           "Microsoft.CSharp": "4.7.0",
           "Microsoft.Data.Sqlite": "7.0.5",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "2.2.0",
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.13.1"
+          "Speckle.Sdk.Dependencies": "3.15.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "McLXS+Hd/bW+AdJifxGUIQi+ftofGY5r6i/X00HmlnbOvHJKZAR6fzJ12E8otMhMd78He8tcyjBD3R2jOR9ctA=="
+        "resolved": "3.15.0",
+        "contentHash": "q7CL5P25PXoya5QhfieD4b56HgsM/6nAPsmcitHCURxj6nHrIVECpOeptbnN0T5KaA5SL6RAB5WIj7YYepkXzQ==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
+        }
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -279,7 +281,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "Microsoft.Extensions.Logging": {
@@ -308,11 +310,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.13.1, )",
-        "resolved": "3.13.1",
-        "contentHash": "VRG8SApTbAYA0YmgWTw0Eb+/AHeE0yOxDuKBTvFj3VipuSnwF29fV479BehnZdg3d8OBh4aP/YEx3vPAafybVw==",
+        "requested": "[3.15.0, )",
+        "resolved": "3.15.0",
+        "contentHash": "7/40NmAVbQS+fm4y8J2Y8U7G7oFHTbI8C03HO2dig1tICdCO2EXcv9wpDM9WRfD+vKx/vfx8WwpT+/HUP4DlcQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.13.1"
+          "Speckle.Sdk": "3.15.0"
         }
       }
     }

--- a/Converters/Autocad/Speckle.Converters.Autocad2024/packages.lock.json
+++ b/Converters/Autocad/Speckle.Converters.Autocad2024/packages.lock.json
@@ -73,8 +73,8 @@
       },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
-        "resolved": "5.0.0",
-        "contentHash": "W8DPQjkMScOMTtJbPwmPyj9c3zYSFGawDW3jwlBOOsnY+EzZFLgNQ/UMkK35JmkNOVPdCyPr2Tw7Vv9N+KA3ZQ==",
+        "resolved": "9.0.4",
+        "contentHash": "9VGI5kxIvrNG2mqLQZnUR6y/3fcnygD8eNpHR+CqfbnIXvea6nehnYknDKQTxZVPMpzpNca+7DxLBmpdB3q0Bw==",
         "dependencies": {
           "System.Threading.Tasks.Extensions": "4.5.4"
         }
@@ -171,24 +171,26 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "qCKCPT4HeSCJ7S+wnnjF+N+9Sd6lj5+Ra9DfxDHHrFli9rtXdnQRU5UOObyfcbiWQidVXhc2n0kbo3LPCEcvNw==",
+        "resolved": "3.15.0",
+        "contentHash": "/Qc1ESqxzLulN2c8vR0rEk+SjEHRUzdzKWvcF5i1H2ipWBzxYNi+QdZ2yc7kE+he+LmW6rdALEfAGW6b0hQbig==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
-          "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
           "Microsoft.CSharp": "4.7.0",
           "Microsoft.Data.Sqlite": "7.0.5",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "2.2.0",
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.13.1"
+          "Speckle.Sdk.Dependencies": "3.15.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "McLXS+Hd/bW+AdJifxGUIQi+ftofGY5r6i/X00HmlnbOvHJKZAR6fzJ12E8otMhMd78He8tcyjBD3R2jOR9ctA=="
+        "resolved": "3.15.0",
+        "contentHash": "q7CL5P25PXoya5QhfieD4b56HgsM/6nAPsmcitHCURxj6nHrIVECpOeptbnN0T5KaA5SL6RAB5WIj7YYepkXzQ==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
+        }
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -281,7 +283,7 @@
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -305,7 +307,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -349,11 +351,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.13.1, )",
-        "resolved": "3.13.1",
-        "contentHash": "VRG8SApTbAYA0YmgWTw0Eb+/AHeE0yOxDuKBTvFj3VipuSnwF29fV479BehnZdg3d8OBh4aP/YEx3vPAafybVw==",
+        "requested": "[3.15.0, )",
+        "resolved": "3.15.0",
+        "contentHash": "7/40NmAVbQS+fm4y8J2Y8U7G7oFHTbI8C03HO2dig1tICdCO2EXcv9wpDM9WRfD+vKx/vfx8WwpT+/HUP4DlcQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.13.1"
+          "Speckle.Sdk": "3.15.0"
         }
       }
     }

--- a/Converters/Autocad/Speckle.Converters.Autocad2025/packages.lock.json
+++ b/Converters/Autocad/Speckle.Converters.Autocad2025/packages.lock.json
@@ -157,8 +157,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "qCKCPT4HeSCJ7S+wnnjF+N+9Sd6lj5+Ra9DfxDHHrFli9rtXdnQRU5UOObyfcbiWQidVXhc2n0kbo3LPCEcvNw==",
+        "resolved": "3.15.0",
+        "contentHash": "/Qc1ESqxzLulN2c8vR0rEk+SjEHRUzdzKWvcF5i1H2ipWBzxYNi+QdZ2yc7kE+he+LmW6rdALEfAGW6b0hQbig==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -166,13 +166,13 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.13.1"
+          "Speckle.Sdk.Dependencies": "3.15.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "McLXS+Hd/bW+AdJifxGUIQi+ftofGY5r6i/X00HmlnbOvHJKZAR6fzJ12E8otMhMd78He8tcyjBD3R2jOR9ctA=="
+        "resolved": "3.15.0",
+        "contentHash": "q7CL5P25PXoya5QhfieD4b56HgsM/6nAPsmcitHCURxj6nHrIVECpOeptbnN0T5KaA5SL6RAB5WIj7YYepkXzQ=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -230,7 +230,7 @@
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -254,7 +254,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -298,11 +298,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.13.1, )",
-        "resolved": "3.13.1",
-        "contentHash": "VRG8SApTbAYA0YmgWTw0Eb+/AHeE0yOxDuKBTvFj3VipuSnwF29fV479BehnZdg3d8OBh4aP/YEx3vPAafybVw==",
+        "requested": "[3.15.0, )",
+        "resolved": "3.15.0",
+        "contentHash": "7/40NmAVbQS+fm4y8J2Y8U7G7oFHTbI8C03HO2dig1tICdCO2EXcv9wpDM9WRfD+vKx/vfx8WwpT+/HUP4DlcQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.13.1"
+          "Speckle.Sdk": "3.15.0"
         }
       }
     }

--- a/Converters/Autocad/Speckle.Converters.Autocad2026/packages.lock.json
+++ b/Converters/Autocad/Speckle.Converters.Autocad2026/packages.lock.json
@@ -157,8 +157,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "qCKCPT4HeSCJ7S+wnnjF+N+9Sd6lj5+Ra9DfxDHHrFli9rtXdnQRU5UOObyfcbiWQidVXhc2n0kbo3LPCEcvNw==",
+        "resolved": "3.15.0",
+        "contentHash": "/Qc1ESqxzLulN2c8vR0rEk+SjEHRUzdzKWvcF5i1H2ipWBzxYNi+QdZ2yc7kE+he+LmW6rdALEfAGW6b0hQbig==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -166,13 +166,13 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.13.1"
+          "Speckle.Sdk.Dependencies": "3.15.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "McLXS+Hd/bW+AdJifxGUIQi+ftofGY5r6i/X00HmlnbOvHJKZAR6fzJ12E8otMhMd78He8tcyjBD3R2jOR9ctA=="
+        "resolved": "3.15.0",
+        "contentHash": "q7CL5P25PXoya5QhfieD4b56HgsM/6nAPsmcitHCURxj6nHrIVECpOeptbnN0T5KaA5SL6RAB5WIj7YYepkXzQ=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -230,7 +230,7 @@
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -254,7 +254,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -298,11 +298,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.13.1, )",
-        "resolved": "3.13.1",
-        "contentHash": "VRG8SApTbAYA0YmgWTw0Eb+/AHeE0yOxDuKBTvFj3VipuSnwF29fV479BehnZdg3d8OBh4aP/YEx3vPAafybVw==",
+        "requested": "[3.15.0, )",
+        "resolved": "3.15.0",
+        "contentHash": "7/40NmAVbQS+fm4y8J2Y8U7G7oFHTbI8C03HO2dig1tICdCO2EXcv9wpDM9WRfD+vKx/vfx8WwpT+/HUP4DlcQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.13.1"
+          "Speckle.Sdk": "3.15.0"
         }
       }
     }

--- a/Converters/CSi/Speckle.Converters.ETABS21/packages.lock.json
+++ b/Converters/CSi/Speckle.Converters.ETABS21/packages.lock.json
@@ -73,8 +73,8 @@
       },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
-        "resolved": "5.0.0",
-        "contentHash": "W8DPQjkMScOMTtJbPwmPyj9c3zYSFGawDW3jwlBOOsnY+EzZFLgNQ/UMkK35JmkNOVPdCyPr2Tw7Vv9N+KA3ZQ==",
+        "resolved": "9.0.4",
+        "contentHash": "9VGI5kxIvrNG2mqLQZnUR6y/3fcnygD8eNpHR+CqfbnIXvea6nehnYknDKQTxZVPMpzpNca+7DxLBmpdB3q0Bw==",
         "dependencies": {
           "System.Threading.Tasks.Extensions": "4.5.4"
         }
@@ -171,24 +171,26 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "qCKCPT4HeSCJ7S+wnnjF+N+9Sd6lj5+Ra9DfxDHHrFli9rtXdnQRU5UOObyfcbiWQidVXhc2n0kbo3LPCEcvNw==",
+        "resolved": "3.15.0",
+        "contentHash": "/Qc1ESqxzLulN2c8vR0rEk+SjEHRUzdzKWvcF5i1H2ipWBzxYNi+QdZ2yc7kE+he+LmW6rdALEfAGW6b0hQbig==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
-          "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
           "Microsoft.CSharp": "4.7.0",
           "Microsoft.Data.Sqlite": "7.0.5",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "2.2.0",
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.13.1"
+          "Speckle.Sdk.Dependencies": "3.15.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "McLXS+Hd/bW+AdJifxGUIQi+ftofGY5r6i/X00HmlnbOvHJKZAR6fzJ12E8otMhMd78He8tcyjBD3R2jOR9ctA=="
+        "resolved": "3.15.0",
+        "contentHash": "q7CL5P25PXoya5QhfieD4b56HgsM/6nAPsmcitHCURxj6nHrIVECpOeptbnN0T5KaA5SL6RAB5WIj7YYepkXzQ==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
+        }
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -279,7 +281,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "Microsoft.Extensions.Logging": {
@@ -308,11 +310,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.13.1, )",
-        "resolved": "3.13.1",
-        "contentHash": "VRG8SApTbAYA0YmgWTw0Eb+/AHeE0yOxDuKBTvFj3VipuSnwF29fV479BehnZdg3d8OBh4aP/YEx3vPAafybVw==",
+        "requested": "[3.15.0, )",
+        "resolved": "3.15.0",
+        "contentHash": "7/40NmAVbQS+fm4y8J2Y8U7G7oFHTbI8C03HO2dig1tICdCO2EXcv9wpDM9WRfD+vKx/vfx8WwpT+/HUP4DlcQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.13.1"
+          "Speckle.Sdk": "3.15.0"
         }
       }
     }

--- a/Converters/CSi/Speckle.Converters.ETABS22/packages.lock.json
+++ b/Converters/CSi/Speckle.Converters.ETABS22/packages.lock.json
@@ -157,8 +157,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "qCKCPT4HeSCJ7S+wnnjF+N+9Sd6lj5+Ra9DfxDHHrFli9rtXdnQRU5UOObyfcbiWQidVXhc2n0kbo3LPCEcvNw==",
+        "resolved": "3.15.0",
+        "contentHash": "/Qc1ESqxzLulN2c8vR0rEk+SjEHRUzdzKWvcF5i1H2ipWBzxYNi+QdZ2yc7kE+he+LmW6rdALEfAGW6b0hQbig==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -166,13 +166,13 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.13.1"
+          "Speckle.Sdk.Dependencies": "3.15.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "McLXS+Hd/bW+AdJifxGUIQi+ftofGY5r6i/X00HmlnbOvHJKZAR6fzJ12E8otMhMd78He8tcyjBD3R2jOR9ctA=="
+        "resolved": "3.15.0",
+        "contentHash": "q7CL5P25PXoya5QhfieD4b56HgsM/6nAPsmcitHCURxj6nHrIVECpOeptbnN0T5KaA5SL6RAB5WIj7YYepkXzQ=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -228,7 +228,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "Microsoft.Extensions.Logging": {
@@ -257,11 +257,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.13.1, )",
-        "resolved": "3.13.1",
-        "contentHash": "VRG8SApTbAYA0YmgWTw0Eb+/AHeE0yOxDuKBTvFj3VipuSnwF29fV479BehnZdg3d8OBh4aP/YEx3vPAafybVw==",
+        "requested": "[3.15.0, )",
+        "resolved": "3.15.0",
+        "contentHash": "7/40NmAVbQS+fm4y8J2Y8U7G7oFHTbI8C03HO2dig1tICdCO2EXcv9wpDM9WRfD+vKx/vfx8WwpT+/HUP4DlcQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.13.1"
+          "Speckle.Sdk": "3.15.0"
         }
       }
     }

--- a/Converters/Civil3d/Speckle.Converters.Civil3d2022/packages.lock.json
+++ b/Converters/Civil3d/Speckle.Converters.Civil3d2022/packages.lock.json
@@ -82,8 +82,8 @@
       },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
-        "resolved": "5.0.0",
-        "contentHash": "W8DPQjkMScOMTtJbPwmPyj9c3zYSFGawDW3jwlBOOsnY+EzZFLgNQ/UMkK35JmkNOVPdCyPr2Tw7Vv9N+KA3ZQ==",
+        "resolved": "9.0.4",
+        "contentHash": "9VGI5kxIvrNG2mqLQZnUR6y/3fcnygD8eNpHR+CqfbnIXvea6nehnYknDKQTxZVPMpzpNca+7DxLBmpdB3q0Bw==",
         "dependencies": {
           "System.Threading.Tasks.Extensions": "4.5.4"
         }
@@ -180,24 +180,26 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "qCKCPT4HeSCJ7S+wnnjF+N+9Sd6lj5+Ra9DfxDHHrFli9rtXdnQRU5UOObyfcbiWQidVXhc2n0kbo3LPCEcvNw==",
+        "resolved": "3.15.0",
+        "contentHash": "/Qc1ESqxzLulN2c8vR0rEk+SjEHRUzdzKWvcF5i1H2ipWBzxYNi+QdZ2yc7kE+he+LmW6rdALEfAGW6b0hQbig==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
-          "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
           "Microsoft.CSharp": "4.7.0",
           "Microsoft.Data.Sqlite": "7.0.5",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "2.2.0",
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.13.1"
+          "Speckle.Sdk.Dependencies": "3.15.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "McLXS+Hd/bW+AdJifxGUIQi+ftofGY5r6i/X00HmlnbOvHJKZAR6fzJ12E8otMhMd78He8tcyjBD3R2jOR9ctA=="
+        "resolved": "3.15.0",
+        "contentHash": "q7CL5P25PXoya5QhfieD4b56HgsM/6nAPsmcitHCURxj6nHrIVECpOeptbnN0T5KaA5SL6RAB5WIj7YYepkXzQ==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
+        }
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -288,7 +290,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "Microsoft.Extensions.Logging": {
@@ -317,11 +319,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.13.1, )",
-        "resolved": "3.13.1",
-        "contentHash": "VRG8SApTbAYA0YmgWTw0Eb+/AHeE0yOxDuKBTvFj3VipuSnwF29fV479BehnZdg3d8OBh4aP/YEx3vPAafybVw==",
+        "requested": "[3.15.0, )",
+        "resolved": "3.15.0",
+        "contentHash": "7/40NmAVbQS+fm4y8J2Y8U7G7oFHTbI8C03HO2dig1tICdCO2EXcv9wpDM9WRfD+vKx/vfx8WwpT+/HUP4DlcQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.13.1"
+          "Speckle.Sdk": "3.15.0"
         }
       }
     }

--- a/Converters/Civil3d/Speckle.Converters.Civil3d2023/packages.lock.json
+++ b/Converters/Civil3d/Speckle.Converters.Civil3d2023/packages.lock.json
@@ -82,8 +82,8 @@
       },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
-        "resolved": "5.0.0",
-        "contentHash": "W8DPQjkMScOMTtJbPwmPyj9c3zYSFGawDW3jwlBOOsnY+EzZFLgNQ/UMkK35JmkNOVPdCyPr2Tw7Vv9N+KA3ZQ==",
+        "resolved": "9.0.4",
+        "contentHash": "9VGI5kxIvrNG2mqLQZnUR6y/3fcnygD8eNpHR+CqfbnIXvea6nehnYknDKQTxZVPMpzpNca+7DxLBmpdB3q0Bw==",
         "dependencies": {
           "System.Threading.Tasks.Extensions": "4.5.4"
         }
@@ -180,24 +180,26 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "qCKCPT4HeSCJ7S+wnnjF+N+9Sd6lj5+Ra9DfxDHHrFli9rtXdnQRU5UOObyfcbiWQidVXhc2n0kbo3LPCEcvNw==",
+        "resolved": "3.15.0",
+        "contentHash": "/Qc1ESqxzLulN2c8vR0rEk+SjEHRUzdzKWvcF5i1H2ipWBzxYNi+QdZ2yc7kE+he+LmW6rdALEfAGW6b0hQbig==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
-          "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
           "Microsoft.CSharp": "4.7.0",
           "Microsoft.Data.Sqlite": "7.0.5",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "2.2.0",
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.13.1"
+          "Speckle.Sdk.Dependencies": "3.15.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "McLXS+Hd/bW+AdJifxGUIQi+ftofGY5r6i/X00HmlnbOvHJKZAR6fzJ12E8otMhMd78He8tcyjBD3R2jOR9ctA=="
+        "resolved": "3.15.0",
+        "contentHash": "q7CL5P25PXoya5QhfieD4b56HgsM/6nAPsmcitHCURxj6nHrIVECpOeptbnN0T5KaA5SL6RAB5WIj7YYepkXzQ==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
+        }
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -288,7 +290,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "Microsoft.Extensions.Logging": {
@@ -317,11 +319,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.13.1, )",
-        "resolved": "3.13.1",
-        "contentHash": "VRG8SApTbAYA0YmgWTw0Eb+/AHeE0yOxDuKBTvFj3VipuSnwF29fV479BehnZdg3d8OBh4aP/YEx3vPAafybVw==",
+        "requested": "[3.15.0, )",
+        "resolved": "3.15.0",
+        "contentHash": "7/40NmAVbQS+fm4y8J2Y8U7G7oFHTbI8C03HO2dig1tICdCO2EXcv9wpDM9WRfD+vKx/vfx8WwpT+/HUP4DlcQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.13.1"
+          "Speckle.Sdk": "3.15.0"
         }
       }
     }

--- a/Converters/Civil3d/Speckle.Converters.Civil3d2024/packages.lock.json
+++ b/Converters/Civil3d/Speckle.Converters.Civil3d2024/packages.lock.json
@@ -82,8 +82,8 @@
       },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
-        "resolved": "5.0.0",
-        "contentHash": "W8DPQjkMScOMTtJbPwmPyj9c3zYSFGawDW3jwlBOOsnY+EzZFLgNQ/UMkK35JmkNOVPdCyPr2Tw7Vv9N+KA3ZQ==",
+        "resolved": "9.0.4",
+        "contentHash": "9VGI5kxIvrNG2mqLQZnUR6y/3fcnygD8eNpHR+CqfbnIXvea6nehnYknDKQTxZVPMpzpNca+7DxLBmpdB3q0Bw==",
         "dependencies": {
           "System.Threading.Tasks.Extensions": "4.5.4"
         }
@@ -180,24 +180,26 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "qCKCPT4HeSCJ7S+wnnjF+N+9Sd6lj5+Ra9DfxDHHrFli9rtXdnQRU5UOObyfcbiWQidVXhc2n0kbo3LPCEcvNw==",
+        "resolved": "3.15.0",
+        "contentHash": "/Qc1ESqxzLulN2c8vR0rEk+SjEHRUzdzKWvcF5i1H2ipWBzxYNi+QdZ2yc7kE+he+LmW6rdALEfAGW6b0hQbig==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
-          "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
           "Microsoft.CSharp": "4.7.0",
           "Microsoft.Data.Sqlite": "7.0.5",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "2.2.0",
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.13.1"
+          "Speckle.Sdk.Dependencies": "3.15.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "McLXS+Hd/bW+AdJifxGUIQi+ftofGY5r6i/X00HmlnbOvHJKZAR6fzJ12E8otMhMd78He8tcyjBD3R2jOR9ctA=="
+        "resolved": "3.15.0",
+        "contentHash": "q7CL5P25PXoya5QhfieD4b56HgsM/6nAPsmcitHCURxj6nHrIVECpOeptbnN0T5KaA5SL6RAB5WIj7YYepkXzQ==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
+        }
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -288,7 +290,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "Microsoft.Extensions.Logging": {
@@ -317,11 +319,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.13.1, )",
-        "resolved": "3.13.1",
-        "contentHash": "VRG8SApTbAYA0YmgWTw0Eb+/AHeE0yOxDuKBTvFj3VipuSnwF29fV479BehnZdg3d8OBh4aP/YEx3vPAafybVw==",
+        "requested": "[3.15.0, )",
+        "resolved": "3.15.0",
+        "contentHash": "7/40NmAVbQS+fm4y8J2Y8U7G7oFHTbI8C03HO2dig1tICdCO2EXcv9wpDM9WRfD+vKx/vfx8WwpT+/HUP4DlcQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.13.1"
+          "Speckle.Sdk": "3.15.0"
         }
       }
     }

--- a/Converters/Civil3d/Speckle.Converters.Civil3d2025/packages.lock.json
+++ b/Converters/Civil3d/Speckle.Converters.Civil3d2025/packages.lock.json
@@ -166,8 +166,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "qCKCPT4HeSCJ7S+wnnjF+N+9Sd6lj5+Ra9DfxDHHrFli9rtXdnQRU5UOObyfcbiWQidVXhc2n0kbo3LPCEcvNw==",
+        "resolved": "3.15.0",
+        "contentHash": "/Qc1ESqxzLulN2c8vR0rEk+SjEHRUzdzKWvcF5i1H2ipWBzxYNi+QdZ2yc7kE+he+LmW6rdALEfAGW6b0hQbig==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -175,13 +175,13 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.13.1"
+          "Speckle.Sdk.Dependencies": "3.15.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "McLXS+Hd/bW+AdJifxGUIQi+ftofGY5r6i/X00HmlnbOvHJKZAR6fzJ12E8otMhMd78He8tcyjBD3R2jOR9ctA=="
+        "resolved": "3.15.0",
+        "contentHash": "q7CL5P25PXoya5QhfieD4b56HgsM/6nAPsmcitHCURxj6nHrIVECpOeptbnN0T5KaA5SL6RAB5WIj7YYepkXzQ=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -239,7 +239,7 @@
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -263,7 +263,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -307,11 +307,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.13.1, )",
-        "resolved": "3.13.1",
-        "contentHash": "VRG8SApTbAYA0YmgWTw0Eb+/AHeE0yOxDuKBTvFj3VipuSnwF29fV479BehnZdg3d8OBh4aP/YEx3vPAafybVw==",
+        "requested": "[3.15.0, )",
+        "resolved": "3.15.0",
+        "contentHash": "7/40NmAVbQS+fm4y8J2Y8U7G7oFHTbI8C03HO2dig1tICdCO2EXcv9wpDM9WRfD+vKx/vfx8WwpT+/HUP4DlcQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.13.1"
+          "Speckle.Sdk": "3.15.0"
         }
       }
     }

--- a/Converters/Civil3d/Speckle.Converters.Civil3d2026/packages.lock.json
+++ b/Converters/Civil3d/Speckle.Converters.Civil3d2026/packages.lock.json
@@ -166,8 +166,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "qCKCPT4HeSCJ7S+wnnjF+N+9Sd6lj5+Ra9DfxDHHrFli9rtXdnQRU5UOObyfcbiWQidVXhc2n0kbo3LPCEcvNw==",
+        "resolved": "3.15.0",
+        "contentHash": "/Qc1ESqxzLulN2c8vR0rEk+SjEHRUzdzKWvcF5i1H2ipWBzxYNi+QdZ2yc7kE+he+LmW6rdALEfAGW6b0hQbig==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -175,13 +175,13 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.13.1"
+          "Speckle.Sdk.Dependencies": "3.15.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "McLXS+Hd/bW+AdJifxGUIQi+ftofGY5r6i/X00HmlnbOvHJKZAR6fzJ12E8otMhMd78He8tcyjBD3R2jOR9ctA=="
+        "resolved": "3.15.0",
+        "contentHash": "q7CL5P25PXoya5QhfieD4b56HgsM/6nAPsmcitHCURxj6nHrIVECpOeptbnN0T5KaA5SL6RAB5WIj7YYepkXzQ=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -239,7 +239,7 @@
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -263,7 +263,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -307,11 +307,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.13.1, )",
-        "resolved": "3.13.1",
-        "contentHash": "VRG8SApTbAYA0YmgWTw0Eb+/AHeE0yOxDuKBTvFj3VipuSnwF29fV479BehnZdg3d8OBh4aP/YEx3vPAafybVw==",
+        "requested": "[3.15.0, )",
+        "resolved": "3.15.0",
+        "contentHash": "7/40NmAVbQS+fm4y8J2Y8U7G7oFHTbI8C03HO2dig1tICdCO2EXcv9wpDM9WRfD+vKx/vfx8WwpT+/HUP4DlcQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.13.1"
+          "Speckle.Sdk": "3.15.0"
         }
       }
     }

--- a/Converters/Navisworks/Speckle.Converters.Navisworks2020/packages.lock.json
+++ b/Converters/Navisworks/Speckle.Converters.Navisworks2020/packages.lock.json
@@ -73,8 +73,8 @@
       },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
-        "resolved": "5.0.0",
-        "contentHash": "W8DPQjkMScOMTtJbPwmPyj9c3zYSFGawDW3jwlBOOsnY+EzZFLgNQ/UMkK35JmkNOVPdCyPr2Tw7Vv9N+KA3ZQ==",
+        "resolved": "9.0.4",
+        "contentHash": "9VGI5kxIvrNG2mqLQZnUR6y/3fcnygD8eNpHR+CqfbnIXvea6nehnYknDKQTxZVPMpzpNca+7DxLBmpdB3q0Bw==",
         "dependencies": {
           "System.Threading.Tasks.Extensions": "4.5.4"
         }
@@ -171,24 +171,26 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "qCKCPT4HeSCJ7S+wnnjF+N+9Sd6lj5+Ra9DfxDHHrFli9rtXdnQRU5UOObyfcbiWQidVXhc2n0kbo3LPCEcvNw==",
+        "resolved": "3.15.0",
+        "contentHash": "/Qc1ESqxzLulN2c8vR0rEk+SjEHRUzdzKWvcF5i1H2ipWBzxYNi+QdZ2yc7kE+he+LmW6rdALEfAGW6b0hQbig==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
-          "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
           "Microsoft.CSharp": "4.7.0",
           "Microsoft.Data.Sqlite": "7.0.5",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "2.2.0",
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.13.1"
+          "Speckle.Sdk.Dependencies": "3.15.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "McLXS+Hd/bW+AdJifxGUIQi+ftofGY5r6i/X00HmlnbOvHJKZAR6fzJ12E8otMhMd78He8tcyjBD3R2jOR9ctA=="
+        "resolved": "3.15.0",
+        "contentHash": "q7CL5P25PXoya5QhfieD4b56HgsM/6nAPsmcitHCURxj6nHrIVECpOeptbnN0T5KaA5SL6RAB5WIj7YYepkXzQ==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
+        }
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -281,7 +283,7 @@
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -298,7 +300,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -336,11 +338,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.13.1, )",
-        "resolved": "3.13.1",
-        "contentHash": "VRG8SApTbAYA0YmgWTw0Eb+/AHeE0yOxDuKBTvFj3VipuSnwF29fV479BehnZdg3d8OBh4aP/YEx3vPAafybVw==",
+        "requested": "[3.15.0, )",
+        "resolved": "3.15.0",
+        "contentHash": "7/40NmAVbQS+fm4y8J2Y8U7G7oFHTbI8C03HO2dig1tICdCO2EXcv9wpDM9WRfD+vKx/vfx8WwpT+/HUP4DlcQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.13.1"
+          "Speckle.Sdk": "3.15.0"
         }
       }
     }

--- a/Converters/Navisworks/Speckle.Converters.Navisworks2021/packages.lock.json
+++ b/Converters/Navisworks/Speckle.Converters.Navisworks2021/packages.lock.json
@@ -73,8 +73,8 @@
       },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
-        "resolved": "5.0.0",
-        "contentHash": "W8DPQjkMScOMTtJbPwmPyj9c3zYSFGawDW3jwlBOOsnY+EzZFLgNQ/UMkK35JmkNOVPdCyPr2Tw7Vv9N+KA3ZQ==",
+        "resolved": "9.0.4",
+        "contentHash": "9VGI5kxIvrNG2mqLQZnUR6y/3fcnygD8eNpHR+CqfbnIXvea6nehnYknDKQTxZVPMpzpNca+7DxLBmpdB3q0Bw==",
         "dependencies": {
           "System.Threading.Tasks.Extensions": "4.5.4"
         }
@@ -171,24 +171,26 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "qCKCPT4HeSCJ7S+wnnjF+N+9Sd6lj5+Ra9DfxDHHrFli9rtXdnQRU5UOObyfcbiWQidVXhc2n0kbo3LPCEcvNw==",
+        "resolved": "3.15.0",
+        "contentHash": "/Qc1ESqxzLulN2c8vR0rEk+SjEHRUzdzKWvcF5i1H2ipWBzxYNi+QdZ2yc7kE+he+LmW6rdALEfAGW6b0hQbig==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
-          "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
           "Microsoft.CSharp": "4.7.0",
           "Microsoft.Data.Sqlite": "7.0.5",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "2.2.0",
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.13.1"
+          "Speckle.Sdk.Dependencies": "3.15.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "McLXS+Hd/bW+AdJifxGUIQi+ftofGY5r6i/X00HmlnbOvHJKZAR6fzJ12E8otMhMd78He8tcyjBD3R2jOR9ctA=="
+        "resolved": "3.15.0",
+        "contentHash": "q7CL5P25PXoya5QhfieD4b56HgsM/6nAPsmcitHCURxj6nHrIVECpOeptbnN0T5KaA5SL6RAB5WIj7YYepkXzQ==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
+        }
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -281,7 +283,7 @@
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -298,7 +300,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -336,11 +338,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.13.1, )",
-        "resolved": "3.13.1",
-        "contentHash": "VRG8SApTbAYA0YmgWTw0Eb+/AHeE0yOxDuKBTvFj3VipuSnwF29fV479BehnZdg3d8OBh4aP/YEx3vPAafybVw==",
+        "requested": "[3.15.0, )",
+        "resolved": "3.15.0",
+        "contentHash": "7/40NmAVbQS+fm4y8J2Y8U7G7oFHTbI8C03HO2dig1tICdCO2EXcv9wpDM9WRfD+vKx/vfx8WwpT+/HUP4DlcQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.13.1"
+          "Speckle.Sdk": "3.15.0"
         }
       }
     }

--- a/Converters/Navisworks/Speckle.Converters.Navisworks2022/packages.lock.json
+++ b/Converters/Navisworks/Speckle.Converters.Navisworks2022/packages.lock.json
@@ -73,8 +73,8 @@
       },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
-        "resolved": "5.0.0",
-        "contentHash": "W8DPQjkMScOMTtJbPwmPyj9c3zYSFGawDW3jwlBOOsnY+EzZFLgNQ/UMkK35JmkNOVPdCyPr2Tw7Vv9N+KA3ZQ==",
+        "resolved": "9.0.4",
+        "contentHash": "9VGI5kxIvrNG2mqLQZnUR6y/3fcnygD8eNpHR+CqfbnIXvea6nehnYknDKQTxZVPMpzpNca+7DxLBmpdB3q0Bw==",
         "dependencies": {
           "System.Threading.Tasks.Extensions": "4.5.4"
         }
@@ -171,24 +171,26 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "qCKCPT4HeSCJ7S+wnnjF+N+9Sd6lj5+Ra9DfxDHHrFli9rtXdnQRU5UOObyfcbiWQidVXhc2n0kbo3LPCEcvNw==",
+        "resolved": "3.15.0",
+        "contentHash": "/Qc1ESqxzLulN2c8vR0rEk+SjEHRUzdzKWvcF5i1H2ipWBzxYNi+QdZ2yc7kE+he+LmW6rdALEfAGW6b0hQbig==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
-          "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
           "Microsoft.CSharp": "4.7.0",
           "Microsoft.Data.Sqlite": "7.0.5",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "2.2.0",
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.13.1"
+          "Speckle.Sdk.Dependencies": "3.15.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "McLXS+Hd/bW+AdJifxGUIQi+ftofGY5r6i/X00HmlnbOvHJKZAR6fzJ12E8otMhMd78He8tcyjBD3R2jOR9ctA=="
+        "resolved": "3.15.0",
+        "contentHash": "q7CL5P25PXoya5QhfieD4b56HgsM/6nAPsmcitHCURxj6nHrIVECpOeptbnN0T5KaA5SL6RAB5WIj7YYepkXzQ==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
+        }
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -281,7 +283,7 @@
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -298,7 +300,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -336,11 +338,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.13.1, )",
-        "resolved": "3.13.1",
-        "contentHash": "VRG8SApTbAYA0YmgWTw0Eb+/AHeE0yOxDuKBTvFj3VipuSnwF29fV479BehnZdg3d8OBh4aP/YEx3vPAafybVw==",
+        "requested": "[3.15.0, )",
+        "resolved": "3.15.0",
+        "contentHash": "7/40NmAVbQS+fm4y8J2Y8U7G7oFHTbI8C03HO2dig1tICdCO2EXcv9wpDM9WRfD+vKx/vfx8WwpT+/HUP4DlcQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.13.1"
+          "Speckle.Sdk": "3.15.0"
         }
       }
     }

--- a/Converters/Navisworks/Speckle.Converters.Navisworks2023/packages.lock.json
+++ b/Converters/Navisworks/Speckle.Converters.Navisworks2023/packages.lock.json
@@ -73,8 +73,8 @@
       },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
-        "resolved": "5.0.0",
-        "contentHash": "W8DPQjkMScOMTtJbPwmPyj9c3zYSFGawDW3jwlBOOsnY+EzZFLgNQ/UMkK35JmkNOVPdCyPr2Tw7Vv9N+KA3ZQ==",
+        "resolved": "9.0.4",
+        "contentHash": "9VGI5kxIvrNG2mqLQZnUR6y/3fcnygD8eNpHR+CqfbnIXvea6nehnYknDKQTxZVPMpzpNca+7DxLBmpdB3q0Bw==",
         "dependencies": {
           "System.Threading.Tasks.Extensions": "4.5.4"
         }
@@ -171,24 +171,26 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "qCKCPT4HeSCJ7S+wnnjF+N+9Sd6lj5+Ra9DfxDHHrFli9rtXdnQRU5UOObyfcbiWQidVXhc2n0kbo3LPCEcvNw==",
+        "resolved": "3.15.0",
+        "contentHash": "/Qc1ESqxzLulN2c8vR0rEk+SjEHRUzdzKWvcF5i1H2ipWBzxYNi+QdZ2yc7kE+he+LmW6rdALEfAGW6b0hQbig==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
-          "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
           "Microsoft.CSharp": "4.7.0",
           "Microsoft.Data.Sqlite": "7.0.5",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "2.2.0",
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.13.1"
+          "Speckle.Sdk.Dependencies": "3.15.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "McLXS+Hd/bW+AdJifxGUIQi+ftofGY5r6i/X00HmlnbOvHJKZAR6fzJ12E8otMhMd78He8tcyjBD3R2jOR9ctA=="
+        "resolved": "3.15.0",
+        "contentHash": "q7CL5P25PXoya5QhfieD4b56HgsM/6nAPsmcitHCURxj6nHrIVECpOeptbnN0T5KaA5SL6RAB5WIj7YYepkXzQ==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
+        }
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -281,7 +283,7 @@
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -298,7 +300,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -336,11 +338,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.13.1, )",
-        "resolved": "3.13.1",
-        "contentHash": "VRG8SApTbAYA0YmgWTw0Eb+/AHeE0yOxDuKBTvFj3VipuSnwF29fV479BehnZdg3d8OBh4aP/YEx3vPAafybVw==",
+        "requested": "[3.15.0, )",
+        "resolved": "3.15.0",
+        "contentHash": "7/40NmAVbQS+fm4y8J2Y8U7G7oFHTbI8C03HO2dig1tICdCO2EXcv9wpDM9WRfD+vKx/vfx8WwpT+/HUP4DlcQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.13.1"
+          "Speckle.Sdk": "3.15.0"
         }
       }
     }

--- a/Converters/Navisworks/Speckle.Converters.Navisworks2024/packages.lock.json
+++ b/Converters/Navisworks/Speckle.Converters.Navisworks2024/packages.lock.json
@@ -73,8 +73,8 @@
       },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
-        "resolved": "5.0.0",
-        "contentHash": "W8DPQjkMScOMTtJbPwmPyj9c3zYSFGawDW3jwlBOOsnY+EzZFLgNQ/UMkK35JmkNOVPdCyPr2Tw7Vv9N+KA3ZQ==",
+        "resolved": "9.0.4",
+        "contentHash": "9VGI5kxIvrNG2mqLQZnUR6y/3fcnygD8eNpHR+CqfbnIXvea6nehnYknDKQTxZVPMpzpNca+7DxLBmpdB3q0Bw==",
         "dependencies": {
           "System.Threading.Tasks.Extensions": "4.5.4"
         }
@@ -171,24 +171,26 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "qCKCPT4HeSCJ7S+wnnjF+N+9Sd6lj5+Ra9DfxDHHrFli9rtXdnQRU5UOObyfcbiWQidVXhc2n0kbo3LPCEcvNw==",
+        "resolved": "3.15.0",
+        "contentHash": "/Qc1ESqxzLulN2c8vR0rEk+SjEHRUzdzKWvcF5i1H2ipWBzxYNi+QdZ2yc7kE+he+LmW6rdALEfAGW6b0hQbig==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
-          "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
           "Microsoft.CSharp": "4.7.0",
           "Microsoft.Data.Sqlite": "7.0.5",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "2.2.0",
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.13.1"
+          "Speckle.Sdk.Dependencies": "3.15.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "McLXS+Hd/bW+AdJifxGUIQi+ftofGY5r6i/X00HmlnbOvHJKZAR6fzJ12E8otMhMd78He8tcyjBD3R2jOR9ctA=="
+        "resolved": "3.15.0",
+        "contentHash": "q7CL5P25PXoya5QhfieD4b56HgsM/6nAPsmcitHCURxj6nHrIVECpOeptbnN0T5KaA5SL6RAB5WIj7YYepkXzQ==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
+        }
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -281,7 +283,7 @@
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -298,7 +300,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -336,11 +338,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.13.1, )",
-        "resolved": "3.13.1",
-        "contentHash": "VRG8SApTbAYA0YmgWTw0Eb+/AHeE0yOxDuKBTvFj3VipuSnwF29fV479BehnZdg3d8OBh4aP/YEx3vPAafybVw==",
+        "requested": "[3.15.0, )",
+        "resolved": "3.15.0",
+        "contentHash": "7/40NmAVbQS+fm4y8J2Y8U7G7oFHTbI8C03HO2dig1tICdCO2EXcv9wpDM9WRfD+vKx/vfx8WwpT+/HUP4DlcQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.13.1"
+          "Speckle.Sdk": "3.15.0"
         }
       }
     }

--- a/Converters/Navisworks/Speckle.Converters.Navisworks2025/packages.lock.json
+++ b/Converters/Navisworks/Speckle.Converters.Navisworks2025/packages.lock.json
@@ -73,8 +73,8 @@
       },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
-        "resolved": "5.0.0",
-        "contentHash": "W8DPQjkMScOMTtJbPwmPyj9c3zYSFGawDW3jwlBOOsnY+EzZFLgNQ/UMkK35JmkNOVPdCyPr2Tw7Vv9N+KA3ZQ==",
+        "resolved": "9.0.4",
+        "contentHash": "9VGI5kxIvrNG2mqLQZnUR6y/3fcnygD8eNpHR+CqfbnIXvea6nehnYknDKQTxZVPMpzpNca+7DxLBmpdB3q0Bw==",
         "dependencies": {
           "System.Threading.Tasks.Extensions": "4.5.4"
         }
@@ -171,24 +171,26 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "qCKCPT4HeSCJ7S+wnnjF+N+9Sd6lj5+Ra9DfxDHHrFli9rtXdnQRU5UOObyfcbiWQidVXhc2n0kbo3LPCEcvNw==",
+        "resolved": "3.15.0",
+        "contentHash": "/Qc1ESqxzLulN2c8vR0rEk+SjEHRUzdzKWvcF5i1H2ipWBzxYNi+QdZ2yc7kE+he+LmW6rdALEfAGW6b0hQbig==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
-          "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
           "Microsoft.CSharp": "4.7.0",
           "Microsoft.Data.Sqlite": "7.0.5",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "2.2.0",
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.13.1"
+          "Speckle.Sdk.Dependencies": "3.15.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "McLXS+Hd/bW+AdJifxGUIQi+ftofGY5r6i/X00HmlnbOvHJKZAR6fzJ12E8otMhMd78He8tcyjBD3R2jOR9ctA=="
+        "resolved": "3.15.0",
+        "contentHash": "q7CL5P25PXoya5QhfieD4b56HgsM/6nAPsmcitHCURxj6nHrIVECpOeptbnN0T5KaA5SL6RAB5WIj7YYepkXzQ==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
+        }
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -281,7 +283,7 @@
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -298,7 +300,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -336,11 +338,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.13.1, )",
-        "resolved": "3.13.1",
-        "contentHash": "VRG8SApTbAYA0YmgWTw0Eb+/AHeE0yOxDuKBTvFj3VipuSnwF29fV479BehnZdg3d8OBh4aP/YEx3vPAafybVw==",
+        "requested": "[3.15.0, )",
+        "resolved": "3.15.0",
+        "contentHash": "7/40NmAVbQS+fm4y8J2Y8U7G7oFHTbI8C03HO2dig1tICdCO2EXcv9wpDM9WRfD+vKx/vfx8WwpT+/HUP4DlcQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.13.1"
+          "Speckle.Sdk": "3.15.0"
         }
       }
     }

--- a/Converters/Navisworks/Speckle.Converters.Navisworks2026/packages.lock.json
+++ b/Converters/Navisworks/Speckle.Converters.Navisworks2026/packages.lock.json
@@ -82,8 +82,8 @@
       },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
-        "resolved": "5.0.0",
-        "contentHash": "W8DPQjkMScOMTtJbPwmPyj9c3zYSFGawDW3jwlBOOsnY+EzZFLgNQ/UMkK35JmkNOVPdCyPr2Tw7Vv9N+KA3ZQ==",
+        "resolved": "9.0.4",
+        "contentHash": "9VGI5kxIvrNG2mqLQZnUR6y/3fcnygD8eNpHR+CqfbnIXvea6nehnYknDKQTxZVPMpzpNca+7DxLBmpdB3q0Bw==",
         "dependencies": {
           "System.Threading.Tasks.Extensions": "4.5.4"
         }
@@ -180,24 +180,26 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "qCKCPT4HeSCJ7S+wnnjF+N+9Sd6lj5+Ra9DfxDHHrFli9rtXdnQRU5UOObyfcbiWQidVXhc2n0kbo3LPCEcvNw==",
+        "resolved": "3.15.0",
+        "contentHash": "/Qc1ESqxzLulN2c8vR0rEk+SjEHRUzdzKWvcF5i1H2ipWBzxYNi+QdZ2yc7kE+he+LmW6rdALEfAGW6b0hQbig==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
-          "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
           "Microsoft.CSharp": "4.7.0",
           "Microsoft.Data.Sqlite": "7.0.5",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "2.2.0",
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.13.1"
+          "Speckle.Sdk.Dependencies": "3.15.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "McLXS+Hd/bW+AdJifxGUIQi+ftofGY5r6i/X00HmlnbOvHJKZAR6fzJ12E8otMhMd78He8tcyjBD3R2jOR9ctA=="
+        "resolved": "3.15.0",
+        "contentHash": "q7CL5P25PXoya5QhfieD4b56HgsM/6nAPsmcitHCURxj6nHrIVECpOeptbnN0T5KaA5SL6RAB5WIj7YYepkXzQ==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
+        }
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -282,7 +284,7 @@
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -299,7 +301,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -337,11 +339,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.13.1, )",
-        "resolved": "3.13.1",
-        "contentHash": "VRG8SApTbAYA0YmgWTw0Eb+/AHeE0yOxDuKBTvFj3VipuSnwF29fV479BehnZdg3d8OBh4aP/YEx3vPAafybVw==",
+        "requested": "[3.15.0, )",
+        "resolved": "3.15.0",
+        "contentHash": "7/40NmAVbQS+fm4y8J2Y8U7G7oFHTbI8C03HO2dig1tICdCO2EXcv9wpDM9WRfD+vKx/vfx8WwpT+/HUP4DlcQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.13.1"
+          "Speckle.Sdk": "3.15.0"
         }
       }
     }

--- a/Converters/Revit/Speckle.Converters.Revit2022/packages.lock.json
+++ b/Converters/Revit/Speckle.Converters.Revit2022/packages.lock.json
@@ -73,8 +73,8 @@
       },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
-        "resolved": "5.0.0",
-        "contentHash": "W8DPQjkMScOMTtJbPwmPyj9c3zYSFGawDW3jwlBOOsnY+EzZFLgNQ/UMkK35JmkNOVPdCyPr2Tw7Vv9N+KA3ZQ==",
+        "resolved": "9.0.4",
+        "contentHash": "9VGI5kxIvrNG2mqLQZnUR6y/3fcnygD8eNpHR+CqfbnIXvea6nehnYknDKQTxZVPMpzpNca+7DxLBmpdB3q0Bw==",
         "dependencies": {
           "System.Threading.Tasks.Extensions": "4.5.4"
         }
@@ -171,24 +171,26 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "qCKCPT4HeSCJ7S+wnnjF+N+9Sd6lj5+Ra9DfxDHHrFli9rtXdnQRU5UOObyfcbiWQidVXhc2n0kbo3LPCEcvNw==",
+        "resolved": "3.15.0",
+        "contentHash": "/Qc1ESqxzLulN2c8vR0rEk+SjEHRUzdzKWvcF5i1H2ipWBzxYNi+QdZ2yc7kE+he+LmW6rdALEfAGW6b0hQbig==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
-          "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
           "Microsoft.CSharp": "4.7.0",
           "Microsoft.Data.Sqlite": "7.0.5",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "2.2.0",
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.13.1"
+          "Speckle.Sdk.Dependencies": "3.15.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "McLXS+Hd/bW+AdJifxGUIQi+ftofGY5r6i/X00HmlnbOvHJKZAR6fzJ12E8otMhMd78He8tcyjBD3R2jOR9ctA=="
+        "resolved": "3.15.0",
+        "contentHash": "q7CL5P25PXoya5QhfieD4b56HgsM/6nAPsmcitHCURxj6nHrIVECpOeptbnN0T5KaA5SL6RAB5WIj7YYepkXzQ==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
+        }
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -286,7 +288,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "LibTessDotNet": {
@@ -321,11 +323,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.13.1, )",
-        "resolved": "3.13.1",
-        "contentHash": "VRG8SApTbAYA0YmgWTw0Eb+/AHeE0yOxDuKBTvFj3VipuSnwF29fV479BehnZdg3d8OBh4aP/YEx3vPAafybVw==",
+        "requested": "[3.15.0, )",
+        "resolved": "3.15.0",
+        "contentHash": "7/40NmAVbQS+fm4y8J2Y8U7G7oFHTbI8C03HO2dig1tICdCO2EXcv9wpDM9WRfD+vKx/vfx8WwpT+/HUP4DlcQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.13.1"
+          "Speckle.Sdk": "3.15.0"
         }
       }
     }

--- a/Converters/Revit/Speckle.Converters.Revit2023/packages.lock.json
+++ b/Converters/Revit/Speckle.Converters.Revit2023/packages.lock.json
@@ -73,8 +73,8 @@
       },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
-        "resolved": "5.0.0",
-        "contentHash": "W8DPQjkMScOMTtJbPwmPyj9c3zYSFGawDW3jwlBOOsnY+EzZFLgNQ/UMkK35JmkNOVPdCyPr2Tw7Vv9N+KA3ZQ==",
+        "resolved": "9.0.4",
+        "contentHash": "9VGI5kxIvrNG2mqLQZnUR6y/3fcnygD8eNpHR+CqfbnIXvea6nehnYknDKQTxZVPMpzpNca+7DxLBmpdB3q0Bw==",
         "dependencies": {
           "System.Threading.Tasks.Extensions": "4.5.4"
         }
@@ -171,24 +171,26 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "qCKCPT4HeSCJ7S+wnnjF+N+9Sd6lj5+Ra9DfxDHHrFli9rtXdnQRU5UOObyfcbiWQidVXhc2n0kbo3LPCEcvNw==",
+        "resolved": "3.15.0",
+        "contentHash": "/Qc1ESqxzLulN2c8vR0rEk+SjEHRUzdzKWvcF5i1H2ipWBzxYNi+QdZ2yc7kE+he+LmW6rdALEfAGW6b0hQbig==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
-          "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
           "Microsoft.CSharp": "4.7.0",
           "Microsoft.Data.Sqlite": "7.0.5",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "2.2.0",
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.13.1"
+          "Speckle.Sdk.Dependencies": "3.15.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "McLXS+Hd/bW+AdJifxGUIQi+ftofGY5r6i/X00HmlnbOvHJKZAR6fzJ12E8otMhMd78He8tcyjBD3R2jOR9ctA=="
+        "resolved": "3.15.0",
+        "contentHash": "q7CL5P25PXoya5QhfieD4b56HgsM/6nAPsmcitHCURxj6nHrIVECpOeptbnN0T5KaA5SL6RAB5WIj7YYepkXzQ==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
+        }
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -286,7 +288,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "LibTessDotNet": {
@@ -321,11 +323,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.13.1, )",
-        "resolved": "3.13.1",
-        "contentHash": "VRG8SApTbAYA0YmgWTw0Eb+/AHeE0yOxDuKBTvFj3VipuSnwF29fV479BehnZdg3d8OBh4aP/YEx3vPAafybVw==",
+        "requested": "[3.15.0, )",
+        "resolved": "3.15.0",
+        "contentHash": "7/40NmAVbQS+fm4y8J2Y8U7G7oFHTbI8C03HO2dig1tICdCO2EXcv9wpDM9WRfD+vKx/vfx8WwpT+/HUP4DlcQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.13.1"
+          "Speckle.Sdk": "3.15.0"
         }
       }
     }

--- a/Converters/Revit/Speckle.Converters.Revit2024/packages.lock.json
+++ b/Converters/Revit/Speckle.Converters.Revit2024/packages.lock.json
@@ -73,8 +73,8 @@
       },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
-        "resolved": "5.0.0",
-        "contentHash": "W8DPQjkMScOMTtJbPwmPyj9c3zYSFGawDW3jwlBOOsnY+EzZFLgNQ/UMkK35JmkNOVPdCyPr2Tw7Vv9N+KA3ZQ==",
+        "resolved": "9.0.4",
+        "contentHash": "9VGI5kxIvrNG2mqLQZnUR6y/3fcnygD8eNpHR+CqfbnIXvea6nehnYknDKQTxZVPMpzpNca+7DxLBmpdB3q0Bw==",
         "dependencies": {
           "System.Threading.Tasks.Extensions": "4.5.4"
         }
@@ -171,24 +171,26 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "qCKCPT4HeSCJ7S+wnnjF+N+9Sd6lj5+Ra9DfxDHHrFli9rtXdnQRU5UOObyfcbiWQidVXhc2n0kbo3LPCEcvNw==",
+        "resolved": "3.15.0",
+        "contentHash": "/Qc1ESqxzLulN2c8vR0rEk+SjEHRUzdzKWvcF5i1H2ipWBzxYNi+QdZ2yc7kE+he+LmW6rdALEfAGW6b0hQbig==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
-          "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
           "Microsoft.CSharp": "4.7.0",
           "Microsoft.Data.Sqlite": "7.0.5",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "2.2.0",
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.13.1"
+          "Speckle.Sdk.Dependencies": "3.15.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "McLXS+Hd/bW+AdJifxGUIQi+ftofGY5r6i/X00HmlnbOvHJKZAR6fzJ12E8otMhMd78He8tcyjBD3R2jOR9ctA=="
+        "resolved": "3.15.0",
+        "contentHash": "q7CL5P25PXoya5QhfieD4b56HgsM/6nAPsmcitHCURxj6nHrIVECpOeptbnN0T5KaA5SL6RAB5WIj7YYepkXzQ==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
+        }
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -286,7 +288,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "LibTessDotNet": {
@@ -321,11 +323,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.13.1, )",
-        "resolved": "3.13.1",
-        "contentHash": "VRG8SApTbAYA0YmgWTw0Eb+/AHeE0yOxDuKBTvFj3VipuSnwF29fV479BehnZdg3d8OBh4aP/YEx3vPAafybVw==",
+        "requested": "[3.15.0, )",
+        "resolved": "3.15.0",
+        "contentHash": "7/40NmAVbQS+fm4y8J2Y8U7G7oFHTbI8C03HO2dig1tICdCO2EXcv9wpDM9WRfD+vKx/vfx8WwpT+/HUP4DlcQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.13.1"
+          "Speckle.Sdk": "3.15.0"
         }
       }
     }

--- a/Converters/Revit/Speckle.Converters.Revit2025/packages.lock.json
+++ b/Converters/Revit/Speckle.Converters.Revit2025/packages.lock.json
@@ -157,8 +157,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "qCKCPT4HeSCJ7S+wnnjF+N+9Sd6lj5+Ra9DfxDHHrFli9rtXdnQRU5UOObyfcbiWQidVXhc2n0kbo3LPCEcvNw==",
+        "resolved": "3.15.0",
+        "contentHash": "/Qc1ESqxzLulN2c8vR0rEk+SjEHRUzdzKWvcF5i1H2ipWBzxYNi+QdZ2yc7kE+he+LmW6rdALEfAGW6b0hQbig==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -166,13 +166,13 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.13.1"
+          "Speckle.Sdk.Dependencies": "3.15.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "McLXS+Hd/bW+AdJifxGUIQi+ftofGY5r6i/X00HmlnbOvHJKZAR6fzJ12E8otMhMd78He8tcyjBD3R2jOR9ctA=="
+        "resolved": "3.15.0",
+        "contentHash": "q7CL5P25PXoya5QhfieD4b56HgsM/6nAPsmcitHCURxj6nHrIVECpOeptbnN0T5KaA5SL6RAB5WIj7YYepkXzQ=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -235,7 +235,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "LibTessDotNet": {
@@ -270,11 +270,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.13.1, )",
-        "resolved": "3.13.1",
-        "contentHash": "VRG8SApTbAYA0YmgWTw0Eb+/AHeE0yOxDuKBTvFj3VipuSnwF29fV479BehnZdg3d8OBh4aP/YEx3vPAafybVw==",
+        "requested": "[3.15.0, )",
+        "resolved": "3.15.0",
+        "contentHash": "7/40NmAVbQS+fm4y8J2Y8U7G7oFHTbI8C03HO2dig1tICdCO2EXcv9wpDM9WRfD+vKx/vfx8WwpT+/HUP4DlcQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.13.1"
+          "Speckle.Sdk": "3.15.0"
         }
       }
     }

--- a/Converters/Revit/Speckle.Converters.Revit2026/packages.lock.json
+++ b/Converters/Revit/Speckle.Converters.Revit2026/packages.lock.json
@@ -157,8 +157,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "qCKCPT4HeSCJ7S+wnnjF+N+9Sd6lj5+Ra9DfxDHHrFli9rtXdnQRU5UOObyfcbiWQidVXhc2n0kbo3LPCEcvNw==",
+        "resolved": "3.15.0",
+        "contentHash": "/Qc1ESqxzLulN2c8vR0rEk+SjEHRUzdzKWvcF5i1H2ipWBzxYNi+QdZ2yc7kE+he+LmW6rdALEfAGW6b0hQbig==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -166,13 +166,13 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.13.1"
+          "Speckle.Sdk.Dependencies": "3.15.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "McLXS+Hd/bW+AdJifxGUIQi+ftofGY5r6i/X00HmlnbOvHJKZAR6fzJ12E8otMhMd78He8tcyjBD3R2jOR9ctA=="
+        "resolved": "3.15.0",
+        "contentHash": "q7CL5P25PXoya5QhfieD4b56HgsM/6nAPsmcitHCURxj6nHrIVECpOeptbnN0T5KaA5SL6RAB5WIj7YYepkXzQ=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -235,7 +235,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "LibTessDotNet": {
@@ -270,11 +270,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.13.1, )",
-        "resolved": "3.13.1",
-        "contentHash": "VRG8SApTbAYA0YmgWTw0Eb+/AHeE0yOxDuKBTvFj3VipuSnwF29fV479BehnZdg3d8OBh4aP/YEx3vPAafybVw==",
+        "requested": "[3.15.0, )",
+        "resolved": "3.15.0",
+        "contentHash": "7/40NmAVbQS+fm4y8J2Y8U7G7oFHTbI8C03HO2dig1tICdCO2EXcv9wpDM9WRfD+vKx/vfx8WwpT+/HUP4DlcQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.13.1"
+          "Speckle.Sdk": "3.15.0"
         }
       }
     }

--- a/Converters/Rhino/Speckle.Converters.Rhino7/packages.lock.json
+++ b/Converters/Rhino/Speckle.Converters.Rhino7/packages.lock.json
@@ -73,8 +73,8 @@
       },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
-        "resolved": "5.0.0",
-        "contentHash": "W8DPQjkMScOMTtJbPwmPyj9c3zYSFGawDW3jwlBOOsnY+EzZFLgNQ/UMkK35JmkNOVPdCyPr2Tw7Vv9N+KA3ZQ==",
+        "resolved": "9.0.4",
+        "contentHash": "9VGI5kxIvrNG2mqLQZnUR6y/3fcnygD8eNpHR+CqfbnIXvea6nehnYknDKQTxZVPMpzpNca+7DxLBmpdB3q0Bw==",
         "dependencies": {
           "System.Threading.Tasks.Extensions": "4.5.4"
         }
@@ -171,24 +171,26 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "qCKCPT4HeSCJ7S+wnnjF+N+9Sd6lj5+Ra9DfxDHHrFli9rtXdnQRU5UOObyfcbiWQidVXhc2n0kbo3LPCEcvNw==",
+        "resolved": "3.15.0",
+        "contentHash": "/Qc1ESqxzLulN2c8vR0rEk+SjEHRUzdzKWvcF5i1H2ipWBzxYNi+QdZ2yc7kE+he+LmW6rdALEfAGW6b0hQbig==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
-          "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
           "Microsoft.CSharp": "4.7.0",
           "Microsoft.Data.Sqlite": "7.0.5",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "2.2.0",
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.13.1"
+          "Speckle.Sdk.Dependencies": "3.15.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "McLXS+Hd/bW+AdJifxGUIQi+ftofGY5r6i/X00HmlnbOvHJKZAR6fzJ12E8otMhMd78He8tcyjBD3R2jOR9ctA=="
+        "resolved": "3.15.0",
+        "contentHash": "q7CL5P25PXoya5QhfieD4b56HgsM/6nAPsmcitHCURxj6nHrIVECpOeptbnN0T5KaA5SL6RAB5WIj7YYepkXzQ==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
+        }
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -279,7 +281,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "Microsoft.Extensions.Logging": {
@@ -308,11 +310,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.13.1, )",
-        "resolved": "3.13.1",
-        "contentHash": "VRG8SApTbAYA0YmgWTw0Eb+/AHeE0yOxDuKBTvFj3VipuSnwF29fV479BehnZdg3d8OBh4aP/YEx3vPAafybVw==",
+        "requested": "[3.15.0, )",
+        "resolved": "3.15.0",
+        "contentHash": "7/40NmAVbQS+fm4y8J2Y8U7G7oFHTbI8C03HO2dig1tICdCO2EXcv9wpDM9WRfD+vKx/vfx8WwpT+/HUP4DlcQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.13.1"
+          "Speckle.Sdk": "3.15.0"
         }
       }
     }

--- a/Converters/Rhino/Speckle.Converters.Rhino8/packages.lock.json
+++ b/Converters/Rhino/Speckle.Converters.Rhino8/packages.lock.json
@@ -73,8 +73,8 @@
       },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
-        "resolved": "5.0.0",
-        "contentHash": "W8DPQjkMScOMTtJbPwmPyj9c3zYSFGawDW3jwlBOOsnY+EzZFLgNQ/UMkK35JmkNOVPdCyPr2Tw7Vv9N+KA3ZQ==",
+        "resolved": "9.0.4",
+        "contentHash": "9VGI5kxIvrNG2mqLQZnUR6y/3fcnygD8eNpHR+CqfbnIXvea6nehnYknDKQTxZVPMpzpNca+7DxLBmpdB3q0Bw==",
         "dependencies": {
           "System.Threading.Tasks.Extensions": "4.5.4"
         }
@@ -171,24 +171,26 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "qCKCPT4HeSCJ7S+wnnjF+N+9Sd6lj5+Ra9DfxDHHrFli9rtXdnQRU5UOObyfcbiWQidVXhc2n0kbo3LPCEcvNw==",
+        "resolved": "3.15.0",
+        "contentHash": "/Qc1ESqxzLulN2c8vR0rEk+SjEHRUzdzKWvcF5i1H2ipWBzxYNi+QdZ2yc7kE+he+LmW6rdALEfAGW6b0hQbig==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
-          "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
           "Microsoft.CSharp": "4.7.0",
           "Microsoft.Data.Sqlite": "7.0.5",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "2.2.0",
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.13.1"
+          "Speckle.Sdk.Dependencies": "3.15.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "McLXS+Hd/bW+AdJifxGUIQi+ftofGY5r6i/X00HmlnbOvHJKZAR6fzJ12E8otMhMd78He8tcyjBD3R2jOR9ctA=="
+        "resolved": "3.15.0",
+        "contentHash": "q7CL5P25PXoya5QhfieD4b56HgsM/6nAPsmcitHCURxj6nHrIVECpOeptbnN0T5KaA5SL6RAB5WIj7YYepkXzQ==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
+        }
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -279,7 +281,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "Microsoft.Extensions.Logging": {
@@ -308,11 +310,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.13.1, )",
-        "resolved": "3.13.1",
-        "contentHash": "VRG8SApTbAYA0YmgWTw0Eb+/AHeE0yOxDuKBTvFj3VipuSnwF29fV479BehnZdg3d8OBh4aP/YEx3vPAafybVw==",
+        "requested": "[3.15.0, )",
+        "resolved": "3.15.0",
+        "contentHash": "7/40NmAVbQS+fm4y8J2Y8U7G7oFHTbI8C03HO2dig1tICdCO2EXcv9wpDM9WRfD+vKx/vfx8WwpT+/HUP4DlcQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.13.1"
+          "Speckle.Sdk": "3.15.0"
         }
       }
     },
@@ -480,8 +482,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "qCKCPT4HeSCJ7S+wnnjF+N+9Sd6lj5+Ra9DfxDHHrFli9rtXdnQRU5UOObyfcbiWQidVXhc2n0kbo3LPCEcvNw==",
+        "resolved": "3.15.0",
+        "contentHash": "/Qc1ESqxzLulN2c8vR0rEk+SjEHRUzdzKWvcF5i1H2ipWBzxYNi+QdZ2yc7kE+he+LmW6rdALEfAGW6b0hQbig==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -489,13 +491,13 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.13.1"
+          "Speckle.Sdk.Dependencies": "3.15.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "McLXS+Hd/bW+AdJifxGUIQi+ftofGY5r6i/X00HmlnbOvHJKZAR6fzJ12E8otMhMd78He8tcyjBD3R2jOR9ctA=="
+        "resolved": "3.15.0",
+        "contentHash": "q7CL5P25PXoya5QhfieD4b56HgsM/6nAPsmcitHCURxj6nHrIVECpOeptbnN0T5KaA5SL6RAB5WIj7YYepkXzQ=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -559,7 +561,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "Microsoft.Extensions.Logging": {
@@ -588,11 +590,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.13.1, )",
-        "resolved": "3.13.1",
-        "contentHash": "VRG8SApTbAYA0YmgWTw0Eb+/AHeE0yOxDuKBTvFj3VipuSnwF29fV479BehnZdg3d8OBh4aP/YEx3vPAafybVw==",
+        "requested": "[3.15.0, )",
+        "resolved": "3.15.0",
+        "contentHash": "7/40NmAVbQS+fm4y8J2Y8U7G7oFHTbI8C03HO2dig1tICdCO2EXcv9wpDM9WRfD+vKx/vfx8WwpT+/HUP4DlcQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.13.1"
+          "Speckle.Sdk": "3.15.0"
         }
       }
     }

--- a/Converters/Tekla/Speckle.Converter.Tekla2023/packages.lock.json
+++ b/Converters/Tekla/Speckle.Converter.Tekla2023/packages.lock.json
@@ -90,8 +90,8 @@
       },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
-        "resolved": "5.0.0",
-        "contentHash": "W8DPQjkMScOMTtJbPwmPyj9c3zYSFGawDW3jwlBOOsnY+EzZFLgNQ/UMkK35JmkNOVPdCyPr2Tw7Vv9N+KA3ZQ==",
+        "resolved": "9.0.4",
+        "contentHash": "9VGI5kxIvrNG2mqLQZnUR6y/3fcnygD8eNpHR+CqfbnIXvea6nehnYknDKQTxZVPMpzpNca+7DxLBmpdB3q0Bw==",
         "dependencies": {
           "System.Threading.Tasks.Extensions": "4.5.4"
         }
@@ -188,24 +188,26 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "qCKCPT4HeSCJ7S+wnnjF+N+9Sd6lj5+Ra9DfxDHHrFli9rtXdnQRU5UOObyfcbiWQidVXhc2n0kbo3LPCEcvNw==",
+        "resolved": "3.15.0",
+        "contentHash": "/Qc1ESqxzLulN2c8vR0rEk+SjEHRUzdzKWvcF5i1H2ipWBzxYNi+QdZ2yc7kE+he+LmW6rdALEfAGW6b0hQbig==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
-          "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
           "Microsoft.CSharp": "4.7.0",
           "Microsoft.Data.Sqlite": "7.0.5",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "2.2.0",
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.13.1"
+          "Speckle.Sdk.Dependencies": "3.15.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "McLXS+Hd/bW+AdJifxGUIQi+ftofGY5r6i/X00HmlnbOvHJKZAR6fzJ12E8otMhMd78He8tcyjBD3R2jOR9ctA=="
+        "resolved": "3.15.0",
+        "contentHash": "q7CL5P25PXoya5QhfieD4b56HgsM/6nAPsmcitHCURxj6nHrIVECpOeptbnN0T5KaA5SL6RAB5WIj7YYepkXzQ==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
+        }
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -323,7 +325,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "LibTessDotNet": {
@@ -358,11 +360,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.13.1, )",
-        "resolved": "3.13.1",
-        "contentHash": "VRG8SApTbAYA0YmgWTw0Eb+/AHeE0yOxDuKBTvFj3VipuSnwF29fV479BehnZdg3d8OBh4aP/YEx3vPAafybVw==",
+        "requested": "[3.15.0, )",
+        "resolved": "3.15.0",
+        "contentHash": "7/40NmAVbQS+fm4y8J2Y8U7G7oFHTbI8C03HO2dig1tICdCO2EXcv9wpDM9WRfD+vKx/vfx8WwpT+/HUP4DlcQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.13.1"
+          "Speckle.Sdk": "3.15.0"
         }
       },
       "Tekla.Structures.Dialog": {

--- a/Converters/Tekla/Speckle.Converter.Tekla2024/packages.lock.json
+++ b/Converters/Tekla/Speckle.Converter.Tekla2024/packages.lock.json
@@ -95,8 +95,8 @@
       },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
-        "resolved": "5.0.0",
-        "contentHash": "W8DPQjkMScOMTtJbPwmPyj9c3zYSFGawDW3jwlBOOsnY+EzZFLgNQ/UMkK35JmkNOVPdCyPr2Tw7Vv9N+KA3ZQ==",
+        "resolved": "9.0.4",
+        "contentHash": "9VGI5kxIvrNG2mqLQZnUR6y/3fcnygD8eNpHR+CqfbnIXvea6nehnYknDKQTxZVPMpzpNca+7DxLBmpdB3q0Bw==",
         "dependencies": {
           "System.Threading.Tasks.Extensions": "4.5.4"
         }
@@ -198,24 +198,26 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "qCKCPT4HeSCJ7S+wnnjF+N+9Sd6lj5+Ra9DfxDHHrFli9rtXdnQRU5UOObyfcbiWQidVXhc2n0kbo3LPCEcvNw==",
+        "resolved": "3.15.0",
+        "contentHash": "/Qc1ESqxzLulN2c8vR0rEk+SjEHRUzdzKWvcF5i1H2ipWBzxYNi+QdZ2yc7kE+he+LmW6rdALEfAGW6b0hQbig==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
-          "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
           "Microsoft.CSharp": "4.7.0",
           "Microsoft.Data.Sqlite": "7.0.5",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "2.2.0",
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.13.1"
+          "Speckle.Sdk.Dependencies": "3.15.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "McLXS+Hd/bW+AdJifxGUIQi+ftofGY5r6i/X00HmlnbOvHJKZAR6fzJ12E8otMhMd78He8tcyjBD3R2jOR9ctA=="
+        "resolved": "3.15.0",
+        "contentHash": "q7CL5P25PXoya5QhfieD4b56HgsM/6nAPsmcitHCURxj6nHrIVECpOeptbnN0T5KaA5SL6RAB5WIj7YYepkXzQ==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
+        }
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -364,7 +366,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "LibTessDotNet": {
@@ -399,11 +401,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.13.1, )",
-        "resolved": "3.13.1",
-        "contentHash": "VRG8SApTbAYA0YmgWTw0Eb+/AHeE0yOxDuKBTvFj3VipuSnwF29fV479BehnZdg3d8OBh4aP/YEx3vPAafybVw==",
+        "requested": "[3.15.0, )",
+        "resolved": "3.15.0",
+        "contentHash": "7/40NmAVbQS+fm4y8J2Y8U7G7oFHTbI8C03HO2dig1tICdCO2EXcv9wpDM9WRfD+vKx/vfx8WwpT+/HUP4DlcQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.13.1"
+          "Speckle.Sdk": "3.15.0"
         }
       },
       "Tekla.Structures.Plugins": {

--- a/Converters/Tekla/Speckle.Converter.Tekla2025/packages.lock.json
+++ b/Converters/Tekla/Speckle.Converter.Tekla2025/packages.lock.json
@@ -95,8 +95,8 @@
       },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
-        "resolved": "5.0.0",
-        "contentHash": "W8DPQjkMScOMTtJbPwmPyj9c3zYSFGawDW3jwlBOOsnY+EzZFLgNQ/UMkK35JmkNOVPdCyPr2Tw7Vv9N+KA3ZQ==",
+        "resolved": "9.0.4",
+        "contentHash": "9VGI5kxIvrNG2mqLQZnUR6y/3fcnygD8eNpHR+CqfbnIXvea6nehnYknDKQTxZVPMpzpNca+7DxLBmpdB3q0Bw==",
         "dependencies": {
           "System.Threading.Tasks.Extensions": "4.5.4"
         }
@@ -198,24 +198,26 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "qCKCPT4HeSCJ7S+wnnjF+N+9Sd6lj5+Ra9DfxDHHrFli9rtXdnQRU5UOObyfcbiWQidVXhc2n0kbo3LPCEcvNw==",
+        "resolved": "3.15.0",
+        "contentHash": "/Qc1ESqxzLulN2c8vR0rEk+SjEHRUzdzKWvcF5i1H2ipWBzxYNi+QdZ2yc7kE+he+LmW6rdALEfAGW6b0hQbig==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
-          "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
           "Microsoft.CSharp": "4.7.0",
           "Microsoft.Data.Sqlite": "7.0.5",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "2.2.0",
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.13.1"
+          "Speckle.Sdk.Dependencies": "3.15.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "McLXS+Hd/bW+AdJifxGUIQi+ftofGY5r6i/X00HmlnbOvHJKZAR6fzJ12E8otMhMd78He8tcyjBD3R2jOR9ctA=="
+        "resolved": "3.15.0",
+        "contentHash": "q7CL5P25PXoya5QhfieD4b56HgsM/6nAPsmcitHCURxj6nHrIVECpOeptbnN0T5KaA5SL6RAB5WIj7YYepkXzQ==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
+        }
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -364,7 +366,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "LibTessDotNet": {
@@ -399,11 +401,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.13.1, )",
-        "resolved": "3.13.1",
-        "contentHash": "VRG8SApTbAYA0YmgWTw0Eb+/AHeE0yOxDuKBTvFj3VipuSnwF29fV479BehnZdg3d8OBh4aP/YEx3vPAafybVw==",
+        "requested": "[3.15.0, )",
+        "resolved": "3.15.0",
+        "contentHash": "7/40NmAVbQS+fm4y8J2Y8U7G7oFHTbI8C03HO2dig1tICdCO2EXcv9wpDM9WRfD+vKx/vfx8WwpT+/HUP4DlcQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.13.1"
+          "Speckle.Sdk": "3.15.0"
         }
       },
       "Tekla.Structures.Plugins": {

--- a/DUI3/Speckle.Connectors.DUI.Tests/packages.lock.json
+++ b/DUI3/Speckle.Connectors.DUI.Tests/packages.lock.json
@@ -238,8 +238,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "qCKCPT4HeSCJ7S+wnnjF+N+9Sd6lj5+Ra9DfxDHHrFli9rtXdnQRU5UOObyfcbiWQidVXhc2n0kbo3LPCEcvNw==",
+        "resolved": "3.15.0",
+        "contentHash": "/Qc1ESqxzLulN2c8vR0rEk+SjEHRUzdzKWvcF5i1H2ipWBzxYNi+QdZ2yc7kE+he+LmW6rdALEfAGW6b0hQbig==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -247,13 +247,13 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.13.1"
+          "Speckle.Sdk.Dependencies": "3.15.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "McLXS+Hd/bW+AdJifxGUIQi+ftofGY5r6i/X00HmlnbOvHJKZAR6fzJ12E8otMhMd78He8tcyjBD3R2jOR9ctA=="
+        "resolved": "3.15.0",
+        "contentHash": "q7CL5P25PXoya5QhfieD4b56HgsM/6nAPsmcitHCURxj6nHrIVECpOeptbnN0T5KaA5SL6RAB5WIj7YYepkXzQ=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -334,7 +334,7 @@
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -351,7 +351,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "speckle.testing": {
@@ -360,7 +360,7 @@
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Moq": "[4.20.70, )",
           "NUnit": "[4.1.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -398,11 +398,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.13.1, )",
-        "resolved": "3.13.1",
-        "contentHash": "VRG8SApTbAYA0YmgWTw0Eb+/AHeE0yOxDuKBTvFj3VipuSnwF29fV479BehnZdg3d8OBh4aP/YEx3vPAafybVw==",
+        "requested": "[3.15.0, )",
+        "resolved": "3.15.0",
+        "contentHash": "7/40NmAVbQS+fm4y8J2Y8U7G7oFHTbI8C03HO2dig1tICdCO2EXcv9wpDM9WRfD+vKx/vfx8WwpT+/HUP4DlcQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.13.1"
+          "Speckle.Sdk": "3.15.0"
         }
       }
     }

--- a/DUI3/Speckle.Connectors.DUI.WebView/packages.lock.json
+++ b/DUI3/Speckle.Connectors.DUI.WebView/packages.lock.json
@@ -73,8 +73,8 @@
       },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
-        "resolved": "5.0.0",
-        "contentHash": "W8DPQjkMScOMTtJbPwmPyj9c3zYSFGawDW3jwlBOOsnY+EzZFLgNQ/UMkK35JmkNOVPdCyPr2Tw7Vv9N+KA3ZQ==",
+        "resolved": "9.0.4",
+        "contentHash": "9VGI5kxIvrNG2mqLQZnUR6y/3fcnygD8eNpHR+CqfbnIXvea6nehnYknDKQTxZVPMpzpNca+7DxLBmpdB3q0Bw==",
         "dependencies": {
           "System.Threading.Tasks.Extensions": "4.5.4"
         }
@@ -171,24 +171,26 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "qCKCPT4HeSCJ7S+wnnjF+N+9Sd6lj5+Ra9DfxDHHrFli9rtXdnQRU5UOObyfcbiWQidVXhc2n0kbo3LPCEcvNw==",
+        "resolved": "3.15.0",
+        "contentHash": "/Qc1ESqxzLulN2c8vR0rEk+SjEHRUzdzKWvcF5i1H2ipWBzxYNi+QdZ2yc7kE+he+LmW6rdALEfAGW6b0hQbig==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
-          "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
           "Microsoft.CSharp": "4.7.0",
           "Microsoft.Data.Sqlite": "7.0.5",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "2.2.0",
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.13.1"
+          "Speckle.Sdk.Dependencies": "3.15.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "McLXS+Hd/bW+AdJifxGUIQi+ftofGY5r6i/X00HmlnbOvHJKZAR6fzJ12E8otMhMd78He8tcyjBD3R2jOR9ctA=="
+        "resolved": "3.15.0",
+        "contentHash": "q7CL5P25PXoya5QhfieD4b56HgsM/6nAPsmcitHCURxj6nHrIVECpOeptbnN0T5KaA5SL6RAB5WIj7YYepkXzQ==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
+        }
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -281,7 +283,7 @@
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -298,7 +300,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -336,11 +338,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.13.1, )",
-        "resolved": "3.13.1",
-        "contentHash": "VRG8SApTbAYA0YmgWTw0Eb+/AHeE0yOxDuKBTvFj3VipuSnwF29fV479BehnZdg3d8OBh4aP/YEx3vPAafybVw==",
+        "requested": "[3.15.0, )",
+        "resolved": "3.15.0",
+        "contentHash": "7/40NmAVbQS+fm4y8J2Y8U7G7oFHTbI8C03HO2dig1tICdCO2EXcv9wpDM9WRfD+vKx/vfx8WwpT+/HUP4DlcQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.13.1"
+          "Speckle.Sdk": "3.15.0"
         }
       }
     },
@@ -500,8 +502,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "qCKCPT4HeSCJ7S+wnnjF+N+9Sd6lj5+Ra9DfxDHHrFli9rtXdnQRU5UOObyfcbiWQidVXhc2n0kbo3LPCEcvNw==",
+        "resolved": "3.15.0",
+        "contentHash": "/Qc1ESqxzLulN2c8vR0rEk+SjEHRUzdzKWvcF5i1H2ipWBzxYNi+QdZ2yc7kE+he+LmW6rdALEfAGW6b0hQbig==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -509,13 +511,13 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.13.1"
+          "Speckle.Sdk.Dependencies": "3.15.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "McLXS+Hd/bW+AdJifxGUIQi+ftofGY5r6i/X00HmlnbOvHJKZAR6fzJ12E8otMhMd78He8tcyjBD3R2jOR9ctA=="
+        "resolved": "3.15.0",
+        "contentHash": "q7CL5P25PXoya5QhfieD4b56HgsM/6nAPsmcitHCURxj6nHrIVECpOeptbnN0T5KaA5SL6RAB5WIj7YYepkXzQ=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -573,7 +575,7 @@
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -590,7 +592,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -628,11 +630,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.13.1, )",
-        "resolved": "3.13.1",
-        "contentHash": "VRG8SApTbAYA0YmgWTw0Eb+/AHeE0yOxDuKBTvFj3VipuSnwF29fV479BehnZdg3d8OBh4aP/YEx3vPAafybVw==",
+        "requested": "[3.15.0, )",
+        "resolved": "3.15.0",
+        "contentHash": "7/40NmAVbQS+fm4y8J2Y8U7G7oFHTbI8C03HO2dig1tICdCO2EXcv9wpDM9WRfD+vKx/vfx8WwpT+/HUP4DlcQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.13.1"
+          "Speckle.Sdk": "3.15.0"
         }
       }
     }

--- a/DUI3/Speckle.Connectors.DUI/packages.lock.json
+++ b/DUI3/Speckle.Connectors.DUI/packages.lock.json
@@ -73,8 +73,8 @@
       },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
-        "resolved": "5.0.0",
-        "contentHash": "W8DPQjkMScOMTtJbPwmPyj9c3zYSFGawDW3jwlBOOsnY+EzZFLgNQ/UMkK35JmkNOVPdCyPr2Tw7Vv9N+KA3ZQ==",
+        "resolved": "9.0.4",
+        "contentHash": "9VGI5kxIvrNG2mqLQZnUR6y/3fcnygD8eNpHR+CqfbnIXvea6nehnYknDKQTxZVPMpzpNca+7DxLBmpdB3q0Bw==",
         "dependencies": {
           "System.Threading.Tasks.Extensions": "4.5.4"
         }
@@ -171,24 +171,26 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "qCKCPT4HeSCJ7S+wnnjF+N+9Sd6lj5+Ra9DfxDHHrFli9rtXdnQRU5UOObyfcbiWQidVXhc2n0kbo3LPCEcvNw==",
+        "resolved": "3.15.0",
+        "contentHash": "/Qc1ESqxzLulN2c8vR0rEk+SjEHRUzdzKWvcF5i1H2ipWBzxYNi+QdZ2yc7kE+he+LmW6rdALEfAGW6b0hQbig==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
-          "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
           "Microsoft.CSharp": "4.7.0",
           "Microsoft.Data.Sqlite": "7.0.5",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "2.2.0",
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.13.1"
+          "Speckle.Sdk.Dependencies": "3.15.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "McLXS+Hd/bW+AdJifxGUIQi+ftofGY5r6i/X00HmlnbOvHJKZAR6fzJ12E8otMhMd78He8tcyjBD3R2jOR9ctA=="
+        "resolved": "3.15.0",
+        "contentHash": "q7CL5P25PXoya5QhfieD4b56HgsM/6nAPsmcitHCURxj6nHrIVECpOeptbnN0T5KaA5SL6RAB5WIj7YYepkXzQ==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
+        }
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -281,7 +283,7 @@
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "speckle.connectors.logging": {
@@ -291,7 +293,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -323,11 +325,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.13.1, )",
-        "resolved": "3.13.1",
-        "contentHash": "VRG8SApTbAYA0YmgWTw0Eb+/AHeE0yOxDuKBTvFj3VipuSnwF29fV479BehnZdg3d8OBh4aP/YEx3vPAafybVw==",
+        "requested": "[3.15.0, )",
+        "resolved": "3.15.0",
+        "contentHash": "7/40NmAVbQS+fm4y8J2Y8U7G7oFHTbI8C03HO2dig1tICdCO2EXcv9wpDM9WRfD+vKx/vfx8WwpT+/HUP4DlcQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.13.1"
+          "Speckle.Sdk": "3.15.0"
         }
       }
     },
@@ -487,8 +489,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "qCKCPT4HeSCJ7S+wnnjF+N+9Sd6lj5+Ra9DfxDHHrFli9rtXdnQRU5UOObyfcbiWQidVXhc2n0kbo3LPCEcvNw==",
+        "resolved": "3.15.0",
+        "contentHash": "/Qc1ESqxzLulN2c8vR0rEk+SjEHRUzdzKWvcF5i1H2ipWBzxYNi+QdZ2yc7kE+he+LmW6rdALEfAGW6b0hQbig==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -496,13 +498,13 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.13.1"
+          "Speckle.Sdk.Dependencies": "3.15.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "McLXS+Hd/bW+AdJifxGUIQi+ftofGY5r6i/X00HmlnbOvHJKZAR6fzJ12E8otMhMd78He8tcyjBD3R2jOR9ctA=="
+        "resolved": "3.15.0",
+        "contentHash": "q7CL5P25PXoya5QhfieD4b56HgsM/6nAPsmcitHCURxj6nHrIVECpOeptbnN0T5KaA5SL6RAB5WIj7YYepkXzQ=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -560,7 +562,7 @@
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "speckle.connectors.logging": {
@@ -570,7 +572,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -602,11 +604,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.13.1, )",
-        "resolved": "3.13.1",
-        "contentHash": "VRG8SApTbAYA0YmgWTw0Eb+/AHeE0yOxDuKBTvFj3VipuSnwF29fV479BehnZdg3d8OBh4aP/YEx3vPAafybVw==",
+        "requested": "[3.15.0, )",
+        "resolved": "3.15.0",
+        "contentHash": "7/40NmAVbQS+fm4y8J2Y8U7G7oFHTbI8C03HO2dig1tICdCO2EXcv9wpDM9WRfD+vKx/vfx8WwpT+/HUP4DlcQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.13.1"
+          "Speckle.Sdk": "3.15.0"
         }
       }
     }

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -54,7 +54,7 @@
     <PackageVersion Include="Speckle.Civil3D.API" Version="2022.0.2" />
     <PackageVersion Include="Speckle.Revit.API" Version="2023.0.0" />
     <PackageVersion Include="Speckle.Navisworks.API" Version="2024.0.0" />
-    <PackageVersion Include="Speckle.Objects" Version="3.13.1" />
+    <PackageVersion Include="Speckle.Objects" Version="3.15.0" />
     <PackageVersion Include="SimpleExec" Version="12.0.0" />
     <GlobalPackageReference Include="PolySharp" Version="1.14.1" />
     <GlobalPackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />

--- a/Importers/Rhino/Speckle.Importers.JobProcessor/packages.lock.json
+++ b/Importers/Rhino/Speckle.Importers.JobProcessor/packages.lock.json
@@ -413,8 +413,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "qCKCPT4HeSCJ7S+wnnjF+N+9Sd6lj5+Ra9DfxDHHrFli9rtXdnQRU5UOObyfcbiWQidVXhc2n0kbo3LPCEcvNw==",
+        "resolved": "3.15.0",
+        "contentHash": "/Qc1ESqxzLulN2c8vR0rEk+SjEHRUzdzKWvcF5i1H2ipWBzxYNi+QdZ2yc7kE+he+LmW6rdALEfAGW6b0hQbig==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -422,13 +422,13 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.13.1"
+          "Speckle.Sdk.Dependencies": "3.15.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "McLXS+Hd/bW+AdJifxGUIQi+ftofGY5r6i/X00HmlnbOvHJKZAR6fzJ12E8otMhMd78He8tcyjBD3R2jOR9ctA=="
+        "resolved": "3.15.0",
+        "contentHash": "q7CL5P25PXoya5QhfieD4b56HgsM/6nAPsmcitHCURxj6nHrIVECpOeptbnN0T5KaA5SL6RAB5WIj7YYepkXzQ=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -513,7 +513,7 @@
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -545,7 +545,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "speckle.converters.rhino8": {
@@ -622,11 +622,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.13.1, )",
-        "resolved": "3.13.1",
-        "contentHash": "VRG8SApTbAYA0YmgWTw0Eb+/AHeE0yOxDuKBTvFj3VipuSnwF29fV479BehnZdg3d8OBh4aP/YEx3vPAafybVw==",
+        "requested": "[3.15.0, )",
+        "resolved": "3.15.0",
+        "contentHash": "7/40NmAVbQS+fm4y8J2Y8U7G7oFHTbI8C03HO2dig1tICdCO2EXcv9wpDM9WRfD+vKx/vfx8WwpT+/HUP4DlcQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.13.1"
+          "Speckle.Sdk": "3.15.0"
         }
       }
     }

--- a/Importers/Rhino/Speckle.Importers.Rhino/packages.lock.json
+++ b/Importers/Rhino/Speckle.Importers.Rhino/packages.lock.json
@@ -193,8 +193,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "qCKCPT4HeSCJ7S+wnnjF+N+9Sd6lj5+Ra9DfxDHHrFli9rtXdnQRU5UOObyfcbiWQidVXhc2n0kbo3LPCEcvNw==",
+        "resolved": "3.15.0",
+        "contentHash": "/Qc1ESqxzLulN2c8vR0rEk+SjEHRUzdzKWvcF5i1H2ipWBzxYNi+QdZ2yc7kE+he+LmW6rdALEfAGW6b0hQbig==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -202,13 +202,13 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.13.1"
+          "Speckle.Sdk.Dependencies": "3.15.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "McLXS+Hd/bW+AdJifxGUIQi+ftofGY5r6i/X00HmlnbOvHJKZAR6fzJ12E8otMhMd78He8tcyjBD3R2jOR9ctA=="
+        "resolved": "3.15.0",
+        "contentHash": "q7CL5P25PXoya5QhfieD4b56HgsM/6nAPsmcitHCURxj6nHrIVECpOeptbnN0T5KaA5SL6RAB5WIj7YYepkXzQ=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -274,7 +274,7 @@
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -306,7 +306,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "speckle.converters.rhino8": {
@@ -356,11 +356,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.13.1, )",
-        "resolved": "3.13.1",
-        "contentHash": "VRG8SApTbAYA0YmgWTw0Eb+/AHeE0yOxDuKBTvFj3VipuSnwF29fV479BehnZdg3d8OBh4aP/YEx3vPAafybVw==",
+        "requested": "[3.15.0, )",
+        "resolved": "3.15.0",
+        "contentHash": "7/40NmAVbQS+fm4y8J2Y8U7G7oFHTbI8C03HO2dig1tICdCO2EXcv9wpDM9WRfD+vKx/vfx8WwpT+/HUP4DlcQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.13.1"
+          "Speckle.Sdk": "3.15.0"
         }
       }
     }

--- a/Sdk/Speckle.Connectors.Common.Tests/packages.lock.json
+++ b/Sdk/Speckle.Connectors.Common.Tests/packages.lock.json
@@ -232,8 +232,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "qCKCPT4HeSCJ7S+wnnjF+N+9Sd6lj5+Ra9DfxDHHrFli9rtXdnQRU5UOObyfcbiWQidVXhc2n0kbo3LPCEcvNw==",
+        "resolved": "3.15.0",
+        "contentHash": "/Qc1ESqxzLulN2c8vR0rEk+SjEHRUzdzKWvcF5i1H2ipWBzxYNi+QdZ2yc7kE+he+LmW6rdALEfAGW6b0hQbig==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -241,13 +241,13 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.13.1"
+          "Speckle.Sdk.Dependencies": "3.15.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "McLXS+Hd/bW+AdJifxGUIQi+ftofGY5r6i/X00HmlnbOvHJKZAR6fzJ12E8otMhMd78He8tcyjBD3R2jOR9ctA=="
+        "resolved": "3.15.0",
+        "contentHash": "q7CL5P25PXoya5QhfieD4b56HgsM/6nAPsmcitHCURxj6nHrIVECpOeptbnN0T5KaA5SL6RAB5WIj7YYepkXzQ=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -328,7 +328,7 @@
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "speckle.connectors.logging": {
@@ -338,7 +338,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "speckle.testing": {
@@ -347,7 +347,7 @@
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Moq": "[4.20.70, )",
           "NUnit": "[4.1.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "Microsoft.Extensions.Logging": {
@@ -391,11 +391,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.13.1, )",
-        "resolved": "3.13.1",
-        "contentHash": "VRG8SApTbAYA0YmgWTw0Eb+/AHeE0yOxDuKBTvFj3VipuSnwF29fV479BehnZdg3d8OBh4aP/YEx3vPAafybVw==",
+        "requested": "[3.15.0, )",
+        "resolved": "3.15.0",
+        "contentHash": "7/40NmAVbQS+fm4y8J2Y8U7G7oFHTbI8C03HO2dig1tICdCO2EXcv9wpDM9WRfD+vKx/vfx8WwpT+/HUP4DlcQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.13.1"
+          "Speckle.Sdk": "3.15.0"
         }
       }
     }

--- a/Sdk/Speckle.Connectors.Common/ConnectorActivityFactory.cs
+++ b/Sdk/Speckle.Connectors.Common/ConnectorActivityFactory.cs
@@ -1,12 +1,9 @@
-﻿using System.Runtime.CompilerServices;
-using Speckle.Connectors.Logging;
-using Speckle.Sdk;
-using Speckle.Sdk.Common;
+﻿using Speckle.Connectors.Logging;
 using Speckle.Sdk.Logging;
 
 namespace Speckle.Connectors.Common;
 
-public sealed class ConnectorActivityFactory(ISpeckleApplication application) : ISdkActivityFactory, IDisposable
+public sealed class ConnectorActivityFactory : ISdkActivityFactory
 {
   private readonly LoggingActivityFactory _loggingActivityFactory = new();
 
@@ -14,15 +11,42 @@ public sealed class ConnectorActivityFactory(ISpeckleApplication application) : 
 
   public void Dispose() => _loggingActivityFactory.Dispose();
 
-  public ISdkActivity? Start(string? name = default, [CallerMemberName] string source = "")
+  public ISdkActivity? Start(string? name, SdkActivityKind kind, string source)
   {
-    var activity = _loggingActivityFactory.Start(application.ApplicationAndVersion + " " + (name ?? source));
+    LoggingActivity? activity = _loggingActivityFactory.Start(name ?? source, ToLoggingType(kind));
     if (activity is null)
     {
       return null;
     }
-    return new ConnectorActivity(activity.NotNull());
+
+    return new ConnectorActivity(activity.Value);
   }
+
+  /// <param name="traceContext">W3C trace context header</param>
+  /// <param name="kind"></param>
+  /// <param name="name"></param>
+  /// <returns></returns>
+  public ISdkActivity? StartRemote(string traceContext, SdkActivityKind kind, string? name, string source)
+  {
+    LoggingActivity? activity = _loggingActivityFactory.StartRemote(name ?? source, traceContext, ToLoggingType(kind));
+    if (activity is null)
+    {
+      return null;
+    }
+    return new ConnectorActivity(activity.Value);
+  }
+
+  //We need to do this gymnastics due to ILRepack
+  private static LoggingActivityKind ToLoggingType(SdkActivityKind kind) =>
+    kind switch
+    {
+      SdkActivityKind.Internal => LoggingActivityKind.Internal,
+      SdkActivityKind.Server => LoggingActivityKind.Server,
+      SdkActivityKind.Client => LoggingActivityKind.Client,
+      SdkActivityKind.Producer => LoggingActivityKind.Producer,
+      SdkActivityKind.Consumer => LoggingActivityKind.Consumer,
+      _ => throw new ArgumentOutOfRangeException(nameof(kind), kind, null)
+    };
 
   private readonly struct ConnectorActivity(LoggingActivity activity) : ISdkActivity
   {
@@ -33,6 +57,7 @@ public sealed class ConnectorActivityFactory(ISpeckleApplication application) : 
     public void RecordException(Exception e) => activity.RecordException(e);
 
     public string TraceId => activity.TraceId;
+    public string SpanId => activity.SpanId;
 
     public void SetStatus(SdkActivityStatusCode code) =>
       activity.SetStatus(

--- a/Sdk/Speckle.Connectors.Common/packages.lock.json
+++ b/Sdk/Speckle.Connectors.Common/packages.lock.json
@@ -44,11 +44,11 @@
       },
       "Speckle.Objects": {
         "type": "Direct",
-        "requested": "[3.13.1, )",
-        "resolved": "3.13.1",
-        "contentHash": "VRG8SApTbAYA0YmgWTw0Eb+/AHeE0yOxDuKBTvFj3VipuSnwF29fV479BehnZdg3d8OBh4aP/YEx3vPAafybVw==",
+        "requested": "[3.15.0, )",
+        "resolved": "3.15.0",
+        "contentHash": "7/40NmAVbQS+fm4y8J2Y8U7G7oFHTbI8C03HO2dig1tICdCO2EXcv9wpDM9WRfD+vKx/vfx8WwpT+/HUP4DlcQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.13.1"
+          "Speckle.Sdk": "3.15.0"
         }
       },
       "GraphQL.Client": {
@@ -85,8 +85,8 @@
       },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
-        "resolved": "5.0.0",
-        "contentHash": "W8DPQjkMScOMTtJbPwmPyj9c3zYSFGawDW3jwlBOOsnY+EzZFLgNQ/UMkK35JmkNOVPdCyPr2Tw7Vv9N+KA3ZQ==",
+        "resolved": "9.0.4",
+        "contentHash": "9VGI5kxIvrNG2mqLQZnUR6y/3fcnygD8eNpHR+CqfbnIXvea6nehnYknDKQTxZVPMpzpNca+7DxLBmpdB3q0Bw==",
         "dependencies": {
           "System.Threading.Tasks.Extensions": "4.5.4"
         }
@@ -183,24 +183,26 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "qCKCPT4HeSCJ7S+wnnjF+N+9Sd6lj5+Ra9DfxDHHrFli9rtXdnQRU5UOObyfcbiWQidVXhc2n0kbo3LPCEcvNw==",
+        "resolved": "3.15.0",
+        "contentHash": "/Qc1ESqxzLulN2c8vR0rEk+SjEHRUzdzKWvcF5i1H2ipWBzxYNi+QdZ2yc7kE+he+LmW6rdALEfAGW6b0hQbig==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
-          "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
           "Microsoft.CSharp": "4.7.0",
           "Microsoft.Data.Sqlite": "7.0.5",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "2.2.0",
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.13.1"
+          "Speckle.Sdk.Dependencies": "3.15.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "McLXS+Hd/bW+AdJifxGUIQi+ftofGY5r6i/X00HmlnbOvHJKZAR6fzJ12E8otMhMd78He8tcyjBD3R2jOR9ctA=="
+        "resolved": "3.15.0",
+        "contentHash": "q7CL5P25PXoya5QhfieD4b56HgsM/6nAPsmcitHCURxj6nHrIVECpOeptbnN0T5KaA5SL6RAB5WIj7YYepkXzQ==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
+        }
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -294,7 +296,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "Microsoft.Extensions.Logging": {
@@ -365,11 +367,11 @@
       },
       "Speckle.Objects": {
         "type": "Direct",
-        "requested": "[3.13.1, )",
-        "resolved": "3.13.1",
-        "contentHash": "VRG8SApTbAYA0YmgWTw0Eb+/AHeE0yOxDuKBTvFj3VipuSnwF29fV479BehnZdg3d8OBh4aP/YEx3vPAafybVw==",
+        "requested": "[3.15.0, )",
+        "resolved": "3.15.0",
+        "contentHash": "7/40NmAVbQS+fm4y8J2Y8U7G7oFHTbI8C03HO2dig1tICdCO2EXcv9wpDM9WRfD+vKx/vfx8WwpT+/HUP4DlcQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.13.1"
+          "Speckle.Sdk": "3.15.0"
         }
       },
       "GraphQL.Client": {
@@ -490,8 +492,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "qCKCPT4HeSCJ7S+wnnjF+N+9Sd6lj5+Ra9DfxDHHrFli9rtXdnQRU5UOObyfcbiWQidVXhc2n0kbo3LPCEcvNw==",
+        "resolved": "3.15.0",
+        "contentHash": "/Qc1ESqxzLulN2c8vR0rEk+SjEHRUzdzKWvcF5i1H2ipWBzxYNi+QdZ2yc7kE+he+LmW6rdALEfAGW6b0hQbig==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -499,13 +501,13 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.13.1"
+          "Speckle.Sdk.Dependencies": "3.15.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "McLXS+Hd/bW+AdJifxGUIQi+ftofGY5r6i/X00HmlnbOvHJKZAR6fzJ12E8otMhMd78He8tcyjBD3R2jOR9ctA=="
+        "resolved": "3.15.0",
+        "contentHash": "q7CL5P25PXoya5QhfieD4b56HgsM/6nAPsmcitHCURxj6nHrIVECpOeptbnN0T5KaA5SL6RAB5WIj7YYepkXzQ=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -564,7 +566,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "Microsoft.Extensions.Logging": {

--- a/Sdk/Speckle.Connectors.Logging/ActivityScopeExtensions.cs
+++ b/Sdk/Speckle.Connectors.Logging/ActivityScopeExtensions.cs
@@ -3,9 +3,9 @@ namespace Speckle.Connectors.Logging;
 public static class ActivityScope
 {
   private static readonly AsyncLocal<Dictionary<string, object?>> s_tags = new() { Value = new() };
-  public static IReadOnlyDictionary<string, object?> Tags => s_tags.Value ?? [];
+  public static IReadOnlyDictionary<string, object?> Tags => s_tags.Value ??= new();
   public static IReadOnlyList<KeyValuePair<string, object?>> TagsList { get; } =
-    new List<KeyValuePair<string, object?>>(s_tags.Value ?? []);
+    new List<KeyValuePair<string, object?>>(s_tags.Value ??= new());
 
   public static IDisposable SetTag(string key, string value)
   {

--- a/Sdk/Speckle.Connectors.Logging/LoggingActivity.cs
+++ b/Sdk/Speckle.Connectors.Logging/LoggingActivity.cs
@@ -18,8 +18,10 @@ public readonly struct LoggingActivity
   public void RecordException(Exception e) => _activity.AddException(e);
 
   public string TraceId => _activity.TraceId.ToString();
+  public string SpanId => _activity.SpanId.ToString();
 
   public void SetStatus(LoggingActivityStatusCode code) =>
+    //We need to do this gymnastics due to ILRepack
     _activity.SetStatus(
       code switch
       {

--- a/Sdk/Speckle.Connectors.Logging/LoggingActivityFactory.cs
+++ b/Sdk/Speckle.Connectors.Logging/LoggingActivityFactory.cs
@@ -12,10 +12,26 @@ public sealed class LoggingActivityFactory : IDisposable
 
   public void SetTag(string key, object? value) => _tags[key] = value;
 
-  public LoggingActivity? Start(string name)
+  public LoggingActivity? StartRemote(string name, string traceContext, LoggingActivityKind activityKind)
+  {
+    if (!ActivityContext.TryParse(traceContext, null, true, out ActivityContext context))
+    {
+      throw new ArgumentException("traceContext was not parsable to a valid W3C Header", nameof(traceContext));
+    }
+
+    //If you get a MissingManifestResourceException, Likely source or name is empty string, which is no good.
+    var activity = _activitySource.StartActivity(name, ToOtelType(activityKind), context, _tags);
+    if (activity is null)
+    {
+      return null;
+    }
+    return new LoggingActivity(activity);
+  }
+
+  public LoggingActivity? Start(string name, LoggingActivityKind activityKind)
   {
     //If you get a MissingManifestResourceException, Likely source or name is empty string, which is no good.
-    var activity = _activitySource.StartActivity(name: name, kind: ActivityKind.Client, tags: _tags);
+    var activity = _activitySource.StartActivity(ToOtelType(activityKind), tags: _tags, name: name);
     if (activity is null)
     {
       return null;
@@ -24,4 +40,15 @@ public sealed class LoggingActivityFactory : IDisposable
   }
 
   public void Dispose() => _activitySource.Dispose();
+
+  private static ActivityKind ToOtelType(LoggingActivityKind kind) =>
+    kind switch
+    {
+      LoggingActivityKind.Internal => ActivityKind.Internal,
+      LoggingActivityKind.Server => ActivityKind.Server,
+      LoggingActivityKind.Client => ActivityKind.Client,
+      LoggingActivityKind.Producer => ActivityKind.Producer,
+      LoggingActivityKind.Consumer => ActivityKind.Consumer,
+      _ => throw new ArgumentOutOfRangeException(nameof(kind), kind, null)
+    };
 }

--- a/Sdk/Speckle.Connectors.Logging/LoggingActivityKind.cs
+++ b/Sdk/Speckle.Connectors.Logging/LoggingActivityKind.cs
@@ -1,0 +1,30 @@
+namespace Speckle.Connectors.Logging;
+
+public enum LoggingActivityKind
+{
+  /// <summary>
+  /// Default value.
+  /// Indicates that the Activity represents an internal operation within an application, as opposed to an operations with remote parents or children.
+  /// </summary>
+  Internal = 0,
+
+  /// <summary>
+  /// Server activity represents request incoming from external component.
+  /// </summary>
+  Server = 1,
+
+  /// <summary>
+  /// Client activity represents outgoing request to the external component.
+  /// </summary>
+  Client = 2,
+
+  /// <summary>
+  /// Producer activity represents output provided to external components.
+  /// </summary>
+  Producer = 3,
+
+  /// <summary>
+  /// Consumer activity represents output received from an external component.
+  /// </summary>
+  Consumer = 4,
+}

--- a/Sdk/Speckle.Connectors.Logging/SpeckleLogger.cs
+++ b/Sdk/Speckle.Connectors.Logging/SpeckleLogger.cs
@@ -5,6 +5,7 @@ namespace Speckle.Connectors.Logging;
 public sealed class Logger(ILogger logger)
 {
   private static LogLevel GetLevel(SpeckleLogLevel speckleLogLevel) =>
+    //We need to do this gymnastics due to ILRepack
     speckleLogLevel switch
     {
       SpeckleLogLevel.Debug => LogLevel.Debug,

--- a/Sdk/Speckle.Converters.Common.Tests/packages.lock.json
+++ b/Sdk/Speckle.Converters.Common.Tests/packages.lock.json
@@ -247,8 +247,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "qCKCPT4HeSCJ7S+wnnjF+N+9Sd6lj5+Ra9DfxDHHrFli9rtXdnQRU5UOObyfcbiWQidVXhc2n0kbo3LPCEcvNw==",
+        "resolved": "3.15.0",
+        "contentHash": "/Qc1ESqxzLulN2c8vR0rEk+SjEHRUzdzKWvcF5i1H2ipWBzxYNi+QdZ2yc7kE+he+LmW6rdALEfAGW6b0hQbig==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -256,13 +256,13 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.13.1"
+          "Speckle.Sdk.Dependencies": "3.15.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "McLXS+Hd/bW+AdJifxGUIQi+ftofGY5r6i/X00HmlnbOvHJKZAR6fzJ12E8otMhMd78He8tcyjBD3R2jOR9ctA=="
+        "resolved": "3.15.0",
+        "contentHash": "q7CL5P25PXoya5QhfieD4b56HgsM/6nAPsmcitHCURxj6nHrIVECpOeptbnN0T5KaA5SL6RAB5WIj7YYepkXzQ=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -341,7 +341,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[2.2.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "speckle.testing": {
@@ -350,7 +350,7 @@
           "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
           "Moq": "[4.20.70, )",
           "NUnit": "[4.1.0, )",
-          "Speckle.Objects": "[3.13.1, )"
+          "Speckle.Objects": "[3.15.0, )"
         }
       },
       "Microsoft.Extensions.Logging": {
@@ -379,11 +379,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.13.1, )",
-        "resolved": "3.13.1",
-        "contentHash": "VRG8SApTbAYA0YmgWTw0Eb+/AHeE0yOxDuKBTvFj3VipuSnwF29fV479BehnZdg3d8OBh4aP/YEx3vPAafybVw==",
+        "requested": "[3.15.0, )",
+        "resolved": "3.15.0",
+        "contentHash": "7/40NmAVbQS+fm4y8J2Y8U7G7oFHTbI8C03HO2dig1tICdCO2EXcv9wpDM9WRfD+vKx/vfx8WwpT+/HUP4DlcQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.13.1"
+          "Speckle.Sdk": "3.15.0"
         }
       }
     }

--- a/Sdk/Speckle.Converters.Common/packages.lock.json
+++ b/Sdk/Speckle.Converters.Common/packages.lock.json
@@ -41,11 +41,11 @@
       },
       "Speckle.Objects": {
         "type": "Direct",
-        "requested": "[3.13.1, )",
-        "resolved": "3.13.1",
-        "contentHash": "VRG8SApTbAYA0YmgWTw0Eb+/AHeE0yOxDuKBTvFj3VipuSnwF29fV479BehnZdg3d8OBh4aP/YEx3vPAafybVw==",
+        "requested": "[3.15.0, )",
+        "resolved": "3.15.0",
+        "contentHash": "7/40NmAVbQS+fm4y8J2Y8U7G7oFHTbI8C03HO2dig1tICdCO2EXcv9wpDM9WRfD+vKx/vfx8WwpT+/HUP4DlcQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.13.1"
+          "Speckle.Sdk": "3.15.0"
         }
       },
       "GraphQL.Client": {
@@ -82,8 +82,8 @@
       },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
-        "resolved": "5.0.0",
-        "contentHash": "W8DPQjkMScOMTtJbPwmPyj9c3zYSFGawDW3jwlBOOsnY+EzZFLgNQ/UMkK35JmkNOVPdCyPr2Tw7Vv9N+KA3ZQ==",
+        "resolved": "9.0.4",
+        "contentHash": "9VGI5kxIvrNG2mqLQZnUR6y/3fcnygD8eNpHR+CqfbnIXvea6nehnYknDKQTxZVPMpzpNca+7DxLBmpdB3q0Bw==",
         "dependencies": {
           "System.Threading.Tasks.Extensions": "4.5.4"
         }
@@ -180,24 +180,26 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "qCKCPT4HeSCJ7S+wnnjF+N+9Sd6lj5+Ra9DfxDHHrFli9rtXdnQRU5UOObyfcbiWQidVXhc2n0kbo3LPCEcvNw==",
+        "resolved": "3.15.0",
+        "contentHash": "/Qc1ESqxzLulN2c8vR0rEk+SjEHRUzdzKWvcF5i1H2ipWBzxYNi+QdZ2yc7kE+he+LmW6rdALEfAGW6b0hQbig==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
-          "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
           "Microsoft.CSharp": "4.7.0",
           "Microsoft.Data.Sqlite": "7.0.5",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "2.2.0",
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.13.1"
+          "Speckle.Sdk.Dependencies": "3.15.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "McLXS+Hd/bW+AdJifxGUIQi+ftofGY5r6i/X00HmlnbOvHJKZAR6fzJ12E8otMhMd78He8tcyjBD3R2jOR9ctA=="
+        "resolved": "3.15.0",
+        "contentHash": "q7CL5P25PXoya5QhfieD4b56HgsM/6nAPsmcitHCURxj6nHrIVECpOeptbnN0T5KaA5SL6RAB5WIj7YYepkXzQ==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
+        }
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -343,11 +345,11 @@
       },
       "Speckle.Objects": {
         "type": "Direct",
-        "requested": "[3.13.1, )",
-        "resolved": "3.13.1",
-        "contentHash": "VRG8SApTbAYA0YmgWTw0Eb+/AHeE0yOxDuKBTvFj3VipuSnwF29fV479BehnZdg3d8OBh4aP/YEx3vPAafybVw==",
+        "requested": "[3.15.0, )",
+        "resolved": "3.15.0",
+        "contentHash": "7/40NmAVbQS+fm4y8J2Y8U7G7oFHTbI8C03HO2dig1tICdCO2EXcv9wpDM9WRfD+vKx/vfx8WwpT+/HUP4DlcQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.13.1"
+          "Speckle.Sdk": "3.15.0"
         }
       },
       "GraphQL.Client": {
@@ -468,8 +470,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "qCKCPT4HeSCJ7S+wnnjF+N+9Sd6lj5+Ra9DfxDHHrFli9rtXdnQRU5UOObyfcbiWQidVXhc2n0kbo3LPCEcvNw==",
+        "resolved": "3.15.0",
+        "contentHash": "/Qc1ESqxzLulN2c8vR0rEk+SjEHRUzdzKWvcF5i1H2ipWBzxYNi+QdZ2yc7kE+he+LmW6rdALEfAGW6b0hQbig==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -477,13 +479,13 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.13.1"
+          "Speckle.Sdk.Dependencies": "3.15.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "McLXS+Hd/bW+AdJifxGUIQi+ftofGY5r6i/X00HmlnbOvHJKZAR6fzJ12E8otMhMd78He8tcyjBD3R2jOR9ctA=="
+        "resolved": "3.15.0",
+        "contentHash": "q7CL5P25PXoya5QhfieD4b56HgsM/6nAPsmcitHCURxj6nHrIVECpOeptbnN0T5KaA5SL6RAB5WIj7YYepkXzQ=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",

--- a/Sdk/Speckle.Testing/packages.lock.json
+++ b/Sdk/Speckle.Testing/packages.lock.json
@@ -59,11 +59,11 @@
       },
       "Speckle.Objects": {
         "type": "Direct",
-        "requested": "[3.13.1, )",
-        "resolved": "3.13.1",
-        "contentHash": "VRG8SApTbAYA0YmgWTw0Eb+/AHeE0yOxDuKBTvFj3VipuSnwF29fV479BehnZdg3d8OBh4aP/YEx3vPAafybVw==",
+        "requested": "[3.15.0, )",
+        "resolved": "3.15.0",
+        "contentHash": "7/40NmAVbQS+fm4y8J2Y8U7G7oFHTbI8C03HO2dig1tICdCO2EXcv9wpDM9WRfD+vKx/vfx8WwpT+/HUP4DlcQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.13.1"
+          "Speckle.Sdk": "3.15.0"
         }
       },
       "Castle.Core": {
@@ -192,8 +192,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "qCKCPT4HeSCJ7S+wnnjF+N+9Sd6lj5+Ra9DfxDHHrFli9rtXdnQRU5UOObyfcbiWQidVXhc2n0kbo3LPCEcvNw==",
+        "resolved": "3.15.0",
+        "contentHash": "/Qc1ESqxzLulN2c8vR0rEk+SjEHRUzdzKWvcF5i1H2ipWBzxYNi+QdZ2yc7kE+he+LmW6rdALEfAGW6b0hQbig==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -201,13 +201,13 @@
           "Microsoft.Extensions.Logging": "2.2.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.13.1"
+          "Speckle.Sdk.Dependencies": "3.15.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.13.1",
-        "contentHash": "McLXS+Hd/bW+AdJifxGUIQi+ftofGY5r6i/X00HmlnbOvHJKZAR6fzJ12E8otMhMd78He8tcyjBD3R2jOR9ctA=="
+        "resolved": "3.15.0",
+        "contentHash": "q7CL5P25PXoya5QhfieD4b56HgsM/6nAPsmcitHCURxj6nHrIVECpOeptbnN0T5KaA5SL6RAB5WIj7YYepkXzQ=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",


### PR DESCRIPTION
For the auth changes, I need to bump the SDK version.
The SDK contains a couple logging changes that have already been applied to oguzhan/duck-connectors

I've cherry picked the changes and applied them here so that I can rebase the auth changes in a separate PR.