### PR TITLE
fix (plant3d): avoid rendering invisible texts

### DIFF
--- a/Connectors/Autocad/Speckle.Connectors.AutocadShared/HostApp/AutocadInstanceUnpacker.cs
+++ b/Connectors/Autocad/Speckle.Connectors.AutocadShared/HostApp/AutocadInstanceUnpacker.cs
@@ -40,6 +40,13 @@ public class AutocadInstanceUnpacker : IInstanceUnpacker<AutocadRootObject>
 
     foreach (var obj in objects)
     {
+      // Skip hidden attributes from the selection. Their values are kept on the InstanceProxy
+      // via GetInstanceAttributes, so we just avoid sending them as floating Text.
+      if (obj.Root is AttributeReference attrRef && (!attrRef.Visible || attrRef.Invisible))
+      {
+        continue;
+      }
+
       // Note: isDynamicBlock always returns false for a selection of doc objects. Instances of dynamic blocks are represented in the document as blocks that have
       // a definition reference to the anonymous block table record.
       if (obj.Root is BlockReference blockReference && !blockReference.IsDynamicBlock)
@@ -131,6 +138,12 @@ public class AutocadInstanceUnpacker : IInstanceUnpacker<AutocadRootObject>
       foreach (ObjectId id in instance.AttributeCollection)
       {
         var reference = (AttributeReference)transaction.GetObject(id, OpenMode.ForRead);
+        // Skip hidden attributes. Their values are still kept on the InstanceProxy via
+        // GetInstanceAttributes, so we just avoid sending them as floating Text.
+        if (!reference.Visible || reference.Invisible)
+        {
+          continue;
+        }
         string refAppId = reference.GetSpeckleApplicationId();
         _instanceObjectsManager.AddAtomicObject(refAppId, new(reference, refAppId));
       }

--- a/Converters/Autocad/Speckle.Converters.AutocadShared/ToSpeckle/Raw/DBTextToSpeckleRawConverter.cs
+++ b/Converters/Autocad/Speckle.Converters.AutocadShared/ToSpeckle/Raw/DBTextToSpeckleRawConverter.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using Speckle.Converters.Autocad.Helpers;
 using Speckle.Converters.Common;
 using Speckle.Converters.Common.Objects;
@@ -57,7 +58,7 @@ public class DBTextToSpeckleRawConverter : ITypedConverter<ADB.DBText, Text>
     };
   }
 
