### PR TITLE
fix(revit): Lighting source material is included in the material quantities

### DIFF
--- a/Converters/Revit/Speckle.Converters.RevitShared/ToSpeckle/Raw/MaterialQuantitiesToSpeckle.cs
+++ b/Converters/Revit/Speckle.Converters.RevitShared/ToSpeckle/Raw/MaterialQuantitiesToSpeckle.cs
@@ -32,6 +32,14 @@ public class MaterialQuantitiesToSpeckleLite : ITypedConverter<DB.Element, Dicti
   private readonly IConverterSettingsStore<RevitConversionSettings> _converterSettings;
   private readonly StructuralMaterialAssetExtractor _structuralAssetExtractor;
 
+  // Materials excluded from quantity extraction. Revit's GetMaterialIds() returns materials
+  // applied to geometry that we already exclude from display values (e.g. lighting cone).
+  // The API provides no way to identify such materials programmatically, so we exclude by name.
+  // Known limitation: custom material names are not covered.
+  private static readonly HashSet<string> s_excludedMaterialNames = ["Default Light Source"];
+
+  private static bool IsExcludedMaterial(string materialName) => s_excludedMaterialNames.Contains(materialName);
+
   public MaterialQuantitiesToSpeckleLite(
     ScalingServiceToSpeckle scalingService,
     IConverterSettingsStore<RevitConversionSettings> converterSettings,
@@ -88,6 +96,10 @@ public class MaterialQuantitiesToSpeckleLite : ITypedConverter<DB.Element, Dicti
         // add material props
         if (TryAddMaterialPropertiesToQuantitiesDict(matId, materialQuantity, out string matName))
         {
+          if (IsExcludedMaterial(matName))
+          {
+            continue;
+          }
           quantities[matName] = materialQuantity;
         }
 

--- a/Converters/Revit/Speckle.Converters.RevitShared/ToSpeckle/Raw/MaterialQuantitiesToSpeckle.cs
+++ b/Converters/Revit/Speckle.Converters.RevitShared/ToSpeckle/Raw/MaterialQuantitiesToSpeckle.cs
@@ -38,8 +38,6 @@ public class MaterialQuantitiesToSpeckleLite : ITypedConverter<DB.Element, Dicti
   // Known limitation: custom material names are not covered.
   private static readonly HashSet<string> s_excludedMaterialNames = ["Default Light Source"];
 
-  private static bool IsExcludedMaterial(string materialName) => s_excludedMaterialNames.Contains(materialName);
-
   public MaterialQuantitiesToSpeckleLite(
     ScalingServiceToSpeckle scalingService,
     IConverterSettingsStore<RevitConversionSettings> converterSettings,
@@ -96,10 +94,6 @@ public class MaterialQuantitiesToSpeckleLite : ITypedConverter<DB.Element, Dicti
         // add material props
         if (TryAddMaterialPropertiesToQuantitiesDict(matId, materialQuantity, out string matName))
         {
-          if (IsExcludedMaterial(matName))
-          {
-            continue;
-          }
           quantities[matName] = materialQuantity;
         }
 
@@ -215,6 +209,10 @@ public class MaterialQuantitiesToSpeckleLite : ITypedConverter<DB.Element, Dicti
     matName = "";
     if (_converterSettings.Current.Document.GetElement(matId) is DB.Material material)
     {
+      if (s_excludedMaterialNames.Contains(material.Name))
+      {
+        return false;
+      }
       materialQuantity["materialName"] = material.Name;
       materialQuantity["materialCategory"] = material.MaterialCategory;
       materialQuantity["materialClass"] = material.MaterialClass;

--- a/Converters/Revit/Speckle.Converters.RevitShared/ToSpeckle/Raw/MaterialQuantitiesToSpeckle.cs
+++ b/Converters/Revit/Speckle.Converters.RevitShared/ToSpeckle/Raw/MaterialQuantitiesToSpeckle.cs
@@ -32,12 +32,6 @@ public class MaterialQuantitiesToSpeckleLite : ITypedConverter<DB.Element, Dicti
   private readonly IConverterSettingsStore<RevitConversionSettings> _converterSettings;
   private readonly StructuralMaterialAssetExtractor _structuralAssetExtractor;
 
-  // Materials excluded from quantity extraction. Revit's GetMaterialIds() returns materials
-  // applied to geometry that we already exclude from display values (e.g. lighting cone).
-  // The API provides no way to identify such materials programmatically, so we exclude by name.
-  // Known limitation: custom material names are not covered.
-  private static readonly HashSet<string> s_excludedMaterialNames = ["Default Light Source"];
-
   public MaterialQuantitiesToSpeckleLite(
     ScalingServiceToSpeckle scalingService,
     IConverterSettingsStore<RevitConversionSettings> converterSettings,
@@ -209,7 +203,8 @@ public class MaterialQuantitiesToSpeckleLite : ITypedConverter<DB.Element, Dicti
     matName = "";
     if (_converterSettings.Current.Document.GetElement(matId) is DB.Material material)
     {
-      if (s_excludedMaterialNames.Contains(material.Name))
+      // No API to identify light-cone materials by ID; exclude by well-known default name.
+      if (material.Name == "Default Light Source")
       {
         return false;
       }


### PR DESCRIPTION
`GetMaterialIds()` on lighting fixture elements returns the IDs of all materials applied to that element, including materials applied to lighting cone geometry (the visual "light source" cone/sphere Revit renders). This causes spurious entries in `properties["Material Quantities"]` for lighting fixtures, e.g. a material named "Default Light Source" with a non-zero area/volume.

The display-value side of the pipeline already excludes this geometry in `DisplayValueExtractor.SkipGeometry()` by checking `OST_LightingFixtureSource` on the geometry object's graphics style. However, the Revit API offers no equivalent on `GetMaterialIds()`. There is no way to ask "which material IDs belong to light source geometry vs. structural geometry". The fix is to exclude by the well-known default name.

**Known limitation:** users who have renamed or replaced the default light source material with a custom name will not be covered.