### PR TITLE
fix(revit): apply accumulated transform to curves in linked DirectShapes

### DIFF
--- a/Converters/Revit/Speckle.Converters.RevitShared/Helpers/DisplayValueExtractor.cs
+++ b/Converters/Revit/Speckle.Converters.RevitShared/Helpers/DisplayValueExtractor.cs
@@ -318,32 +318,16 @@ public sealed class DisplayValueExtractor
       );
     }
 
-    foreach (var curve in collections.Curves)
+    foreach (var (curve, accumulatedTransform) in collections.Curves)
     {
-      if (curveTransform is not null)
-      {
-        using var transformedCurve = curve.CreateTransformed(curveTransform);
-        displayValue.Add(DisplayValueResult.WithoutTransform(GetCurveDisplayValue(transformedCurve)));
-      }
-      else
-      {
-        displayValue.Add(DisplayValueResult.WithoutTransform(GetCurveDisplayValue(curve)));
-      }
+      using var resolvedCurve = ResolveCurveTransforms(curve, accumulatedTransform, curveTransform);
+      displayValue.Add(DisplayValueResult.WithoutTransform(GetCurveDisplayValue(resolvedCurve)));
     }
 
-    foreach (var polyline in collections.Polylines)
+    foreach (var (polyline, accumulatedTransform) in collections.Polylines)
     {
-      if (curveTransform is not null)
-      {
-        var coords = polyline.GetCoordinates();
-        var transformedCoords = coords.Select(coord => curveTransform.OfPoint(coord)).ToList();
-        using var transformedPolyline = DB.PolyLine.Create(transformedCoords);
-        displayValue.Add(DisplayValueResult.WithoutTransform(_polylineConverter.Convert(transformedPolyline)));
-      }
-      else
-      {
-        displayValue.Add(DisplayValueResult.WithoutTransform(_polylineConverter.Convert(polyline)));
-      }
+      using var resolvedPolyline = ResolvePolylineTransforms(polyline, accumulatedTransform, curveTransform);
+      displayValue.Add(DisplayValueResult.WithoutTransform(_polylineConverter.Convert(resolvedPolyline)));
     }
 
     foreach (var point in collections.Points)
@@ -498,13 +482,15 @@ public sealed class DisplayValueExtractor
           break;
 
         case DB.Curve curve:
-          // curves are stored as-is; transforms are applied later in ProcessGeometryCollections
-          collections.Curves.Add(curve);
+          // store the curve together with whatever accumulatedTransform is active at this
+          // recursion depth. See GeometryCollections remarks for why we do this rather than
+          // applying the transform here the way we do for meshes and solids.
+          collections.Curves.Add((curve, accumulatedTransform));
           break;
 
         case DB.PolyLine polyline:
-          // polylines also handled later during display value processing
-          collections.Polylines.Add(polyline);
+          // same reasoning as curves above
+          collections.Polylines.Add((polyline, accumulatedTransform));
           break;
 
         case DB.Point point:
@@ -758,22 +744,80 @@ public sealed class DisplayValueExtractor
   }
 
   /// <summary>
-  /// Represents sorted collections of different geometry types extracted from an element.
-  /// Used to pass multiple geometry collections as a single parameter to improve code readability
-  /// and reduce the risk of parameter ordering errors.
+  /// Applies up to two transforms to a curve in order:
+  /// 1. accumulatedTransform — the GeometryInstance transform from SortGeometry.
+  ///    Only set for DirectShape elements (linked IFC/DWG) where the real position
+  ///    lives inside a nested GeometryInstance rather than on the element itself.
+  /// 2. curveTransform — the instance transform (localToDocument).
+  ///    Only set for FamilyInstance elements.
   /// </summary>
