### PR TITLE
fix(grasshopper): clear Base.id in UnwrapGeometry to prevent stale chunked mesh references on republish

### DIFF
--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Operations/Send/GrasshopperContinuousTraversalBuilder.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Operations/Send/GrasshopperContinuousTraversalBuilder.cs
@@ -154,6 +154,7 @@ public class GrasshopperContinuousTraversalBuilder(
   {
     Dictionary<string, object?> props = [];
     Base baseObject = wrapper.Base;
+    baseObject.id = null; // force fresh serialization — cached id may point to chunked mesh from original source (CNX-3303)
     if (wrapper.Properties.CastTo(ref props))
     {
       baseObject["properties"] = props;

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Operations/Send/GrasshopperSendOperation.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Operations/Send/GrasshopperSendOperation.cs
@@ -158,6 +158,7 @@ public class GrasshopperRootObjectBuilder : IRootObjectBuilder<SpeckleCollection
   {
     Dictionary<string, object?> props = [];
     Base baseObject = wrapper.Base;
+    baseObject.id = null; // force fresh serialization — cached id may point to chunked mesh from original source (CNX-3303)
     if (wrapper.Properties.CastTo(ref props))
     {
       baseObject["properties"] = props; // setting props here on base since it's not auto-set, like name and appid


### PR DESCRIPTION
## Description

TBD

## User Value

Geometry is no longer lost when receiving a Grasshopper-republished version of an (e.g.) IFC model originally published by another connector.

## Changes

TBD

## Reproduction Steps

- Load large IFC model in GH

<img width="526" height="200" alt="image" src="https://github.com/user-attachments/assets/db208b7e-a68a-4d98-bffd-e837d0983d10" />


- Flatten all `DataObject`s and split between those with and those without a `displayValue`.

<img width="773" height="203" alt="image" src="https://github.com/user-attachments/assets/f6f38c22-5606-4777-9b3b-2ecbe208295a" />


- Take `DataObject` s with `displayValue`, pipe them through the `Speckle Data Object` passthrough, so it triggers geometry castings etc. Just use a subset of 20 randomly selected `DataObject`s.

<img width="604" height="283" alt="image" src="https://github.com/user-attachments/assets/9196b915-a946-42e5-8af5-b233d3f0b35c" />


- Merge those `DataObject`s back with the original subset of geometryless `DataObject`s and publish.

<img width="543" height="324" alt="image" src="https://github.com/user-attachments/assets/846dcaa2-a173-433c-832e-f8656a86a167" />


- Load published model back and get a count for the number of `DataObject`s with a `displayValue`. It should equal the random subset (= 20).

<img width="773" height="217" alt="image" src="https://github.com/user-attachments/assets/7d882335-a1e4-4c78-abd7-9a90bd9572d9" />

## Validation of changes

### Before

### After

## Checklist:
- [ ] My commits are related to the pull request and do not amend unrelated code or documentation.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.