### PR TITLE
hotfix(revit): Fix null reference on load in Revit 2023, Revit 2024, Revit 2025

### DIFF
--- a/Connectors/Revit/Speckle.Connectors.RevitShared.Cef/CefSharpPanel.xaml.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared.Cef/CefSharpPanel.xaml.cs
@@ -13,11 +13,11 @@ public partial class CefSharpPanel : Page, Autodesk.Revit.UI.IDockablePaneProvid
 
   public CefSharpPanel(IGlobalConfigResolver globalConfigResolver)
   {
+    DuiUrl = globalConfigResolver.GetDuiUrl().ToString();
+    InitializeComponent();
 #if REVIT2023_OR_GREATER
     Browser.JavascriptObjectRepository.NameConverter = null;
 #endif
-    DuiUrl = globalConfigResolver.GetDuiUrl().ToString();
-    InitializeComponent();
   }
 
   /// <inheritdoc/>


### PR DESCRIPTION
remade https://github.com/specklesystems/speckle-sharp-connectors/pull/1383 to target main