### PR TITLE
feat (acad, civil): extract as dataobjects

### DIFF
--- a/Connectors/Autocad/Speckle.Connectors.AutocadShared/HostApp/AutocadInstanceUnpacker.cs
+++ b/Connectors/Autocad/Speckle.Connectors.AutocadShared/HostApp/AutocadInstanceUnpacker.cs
@@ -78,7 +78,13 @@ public class AutocadInstanceUnpacker : IInstanceUnpacker<AutocadRootObject>
       };
 
       var properties = _propertiesExtractor.GetProperties(instance);
-      if (properties?.Count > 0)
+      var attributes = GetInstanceAttributes(instance, transaction);
+      if (attributes.Count > 0)
+      {
+        properties["Attributes"] = attributes;
+      }
+
+      if (properties.Count > 0)
       {
         instanceProxy["properties"] = properties;
       }
@@ -184,5 +190,18 @@ public class AutocadInstanceUnpacker : IInstanceUnpacker<AutocadRootObject>
     {
       _logger.LogError(ex, "Failed unpacking Autocad instance");
     }
+  }
+
+  private static Dictionary<string, object?> GetInstanceAttributes(BlockReference instance, Transaction transaction)
+  {
+    var attributes = new Dictionary<string, object?>();
+
+    foreach (ObjectId id in instance.AttributeCollection)
+    {
+      var reference = (AttributeReference)transaction.GetObject(id, OpenMode.ForRead);
+      attributes[reference.Tag] = reference.TextString;
+    }
+
+    return attributes;
   }
 }

--- a/Converters/Autocad/Speckle.Converters.AutocadShared/AutocadRootToSpeckleConverter.cs
+++ b/Converters/Autocad/Speckle.Converters.AutocadShared/AutocadRootToSpeckleConverter.cs
@@ -3,6 +3,7 @@ using Speckle.Converters.AutocadShared.ToSpeckle;
 using Speckle.Converters.Common;
 using Speckle.Converters.Common.Objects;
 using Speckle.Converters.Common.Registration;
+using Speckle.Objects.Data;
 using Speckle.Sdk.Common.Exceptions;
 using Speckle.Sdk.Models;
 
@@ -40,16 +41,27 @@ public class AutocadRootToSpeckleConverter : IRootToSpeckleConverter
     using var tr = _settingsStore.Current.Document.Database.TransactionManager.StartTransaction();
     var objectConverter = _toSpeckle.ResolveConverter(type);
 
-    var convertedObject = objectConverter.Convert(dbObject);
-
-    // add properties
-    Dictionary<string, object?> properties = _propertiesExtractor.GetProperties((Entity)dbObject);
-    if (properties.Count > 0)
-    {
-      convertedObject["properties"] = properties;
-    }
+    var rawGeometry = objectConverter.Convert(dbObject);
 
     tr.Commit();
-    return convertedObject;
+
+    if (dbObject is not Entity entity)
+    {
+      return rawGeometry;
+    }
+
+    var (displayValue, rawEncoding) = DataObjectDisplayValueExtractor.Extract(rawGeometry);
+    var properties = _propertiesExtractor.GetProperties(entity);
+    string typeName = type.Name;
+
+    return new AutocadObject
+    {
+      name = typeName,
+      type = typeName,
+      displayValue = displayValue,
+      properties = properties,
+      units = _settingsStore.Current.SpeckleUnits,
+      rawEncoding = rawEncoding,
+    };
   }
 }

--- a/Converters/Autocad/Speckle.Converters.AutocadShared/Speckle.Converters.AutocadShared.projitems
+++ b/Converters/Autocad/Speckle.Converters.AutocadShared/Speckle.Converters.AutocadShared.projitems
@@ -54,6 +54,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)GlobalUsings.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ToHost\Raw\PointToHostRawConverter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ToHost\Geometry\PointToHostConverter.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)ToSpeckle\DataObjectDisplayValueExtractor.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ToSpeckle\Geometry\ArcToSpeckleConverter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ToSpeckle\Geometry\HatchToSpeckleConverter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ToSpeckle\Geometry\MTextToSpeckleConverter.cs" />

--- a/Converters/Autocad/Speckle.Converters.AutocadShared/ToHost/Geometry/DataObjectConverter.cs
+++ b/Converters/Autocad/Speckle.Converters.AutocadShared/ToHost/Geometry/DataObjectConverter.cs
@@ -57,8 +57,11 @@ public class DataObjectConverter : IToHostTopLevelConverter, ITypedConverter<Dat
       return []; // return empty - defer to instance baker
     }
 
