### PR TITLE
fix(rhino): resolve material type editing

### DIFF
--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/HostApp/RhinoInstanceBaker.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/HostApp/RhinoInstanceBaker.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.Logging;
 using Rhino;
 using Rhino.DocObjects;
 using Rhino.Geometry;
+using Rhino.Render;
 using Speckle.Connectors.Common.Conversion;
 using Speckle.Connectors.Common.Instances;
 using Speckle.Connectors.Common.Operations;
@@ -141,7 +142,7 @@ public class RhinoInstanceBaker : IInstanceBaker<IReadOnlyCollection<string>>
           // set material using Guid
           if (_materialBaker.ObjectIdAndMaterialIdMap.TryGetValue(instanceProxyId, out Guid materialGuid))
           {
-            atts.RenderMaterial = doc.RenderMaterials.Find(materialGuid);
+            atts.RenderMaterial = RenderContent.FromId(doc, materialGuid) as RenderMaterial;
             atts.MaterialSource = ObjectMaterialSource.MaterialFromObject;
           }
 

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/HostApp/RhinoInstanceBaker.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/HostApp/RhinoInstanceBaker.cs
@@ -137,9 +137,11 @@ public class RhinoInstanceBaker : IInstanceBaker<IReadOnlyCollection<string>>
           // create attributes
           ObjectAttributes atts = instanceProxy.GetAttributes();
           atts.LayerIndex = layerIndex;
-          if (_materialBaker.ObjectIdAndMaterialIndexMap.TryGetValue(instanceProxyId, out int mIndex))
+
+          // set material using Guid
+          if (_materialBaker.ObjectIdAndMaterialIdMap.TryGetValue(instanceProxyId, out Guid materialGuid))
           {
-            atts.MaterialIndex = mIndex;
+            atts.RenderMaterial = doc.RenderMaterials.Find(materialGuid);
             atts.MaterialSource = ObjectMaterialSource.MaterialFromObject;
           }
 

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/HostApp/RhinoLayerBaker.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/HostApp/RhinoLayerBaker.cs
@@ -104,8 +104,7 @@ public class RhinoLayerBaker : TraversalContextUnpacker
   /// </summary>
   /// <param name="collectionPath">An array of Collection objects representing the path to create the layer.</param>
   /// <param name="baseLayerName">The base layer name to start creating the new layer.</param>
-  /// <returns>The index of the last created layer.</returns>
-  private int CreateLayerFromPath(Collection[] collectionPath, string baseLayerName)
+  private void CreateLayerFromPath(Collection[] collectionPath, string baseLayerName)
   {
     var currentLayerName = baseLayerName;
     var currentDocument = RhinoDoc.ActiveDoc; // POC: too much effort right now to wrap around the interfaced layers
@@ -135,13 +134,13 @@ public class RhinoLayerBaker : TraversalContextUnpacker
 
       // set material
       if (
-        _materialBaker.ObjectIdAndMaterialIndexMap.TryGetValue(
+        _materialBaker.ObjectIdAndMaterialIdMap.TryGetValue(
           collection.applicationId ?? collection.id.NotNull(),
-          out int mIndex
+          out System.Guid materialGuid
         )
       )
       {
-        newLayer.RenderMaterialIndex = mIndex;
+        newLayer.RenderMaterial.Id = materialGuid;
       }
 
       // set color
@@ -164,7 +163,5 @@ public class RhinoLayerBaker : TraversalContextUnpacker
       _hostLayerCache.Add(currentLayerName, index);
       previousLayer = currentDocument.Layers.FindIndex(index); // note we need to get the correct id out, hence why we're double calling this
     }
-
-    return previousLayer.Index;
   }
 }

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/HostApp/RhinoLayerBaker.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/HostApp/RhinoLayerBaker.cs
@@ -1,5 +1,6 @@
 using Rhino;
 using Rhino.DocObjects;
+using Rhino.Render;
 using Speckle.Connectors.Common.Operations.Receive;
 using Speckle.Sdk;
 using Speckle.Sdk.Common;