+  private DB.Curve ResolveCurveTransforms(
+    DB.Curve curve,
+    DB.Transform? accumulatedTransform,
+    DB.Transform? curveTransform
+  )
+  {
+    var result = accumulatedTransform is not null ? curve.CreateTransformed(accumulatedTransform) : curve;
+
+    if (curveTransform is not null)
+    {
+      var next = result.CreateTransformed(curveTransform);
+      if (accumulatedTransform is not null)
+      {
+        result.Dispose();
+      }
+
+      return next;
+    }
+
+    return result;
+  }
+
+  /// <summary>
+  /// Same two-step transform logic as <see cref="ResolveCurveTransforms"/>.
+  /// Operates on raw XYZ coordinates since PolyLine has no CreateTransformed API.
+  /// </summary>
+  private DB.PolyLine ResolvePolylineTransforms(
+    DB.PolyLine polyline,
+    DB.Transform? accumulatedTransform,
+    DB.Transform? curveTransform
+  )
+  {
+    var coords = polyline.GetCoordinates();
+
+    if (accumulatedTransform is not null)
+    {
+      coords = coords.Select(accumulatedTransform.OfPoint).ToList();
+    }
+
+    if (curveTransform is not null)
+    {
+      coords = coords.Select(curveTransform.OfPoint).ToList();
+    }
+
+    return DB.PolyLine.Create(coords.ToList());
+  }
+
   /// <remarks>
-  /// <see cref="Solids"/> and <see cref="Meshes"/> are transformed to symbol space in SortGeometry.
-  /// <see cref="Curves"/>, <see cref="Polylines"/>, and <see cref="Points"/> remain in their original coordinate space
-  /// and receive only the instance transform (if any) in ProcessGeometryCollections - reference point
-  /// transform is handled by the point converters during conversion.
+  /// Solids and meshes are transformed to world space inline in SortGeometry.
+  /// Curves and polylines can't follow the same pattern because their transform
+  /// path splits by element type — see ResolveCurveTransforms for details.
+  /// The AccumulatedTransform in each tuple carries the GeometryInstance transform
+  /// that SortGeometry would otherwise drop.
   /// </remarks>
   private sealed record GeometryCollections
   {
     public List<DB.Solid> Solids { get; } = new();
     public List<DB.Mesh> Meshes { get; } = new();
-    public List<DB.Curve> Curves { get; } = new();
-    public List<DB.PolyLine> Polylines { get; } = new();
+
+    // The transform stored alongside each curve/polyline is the accumulatedTransform that was
+    // active when SortGeometry encountered it. For FamilyInstance this will be identity (the
+    // instance and its inverse cancel out), so applying it is a no-op. For DirectShape elements
+    // from linked IFC/DWG files it carries the real GeometryInstance transform that would
+    // otherwise be silently dropped, placing curves at the origin instead of their correct position.
+    public List<(DB.Curve Curve, DB.Transform? AccumulatedTransform)> Curves { get; } = new();
+    public List<(DB.PolyLine Polyline, DB.Transform? AccumulatedTransform)> Polylines { get; } = new();
+
     public List<DB.Point> Points { get; } = new();
 
     public int TotalCount => Solids.Count + Meshes.Count + Curves.Count + Polylines.Count + Points.Count;

--- a/Converters/Revit/Speckle.Converters.RevitShared/Helpers/DisplayValueExtractor.cs
+++ b/Converters/Revit/Speckle.Converters.RevitShared/Helpers/DisplayValueExtractor.cs
@@ -783,19 +783,26 @@ public sealed class DisplayValueExtractor
     DB.Transform? curveTransform
   )
   {
+    DB.Transform? combined = (accumulatedTransform, curveTransform) switch
+    {
+      (not null, not null) => curveTransform.Multiply(accumulatedTransform),
+      _ => accumulatedTransform ?? curveTransform
+    };
+
     var coords = polyline.GetCoordinates();
 
-    if (accumulatedTransform is not null)
+    if (combined is null || combined.IsIdentity)
     {
-      coords = coords.Select(accumulatedTransform.OfPoint).ToList();
+      return DB.PolyLine.Create(coords);
     }
 
-    if (curveTransform is not null)
+    var transformed = new List<DB.XYZ>(coords.Count);
+    foreach (var pt in coords)
     {
-      coords = coords.Select(curveTransform.OfPoint).ToList();
+      transformed.Add(combined.OfPoint(pt));
     }
 
-    return DB.PolyLine.Create(coords.ToList());
+    return DB.PolyLine.Create(transformed);
   }
 
   /// <remarks>