-  private static bool TryGetBackingMText(ADB.DBText target, out ADB.MText? mtext)
+  private static bool TryGetBackingMText(ADB.DBText target, [NotNullWhen(true)] out ADB.MText? mtext)
   {
     switch (target)
     {

--- a/Converters/Autocad/Speckle.Converters.AutocadShared/ToSpeckle/Raw/DBTextToSpeckleRawConverter.cs
+++ b/Converters/Autocad/Speckle.Converters.AutocadShared/ToSpeckle/Raw/DBTextToSpeckleRawConverter.cs
@@ -9,16 +9,19 @@ public class DBTextToSpeckleRawConverter : ITypedConverter<ADB.DBText, Text>
 {
   private readonly ITypedConverter<AG.Point3d, SOG.Point> _pointConverter;
   private readonly ITypedConverter<AG.Vector3d, SOG.Vector> _vectorConverter;
+  private readonly ITypedConverter<ADB.MText, Text> _mtextConverter;
   private readonly IConverterSettingsStore<AutocadConversionSettings> _settingsStore;
 
   public DBTextToSpeckleRawConverter(
     ITypedConverter<AG.Point3d, SOG.Point> pointConverter,
     ITypedConverter<AG.Vector3d, SOG.Vector> vectorConverter,
+    ITypedConverter<ADB.MText, Text> mtextConverter,
     IConverterSettingsStore<AutocadConversionSettings> settingsStore
   )
   {
     _pointConverter = pointConverter;
     _vectorConverter = vectorConverter;
+    _mtextConverter = mtextConverter;
     _settingsStore = settingsStore;
   }
 
@@ -27,12 +30,23 @@ public class DBTextToSpeckleRawConverter : ITypedConverter<ADB.DBText, Text>
   /// </summary>
   /// <param name="target">The AutoCAD DBText to convert.</param>
   /// <returns>The converted Speckle Text object.</returns>
-  public Text Convert(ADB.DBText target) =>
+  public Text Convert(ADB.DBText target)
+  {
+    // Multi-line attributes are backed by an MText. Convert via the MText converter so the
+    // viewer keeps the wrap and renders multiple lines.
+    if (TryGetBackingMText(target, out ADB.MText? mtext))
+    {
+      using (mtext)
+      {
+        return _mtextConverter.Convert(mtext);
+      }
+    }
+
     // target.WidthFactor is ignored, because we don't support 1-dimensional text scaling
     // AlignmentPoint can be ignored, as, if used for positioning, it will be already reflected in Rotation and Height
-    new()
+    return new()
     {
-      value = target.TextString,
+      value = target.TextString ?? string.Empty,
       height = target.Height,
       maxWidth = null, // always 1 line
       plane = GetTextPlane(target),
@@ -41,6 +55,23 @@ public class DBTextToSpeckleRawConverter : ITypedConverter<ADB.DBText, Text>
       alignmentV = AlignmentVertical.Bottom, // constant relevant to Position (.Justify & .Alignment Point can be ignored)
       units = _settingsStore.Current.SpeckleUnits,
     };
+  }
+
+  private static bool TryGetBackingMText(ADB.DBText target, out ADB.MText? mtext)
+  {
+    switch (target)
+    {
+      case ADB.AttributeReference attRef when attRef.IsMTextAttribute:
+        mtext = attRef.MTextAttribute;
+        return true;
+      case ADB.AttributeDefinition attDef when attDef.IsMTextAttributeDefinition:
+        mtext = attDef.MTextAttributeDefinition;
+        return true;
+      default:
+        mtext = null;
+        return false;
+    }
+  }
 
   // For DBText, the following properties are stored in:
   // - Position: WCS

--- a/Converters/Autocad/Speckle.Converters.AutocadShared/ToSpeckle/Raw/MTextToSpeckleRawConverter.cs
+++ b/Converters/Autocad/Speckle.Converters.AutocadShared/ToSpeckle/Raw/MTextToSpeckleRawConverter.cs
@@ -1,3 +1,4 @@
+using System.Text.RegularExpressions;
 using Speckle.Converters.Common;
 using Speckle.Converters.Common.Objects;
 
@@ -28,7 +29,7 @@ public class MTextToSpeckleRawConverter : ITypedConverter<ADB.MText, SA.Text>
   public SA.Text Convert(ADB.MText target) =>
     new()
     {
-      value = target.Text,
+      value = ConvertMTextToPlainText(target.Contents ?? string.Empty),
       height = target.TextHeight,
       maxWidth = target.Width,
       plane = GetTextPlane(target),
@@ -37,6 +38,32 @@ public class MTextToSpeckleRawConverter : ITypedConverter<ADB.MText, SA.Text>
       alignmentV = GetVerticalAlignment(target.Attachment),
       units = _settingsStore.Current.SpeckleUnits,
     };
+
+  // Codes with parameters that end in `;` (font, color, height, etc.)
+  private static readonly Regex s_paramCodeRegex = new(@"\\[A-Za-z][^\\;]*;", RegexOptions.Compiled);
+
+  // Toggle codes with no parameters (underline, overline, strikethrough)
+  private static readonly Regex s_toggleCodeRegex = new(@"\\[LlOoKkX]", RegexOptions.Compiled);
+
+  /// <summary>
+  /// Turns raw MText contents into plain text with real newlines, so the viewer can render it
+  /// on multiple lines. Covers common formatting; exotic cases may still need cleanup.
+  /// </summary>
+  private static string ConvertMTextToPlainText(string contents)
+  {
+    if (string.IsNullOrEmpty(contents))
+    {
+      return contents;
+    }
+
+    // Convert paragraph breaks first so they aren't eaten by the strip below.
+    string result = contents.Replace("\\P", "\n");
+    result = s_paramCodeRegex.Replace(result, string.Empty);
+    result = s_toggleCodeRegex.Replace(result, string.Empty);
+    result = result.Replace("\\~", " ");
+    result = result.Replace("{", string.Empty).Replace("}", string.Empty);
+    return result;
+  }
 
   // For MText, the following properties are stored in:
   // - Position: WCS


### PR DESCRIPTION
Plant3D blocks has a lot of hidden attribute data. These are not displayed in Plant3D, but Speckle was sending them as visible `Text` objects.

Now we skip attribute references that are hidden in the host app (`Visible = false` or the ATTDEF `Invisible` flag is set). 

Also long texts were sent as one long line in speckle. 

Now MText converts `\P` to newlines and multi-line attributes are routed through the MText converter so the width are preserved.