### PR TITLE
fix (plant3d): add labels

### DIFF
--- a/Converters/Autocad/Speckle.Converters.AutocadShared/Speckle.Converters.AutocadShared.projitems
+++ b/Converters/Autocad/Speckle.Converters.AutocadShared/Speckle.Converters.AutocadShared.projitems
@@ -56,6 +56,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)ToHost\Geometry\PointToHostConverter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ToSpeckle\DataObjectDisplayValueExtractor.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ToSpeckle\Geometry\ArcToSpeckleConverter.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)ToSpeckle\Geometry\AttributeDefinitionToSpeckleConverter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ToSpeckle\Geometry\HatchToSpeckleConverter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ToSpeckle\Geometry\MTextToSpeckleConverter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ToSpeckle\Geometry\RegionToSpeckleConverter.cs" />

--- a/Converters/Autocad/Speckle.Converters.AutocadShared/ToSpeckle/Geometry/AttributeDefinitionToSpeckleConverter.cs
+++ b/Converters/Autocad/Speckle.Converters.AutocadShared/ToSpeckle/Geometry/AttributeDefinitionToSpeckleConverter.cs
@@ -1,0 +1,29 @@
+using Speckle.Converters.Common;
+using Speckle.Converters.Common.Objects;
+using Speckle.Sdk.Models;
+
+namespace Speckle.Converters.Autocad.ToSpeckle.Geometry;
+
+// AttributeDefinition inherits from DBText. Without this converter, ATTDEF entities
+// falls back to DBTextToSpeckleConverter which reads `TextString`
+// The default attribute value, typically empty for a ATTDEF
+// The visible text in the drawing is the Tag, so we use that instead.
+[NameAndRankValue(typeof(ADB.AttributeDefinition), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
+public class AttributeDefinitionToSpeckleConverter : IToSpeckleTopLevelConverter
+{
+  private readonly ITypedConverter<ADB.DBText, SA.Text> _textConverter;
+
+  public AttributeDefinitionToSpeckleConverter(ITypedConverter<ADB.DBText, SA.Text> textConverter)
+  {
+    _textConverter = textConverter;
+  }
+
+  public Base Convert(object target) => Convert((ADB.AttributeDefinition)target);
+
+  public SA.Text Convert(ADB.AttributeDefinition target)
+  {
+    SA.Text result = _textConverter.Convert(target);
+    result.value = !string.IsNullOrEmpty(target.Tag) ? target.Tag : target.TextString;
+    return result;
+  }
+}

--- a/Converters/Plant3d/Speckle.Converters.Plant3dShared/ToSpeckle/Geometry/Plant3dEntityToSpeckleConverter.cs
+++ b/Converters/Plant3d/Speckle.Converters.Plant3dShared/ToSpeckle/Geometry/Plant3dEntityToSpeckleConverter.cs
@@ -1,3 +1,4 @@
+using Speckle.Converters.Autocad.Extensions;
 using Speckle.Converters.Common.Objects;
 using Speckle.Converters.Common.Registration;
 using Speckle.Objects.Data;
@@ -66,9 +67,16 @@ public abstract class Plant3dEntityToSpeckleConverter : IToSpeckleTopLevelConver
   /// </summary>
   private void CollectDisplayObjects(ADB.Entity entity, List<Base> results, int depth)
   {
+    // ATTDEFs in a block definition hold the field template (e.g. "#(TargetObject.Type)"),
+    // not the rendered text. The real string lives on each instance's AttributeReference,
+    // which we capture below from the parent BlockReference's AttributeCollection.
+    if (entity is ADB.AttributeDefinition)
+      return;
+    }
+
     // If this is NOT a block reference, try converting it directly
     // (Line, Arc, Circle, Polyline, Solid3d, etc.)
-    if (entity is not ADB.BlockReference)
+    if (entity is not ADB.BlockReference blockRef)
     {
       try
       {
@@ -81,6 +89,32 @@ public abstract class Plant3dEntityToSpeckleConverter : IToSpeckleTopLevelConver
       catch (System.Exception)
       {
         // Fall through to explode on ConversionNotSupportedException or failed
+      }
+    }
+    else
+    {
+      // AttributeReference inherits from DBText, so it resolves
+      // the existing DBText converter without any template parsing on our side.
+      foreach (
+        ADB.AttributeReference attRef in blockRef.GetSubEntities<ADB.AttributeReference>(
+          source: blockRef.AttributeCollection
+        )
+      )
+      {
+        if (!attRef.Visible || string.IsNullOrWhiteSpace(attRef.TextString))
+        {
+          continue;
+        }
+
+        try
+        {
+          var converter = _converterManager.ResolveConverter(attRef.GetType());
+          results.Add(converter.Convert(attRef));
+        }
+        catch (System.Exception)
+        {
+          // Skip any attribute reference we can't convert; continue with the rest.
+        }
       }
     }
 

--- a/Converters/Plant3d/Speckle.Converters.Plant3dShared/ToSpeckle/Geometry/Plant3dEntityToSpeckleConverter.cs
+++ b/Converters/Plant3d/Speckle.Converters.Plant3dShared/ToSpeckle/Geometry/Plant3dEntityToSpeckleConverter.cs
@@ -71,6 +71,7 @@ public abstract class Plant3dEntityToSpeckleConverter : IToSpeckleTopLevelConver
     // not the rendered text. The real string lives on each instance's AttributeReference,
     // which we capture below from the parent BlockReference's AttributeCollection.
     if (entity is ADB.AttributeDefinition)
+    {
       return;
     }
 


### PR DESCRIPTION
### Problem
AutoCAD Plant 3D ATTDEF (attribute definition) objects are not being correctly extracted by the connector. When published to Speckle, the object appears in the selection tree but has no visual representation, and its tag value is sent as an empty string. This means any text defined via the ATTDEF command is silently lost on publish.

### Solution
`AttributeDefinition` inherits from `DBText`. Without a converter it falls back to `DBTextToSpeckleConverter` but the default value for `TextString` is empty for this. Adding a new converter for attribute definition type maps the conversion to the correct target.

Here is the attribute definition in Plant3D
<img width="588" height="685" alt="image" src="https://github.com/user-attachments/assets/02043287-278f-44fd-9187-1852981a3a6a" />


Before the implementation it was empty visually
<img width="1834" height="922" alt="image" src="https://github.com/user-attachments/assets/cc602b7d-6a4f-4b7b-ae32-56cc2fe3e02b" />

Now it converts correctly. 
<img width="1905" height="660" alt="image" src="https://github.com/user-attachments/assets/ed95b204-f16e-41af-8cbf-2ee5ffbedef3" />


Also previously, CollectDisplayObjects() exploded BlockReferences and converted AttributeDefinitions, which exposed template strings. The converter now reads visible AttributeReferences from the instance AttributeCollection, converts them through the existing DBText path.

How it looks in Plant3D:
<img width="611" height="460" alt="image" src="https://github.com/user-attachments/assets/8aab5987-ec9f-4b06-a110-e8d61e46d488" />

Before:
<img width="1170" height="1022" alt="image" src="https://github.com/user-attachments/assets/1d3db941-0017-41c2-80ad-d55c7aa49855" />

Now:
<img width="966" height="718" alt="image" src="https://github.com/user-attachments/assets/55d4ef0b-0026-40c5-a3f2-55f66cd982cd" />



