### PR TITLE
fix(acad, c3d, p3d): "Create New Model" pre-fills file name

### DIFF
--- a/Connectors/Autocad/Speckle.Connectors.AutocadShared/Bindings/AutocadBasicConnectorBinding.cs
+++ b/Connectors/Autocad/Speckle.Connectors.AutocadShared/Bindings/AutocadBasicConnectorBinding.cs
@@ -67,7 +67,7 @@ public class AutocadBasicConnectorBinding : IBasicConnectorBinding
     {
       return null;
     }
-    string name = doc.Name.Split(System.IO.Path.PathSeparator).Last();
+    string name = System.IO.Path.GetFileName(doc.Name);
     return new DocumentInfo(doc.Name, name, doc.GetHashCode().ToString());
   }
 


### PR DESCRIPTION
Show file name instead of full path as the default value of the create model name.

<img width="365" height="176" alt="image" src="https://github.com/user-attachments/assets/dac4d317-2875-4c0c-b57e-f127a18b5bdb" />
