### PR TITLE
Bilal/cnx 3296 expose drawing name as a top level object property

### DIFF
--- a/Converters/Plant3d/Speckle.Converters.Plant3dShared/ToSpeckle/Properties/PropertiesExtractor.cs
+++ b/Converters/Plant3d/Speckle.Converters.Plant3dShared/ToSpeckle/Properties/PropertiesExtractor.cs
@@ -23,8 +23,8 @@ public class PropertiesExtractor : Speckle.Converters.AutocadShared.ToSpeckle.IP
   {
     Dictionary<string, object?> properties = new();
 
-    // Add source drawing name so objects from multi-drawing Plant 3D
-    // projects can be traced back to their origin file.
+    // TODO: Add Plant3D class-specific property extraction here
+    // For example, extract pipe spec data, equipment data, etc.
     properties["Drawing Name"] = _drawingName;
 
     // add property sets and extension dictionaries to the properties dict

--- a/Converters/Plant3d/Speckle.Converters.Plant3dShared/ToSpeckle/Properties/PropertiesExtractor.cs
+++ b/Converters/Plant3d/Speckle.Converters.Plant3dShared/ToSpeckle/Properties/PropertiesExtractor.cs
@@ -1,3 +1,5 @@
+using Speckle.Converters.Common;
+
 namespace Speckle.Converters.Plant3dShared.ToSpeckle;
 
 /// <summary>
@@ -6,18 +8,24 @@ namespace Speckle.Converters.Plant3dShared.ToSpeckle;
 public class PropertiesExtractor : Speckle.Converters.AutocadShared.ToSpeckle.IPropertiesExtractor
 {
   private readonly ExtensionDictionaryExtractor _extensionDictionaryExtractor;
+  private readonly IConverterSettingsStore<Plant3dConversionSettings> _settingsStore;
 
-  public PropertiesExtractor(ExtensionDictionaryExtractor extensionDictionaryExtractor)
+  public PropertiesExtractor(
+    ExtensionDictionaryExtractor extensionDictionaryExtractor,
+    IConverterSettingsStore<Plant3dConversionSettings> settingsStore
+  )
   {
     _extensionDictionaryExtractor = extensionDictionaryExtractor;
+    _settingsStore = settingsStore;
   }
 
   public Dictionary<string, object?> GetProperties(ADB.Entity entity)
   {
     Dictionary<string, object?> properties = new();
 
-    // TODO: Add Plant3D class-specific property extraction here
-    // For example, extract pipe spec data, equipment data, etc.
+    // Add source drawing name so objects from multi-drawing Plant 3D
+    // projects can be traced back to their origin file.
+    properties["Drawing Name"] = Path.GetFileName(_settingsStore.Current.Document.Name);
 
     // add property sets and extension dictionaries to the properties dict
     AddDictionaryToPropertyDictionary(

--- a/Converters/Plant3d/Speckle.Converters.Plant3dShared/ToSpeckle/Properties/PropertiesExtractor.cs
+++ b/Converters/Plant3d/Speckle.Converters.Plant3dShared/ToSpeckle/Properties/PropertiesExtractor.cs
@@ -8,7 +8,7 @@ namespace Speckle.Converters.Plant3dShared.ToSpeckle;
 public class PropertiesExtractor : Speckle.Converters.AutocadShared.ToSpeckle.IPropertiesExtractor
 {
   private readonly ExtensionDictionaryExtractor _extensionDictionaryExtractor;
-  private readonly IConverterSettingsStore<Plant3dConversionSettings> _settingsStore;
+  private readonly string _drawingName;
 
   public PropertiesExtractor(
     ExtensionDictionaryExtractor extensionDictionaryExtractor,
@@ -16,7 +16,7 @@ public class PropertiesExtractor : Speckle.Converters.AutocadShared.ToSpeckle.IP
   )
   {
     _extensionDictionaryExtractor = extensionDictionaryExtractor;
-    _settingsStore = settingsStore;
+    _drawingName = Path.GetFileName(settingsStore.Current.Document.Name);
   }
 
   public Dictionary<string, object?> GetProperties(ADB.Entity entity)
@@ -25,7 +25,7 @@ public class PropertiesExtractor : Speckle.Converters.AutocadShared.ToSpeckle.IP
 
     // Add source drawing name so objects from multi-drawing Plant 3D
     // projects can be traced back to their origin file.
-    properties["Drawing Name"] = Path.GetFileName(_settingsStore.Current.Document.Name);
+    properties["Drawing Name"] = _drawingName;
 
     // add property sets and extension dictionaries to the properties dict
     AddDictionaryToPropertyDictionary(


### PR DESCRIPTION
Adds a Drawing Name property to all Plant3D entities during conversion. This lets objects from multi-drawing Plant3D projects be traced back to their origin file after being sent to Speckle.

<img width="354" height="146" alt="image" src="https://github.com/user-attachments/assets/159fabb2-ba99-475e-8f8f-2b8bb82bc45b" />

## Changes

- `PropertiesExtractor `now injects `IConverterSettingsStore`<Plant3dConversionSettings> and resolves `Path.GetFileName(Document.Name)` once at construction, storing it as a plain string field rather than keeping a reference to the store.
