### PR TITLE
feat(revit): generalize parentApplicationId to all hosted FamilyInstance elements

### DIFF
--- a/Converters/Revit/Speckle.Converters.RevitShared/ToSpeckle/Properties/ClassPropertiesExtractor.cs
+++ b/Converters/Revit/Speckle.Converters.RevitShared/ToSpeckle/Properties/ClassPropertiesExtractor.cs
@@ -91,21 +91,8 @@ public class ClassPropertiesExtractor
           elementProperties.Add("fromRoomApplicationId", familyInstance.FromRoom.UniqueId.ToString());
         }
 
-        Element? parent = null;
-
-#if REVIT2023_OR_GREATER
-        BuiltInCategory bic = familyInstance.Category.BuiltInCategory;
-#else
-        // Cast for 2022 and older
-        BuiltInCategory bic = (BuiltInCategory)familyInstance.Category.Id.IntegerValue;
-#endif
-
-        if (bic == BuiltInCategory.OST_CurtainWallMullions || bic == BuiltInCategory.OST_CurtainWallPanels)
-        {
-          parent = familyInstance.Host;
-        }
-
-        parent ??= familyInstance.SuperComponent;
+        // parent: prefer Host (e.g. wall, floor, ceiling), fall back to SuperComponent (nested family)
+        Element? parent = familyInstance.Host ?? familyInstance.SuperComponent;
 
         if (parent != null)
         {


### PR DESCRIPTION
Previously, `parentApplicationId` was only populated for curtain wall mullions and panels. This change extends that behaviour to **any** `FamilyInstance` that has a `Host` (including doors, windows, face-hosted families, MEP fixtures, etc.).

This also removes the `#if REVIT2023_OR_GREATER` compile-time block that was only needed to support the now-deleted category check.

https://github.com/user-attachments/assets/0f09558b-d5c9-4dd2-b88f-28c1e63fa304

cc @jsdbroughton @didimitrie 