### PR TITLE
fix(revit): skip out-of-bounds snapping references for far-from-origin DirectShapes

### DIFF
--- a/Converters/Revit/Speckle.Converters.RevitShared/ToHost/Raw/LocalToGlobalToDirectShapeConverter.cs
+++ b/Converters/Revit/Speckle.Converters.RevitShared/ToHost/Raw/LocalToGlobalToDirectShapeConverter.cs
@@ -72,20 +72,35 @@ public class LocalToGlobalToDirectShapeConverter
       var def = DB
         .DirectShapeLibrary.GetDirectShapeLibrary(_converterSettings.Current.Document)
         .FindDefinition(target.atomicObject.applicationId ?? target.atomicObject.id.NotNull());
+
       result.SetShape(def);
 
       // add snapping references for meshes and curves
+      // cnx-3292: best-effort NOT all-or-nothing. AddReferencePoint and AddReferenceCurve purely additive for snapping.
+      // Their absence doesn't corrupt element, so failure below (rvt api limitation!) shouldn't terminate receive
       foreach (var shape in def)
       {
         switch (shape)
         {
           case DB.Mesh m:
+            if (m.Vertices.Any(v => !DB.XYZ.IsWithinLengthLimits(v)))
+            {
+              // right now there's no path to surface a warning into the UI report from within the converter itself
+              // making this bubble all the way up is not worth the refactor (unless we get more reports)
+              break;
+            }
             foreach (var v in m.Vertices)
             {
               result.AddReferencePoint(v);
             }
             break;
+
           case DB.Curve c:
+            if (!DB.XYZ.IsWithinLengthLimits(c.GetEndPoint(0)) || !DB.XYZ.IsWithinLengthLimits(c.GetEndPoint(1)))
+            {
+              // see comment in DB.Mesh case
+              break;
+            }
             result.AddReferenceCurve(c);
             break;
         }


### PR DESCRIPTION
## Description
Receiving a model into Revit was failing with `The input point lies outside of Revit design limits` during DirectShape creation for geometry far from internal origin.

Related to a previous fix for the same underlying API limitation in the ToSpeckle direction (`CurveOriginToPlaneConverter`), but this time failing on receive in `LocalToGlobalToDirectShapeConverter` when calling `AddReferencePoint` and `AddReferenceCurve` on mesh vertices and curve endpoints.

See [CNX-3292](https://linear.app/speckle/issue/CNX-3292/revit-receive-fails-with-point-outside-design-limits-for-valid).

## User Value
Users can now successfully receive far-from-origin models (IFC/Navisworks pipelines) into Revit without all objects failing conversion. They may not be able to snap to them, but at least the geometry is there.

## Changes:
- In `LocalToGlobalToDirectShapeConverter`, guarded `AddReferencePoint` and `AddReferenceCurve` calls with `DB.XYZ.IsWithinLengthLimits` checks
- If any mesh vertex is out of bounds, skip reference points for the entire mesh
- Same guard for curves — both endpoints must be within limits
- Geometry itself is unaffected — `SetShape` already succeeded before we hit this; snapping refs are best-effort and their absence doesn't corrupt or misplace the element
- Decided against logging/bubbling a warning to the UI — `WARNING` status is unused in rvt host object builder, don't like how the refactor would look, and this is speculative until users actually report snapping issues. Code comment documents the reasoning if it comes up.

## To-do before merge
- [x] @bimgeek let's discuss this logging decision (see above). I'm on the fence here. 

## Validation of changes:
Could load reported model.

### Before

<img width="828" height="872" alt="image" src="https://github.com/user-attachments/assets/fc47f0b3-48de-4976-a8db-b6f421b0e388" />

### After

<img width="1280" height="689" alt="image" src="https://github.com/user-attachments/assets/033fb8e3-36a7-47fa-ac8a-fe5481e6331b" />

## Checklist:

- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] I have added appropriate tests.
- [x] I have updated or added relevant documentation.