### PR TITLE
feat (rhino): dataobject wrapper

### DIFF
--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Operations/Receive/GrasshopperBlockUnpacker.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Operations/Receive/GrasshopperBlockUnpacker.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Logging;
 using Rhino.Geometry;
 using Speckle.Connectors.Common.Operations.Receive;
 using Speckle.Connectors.GrasshopperShared.HostApp;
@@ -21,16 +22,19 @@ internal sealed class GrasshopperBlockUnpacker
   private readonly TraversalContextUnpacker _traversalContextUnpacker;
   private readonly GrasshopperColorUnpacker _colorUnpacker;
   private readonly GrasshopperMaterialUnpacker _materialUnpacker;
+  private readonly ILogger<GrasshopperBlockUnpacker> _logger;
 
   public GrasshopperBlockUnpacker(
     TraversalContextUnpacker traversalContextUnpacker,
     GrasshopperColorUnpacker colorUnpacker,
-    GrasshopperMaterialUnpacker materialUnpacker
+    GrasshopperMaterialUnpacker materialUnpacker,
+    ILogger<GrasshopperBlockUnpacker> logger
   )
   {
     _traversalContextUnpacker = traversalContextUnpacker;
     _colorUnpacker = colorUnpacker;
     _materialUnpacker = materialUnpacker;
+    _logger = logger;
   }
 
   /// <summary>
@@ -121,7 +125,13 @@ internal sealed class GrasshopperBlockUnpacker
         }
         else
         {
-          // TODO: throw?
+          _logger.LogWarning(
+            "Block definition {defId} ({defName}) could not be built because none of its member "
+              + "objects were found in the converted objects map. All instances of this definition "
+              + "will be dropped.",
+            definitionId,
+            definitionProxy.name
+          );
         }
       }
       else if (component is InstanceProxy instanceProxy)
@@ -142,7 +152,12 @@ internal sealed class GrasshopperBlockUnpacker
         }
         else
         {
-          // TODO: throw?
+          _logger.LogWarning(
+            "Failed to create block instance {instanceId}: definition {defId} was not available. "
+              + "The instance will not appear in the scene.",
+            instanceId,
+            instanceProxy.definitionId
+          );
         }
       }
     }