@@ -136,11 +137,15 @@ public class RhinoLayerBaker : TraversalContextUnpacker
       if (
         _materialBaker.ObjectIdAndMaterialIdMap.TryGetValue(
           collection.applicationId ?? collection.id.NotNull(),
-          out System.Guid materialGuid
+          out Guid materialGuid
         )
       )
       {
-        newLayer.RenderMaterial.Id = materialGuid;
+        var rc = RenderContent.FromId(currentDocument, materialGuid);
+        if (rc is RenderMaterial rm)
+        {
+          newLayer.RenderMaterialIndex = rm.DocumentAssoc.Materials.CurrentMaterialIndex;
+        }
       }
 
       // set color

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/HostApp/RhinoMaterialBaker.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/HostApp/RhinoMaterialBaker.cs
@@ -3,7 +3,6 @@ using Speckle.Converters.Common;
 using Speckle.Converters.Rhino;
 using Speckle.Objects.Other;
 using Speckle.Sdk;
-using Speckle.Sdk.Common;
 using Speckle.Sdk.Common.Exceptions;
 using Material = Rhino.DocObjects.Material;
 using RenderMaterial = Rhino.Render.RenderMaterial;
@@ -30,7 +29,7 @@ public class RhinoMaterialBaker
   /// </summary>
   public Dictionary<string, Guid> ObjectIdAndMaterialIdMap { get; } = [];
 
-  public void BakeMaterials(IReadOnlyCollection<RenderMaterialProxy> speckleRenderMaterialProxies, string baseLayerName)
+  public void BakeMaterials(IReadOnlyCollection<RenderMaterialProxy> speckleRenderMaterialProxies)
   {
     var doc = _converterSettings.Current.Document; // POC: too much right now to interface around
     // List<ReceiveConversionResult> conversionResults = new(); // TODO: return this guy
@@ -42,8 +41,7 @@ public class RhinoMaterialBaker
       try
       {
         // POC: Currently we're relying on the render material name for identification if it's coming from speckle and from which model; could we do something else?
-        string materialId = speckleRenderMaterial.applicationId ?? speckleRenderMaterial.id.NotNull();
-        string matName = $"{speckleRenderMaterial.name}-({materialId})-{baseLayerName}";
+        string matName = speckleRenderMaterial.name;
         matName = matName.Replace("[", "").Replace("]", ""); // "Material" doesn't like square brackets if we create from here. Once they created from Rhino UI, all good..
 
         // Check if material with this name already exists in the document

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/HostApp/RhinoMaterialBaker.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/HostApp/RhinoMaterialBaker.cs
@@ -25,9 +25,10 @@ public class RhinoMaterialBaker
   }
 
   /// <summary>
-  /// A map keeping track of ids, <b>either layer id or object id</b>, and their material index. It's generated from the material proxy list as we bake materials; <see cref="BakeMaterials"/> must be called in advance for this to be populated with the correct data.
+  /// A map keeping track of ids, either layer id or object id, and their Render Material Guid.
+  /// It's generated from the material proxy list as we <see cref="BakeMaterials"/>.
   /// </summary>
-  public Dictionary<string, int> ObjectIdAndMaterialIndexMap { get; } = new();
+  public Dictionary<string, Guid> ObjectIdAndMaterialIdMap { get; } = [];
 
   public void BakeMaterials(IReadOnlyCollection<RenderMaterialProxy> speckleRenderMaterialProxies, string baseLayerName)
   {
@@ -46,10 +47,10 @@ public class RhinoMaterialBaker
         matName = matName.Replace("[", "").Replace("]", ""); // "Material" doesn't like square brackets if we create from here. Once they created from Rhino UI, all good..
 
         // Check if material with this name already exists in the document
-        int matIndex = doc.Materials.Find(matName, ignoreDeletedMaterials: true);
+        var existingRenderMaterial = doc.RenderMaterials.FirstOrDefault(m => m.Name == matName);
+        Guid materialGuid;
 
-        // If material doesn't exist, create it
-        if (matIndex == -1)
+        if (existingRenderMaterial == null)
         {
           Color diffuse = Color.FromArgb(speckleRenderMaterial.diffuse);
           Color emissive = Color.FromArgb(speckleRenderMaterial.emissive);
@@ -74,29 +75,32 @@ public class RhinoMaterialBaker
             rhinoMaterial.Shine = shine;
           }
 
-          // create RDK RenderMaterial and add to RDK RenderMaterials (not doc.Materials) (CNX-2896)
+          // create RenderMaterial wrapper (CNX-2896)
           var renderMaterial = RenderMaterial.CreateBasicMaterial(rhinoMaterial, doc);
+
+          // add to RenderMaterial table. From my understanding, this internally manages the legacy Material table entry
           doc.RenderMaterials.Add(renderMaterial);
-
-          // retrieve the index of the underlying legacy material that Rhino automatically synced
-          matIndex = doc.Materials.Add(rhinoMaterial);
-
-          // POC: check on matIndex -1, means we haven't created anything - this is most likely an recoverable error at this stage
-          if (matIndex == -1)
-          {
-            throw new ConversionException($"Failed to add a material to the document: '{matName}' (ID: {materialId})");
-          }
+          materialGuid = renderMaterial.Id;
+        }
+        else
+        {
+          materialGuid = existingRenderMaterial.Id;
         }
 
-        // Create the object <> material index map
+        if (materialGuid == Guid.Empty)
+        {
+          throw new ConversionException($"Failed to create or retrieve RenderMaterial Guid for: '{matName}'");
+        }
+
+        // map object ID to Material Guid
         foreach (var objectId in proxy.objects)
         {
-          ObjectIdAndMaterialIndexMap[objectId] = matIndex;
+          ObjectIdAndMaterialIdMap[objectId] = materialGuid;
         }
       }
       catch (Exception ex) when (!ex.IsFatal())
       {
-        _logger.LogError(ex, "Failed to add a material to the document");
+        _logger.LogError(ex, "Failed to add a modern RenderMaterial to the document");
       }
     }
   }

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/HostApp/RhinoMaterialBaker.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/HostApp/RhinoMaterialBaker.cs
@@ -6,6 +6,7 @@ using Speckle.Sdk;
 using Speckle.Sdk.Common;
 using Speckle.Sdk.Common.Exceptions;
 using Material = Rhino.DocObjects.Material;
