### PR TITLE
feat (acad): support for converting leader arrowheads

### DIFF
--- a/Converters/Autocad/Speckle.Converters.AutocadShared/Speckle.Converters.AutocadShared.projitems
+++ b/Converters/Autocad/Speckle.Converters.AutocadShared/Speckle.Converters.AutocadShared.projitems
@@ -58,6 +58,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)ToSpeckle\Geometry\ArcToSpeckleConverter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ToSpeckle\Geometry\AttributeDefinitionToSpeckleConverter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ToSpeckle\Geometry\HatchToSpeckleConverter.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)ToSpeckle\Geometry\LeaderToSpeckleConverter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ToSpeckle\Geometry\MTextToSpeckleConverter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ToSpeckle\Geometry\RegionToSpeckleConverter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ToSpeckle\Geometry\SubDMeshToSpeckleConverter.cs" />

--- a/Converters/Autocad/Speckle.Converters.AutocadShared/ToSpeckle/Geometry/LeaderToSpeckleConverter.cs
+++ b/Converters/Autocad/Speckle.Converters.AutocadShared/ToSpeckle/Geometry/LeaderToSpeckleConverter.cs
@@ -1,0 +1,83 @@
+using Speckle.Converters.Common;
+using Speckle.Converters.Common.Objects;
+using Speckle.Sdk.Models;
+
+namespace Speckle.Converters.Autocad.ToSpeckle.Geometry;
+
+[NameAndRankValue(typeof(ADB.Leader), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
+public class LeaderToSpeckleConverter : IToSpeckleTopLevelConverter
+{
+  private const double ARROW_WIDTH_FACTOR = 0.35;
+
+  private readonly ITypedConverter<List<double>, SOG.Polyline> _polylineConverter;
+
+  public LeaderToSpeckleConverter(ITypedConverter<List<double>, SOG.Polyline> polylineConverter)
+  {
+    _polylineConverter = polylineConverter;
+  }
+
+  public Base Convert(object target) => Convert((ADB.Leader)target);
+
+  public SOG.Polyline Convert(ADB.Leader target)
+  {
+    List<double> value = new();
+
+    if (target.HasArrowHead && target.NumVertices > 1)
+    {
+      AppendArrowhead(target, value);
+    }
+
+    for (int i = 0; i < target.NumVertices; i++)
+    {
+      AppendPoint(value, target.VertexAt(i));
+    }
+
+    SOG.Polyline polyline = _polylineConverter.Convert(value);
+    polyline.closed = false;
+    return polyline;
+  }
+
+  private static void AppendArrowhead(ADB.Leader leader, List<double> value)
+  {
+    double arrowSize = leader.Dimasz;
+    if (leader.Dimscale > 0)
+    {
+      arrowSize *= leader.Dimscale;
+    }
+
+    if (arrowSize <= 0)
+    {
+      return;
+    }
+
+    AG.Point3d head = leader.VertexAt(0);
+    AG.Point3d next = leader.VertexAt(1);
+    AG.Vector3d leaderDirection = next - head;
+    if (leaderDirection.IsZeroLength())
+    {
+      return;
+    }
+
+    AG.Vector3d backDirection = leaderDirection.GetNormal();
+    AG.Vector3d sideDirection = leader.Normal.CrossProduct(backDirection);
+    if (sideDirection.IsZeroLength())
+    {
+      return;
+    }
+
+    AG.Point3d arrowBase = head + backDirection * arrowSize;
+    AG.Vector3d halfWidth = sideDirection.GetNormal() * arrowSize * ARROW_WIDTH_FACTOR;
+
+    AppendPoint(value, arrowBase + halfWidth);
+    AppendPoint(value, head);
+    AppendPoint(value, arrowBase - halfWidth);
+    AppendPoint(value, head);
+  }
+
+  private static void AppendPoint(List<double> value, AG.Point3d point)
+  {
+    value.Add(point.X);
+    value.Add(point.Y);
+    value.Add(point.Z);
+  }
+}


### PR DESCRIPTION
Previously, arrowheads of leader lines were missing in our viewer. This adds a `LeaderToSpeckleConverter` that converts the leader path to a Speckle polyline and creates a simple V shaped arrowhead based on the arrow size. 

AutoCAD:

<img width="645" height="542" alt="Screenshot_1" src="https://github.com/user-attachments/assets/080c3f52-4dd0-4e13-96df-b05e902cc37d" />

Before:

<img width="996" height="763" alt="Screenshot_2" src="https://github.com/user-attachments/assets/2a4df637-6e92-4e6a-bc3f-4195af9689a0" />

After:

<img width="990" height="786" alt="Screenshot_3" src="https://github.com/user-attachments/assets/18f5725e-9c54-4fbc-97bc-076be30b9cfb" />