@@ -175,7 +190,14 @@ internal sealed class GrasshopperBlockUnpacker
       }
       else
       {
-        // TODO: throw?
+        _logger.LogWarning(
+          "Block definition {defId} ({defName}) references object {objId} which was not found in "
+            + "the converted objects map. This geometry will be missing from the definition and "
+            + "therefore from all its instances.",
+          definitionId,
+          definitionProxy.name,
+          objectId
+        );
       }
     }
 

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Operations/Receive/GrasshopperCollectionRebuilder.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Operations/Receive/GrasshopperCollectionRebuilder.cs
@@ -112,11 +112,17 @@ internal sealed class GrasshopperCollectionRebuilder
     HashSet<string> consumedObjectIds
   )
   {
-    // Remove consumed objects from this level
+    // Remove consumed objects from this level.
+    // Matches both SpeckleGeometryWrapper (legacy path) and SpeckleDataObjectWrapper
+    // (current Rhino path, where atomic objects are wrapped in RhinoDataObject).
     collection.Elements.RemoveAll(element =>
-      element is SpeckleGeometryWrapper obj
-      && obj.ApplicationId != null
-      && consumedObjectIds.Contains(obj.ApplicationId)
+      element switch
+      {
+        SpeckleGeometryWrapper obj => obj.ApplicationId != null && consumedObjectIds.Contains(obj.ApplicationId),
+        SpeckleDataObjectWrapper dataObj => dataObj.ApplicationId != null
+                                            && consumedObjectIds.Contains(dataObj.ApplicationId),
+        _ => false,
+      }
     );
 
     // Recurse into child collections

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Operations/Receive/LocalToGlobalMapHandler.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Operations/Receive/LocalToGlobalMapHandler.cs
@@ -32,6 +32,7 @@ internal sealed class LocalToGlobalMapHandler
   // injected via constructor (DI-managed)
   private readonly IDataObjectInstanceRegistry _dataObjectInstanceRegistry;
   private readonly ILogger<LocalToGlobalMapHandler> _logger;
+  private readonly ILogger<GrasshopperBlockUnpacker> _blockUnpackerLogger;
   private readonly IConverterSettingsStore<RhinoConversionSettings> _settingsStore;
 
   // set via Initialize() method (per-operation data)
@@ -45,12 +46,14 @@ internal sealed class LocalToGlobalMapHandler
 
   public LocalToGlobalMapHandler(
     IDataObjectInstanceRegistry dataObjectInstanceRegistry,
-    ILogger<LocalToGlobalMapHandler> logger,
+    ILogger<LocalToGlobalMapHandler> logger, 
+    ILogger<GrasshopperBlockUnpacker> blockUnpackerLogger,
     IConverterSettingsStore<RhinoConversionSettings> settingsStore
   )
   {
     _dataObjectInstanceRegistry = dataObjectInstanceRegistry;
     _logger = logger;
+    _blockUnpackerLogger = blockUnpackerLogger;
     _settingsStore = settingsStore;
   }
 
@@ -156,6 +159,22 @@ internal sealed class LocalToGlobalMapHandler
         _processedDataObjects.Add(objId);
 
         var geometries = ConvertToGeometryWrappers(converted);
+
+        if (geometries.Count >= 1)
+        {
+          if (geometries.Count > 1) // ASSUMPTION FOR NOW WITH CNX-3169
+          {
+            _logger.LogWarning(
+              "DataObject {objId} produced {count} geometries; only the first is registered for "
+                + "block-definition resolution. If this object is referenced by an InstanceDefinitionProxy, "
+                + "some geometry may be missing from block instances.",
+              objId,
+              geometries.Count
+            );
+          }
+          ConvertedObjectsMap[objId] = geometries[0].DeepCopy();
+        }
+
         var dataObjectWrapper = CreateDataObjectWrapper(normalDataObject, geometries, path, objectCollection);
 
         CollectionRebuilder.AppendSpeckleGrasshopperObject(dataObjectWrapper, path, _colorUnpacker, _materialUnpacker);
@@ -290,7 +309,12 @@ internal sealed class LocalToGlobalMapHandler
       })
       .ToList();
 
