### PR TITLE
fix(ci): Supress otel cve

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ tests/TestArchives/Scratch
 tools
 .vscode
 .idea/
+*wpftmp.csproj
 
 .DS_Store
 *.snupkg

--- a/Sdk/Speckle.Connectors.Logging/Speckle.Connectors.Logging.csproj
+++ b/Sdk/Speckle.Connectors.Logging/Speckle.Connectors.Logging.csproj
@@ -13,7 +13,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" PrivateAssets="all" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" PrivateAssets="all" NoWarn="NU1902" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" PrivateAssets="all" />
     <PackageReference Include="Serilog" PrivateAssets="all" />
     <PackageReference Include="Serilog.Exceptions" PrivateAssets="all" />

--- a/Sdk/Speckle.Connectors.Logging/Speckle.Connectors.Logging.csproj
+++ b/Sdk/Speckle.Connectors.Logging/Speckle.Connectors.Logging.csproj
@@ -13,6 +13,12 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <!--
+    OpenTelemetry.Exporter.OpenTelemetryProtocol 1.13.x has two CVEs. The impact on us is minimal since they allow DOS
+    only if our collector to be compromosed or through MitM.
+    Updating to the fixed 1.15.3 doesn't work for us (I suspect it's not compatbile with ILRepack due to some reflection usage)
+    We've decided it's acceptible to supress. 
+    -->
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" PrivateAssets="all" NoWarn="NU1902" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" PrivateAssets="all" />
     <PackageReference Include="Serilog" PrivateAssets="all" />

--- a/Speckle.Connectors.slnx
+++ b/Speckle.Connectors.slnx
@@ -12,6 +12,7 @@
   <Folder Name="/Config/">
     <File Path=".csharpierrc.yaml" />
     <File Path=".editorconfig" />
+    <File Path=".gitignore" />
     <File Path="codecov.yml" />
     <File Path="CodeMetricsConfig.txt" />
     <File Path="Directory.Build.props" />
@@ -155,7 +156,7 @@
   <Folder Name="/Connectors/Rhino/8/">
     <Project Path="Connectors\Rhino\Speckle.Connectors.Grasshopper8\Speckle.Connectors.Grasshopper8.csproj" />
     <Project Path="Connectors\Rhino\Speckle.Connectors.Rhino8\Speckle.Connectors.Rhino8.csproj" />
-    <Project Path="Connectors\Rhino\Speckle.Connectors.RhinoImporter\Speckle.Connectors.RhinoImporter.csproj" Type="C#" />
+    <Project Path="Connectors\Rhino\Speckle.Connectors.RhinoImporter\Speckle.Connectors.RhinoImporter.csproj" />
     <Project Path="Converters\Rhino\Speckle.Converters.Rhino8\Speckle.Converters.Rhino8.csproj" />
   </Folder>
   <Folder Name="/Connectors/Rhino/Shared/">
@@ -184,7 +185,7 @@
   </Folder>
   <Folder Name="/Importers/" />
   <Folder Name="/Importers/Rhino/">
-    <Project Path="Importers\Rhino\Speckle.Importers.JobProcessor\Speckle.Importers.JobProcessor.csproj" Type="C#">
+    <Project Path="Importers\Rhino\Speckle.Importers.JobProcessor\Speckle.Importers.JobProcessor.csproj">
       <Configuration Solution="Local|Any CPU" Project="Debug|Any CPU" />
     </Project>
     <Project Path="Importers\Rhino\Speckle.Importers.Rhino\Speckle.Importers.Rhino.csproj" />


### PR DESCRIPTION
`OpenTelemetry.Exporter.OpenTelemetryProtocol` nuget has issues two CVEs
 - https://github.com/advisories/GHSA-mr8r-92fq-pj8p
 - https://github.com/advisories/GHSA-q834-8qmm-v933


Unfortunately, we cannot bump to version 1.15.3 (the fixed version), as it appears to be incompatible with ILRepack.
Our options are.
1: Supress the warning since it's not severe
2: Downgrade our otel version (something I'm not a fan of)