### PR TITLE
fix(grasshopper): fix instance proxies now with rhino data object wra…

### DIFF
--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Operations/Receive/GrasshopperBlockUnpacker.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Operations/Receive/GrasshopperBlockUnpacker.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Logging;
 using Rhino.Geometry;
 using Speckle.Connectors.Common.Operations.Receive;
 using Speckle.Connectors.GrasshopperShared.HostApp;
@@ -21,16 +22,19 @@ internal sealed class GrasshopperBlockUnpacker
   private readonly TraversalContextUnpacker _traversalContextUnpacker;
   private readonly GrasshopperColorUnpacker _colorUnpacker;
   private readonly GrasshopperMaterialUnpacker _materialUnpacker;
+  private readonly ILogger<GrasshopperBlockUnpacker> _logger;
 
   public GrasshopperBlockUnpacker(
     TraversalContextUnpacker traversalContextUnpacker,
     GrasshopperColorUnpacker colorUnpacker,
-    GrasshopperMaterialUnpacker materialUnpacker
+    GrasshopperMaterialUnpacker materialUnpacker,
+    ILogger<GrasshopperBlockUnpacker> logger
   )
   {
     _traversalContextUnpacker = traversalContextUnpacker;
     _colorUnpacker = colorUnpacker;
     _materialUnpacker = materialUnpacker;
+    _logger = logger;
   }
 
   /// <summary>
@@ -121,7 +125,13 @@ internal sealed class GrasshopperBlockUnpacker
         }
         else
         {
-          // TODO: throw?
+          _logger.LogWarning(
+            "Block definition {defId} ({defName}) could not be built because none of its member "
+              + "objects were found in the converted objects map. All instances of this definition "
+              + "will be dropped.",
+            definitionId,
+            definitionProxy.name
+          );
         }
       }
       else if (component is InstanceProxy instanceProxy)
@@ -142,7 +152,12 @@ internal sealed class GrasshopperBlockUnpacker
         }
         else
         {
-          // TODO: throw?
+          _logger.LogWarning(
+            "Failed to create block instance {instanceId}: definition {defId} was not available. "
+              + "The instance will not appear in the scene.",
+            instanceId,
+            instanceProxy.definitionId
+          );
         }
       }
     }