-    // Check for SAT encoding first for lossless round-trip
-    if (target["encodedValue"] is RawEncoding encoding && encoding.format == RawEncodingFormats.ACAD_SAT)
+    // Check for SAT encoding first for lossless round-trip.
+    // Prefer the strongly-typed `rawEncoding` field (AutocadObject/Plant3dObject) but
+    // fall back to the legacy dynamic `encodedValue` key used by Civil3dObject.
+    var encodingCandidate = target["rawEncoding"] ?? target["encodedValue"];
+    if (encodingCandidate is RawEncoding encoding && encoding.format == RawEncodingFormats.ACAD_SAT)
     {
       try
       {

--- a/Converters/Autocad/Speckle.Converters.AutocadShared/ToSpeckle/DataObjectDisplayValueExtractor.cs
+++ b/Converters/Autocad/Speckle.Converters.AutocadShared/ToSpeckle/DataObjectDisplayValueExtractor.cs
@@ -1,0 +1,21 @@
+using Speckle.Objects;
+using Speckle.Objects.Other;
+using Speckle.Sdk.Models;
+
+namespace Speckle.Converters.AutocadShared.ToSpeckle;
+
+public static class DataObjectDisplayValueExtractor
+{
+  public static (List<Base> displayValue, RawEncoding? rawEncoding) Extract(Base rawGeometry)
+  {
+    if (rawGeometry is IDisplayValue<List<SOG.Mesh>> hasDisplay && rawGeometry is SOG.IRawEncodedObject rawEncoded)
+    {
+      return (hasDisplay.displayValue.Cast<Base>().ToList(), rawEncoded.encodedValue);
+    }
+    if (rawGeometry is IDisplayValue<List<SOG.Mesh>> hasDisplayMeshes)
+    {
+      return (hasDisplayMeshes.displayValue.Cast<Base>().ToList(), null);
+    }
+    return ([rawGeometry], null);
+  }
+}

--- a/Converters/Civil3d/Speckle.Converters.Civil3dShared/Civil3dRootToSpeckleConverter.cs
+++ b/Converters/Civil3d/Speckle.Converters.Civil3dShared/Civil3dRootToSpeckleConverter.cs
@@ -1,7 +1,9 @@
 using System.ComponentModel.DataAnnotations;
+using Speckle.Converters.AutocadShared.ToSpeckle;
 using Speckle.Converters.Common;
 using Speckle.Converters.Common.Objects;
 using Speckle.Converters.Common.Registration;
+using Speckle.Objects.Data;
 using Speckle.Sdk.Models;
 
 namespace Speckle.Converters.Civil3dShared;
@@ -53,18 +55,29 @@ public class Civil3dRootToSpeckleConverter : IRootToSpeckleConverter
     using var tr = _settingsStore.Current.Document.Database.TransactionManager.StartTransaction();
     var result = objectConverter.Convert(target);
 
-    // This is needed to retrieve property sets on solids
-    // Civil entity properties are retrieved in the CivilEntityToSpeckleTopLevelConverter
-    if (target is not CDB.Entity && target is ADB.Entity autocadEntity)
+    tr.Commit();
+
+    // Civil entity converters already return Civil3dObject. Only wrap raw autocad entities
+    // (eg plain ADB.Line, ADB.Arc via the autocad top-level converters) into an AutocadObject.
+    // If a Civil3d-rank top-level converter (eg Civil3d's Solid3dToSpeckleConverter) already
+    // produced a DataObject for an ADB.Entity target, pass through without re-wrapping.
+    if (target is not CDB.Entity && target is ADB.Entity autocadEntity && result is not DataObject)
     {
+      var (displayValue, rawEncoding) = DataObjectDisplayValueExtractor.Extract(result);
       var properties = _propertiesExtractor.GetProperties(autocadEntity);
-      if (properties.Count > 0)
+      string typeName = autocadEntity.GetType().Name;
+
+      return new AutocadObject
       {
-        result["properties"] = properties;
-      }
+        name = typeName,
+        type = typeName,
+        displayValue = displayValue,
+        properties = properties,
+        units = _settingsStore.Current.SpeckleUnits,
+        rawEncoding = rawEncoding,
+      };
     }
 
-    tr.Commit();
     return result;
   }
 }


### PR DESCRIPTION
Wraps the geometry objects into a DataObject and blocks as instance proxies. Also adds attributes to the blocks. 

Related SDK changes: https://github.com/specklesystems/speckle-sharp-sdk/pull/474