### PR TITLE
Add dwg/dxf config to include material layer color conversion

### DIFF
--- a/Importers/Rhino/Speckle.Importers.Rhino/Internal/FileTypeConfig/DwgConfig.cs
+++ b/Importers/Rhino/Speckle.Importers.Rhino/Internal/FileTypeConfig/DwgConfig.cs
@@ -6,11 +6,7 @@ namespace Speckle.Importers.Rhino.Internal.FileTypeConfig;
 
 internal sealed class DwgConfig : IFileTypeConfig
 {
-  private readonly FileDwgReadOptions _readOptions =
-    new()
-    {
-      SetLayerMaterialToLayerColor = true
-    };
+  private readonly FileDwgReadOptions _readOptions = new() { SetLayerMaterialToLayerColor = true };
 
   public RhinoDoc OpenInHeadlessDocument(string filePath)
   {

--- a/Importers/Rhino/Speckle.Importers.Rhino/Internal/FileTypeConfig/DwgConfig.cs
+++ b/Importers/Rhino/Speckle.Importers.Rhino/Internal/FileTypeConfig/DwgConfig.cs
@@ -1,0 +1,26 @@
+using Rhino;
+using Rhino.FileIO;
+using Speckle.Sdk;
+
+namespace Speckle.Importers.Rhino.Internal.FileTypeConfig;
+
+internal sealed class DwgConfig : IFileTypeConfig
+{
+  private readonly FileDwgReadOptions _readOptions =
+    new()
+    {
+      SetLayerMaterialToLayerColor = true
+    };
+
+  public RhinoDoc OpenInHeadlessDocument(string filePath)
+  {
+    RhinoDoc? doc = RhinoDoc.OpenHeadless(filePath, _readOptions.ToDictionary());
+    if (doc is null)
+    {
+      throw new SpeckleException("Rhino could not open this file");
+    }
+    return doc;
+  }
+
+  public void Dispose() { }
+}

--- a/Importers/Rhino/Speckle.Importers.Rhino/Internal/ImporterInstance.cs
+++ b/Importers/Rhino/Speckle.Importers.Rhino/Internal/ImporterInstance.cs
@@ -66,6 +66,8 @@ internal sealed class ImporterInstance(
       ".obj" => new ObjConfig(),
       ".dgn" => new DgnConfig(),
       ".fbx" => new FbxConfig(),
+      ".dwg" => new DwgConfig(),
+      ".dxf" => new DwgConfig(),
       _ => new DefaultConfig(),
     };
 


### PR DESCRIPTION
Currently the .dwg files imported by our users loose the material/color information.
A solution for us would be to enable the set layer material to layer color option in the rhino import settings.

Obviously this has implications with how materials might be interpreted or overwritten. 
I want to use this PR more as a discussion starter since i am not deep enough into the topic to grasp all possible edge cases.

My key point:
Speckle already reduces the materials to a simple rgb color and basically ignores all complex material systems. Since we loose most material information on the way to speckle having the material to layer color option probably doesn't hurt since the information would've been lost anyways.

Until it is possible to pass more additional data along with the objects from a .dwg source this option feels like a good compromise.
If you think it is not an option, let me know if its worth looking into extending the .dwg import to extract this material information as supplementary data block so we can later extract the information from the speckle object.
I am looking forward to your thoughts. 
I will also create a community post about the topic and will link it here.