+using RenderMaterial = Rhino.Render.RenderMaterial;
 
 namespace Speckle.Connectors.Rhino.HostApp;
 
@@ -73,6 +74,11 @@ public class RhinoMaterialBaker
             rhinoMaterial.Shine = shine;
           }
 
+          // create RDK RenderMaterial and add to RDK RenderMaterials (not doc.Materials) (CNX-2896)
+          var renderMaterial = RenderMaterial.CreateBasicMaterial(rhinoMaterial, doc);
+          doc.RenderMaterials.Add(renderMaterial);
+
+          // retrieve the index of the underlying legacy material that Rhino automatically synced
           matIndex = doc.Materials.Add(rhinoMaterial);
 
           // POC: check on matIndex -1, means we haven't created anything - this is most likely an recoverable error at this stage

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/Operations/Receive/RhinoHostObjectBuilder.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/Operations/Receive/RhinoHostObjectBuilder.cs
@@ -1,6 +1,7 @@
 using Rhino;
 using Rhino.DocObjects;
 using Rhino.Geometry;
+using Rhino.Render;
 using Speckle.Connectors.Common.Builders;
 using Speckle.Connectors.Common.Conversion;
 using Speckle.Connectors.Common.Extensions;
@@ -332,7 +333,7 @@ public class RhinoHostObjectBuilder : IHostObjectBuilder
 
     if (_materialBaker.ObjectIdAndMaterialIdMap.TryGetValue(objectId, out Guid materialGuid))
     {
-      atts.RenderMaterial = _converterSettings.Current.Document.RenderMaterials.Find(materialGuid);
+      atts.RenderMaterial = RenderContent.FromId(_converterSettings.Current.Document, materialGuid) as RenderMaterial;
       atts.MaterialSource = ObjectMaterialSource.MaterialFromObject;
     }
     else if (
@@ -340,7 +341,7 @@ public class RhinoHostObjectBuilder : IHostObjectBuilder
       && (_materialBaker.ObjectIdAndMaterialIdMap.TryGetValue(parentObjectId, out Guid parentGuid))
     )
     {
-      atts.RenderMaterial = _converterSettings.Current.Document.RenderMaterials.Find(parentGuid);
+      atts.RenderMaterial = RenderContent.FromId(_converterSettings.Current.Document, parentGuid) as RenderMaterial;
       atts.MaterialSource = ObjectMaterialSource.MaterialFromObject;
     }
 

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/Operations/Receive/RhinoHostObjectBuilder.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/Operations/Receive/RhinoHostObjectBuilder.cs
@@ -120,7 +120,7 @@ public class RhinoHostObjectBuilder : IHostObjectBuilder
       using var _ = _activityFactory.Start("Render Materials");
       _threadContext.RunOnMain(() =>
       {
-        _materialBaker.BakeMaterials(unpackedRoot.RenderMaterialProxies, baseLayerName);
+        _materialBaker.BakeMaterials(unpackedRoot.RenderMaterialProxies);
       });
     }
 

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/Operations/Receive/RhinoHostObjectBuilder.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/Operations/Receive/RhinoHostObjectBuilder.cs
@@ -330,17 +330,17 @@ public class RhinoHostObjectBuilder : IHostObjectBuilder
   {
     var objectId = originalObject.applicationId ?? originalObject.id.NotNull();
 
-    if (_materialBaker.ObjectIdAndMaterialIndexMap.TryGetValue(objectId, out int mIndex))
+    if (_materialBaker.ObjectIdAndMaterialIdMap.TryGetValue(objectId, out Guid materialGuid))
     {
-      atts.MaterialIndex = mIndex;
+      atts.RenderMaterial = _converterSettings.Current.Document.RenderMaterials.Find(materialGuid);
       atts.MaterialSource = ObjectMaterialSource.MaterialFromObject;
     }
     else if (
       parentObjectId is not null
-      && (_materialBaker.ObjectIdAndMaterialIndexMap.TryGetValue(parentObjectId, out int mIndexSpeckleObj))
+      && (_materialBaker.ObjectIdAndMaterialIdMap.TryGetValue(parentObjectId, out Guid parentGuid))
     )
     {
-      atts.MaterialIndex = mIndexSpeckleObj;
+      atts.RenderMaterial = _converterSettings.Current.Document.RenderMaterials.Find(parentGuid);
       atts.MaterialSource = ObjectMaterialSource.MaterialFromObject;
     }
 


### PR DESCRIPTION
## Description

Fixes a bug where materials created during a load operation couldn't have their types changed (e.g., from Custom to Glass) without duplicating the material. 

The core issue was that we were populating the legacy Material table directly. When changing type, UI switches to `RenderMaterial` which is why we get a duplicate. So, when we only provided legacy materials, Rhino created "Custom" wrappers that broke when edited. By switching to creating `RenderMaterial` directly, we fix this.

During this change, I also need to adopt `Guid` for material tracking. This bypasses the race conditions where the legacy table hasn't synced with the RDK yet, which was causing the "Default Material" assignment bug on received objects.

Fixes [CNX-2896](https://linear.app/speckle/issue/CNX-2896/cant-change-material-type-of-created-material-by-speckle).

## User Value

Users can now natively edit Speckle-received materials in the Rhino Materials panel and change their types (Glass, Plaster, etc.) without breaking the model or creating duplicate materials.

## Changes:

- **RhinoMaterialBaker**: creates `RenderMaterial` wrappers instead of just legacy entries.
- **POC Change**: Replaced integer index mapping with `Guid` mapping (`ObjectIdAndMaterialIdMap`)
- **Bakers Update**: Updated `RhinoLayerBaker`, `RhinoInstanceBaker`, and `RhinoHostObjectBuilder` to assign materials via `RenderMaterialId`.

## Validation of changes:

### Before
- Load model
- Select object
- Edit type of associated material
- Immediately material duplicated ❌ 

https://github.com/user-attachments/assets/0875f7ac-4da6-4574-a5e8-666aa23032ac

### After
- Load model
- Select object
- Edit type of associated material. Edit done in place. ✅ 


https://github.com/user-attachments/assets/4dc35268-5212-46d6-8b25-0b0b6e76d1e6

## Checklist:

- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] I have added appropriate tests.
- [x] I have updated or added relevant documentation.