-    var blockUnpacker = new GrasshopperBlockUnpacker(_traversalContextUnpacker, _colorUnpacker, _materialUnpacker);
+    var blockUnpacker = new GrasshopperBlockUnpacker(
+      _traversalContextUnpacker,
+      _colorUnpacker,
+      _materialUnpacker,
+      _blockUnpackerLogger
+    );
 
     // get consumed object IDs from unpacker
     var consumedObjectIds = blockUnpacker.UnpackBlocks(

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/Operations/Send/RhinoContinousTraversalBuilder.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/Operations/Send/RhinoContinousTraversalBuilder.cs
@@ -11,15 +11,15 @@ using Speckle.Connectors.Rhino.HostApp;
 using Speckle.Connectors.Rhino.HostApp.Properties;
 using Speckle.Converters.Common;
 using Speckle.Converters.Rhino;
+using Speckle.Objects;
+using Speckle.Objects.Geometry;
+using Speckle.Objects.Other;
 using Speckle.Sdk;
 using Speckle.Sdk.Logging;
 using Speckle.Sdk.Models;
 using Speckle.Sdk.Models.Collections;
 using Speckle.Sdk.Models.Instances;
 using Speckle.Sdk.Pipelines.Progress;
-using Speckle.Objects;
-using Speckle.Objects.Geometry;
-using Speckle.Objects.Other;
 using Speckle.Sdk.Pipelines.Send;
 using Layer = Rhino.DocObjects.Layer;
 using RhinoDataObject = Speckle.Objects.Data.RhinoObject;
@@ -220,9 +220,7 @@ public class RhinoContinuousTraversalBuilder : IRootContinuousTraversalBuilder<R
 
         converted = new RhinoDataObject
         {
-          name = !string.IsNullOrEmpty(rhinoObject.Attributes.Name)
-            ? rhinoObject.Attributes.Name
-            : sourceType,
+          name = !string.IsNullOrEmpty(rhinoObject.Attributes.Name) ? rhinoObject.Attributes.Name : sourceType,
           type = sourceType,
           displayValue = displayMeshes,
           properties = _propertiesExtractor.GetProperties(rhinoObject),

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/Operations/Send/RhinoContinousTraversalBuilder.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/Operations/Send/RhinoContinousTraversalBuilder.cs
@@ -17,8 +17,12 @@ using Speckle.Sdk.Models;
 using Speckle.Sdk.Models.Collections;
 using Speckle.Sdk.Models.Instances;
 using Speckle.Sdk.Pipelines.Progress;
+using Speckle.Objects;
+using Speckle.Objects.Geometry;
+using Speckle.Objects.Other;
 using Speckle.Sdk.Pipelines.Send;
 using Layer = Rhino.DocObjects.Layer;
+using RhinoDataObject = Speckle.Objects.Data.RhinoObject;
 
 namespace Speckle.Connectors.Rhino.Operations.Send;
 
@@ -186,21 +190,37 @@ public class RhinoContinuousTraversalBuilder : IRootContinuousTraversalBuilder<R
       }
       else
       {
-        converted = _rootToSpeckleConverter.Convert(rhinoObject);
-        converted.applicationId = applicationId;
-      }
+        var rawGeometry = _rootToSpeckleConverter.Convert(rhinoObject);
 
-      // add name and properties
-      // POC: this is NOT done in the converter because we don't have a RootToSpeckle converter that captures all top level converters
-      if (!string.IsNullOrEmpty(rhinoObject.Attributes.Name))
-      {
-        converted["name"] = rhinoObject.Attributes.Name;
-      }
+        List<Base> displayMeshes;
+        RawEncoding? rawEncoding = null;
 
-      var properties = _propertiesExtractor.GetProperties(rhinoObject);
-      if (properties.Count > 0)
-      {
-        converted["properties"] = properties;
+        if (rawGeometry is IDisplayValue<List<Mesh>> hasDisplay && rawGeometry is IRawEncodedObject rawEncoded)
+        {
+          displayMeshes = hasDisplay.displayValue.Cast<Base>().ToList();
+          rawEncoding = rawEncoded.encodedValue;
+        }
+        else if (rawGeometry is IDisplayValue<List<Mesh>> hasDisplayMeshes)
+        {
+          displayMeshes = hasDisplayMeshes.displayValue.Cast<Base>().ToList();
+        }
+        else
+        {
+          displayMeshes = [rawGeometry];
+        }
+
+        converted = new RhinoDataObject
+        {
+          name = !string.IsNullOrEmpty(rhinoObject.Attributes.Name)
+            ? rhinoObject.Attributes.Name
+            : sourceType,
+          type = sourceType,
+          displayValue = displayMeshes,
+          properties = _propertiesExtractor.GetProperties(rhinoObject),
+          units = _converterSettings.Current.SpeckleUnits,
+          applicationId = applicationId,
+          rawEncoding = rawEncoding,
+        };
       }
 
       // NOTE: this is the main part that differentiate from the main root object builder

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/Operations/Send/RhinoContinousTraversalBuilder.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/Operations/Send/RhinoContinousTraversalBuilder.cs
@@ -183,6 +183,15 @@ public class RhinoContinuousTraversalBuilder : IRootContinuousTraversalBuilder<R
       if (rhinoObject is InstanceObject)
       {
         converted = instanceProxies[applicationId];
+        if (!string.IsNullOrEmpty(rhinoObject.Attributes.Name))
+        {
+          converted["name"] = rhinoObject.Attributes.Name;
+        }
+        var instanceProperties = _propertiesExtractor.GetProperties(rhinoObject);
+        if (instanceProperties.Count > 0)
+        {
+          converted["properties"] = instanceProperties;
+        }
       }
       else if (_sendConversionCache.TryGetValue(projectId, applicationId, out ObjectReference? value))
       {

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/Operations/Send/RhinoRootObjectBuilder.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/Operations/Send/RhinoRootObjectBuilder.cs
@@ -16,8 +16,12 @@ using Speckle.Sdk.Logging;
 using Speckle.Sdk.Models;
 using Speckle.Sdk.Models.Collections;
 using Speckle.Sdk.Models.Instances;
+using Speckle.Objects;
+using Speckle.Objects.Geometry;
+using Speckle.Objects.Other;
 using Speckle.Sdk.Pipelines.Progress;
 using Layer = Rhino.DocObjects.Layer;
+using RhinoDataObject = Speckle.Objects.Data.RhinoObject;
 
 namespace Speckle.Connectors.Rhino.Operations.Send;
 
@@ -178,21 +182,37 @@ public class RhinoRootObjectBuilder : IRootObjectBuilder<RhinoObject>
       }
       else
       {
-        converted = _rootToSpeckleConverter.Convert(rhinoObject);
-        converted.applicationId = applicationId;
-      }
+        var rawGeometry = _rootToSpeckleConverter.Convert(rhinoObject);
 
-      // add name and properties
-      // POC: this is NOT done in the converter because we don't have a RootToSpeckle converter that captures all top level converters
-      if (!string.IsNullOrEmpty(rhinoObject.Attributes.Name))
-      {
-        converted["name"] = rhinoObject.Attributes.Name;
-      }
+        List<Base> displayMeshes;
+        RawEncoding? rawEncoding = null;
 
-      var properties = _propertiesExtractor.GetProperties(rhinoObject);
-      if (properties.Count > 0)
-      {
-        converted["properties"] = properties;
+        if (rawGeometry is IDisplayValue<List<Mesh>> hasDisplay && rawGeometry is IRawEncodedObject rawEncoded)
+        {
+          displayMeshes = hasDisplay.displayValue.Cast<Base>().ToList();
+          rawEncoding = rawEncoded.encodedValue;
+        }
+        else if (rawGeometry is IDisplayValue<List<Mesh>> hasDisplayMeshes)
+        {
+          displayMeshes = hasDisplayMeshes.displayValue.Cast<Base>().ToList();
+        }
+        else
+        {
+          displayMeshes = [rawGeometry];
+        }
+
+        converted = new RhinoDataObject
+        {
+          name = !string.IsNullOrEmpty(rhinoObject.Attributes.Name)
+            ? rhinoObject.Attributes.Name
+            : sourceType,
+          type = sourceType,
+          displayValue = displayMeshes,
+          properties = _propertiesExtractor.GetProperties(rhinoObject),
+          units = _converterSettings.Current.SpeckleUnits,
+          applicationId = applicationId,
+          rawEncoding = rawEncoding,
+        };
       }
 
       // add to host

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/Operations/Send/RhinoRootObjectBuilder.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/Operations/Send/RhinoRootObjectBuilder.cs
@@ -11,14 +11,14 @@ using Speckle.Connectors.Rhino.HostApp;
 using Speckle.Connectors.Rhino.HostApp.Properties;
 using Speckle.Converters.Common;
 using Speckle.Converters.Rhino;
+using Speckle.Objects;
+using Speckle.Objects.Geometry;
+using Speckle.Objects.Other;
 using Speckle.Sdk;
 using Speckle.Sdk.Logging;
 using Speckle.Sdk.Models;
 using Speckle.Sdk.Models.Collections;
 using Speckle.Sdk.Models.Instances;
-using Speckle.Objects;
-using Speckle.Objects.Geometry;
-using Speckle.Objects.Other;
 using Speckle.Sdk.Pipelines.Progress;
 using Layer = Rhino.DocObjects.Layer;
 using RhinoDataObject = Speckle.Objects.Data.RhinoObject;
@@ -212,9 +212,7 @@ public class RhinoRootObjectBuilder : IRootObjectBuilder<RhinoObject>
 
         converted = new RhinoDataObject
         {
-          name = !string.IsNullOrEmpty(rhinoObject.Attributes.Name)
-            ? rhinoObject.Attributes.Name
-            : sourceType,
+          name = !string.IsNullOrEmpty(rhinoObject.Attributes.Name) ? rhinoObject.Attributes.Name : sourceType,
           type = sourceType,
           displayValue = displayMeshes,
           properties = _propertiesExtractor.GetProperties(rhinoObject),

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/Operations/Send/RhinoRootObjectBuilder.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/Operations/Send/RhinoRootObjectBuilder.cs
@@ -175,6 +175,15 @@ public class RhinoRootObjectBuilder : IRootObjectBuilder<RhinoObject>
       if (rhinoObject is InstanceObject)
       {
         converted = instanceProxies[applicationId];
+        if (!string.IsNullOrEmpty(rhinoObject.Attributes.Name))
+        {
+          converted["name"] = rhinoObject.Attributes.Name;
+        }
+        var instanceProperties = _propertiesExtractor.GetProperties(rhinoObject);
+        if (instanceProperties.Count > 0)
+        {
+          converted["properties"] = instanceProperties;
+        }
       }
       else if (_sendConversionCache.TryGetValue(projectId, applicationId, out ObjectReference? value))
       {

--- a/Converters/Revit/Speckle.Converters.RevitShared/ToHost/Raw/BaseToHostGeometryObjectConverter.cs
+++ b/Converters/Revit/Speckle.Converters.RevitShared/ToHost/Raw/BaseToHostGeometryObjectConverter.cs
@@ -4,6 +4,7 @@ using Speckle.Objects;
 using Speckle.Sdk.Common.Exceptions;
 using Speckle.Sdk.Models;
 using Speckle.Sdk.Models.Extensions;
+using RhinoDataObject = Speckle.Objects.Data.RhinoObject;
 
 namespace Speckle.Converters.RevitShared.ToSpeckle;
 
@@ -35,6 +36,10 @@ public class BaseToHostGeometryObjectConverter(
       case SOG.IRawEncodedObject elon:
         var res = encodedObjectConverter.Convert(elon);
         result.AddRange(res);
+        break;
+      case RhinoDataObject rhinoData when rhinoData.rawEncoding is not null:
+        var decoded = ((IRawEncodedObjectConverter)encodedObjectConverter).Convert(rhinoData.rawEncoding, rhinoData);
+        result.AddRange(decoded);
         break;
       default:
         var displayValue = target.TryGetDisplayValue<Base>();

--- a/Converters/Revit/Speckle.Converters.RevitShared/ToHost/Raw/Geometry/IRawEncodedObjectConverter.cs
+++ b/Converters/Revit/Speckle.Converters.RevitShared/ToHost/Raw/Geometry/IRawEncodedObjectConverter.cs
@@ -3,6 +3,7 @@ using Speckle.Converters.Common.FileOps;
 using Speckle.Converters.Common.Objects;
 using Speckle.Converters.RevitShared.Helpers;
 using Speckle.Converters.RevitShared.Settings;
+using Speckle.Objects.Other;
 using Speckle.Sdk.Common;
 using Speckle.Sdk.Models;
 using Speckle.Sdk.Models.Extensions;
@@ -26,12 +27,13 @@ public class IRawEncodedObjectConverter : ITypedConverter<SOG.IRawEncodedObject,
     _revitToHostCacheSingleton = revitToHostCacheSingleton;
   }
 
-  public List<DB.GeometryObject> Convert(SOG.IRawEncodedObject target)
+  public List<DB.GeometryObject> Convert(SOG.IRawEncodedObject target) => Convert(target.encodedValue, (Base)target);
+
+  public List<DB.GeometryObject> Convert(RawEncoding encoding, Base targetAsBase)
   {
-    var targetAsBase = (Base)target;
-    var raw = target.encodedValue.contents;
+    var raw = encoding.contents;
     var bytes = System.Convert.FromBase64String(raw!);
-    var filePath = TempFileProvider.GetTempFile("RevitX", target.encodedValue.format);
+    var filePath = TempFileProvider.GetTempFile("RevitX", encoding.format);
     File.WriteAllBytes(filePath, bytes);
 
     using var importer = new DB.ShapeImporter();

--- a/Converters/Rhino/Speckle.Converters.RhinoShared/ToHost/Helpers/RawEncodingToHost.cs
+++ b/Converters/Rhino/Speckle.Converters.RhinoShared/ToHost/Helpers/RawEncodingToHost.cs
@@ -8,21 +8,23 @@ namespace Speckle.Converters.Rhino.ToHost.Helpers;
 /// </summary>
 public static class RawEncodingToHost
 {
-  public static List<RG.GeometryBase> Convert(SOG.IRawEncodedObject target)
+  public static List<RG.GeometryBase> Convert(SOG.IRawEncodedObject target) => Convert(target.encodedValue);
+
+  public static List<RG.GeometryBase> Convert(SO.RawEncoding encoding)
   {
     // note: I am not sure that we're going to have other encoding formats, but who knows.
-    switch (target.encodedValue.format)
+    switch (encoding.format)
     {
       case SO.RawEncodingFormats.RHINO_3DM:
-        return Handle3dm(target);
+        return Handle3dm(encoding);
       default:
-        throw new ConversionException($"Unsupported brep encoding format: {target.encodedValue.format}");
+        throw new ConversionException($"Unsupported brep encoding format: {encoding.format}");
     }
   }
 
-  private static List<RG.GeometryBase> Handle3dm(SOG.IRawEncodedObject target)
+  private static List<RG.GeometryBase> Handle3dm(SO.RawEncoding encoding)
   {
-    var bytes = System.Convert.FromBase64String(target.encodedValue.contents);
+    var bytes = System.Convert.FromBase64String(encoding.contents);
     var file = File3dm.FromByteArray(bytes);
     var brepObject = file.Objects.Where(o => o.Geometry is not null).Select(o => o.Geometry);
     return brepObject.ToList();

--- a/Converters/Rhino/Speckle.Converters.RhinoShared/ToHost/TopLevel/DataObjectConverter.cs
+++ b/Converters/Rhino/Speckle.Converters.RhinoShared/ToHost/TopLevel/DataObjectConverter.cs
@@ -1,11 +1,13 @@
 using Speckle.Converters.Common;
 using Speckle.Converters.Common.Objects;
 using Speckle.Converters.Common.ToHost;
+using Speckle.Converters.Rhino.ToHost.Helpers;
 using Speckle.Objects.Data;
 using Speckle.Sdk.Common;
 using Speckle.Sdk.Common.Exceptions;
 using Speckle.Sdk.Models;
 using Speckle.Sdk.Models.Instances;
+using RhinoDataObject = Speckle.Objects.Data.RhinoObject;
 
 namespace Speckle.Converters.Rhino.ToHost.TopLevel;
 
@@ -80,6 +82,19 @@ public class DataObjectConverter
     {
       _dataObjectInstanceRegistry.Register(target.applicationId ?? target.id.NotNull(), target, instanceProxies);
 
+      return resultPairs;
+    }
+
+    // prefer rawEncoding when present: decode native geometry (Brep/Extrusion/SubD) from 3dm blob
+    if (target is RhinoDataObject rhinoData && rhinoData.rawEncoding is not null)
+    {
+      var decoded = RawEncodingToHost.Convert(rhinoData.rawEncoding);
+      var unitsTransform = GetUnitsTransform(target);
+      foreach (var geom in decoded)
+      {
+        geom.Transform(unitsTransform);
+        resultPairs.Add((geom, target));
+      }
       return resultPairs;
     }
 


### PR DESCRIPTION
Wraps rhino geometry in the new RhinoObject type so data sent from Rhino matches with general connector extracted data.

Send:
- `RhinoRootObjectBuilder.ConvertRhinoObject` and `RhinoContinuousTraversalBuilder.ConvertRhinoObject` now build a RhinoObject with:
    - displayValue = mesh prims only (for viewer)
    - rawEncoding = native 3dm blob for Breps/Extrusions/SubDs (for receive roundtrip)
    - name, type, units, properties as typed fields

Receive:
- DataObjectConverter now checks for rawEncoding on incoming RhinoObject and decodes it to native Brep/Extrusion/SubD. Falls back to displayValue meshes only when no rawEncoding is present.

Instance handling has done with the following approach:

<img width="594" height="601" alt="image" src="https://github.com/user-attachments/assets/581f7e20-10ca-433f-b287-46d8da489d9b" />


Related SDK changes: https://github.com/specklesystems/speckle-sharp-sdk/pull/473