### PR DESCRIPTION
## Description

Fixes incorrect curve positions inside linked IFC and DWG models.

Fixes [CNX-3166](https://linear.app/speckle/issue/CNX-3166/transform-issue-again-with-structural-framing-elements-in-linked-model) and [CNX-3201](https://linear.app/speckle/issue/CNX-3201/curve-transforms-in-import-objects).

## User Value

Curves and polylines from linked IFC and DWG models now appear in the correct position instead of the origin.

## Changes

When you link an IFC into a host model, Revit converts everything to `DirectShape`. `DirectShape` is not a `DB.Instance`, so our  `GetTransform()` call returns null — and the positional transform is buried inside a nested `GeometryInstance` in the geometry tree instead of sitting on the element itself.

Meshes were fine because `SortGeometry` already applies the accumulated `GeometryInstance` transform to them inline. Curves and polylines were not — that transform was being silently dropped, leaving them at the origin.

The fix carries the accumulated transform out of `SortGeometry` alongside each curve and polyline as a tuple, so `ProcessGeometryCollections` can apply it before the existing `curveTransform` step.

We couldn't just apply it inline in `SortGeometry` the way we do for meshes, because curves have a split transform path — part comes from `accumulatedTransform` and part from `curveTransform` in `ProcessGeometryCollections`. Applying both in `SortGeometry` would double-transform `FamilyInstance` elements.

- `GeometryCollections`: `Curves` and `Polylines` now store `(geometry, accumulatedTransform)`
  tuples instead of raw geometry
- `SortGeometry`: stores `accumulatedTransform` alongside curves and polylines instead of dropping it
- `ProcessGeometryCollections`: extracted `ResolveCurveTransforms` and `ResolvePolylineTransforms`
  helpers that apply the two-step transform chain cleanly
- Removed diagnostic logging and `depth` parameter added during investigation

## Screenshots & Validation of Changes

Borked curve transforms have been bugging us for far too long. I went back and tested all models where we had transform-related issues just to make sure we aren't introducing any regressions.

### CNX-3201
- [Ticket](https://linear.app/speckle/issue/CNX-3201/curve-transforms-in-import-objects)
- [Model](https://app.speckle.systems/projects/03074a2834/models/23edfed431@e06000fb51)
<img width="1919" height="1043" alt="Screenshot 2026-04-09 150557" src="https://github.com/user-attachments/assets/e3d2b475-21f1-4ea9-9615-987c293e6224" />

### CNX-3166
- [Ticket](https://linear.app/speckle/issue/CNX-3166/transform-issue-again-with-structural-framing-elements-in-linked-model)
- [Model](https://app.speckle.systems/projects/03074a2834/models/23edfed431@0907d5f1a7)
<img width="1916" height="1040" alt="Screenshot 2026-04-09 150747" src="https://github.com/user-attachments/assets/7eb3afb9-33b9-4390-81b4-4a595a09ad6d" />

### CNX-2859
- [Ticket](https://linear.app/speckle/issue/CNX-2859/curves-in-linked-elements-in-revit)
- [Model](https://app.speckle.systems/projects/03074a2834/models/23edfed431@49bec79e66)
<img width="1911" height="1037" alt="image" src="https://github.com/user-attachments/assets/382a23e8-593e-4036-8586-40a2be16b2bc" />

### CNX-2875
- [Ticket](https://linear.app/speckle/issue/CNX-2875/weird-transforms-happening-on-a-revit-file)
- [Model](https://app.speckle.systems/projects/03074a2834/models/23edfed431@344f63ac03)
<img width="1917" height="1040" alt="image" src="https://github.com/user-attachments/assets/1683f4f3-570f-4cad-8c32-785e27ff8269" />

## Validation of changes

- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] I have added appropriate tests.
- [x] I have updated or added relevant documentation.