### PR TITLE
fix(revit): reject unimportable geometry cleanly with rollback

### DIFF
--- a/Converters/Revit/Speckle.Converters.RevitShared/ToHost/Raw/Geometry/IRawEncodedObjectConverter.cs
+++ b/Converters/Revit/Speckle.Converters.RevitShared/ToHost/Raw/Geometry/IRawEncodedObjectConverter.cs
@@ -4,6 +4,7 @@ using Speckle.Converters.Common.Objects;
 using Speckle.Converters.RevitShared.Helpers;
 using Speckle.Converters.RevitShared.Settings;
 using Speckle.Sdk.Common;
+using Speckle.Sdk.Common.Exceptions;
 using Speckle.Sdk.Models;
 using Speckle.Sdk.Models.Extensions;
 
@@ -34,8 +35,34 @@ public class IRawEncodedObjectConverter : ITypedConverter<SOG.IRawEncodedObject,
     var filePath = TempFileProvider.GetTempFile("RevitX", target.encodedValue.format);
     File.WriteAllBytes(filePath, bytes);
 
-    using var importer = new DB.ShapeImporter();
-    var shapeImportResult = importer.Convert(_settings.Current.Document, filePath);
+    IList<DB.GeometryObject> shapeImportResult;
+
+    using (var subTx = new DB.SubTransaction(_settings.Current.Document))
+    {
+      subTx.Start();
+      using var importer = new DB.ShapeImporter();
+      shapeImportResult = importer.Convert(_settings.Current.Document, filePath);
+    
+      if (shapeImportResult.Count == 0)
+      {
+        // clean up any invalid state Revit created otherwise we get issues in PostBakePaint and group creation
+        // because we get "ghost" objects
+        subTx.RollBack();
+      }
+      else
+      {
+        subTx.Commit();
+      }
+    }
+
+    // there is an argument to be made that we fallback to display meshes BUT I don't know
+    // we're covering shortcomings of the ShapeImporter here. Rather not do some crazy gymnastics
+    if (shapeImportResult.Count == 0)
+    {
+      throw new ConversionException(
+        $"Object {targetAsBase.applicationId ?? targetAsBase.id} could not be loaded. Try repairing or simplifying the geometry in the source application."
+      );
+    }
 
     DB.ElementId materialId = DB.ElementId.InvalidElementId;
     if (

--- a/Converters/Revit/Speckle.Converters.RevitShared/ToHost/Raw/Geometry/IRawEncodedObjectConverter.cs
+++ b/Converters/Revit/Speckle.Converters.RevitShared/ToHost/Raw/Geometry/IRawEncodedObjectConverter.cs
@@ -42,7 +42,7 @@ public class IRawEncodedObjectConverter : ITypedConverter<SOG.IRawEncodedObject,
       subTx.Start();
       using var importer = new DB.ShapeImporter();
       shapeImportResult = importer.Convert(_settings.Current.Document, filePath);
-    
+
       if (shapeImportResult.Count == 0)
       {
         // clean up any invalid state Revit created otherwise we get issues in PostBakePaint and group creation


### PR DESCRIPTION
## Description

Receiving a Rhino model in Revit that contains geometry Revit cannot import (e.g. geometrically problematic breps) fails with a blocking "Cannot import file" pop-up and then crashes the **entire receive operation** via downstream `InvalidObjectException` in `PostBakePaint` and `NewGroup`.

The root cause is that `ShapeImporter` leaves behind an invalid ghost element in the document when it fails, which then propagates into `postBakePaintTargets` and `_elementIdsForTopLevelGroup`, crashing both.

Fixes [CNX-3276](https://linear.app/speckle/issue/CNX-3276/revit-3171-revit-cannot-import-the-file).

## User Value

Receiving a Rhino model containing geometry Revit cannot import no longer interrupts the operation with a blocking dialog or crashes the receive. The problematic object is cleanly rejected with a clear, actionable message identifying it by ID, and the rest of the model receives successfully.

## Changes:

- Wrap `ShapeImporter.Convert()` in a `SubTransaction` that rolls back on empty result — prevents Revit's ghost element from ever entering the document or any downstream pipeline
- Throw a user-facing `ConversionException` on empty result, caught by `TryConvert` and recorded as a conversion error for that object
- Conversion error message includes the object's `applicationId` so the user can locate it in the viewer

## Screenshots & Validation of changes:
- Testing model contains problematic `BrepX` (open polysurface) from user and one simple `BrepX` (open polysurface)
- Try loading model
- Objective:
   - Problematic geometry gets rejected
   - But this shouldn't cancel entire operation
   - Legit objects should still be loaded
   - User should have some sort of feedback (`applicationId` or similar in order to trace problematic object) 

### Before

- Objective:
   - Problematic geometry gets rejected ✅ 
   - But this shouldn't cancel entire operation ❌ 
   - Legit objects should still be loaded ❌ 
   - User should have some sort of feedback (`applicationId` or similar in order to trace problematic object) ❌ 

https://github.com/user-attachments/assets/24ee5382-223e-4bf1-96e5-477bb1f0f148

### After

- Objective:
   - Problematic geometry gets rejected ✅ 
   - But this shouldn't cancel entire operation ✅ 
   - Legit objects should still be loaded ✅ 
   - User should have some sort of feedback (`applicationId` or similar in order to trace problematic object) ✅ 

https://github.com/user-attachments/assets/46c93c95-1c25-46f0-a55e-06461b01c525

## Checklist:

- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] I have added appropriate tests.
- [x] I have updated or added relevant documentation.