@@ -175,7 +190,14 @@ internal sealed class GrasshopperBlockUnpacker
       }
       else
       {
-        // TODO: throw?
+        _logger.LogWarning(
+          "Block definition {defId} ({defName}) references object {objId} which was not found in "
+            + "the converted objects map. This geometry will be missing from the definition and "
+            + "therefore from all its instances.",
+          definitionId,
+          definitionProxy.name,
+          objectId
+        );
       }
     }
 

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Operations/Receive/GrasshopperCollectionRebuilder.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Operations/Receive/GrasshopperCollectionRebuilder.cs
@@ -112,11 +112,17 @@ internal sealed class GrasshopperCollectionRebuilder
     HashSet<string> consumedObjectIds
   )
   {
-    // Remove consumed objects from this level
+    // Remove consumed objects from this level.
+    // Matches both SpeckleGeometryWrapper (legacy path) and SpeckleDataObjectWrapper
+    // (current Rhino path, where atomic objects are wrapped in RhinoDataObject).
     collection.Elements.RemoveAll(element =>
-      element is SpeckleGeometryWrapper obj
-      && obj.ApplicationId != null
-      && consumedObjectIds.Contains(obj.ApplicationId)
+      element switch
+      {
+        SpeckleGeometryWrapper obj => obj.ApplicationId != null && consumedObjectIds.Contains(obj.ApplicationId),
+        SpeckleDataObjectWrapper dataObj => dataObj.ApplicationId != null
+                                            && consumedObjectIds.Contains(dataObj.ApplicationId),
+        _ => false,
+      }
     );
 
     // Recurse into child collections

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Operations/Receive/LocalToGlobalMapHandler.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Operations/Receive/LocalToGlobalMapHandler.cs
@@ -32,6 +32,7 @@ internal sealed class LocalToGlobalMapHandler
   // injected via constructor (DI-managed)
   private readonly IDataObjectInstanceRegistry _dataObjectInstanceRegistry;
   private readonly ILogger<LocalToGlobalMapHandler> _logger;
+  private readonly ILogger<GrasshopperBlockUnpacker> _blockUnpackerLogger;
   private readonly IConverterSettingsStore<RhinoConversionSettings> _settingsStore;
 
   // set via Initialize() method (per-operation data)
@@ -45,12 +46,14 @@ internal sealed class LocalToGlobalMapHandler
 
   public LocalToGlobalMapHandler(
     IDataObjectInstanceRegistry dataObjectInstanceRegistry,
-    ILogger<LocalToGlobalMapHandler> logger,
+    ILogger<LocalToGlobalMapHandler> logger, 
+    ILogger<GrasshopperBlockUnpacker> blockUnpackerLogger,
     IConverterSettingsStore<RhinoConversionSettings> settingsStore
   )
   {
     _dataObjectInstanceRegistry = dataObjectInstanceRegistry;
     _logger = logger;
+    _blockUnpackerLogger = blockUnpackerLogger;
     _settingsStore = settingsStore;
   }
 
@@ -156,6 +159,22 @@ internal sealed class LocalToGlobalMapHandler
         _processedDataObjects.Add(objId);
 
         var geometries = ConvertToGeometryWrappers(converted);
+
+        if (geometries.Count >= 1)
+        {
+          if (geometries.Count > 1) // ASSUMPTION FOR NOW WITH CNX-3169
+          {
+            _logger.LogWarning(
+              "DataObject {objId} produced {count} geometries; only the first is registered for "
+                + "block-definition resolution. If this object is referenced by an InstanceDefinitionProxy, "
+                + "some geometry may be missing from block instances.",
+              objId,
+              geometries.Count
+            );
+          }
+          ConvertedObjectsMap[objId] = geometries[0].DeepCopy();
+        }
+
         var dataObjectWrapper = CreateDataObjectWrapper(normalDataObject, geometries, path, objectCollection);
 
         CollectionRebuilder.AppendSpeckleGrasshopperObject(dataObjectWrapper, path, _colorUnpacker, _materialUnpacker);
@@ -290,7 +309,12 @@ internal sealed class LocalToGlobalMapHandler
       })
       .ToList();
 
-    var blockUnpacker = new GrasshopperBlockUnpacker(_traversalContextUnpacker, _colorUnpacker, _materialUnpacker);
+    var blockUnpacker = new GrasshopperBlockUnpacker(
+      _traversalContextUnpacker,
+      _colorUnpacker,
+      _materialUnpacker,
+      _blockUnpackerLogger
+    );
 
     // get consumed object IDs from unpacker
     var consumedObjectIds = blockUnpacker.UnpackBlocks(


### PR DESCRIPTION
## Description

When receiving a model from rhino in grasshopper, block instances were appearing at the origin with no transforms applied. This is because the recent rhino changes now wrap every atomic object (including block definition members) in a `RhinoDataObject`. The grasshopper receive handler was hitting the DataObject branch for these, which never populated `ConvertedObjectsMap`. So when the block unpacker later tried to resolve definition members by id, it found nothing. Definitions built as null, instances got dropped silently, and the def geometry rendered as standalone objects on their original layers — which looked like "transforms aren't applying."

## Changes:

- `LocalToGlobalMapHandler.ConvertObjectToCache`: populate `ConvertedObjectsMap` from the DataObject branch, keyed by the DataObject's applicationId
- `GrasshopperCollectionRebuilder.RemoveConsumedObjectsFromCollection`: extended to also match `SpeckleDataObjectWrapper` entries, so def members get stripped from their original layer after block unpacking.

## Validation of changes:

TBD