### PR TITLE
feat(rvt): Append Rooms and Areas toggle

### DIFF
--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Bindings/RevitSendBinding.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Bindings/RevitSendBinding.cs
@@ -324,6 +324,7 @@ internal sealed class RevitSendBinding : RevitBaseBinding, ISendBinding
     }
 
     // append rooms and/or areas from the whole document when requested, independent of the active filter
+    //TODO settings should be configured per filter. This setting is only for view filter when selected view is a 3d view.
     var existingIds = elementsOnMainModel.Select(e => e.UniqueId).ToHashSet();
     elementsOnMainModel.AddRange(_toSpeckleSettingsManager.GetElementsToAppend(document, modelCard, existingIds));
 

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Bindings/RevitSendBinding.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Bindings/RevitSendBinding.cs
@@ -162,6 +162,7 @@ internal sealed class RevitSendBinding : RevitBaseBinding, ISendBinding
       new LinkedModelsSetting(),
       new SendRebarsAsVolumetricSetting(),
       new SendAreasAsMeshSetting(),
+      new AppendRoomsAndAreasSetting(),
     ];
 
   public void CancelSend(string modelCardId) => _cancellationManager.CancelOperation(modelCardId);
@@ -321,6 +322,10 @@ internal sealed class RevitSendBinding : RevitBaseBinding, ISendBinding
       }
       documentElementContexts.AddRange(linkedDocumentContexts);
     }
+
+    // append rooms and/or areas from the whole document when requested, independent of the active filter
+    var existingIds = elementsOnMainModel.Select(e => e.UniqueId).ToHashSet();
+    elementsOnMainModel.AddRange(_toSpeckleSettingsManager.GetElementsToAppend(document, modelCard, existingIds));
 
     // update ID map
     if (modelCard.SendFilter is not null && modelCard.SendFilter.IdMap is not null)

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Bindings/RevitSendBinding.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Bindings/RevitSendBinding.cs
@@ -37,6 +37,7 @@ internal sealed class RevitSendBinding : RevitBaseBinding, ISendBinding
   private readonly RevitToSpeckleCacheSingleton _revitToSpeckleCacheSingleton;
   private readonly ITopLevelExceptionHandler _topLevelExceptionHandler;
   private readonly LinkedModelHandler _linkedModelHandler;
+  private readonly RoomsAndAreasHandler _roomsAndAreasHandler;
   private readonly IThreadContext _threadContext;
   private readonly ISendOperationManagerFactory _sendOperationManagerFactory;
   private readonly ParameterUpdater _parameterUpdater;
@@ -65,6 +66,7 @@ internal sealed class RevitSendBinding : RevitBaseBinding, ISendBinding
     RevitToSpeckleCacheSingleton revitToSpeckleCacheSingleton,
     ITopLevelExceptionHandler topLevelExceptionHandler,
     LinkedModelHandler linkedModelHandler,
+    RoomsAndAreasHandler roomsAndAreasHandler,
     IThreadContext threadContext,
     IRevitTask revitTask,
     ISendOperationManagerFactory sendOperationManagerFactory,
@@ -84,6 +86,7 @@ internal sealed class RevitSendBinding : RevitBaseBinding, ISendBinding
     _revitToSpeckleCacheSingleton = revitToSpeckleCacheSingleton;
     _topLevelExceptionHandler = topLevelExceptionHandler;
     _linkedModelHandler = linkedModelHandler;
+    _roomsAndAreasHandler = roomsAndAreasHandler;
     _threadContext = threadContext;
     _sendOperationManagerFactory = sendOperationManagerFactory;
     _parameterUpdater = parameterUpdater;
@@ -325,8 +328,16 @@ internal sealed class RevitSendBinding : RevitBaseBinding, ISendBinding
 
     // append rooms and/or areas from the whole document when requested, independent of the active filter
     //TODO settings should be configured per filter. This setting is only for view filter when selected view is a 3d view.
-    var existingIds = elementsOnMainModel.Select(e => e.UniqueId).ToHashSet();
-    elementsOnMainModel.AddRange(_toSpeckleSettingsManager.GetElementsToAppend(document, modelCard, existingIds));
+    var roomsAndAreasMode = _toSpeckleSettingsManager.GetAppendRoomsAndAreas(document, modelCard);
+    if (roomsAndAreasMode != AppendRoomsAndAreasMode.None)
+    {
+      var existingIds = elementsOnMainModel.Select(e => e.UniqueId).ToHashSet();
+      elementsOnMainModel.AddRange(
+        _roomsAndAreasHandler
+          .CollectRoomsAndAreas(document, roomsAndAreasMode)
+          .Where(e => !existingIds.Contains(e.UniqueId))
+      );
+    }
 
     // update ID map
     if (modelCard.SendFilter is not null && modelCard.SendFilter.IdMap is not null)

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Bindings/RevitSendBinding.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Bindings/RevitSendBinding.cs
@@ -192,7 +192,7 @@ internal sealed class RevitSendBinding : RevitBaseBinding, ISendBinding
               _toSpeckleSettingsManager.GetLinkedModelsSetting(document, card),
               _toSpeckleSettingsManager.GetSendRebarsAsVolumetric(document, card),
               _toSpeckleSettingsManager.GetSendAreasAsMesh(document, card),
-              _toSpeckleSettingsManager.GetSendRebarsAsVolumetric(document, card)
+              false
             )
           );
       },

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Bindings/RevitSendBinding.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Bindings/RevitSendBinding.cs
@@ -87,7 +87,8 @@ internal sealed class RevitSendBinding : RevitBaseBinding, ISendBinding
 
     revitTask.Run(() =>
     {
-      _documentChangedHandler = (_, e) => _topLevelExceptionHandler.CatchUnhandled(() => _changeTracker.HandleDocChange(e));
+      _documentChangedHandler = (_, e) =>
+        _topLevelExceptionHandler.CatchUnhandled(() => _changeTracker.HandleDocChange(e));
       _store.ModelCardsChanged += (_, e) => OnModelCardsChanged(e);
       _store.DocumentChanged += (_, _) => topLevelExceptionHandler.FireAndForget(async () => await OnDocumentChanged());
     });

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Bindings/RevitSendBinding.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Bindings/RevitSendBinding.cs
@@ -1,6 +1,5 @@
 using System.IO;
 using Autodesk.Revit.DB;
-using Autodesk.Revit.DB.ExtensibleStorage;
 using Microsoft.Extensions.DependencyInjection;
 using Speckle.Connectors.Common.Caching;
 using Speckle.Connectors.Common.Cancellation;
@@ -25,14 +24,12 @@ namespace Speckle.Connectors.Revit.Bindings;
 
 internal sealed class RevitSendBinding : RevitBaseBinding, ISendBinding
 {
-  private readonly RevitIdleManager _revitIdleManager;
   private readonly RevitContext _revitContext;
   private readonly DocumentModelStore _store;
   private readonly ICancellationManager _cancellationManager;
   private readonly ISendConversionCache _sendConversionCache;
 
   private readonly ToSpeckleSettingsManager _toSpeckleSettingsManager;
-  private readonly ElementUnpacker _elementUnpacker;
   private readonly IRevitConversionSettingsFactory _revitConversionSettingsFactory;
   private readonly RevitToSpeckleCacheSingleton _revitToSpeckleCacheSingleton;
   private readonly ITopLevelExceptionHandler _topLevelExceptionHandler;
@@ -41,27 +38,18 @@ internal sealed class RevitSendBinding : RevitBaseBinding, ISendBinding
   private readonly IThreadContext _threadContext;
   private readonly ISendOperationManagerFactory _sendOperationManagerFactory;
   private readonly ParameterUpdater _parameterUpdater;
+  private readonly RevitSendChangeTracker _changeTracker;
   private bool _isDocChangedSubscribed;
   private EventHandler<Autodesk.Revit.DB.Events.DocumentChangedEventArgs>? _documentChangedHandler;
   private readonly ConnectorConfig _config;
 
-  /// <summary>
-  /// Used internally to aggregate the changed objects' id. Note we're using a concurrent dictionary here as the expiry check method is not thread safe, and this was causing problems. See:
-  /// [CNX-202: Unhandled Exception Occurred when receiving in Rhino](https://linear.app/speckle/issue/CNX-202/unhandled-exception-occurred-when-receiving-in-rhino)
-  /// As to why a concurrent dictionary, it's because it's the cheapest/easiest way to do so.
-  /// https://stackoverflow.com/questions/18922985/concurrent-hashsett-in-net-framework
-  /// </summary>
-  private ConcurrentHashSet<ElementId> ChangedObjectIds { get; set; } = new();
-
   public RevitSendBinding(
-    RevitIdleManager revitIdleManager,
     RevitContext revitContext,
     DocumentModelStore store,
     ICancellationManager cancellationManager,
     IBrowserBridge bridge,
     ISendConversionCache sendConversionCache,
     ToSpeckleSettingsManager toSpeckleSettingsManager,
-    ElementUnpacker elementUnpacker,
     IRevitConversionSettingsFactory revitConversionSettingsFactory,
     RevitToSpeckleCacheSingleton revitToSpeckleCacheSingleton,
     ITopLevelExceptionHandler topLevelExceptionHandler,
@@ -71,17 +59,16 @@ internal sealed class RevitSendBinding : RevitBaseBinding, ISendBinding
     IRevitTask revitTask,
     ISendOperationManagerFactory sendOperationManagerFactory,
     ParameterUpdater parameterUpdater,
-    IConfigStore configStore
+    IConfigStore configStore,
+    RevitSendChangeTracker changeTracker
   )
     : base("sendBinding", bridge)
   {
-    _revitIdleManager = revitIdleManager;
     _revitContext = revitContext;
     _store = store;
     _cancellationManager = cancellationManager;
     _sendConversionCache = sendConversionCache;
     _toSpeckleSettingsManager = toSpeckleSettingsManager;
-    _elementUnpacker = elementUnpacker;
     _revitConversionSettingsFactory = revitConversionSettingsFactory;
     _revitToSpeckleCacheSingleton = revitToSpeckleCacheSingleton;
     _topLevelExceptionHandler = topLevelExceptionHandler;
@@ -90,17 +77,17 @@ internal sealed class RevitSendBinding : RevitBaseBinding, ISendBinding
     _threadContext = threadContext;
     _sendOperationManagerFactory = sendOperationManagerFactory;
     _parameterUpdater = parameterUpdater;
+    _changeTracker = changeTracker;
     _config = configStore.GetConnectorConfig();
 
     Commands = new SendBindingUICommands(bridge);
+    _changeTracker.Initialize(Commands, RefreshSenderForActiveDocument);
     // TODO expiry events
     // TODO filters need refresh events
 
     revitTask.Run(() =>
     {
-      // revitContext.UIApplication.NotNull().Application.DocumentChanged += (_, e) =>
-      //   _topLevelExceptionHandler.CatchUnhandled(() => DocChangeHandler(e));
-      _documentChangedHandler = (_, e) => _topLevelExceptionHandler.CatchUnhandled(() => DocChangeHandler(e));
+      _documentChangedHandler = (_, e) => _topLevelExceptionHandler.CatchUnhandled(() => _changeTracker.HandleDocChange(e));
       _store.ModelCardsChanged += (_, e) => OnModelCardsChanged(e);
       _store.DocumentChanged += (_, _) => topLevelExceptionHandler.FireAndForget(async () => await OnDocumentChanged());
     });
@@ -361,220 +348,14 @@ internal sealed class RevitSendBinding : RevitBaseBinding, ISendBinding
     return documentElementContexts;
   }
 
-  /// <summary>
-  /// Keeps track of the changed element ids as well as checks if any of them need to trigger
-  /// a filter refresh (e.g., views being added).
-  /// </summary>
-  /// <param name="e"></param>
-  private void DocChangeHandler(Autodesk.Revit.DB.Events.DocumentChangedEventArgs e)
-  {
-    ICollection<ElementId> modifiedElementIds = e.GetModifiedElementIds();
-    var doc = e.GetDocument();
-    if (doc == null)
-    {
-      return;
-    }
-    // NOTE: Whenever we save data into file this event also trigger changes on its DataStorage.
-    // On every add/remove/update model attempt triggers this handler and was causing unnecessary calls on `RunExpirationChecks`
-    // Re-check it once we implement Linked Documents
-    if (modifiedElementIds.Count == 1)
-    {
-      if (modifiedElementIds.All(el => doc.GetElement(el) is DataStorage))
-      {
-        return;
-      }
-    }
-
-    ICollection<ElementId> addedElementIds = e.GetAddedElementIds();
-    ICollection<ElementId> deletedElementIds = e.GetDeletedElementIds();
-
-    foreach (ElementId elementId in addedElementIds)
-    {
-      ChangedObjectIds.Add(elementId);
-    }
-
-    foreach (ElementId elementId in deletedElementIds)
-    {
-      ChangedObjectIds.Add(elementId);
-    }
-
-    foreach (ElementId elementId in modifiedElementIds)
-    {
-      ChangedObjectIds.Add(elementId);
-    }
-
-    if (addedElementIds.Count > 0)
-    {
-      _revitIdleManager.SubscribeToIdle(nameof(PostSetObjectIds), PostSetObjectIds);
-    }
-
-    if (HaveUnitsChanged(doc))
-    {
-      var objectIds = new List<string>();
-      foreach (var sender in _store.GetSenders().ToList())
-      {
-        if (sender.SendFilter is null)
-        {
-          continue;
-        }
-
-        var selectedObjects = sender.SendFilter.NotNull().SelectedObjectIds;
-        objectIds.AddRange(selectedObjects);
-      }
-      var unpackedObjectIds = _elementUnpacker.GetUnpackedElementIds(objectIds, doc);
-      _sendConversionCache.EvictObjects(unpackedObjectIds);
-    }
-
-    _revitIdleManager.SubscribeToIdle(nameof(CheckFilterExpiration), CheckFilterExpiration);
-    _revitIdleManager.SubscribeToIdle(nameof(RunExpirationChecks), RunExpirationChecks);
-  }
-
-  // Keeps track of doc and current units
-  private readonly Dictionary<string, string> _docUnitCache = new();
-
-  private bool HaveUnitsChanged(Document doc)
-  {
-    var docId = doc.Title + doc.PathName;
-    var unitSpecTypeIds = new List<ForgeTypeId>() // list of units we care about
-    {
-      SpecTypeId.Angle,
-      SpecTypeId.Area,
-      SpecTypeId.Distance,
-      SpecTypeId.Length,
-      SpecTypeId.Volume,
-    };
-    var units = "";
-    foreach (var typeId in unitSpecTypeIds)
-    {
-      units += doc.GetUnits().GetFormatOptions(typeId).GetUnitTypeId().TypeId;
-    }
-
-    if (_docUnitCache.TryGetValue(docId, out string? value))
-    {
-      if (value == units)
-      {
-        return false;
-      }
-      _docUnitCache[docId] = units;
-      return true;
-    }
-
-    _docUnitCache[docId] = units;
-    return false;
-  }
-
-  private async Task PostSetObjectIds()
+  private async Task RefreshSenderForActiveDocument(SenderModelCard sender)
   {
     var document = _revitContext.UIApplication?.ActiveUIDocument?.Document;
     if (document == null)
     {
       return;
     }
-    foreach (var sender in _store.GetSenders().ToList())
-    {
-      await RefreshElementsIdsOnSender(document, sender);
-    }
-  }
-
-  /// <summary>
-  /// Notifies ui if any filters need refreshing. Currently, this only applies for view filters.
-  /// </summary>
-  private async Task CheckFilterExpiration()
-  {
-    // NOTE: below code seems like more make sense in terms of performance, but it causes unmanaged exception on Revit
-    // using var viewCollector = new FilteredElementCollector(RevitContext.UIApplication?.ActiveUIDocument.Document);
-    // var views = viewCollector.OfClass(typeof(View)).Cast<View>().Select(v => v.Id).ToList();
-    // var intersection = ChangedObjectIds.Keys.Intersect(views).ToList();
-    // if (intersection.Count != 0)
-    // {
-    //    await Commands.RefreshSendFilters();
-    // }
-    var doc = _revitContext.UIApplication?.ActiveUIDocument?.Document;
-    if (doc == null)
-    {
-      return;
-    }
-
-    if (ChangedObjectIds.Any(e => doc.GetElement(e) is View))
-    {
-      await Commands.RefreshSendFilters();
-    }
-  }
-
-  private async Task RunExpirationChecks()
-  {
-    var senders = _store.GetSenders().ToList();
-    // string[] objectIdsList = ChangedObjectIds.Keys.ToArray();
-    var doc = _revitContext.UIApplication?.ActiveUIDocument?.Document;
-
-    if (doc == null)
-    {
-      return;
-    }
-
-    var objUniqueIds = new List<string>();
-    var changedIds = ChangedObjectIds.ToList();
-
-    // Handling type changes: if an element's type is changed, we need to mark as changed all objects that have that type.
-    // Step 1: get any changed types
-    var elementTypeIdsList = changedIds
-      .Select(e => doc.GetElement(e))
-      .OfType<ElementType>()
-      .Select(el => el.Id)
-      .ToHashSet(); // ToHashSet() for faster Contains
-
-    // Step 2: Find all elements of the changed types, and add them to the changed ids list.
-    if (elementTypeIdsList.Count != 0)
-    {
-      using var collector = new FilteredElementCollector(doc);
-      var collectorElements = collector
-        .WhereElementIsNotElementType()
-        .Where(e => elementTypeIdsList.Contains(e.GetTypeId()));
-      foreach (var elm in collectorElements)
-      {
-        changedIds.Add(elm.Id);
-      }
-    }
-
-    foreach (var sender in senders)
-    {
-      foreach (var changedElementId in changedIds)
-      {
-        if (sender.SendFilter?.IdMap?.TryGetValue(changedElementId.ToString(), out var id) ?? false)
-        {
-          objUniqueIds.Add(id);
-        }
-      }
-    }
-
-    var unpackedObjectIds = _elementUnpacker.GetUnpackedElementIds(objUniqueIds, doc);
-    _sendConversionCache.EvictObjects(unpackedObjectIds);
-
-    // Note: we're doing object selection and card expiry management by old school ids
-    List<string> expiredSenderIds = new();
-    foreach (SenderModelCard modelCard in senders)
-    {
-      if (modelCard.SendFilter is IRevitSendFilter viewFilter)
-      {
-        viewFilter.SetContext(_revitContext);
-      }
-
-      if (modelCard.SendFilter is null || modelCard.SendFilter.IdMap is null)
-      {
-        continue;
-      }
-
-      var selectedObjects = modelCard.SendFilter.NotNull().IdMap.NotNull().Values;
-      var intersection = selectedObjects.Intersect(objUniqueIds).ToList();
-      bool isExpired = intersection.Count != 0;
-      if (isExpired)
-      {
-        expiredSenderIds.Add(modelCard.ModelCardId.NotNull());
-      }
-    }
-
-    await Commands.SetModelsExpired(expiredSenderIds);
-    ChangedObjectIds = new();
+    await RefreshElementsIdsOnSender(document, sender);
   }
 
   // POC: Will be re-addressed later with better UX with host apps that are friendly on async doc operations.

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/DependencyInjection/RevitConnectorModule.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/DependencyInjection/RevitConnectorModule.cs
@@ -72,6 +72,7 @@ public static class ServiceRegistration
     serviceCollection.AddSingleton<LinkedModelHandler>();
     serviceCollection.AddSingleton<RoomsAndAreasHandler>();
     serviceCollection.AddSingleton<ParameterUpdater>();
+    serviceCollection.AddSingleton<RevitSendChangeTracker>();
 
     // receive operation and dependencies
     serviceCollection.AddScoped<IHostObjectBuilder, RevitHostObjectBuilder>();

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/DependencyInjection/RevitConnectorModule.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/DependencyInjection/RevitConnectorModule.cs
@@ -70,6 +70,7 @@ public static class ServiceRegistration
     serviceCollection.AddSingleton<ToSpeckleSettingsManager>();
     serviceCollection.AddSingleton<ToHostSettingsManager>();
     serviceCollection.AddSingleton<LinkedModelHandler>();
+    serviceCollection.AddSingleton<RoomsAndAreasHandler>();
     serviceCollection.AddSingleton<ParameterUpdater>();
 
     // receive operation and dependencies

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/RevitSendChangeTracker.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/RevitSendChangeTracker.cs
@@ -1,0 +1,278 @@
+using Autodesk.Revit.DB;
+using Autodesk.Revit.DB.ExtensibleStorage;
+using Speckle.Connectors.Common.Caching;
+using Speckle.Connectors.DUI.Bindings;
+using Speckle.Connectors.DUI.Models;
+using Speckle.Connectors.DUI.Models.Card;
+using Speckle.Connectors.Revit.Plugin;
+using Speckle.Connectors.RevitShared.Operations.Send.Filters;
+using Speckle.Converters.Common;
+using Speckle.Converters.RevitShared.Helpers;
+using Speckle.Sdk.Common;
+
+namespace Speckle.Connectors.Revit.HostApp;
+
+/// <summary>
+/// Owns the document-change → idle → expiration pipeline for the Revit send binding:
+/// aggregates changed element ids, evicts the conversion cache on unit changes,
+/// refreshes filters when views change, and marks sender model cards expired when
+/// their tracked elements (or their types) are modified.
+/// </summary>
+internal sealed class RevitSendChangeTracker
+{
+  private readonly RevitIdleManager _revitIdleManager;
+  private readonly RevitContext _revitContext;
+  private readonly DocumentModelStore _store;
+  private readonly ISendConversionCache _sendConversionCache;
+  private readonly ElementUnpacker _elementUnpacker;
+
+  private SendBindingUICommands? _commands;
+  private Func<SenderModelCard, Task>? _refreshSender;
+
+  // tracks doc → concatenated unit type ids, used to detect unit changes
+  private readonly Dictionary<string, string> _docUnitCache = new();
+
+  /// <summary>
+  /// Used internally to aggregate the changed objects' id. Note we're using a concurrent dictionary here as the expiry check method is not thread safe, and this was causing problems. See:
+  /// [CNX-202: Unhandled Exception Occurred when receiving in Rhino](https://linear.app/speckle/issue/CNX-202/unhandled-exception-occurred-when-receiving-in-rhino)
+  /// As to why a concurrent dictionary, it's because it's the cheapest/easiest way to do so.
+  /// https://stackoverflow.com/questions/18922985/concurrent-hashsett-in-net-framework
+  /// </summary>
+  private ConcurrentHashSet<ElementId> ChangedObjectIds { get; set; } = new();
+
+  public RevitSendChangeTracker(
+    RevitIdleManager revitIdleManager,
+    RevitContext revitContext,
+    DocumentModelStore store,
+    ISendConversionCache sendConversionCache,
+    ElementUnpacker elementUnpacker
+  )
+  {
+    _revitIdleManager = revitIdleManager;
+    _revitContext = revitContext;
+    _store = store;
+    _sendConversionCache = sendConversionCache;
+    _elementUnpacker = elementUnpacker;
+  }
+
+  /// <summary>
+  /// Wires the UI commands and per-sender refresh callback. Must be called by the owning
+  /// binding once it has constructed its <see cref="SendBindingUICommands"/>.
+  /// </summary>
+  public void Initialize(SendBindingUICommands commands, Func<SenderModelCard, Task> refreshSender)
+  {
+    _commands = commands;
+    _refreshSender = refreshSender;
+  }
+
+  /// <summary>
+  /// Keeps track of the changed element ids as well as checks if any of them need to trigger
+  /// a filter refresh (e.g., views being added).
+  /// </summary>
+  public void HandleDocChange(Autodesk.Revit.DB.Events.DocumentChangedEventArgs e)
+  {
+    ICollection<ElementId> modifiedElementIds = e.GetModifiedElementIds();
+    var doc = e.GetDocument();
+    if (doc == null)
+    {
+      return;
+    }
+    // NOTE: Whenever we save data into file this event also trigger changes on its DataStorage.
+    // On every add/remove/update model attempt triggers this handler and was causing unnecessary calls on `RunExpirationChecks`
+    // Re-check it once we implement Linked Documents
+    if (modifiedElementIds.Count == 1)
+    {
+      if (modifiedElementIds.All(el => doc.GetElement(el) is DataStorage))
+      {
+        return;
+      }
+    }
+
+    ICollection<ElementId> addedElementIds = e.GetAddedElementIds();
+    ICollection<ElementId> deletedElementIds = e.GetDeletedElementIds();
+
+    foreach (ElementId elementId in addedElementIds)
+    {
+      ChangedObjectIds.Add(elementId);
+    }
+
+    foreach (ElementId elementId in deletedElementIds)
+    {
+      ChangedObjectIds.Add(elementId);
+    }
+
+    foreach (ElementId elementId in modifiedElementIds)
+    {
+      ChangedObjectIds.Add(elementId);
+    }
+
+    if (addedElementIds.Count > 0)
+    {
+      _revitIdleManager.SubscribeToIdle(nameof(PostSetObjectIds), PostSetObjectIds);
+    }
+
+    if (HaveUnitsChanged(doc))
+    {
+      var objectIds = new List<string>();
+      foreach (var sender in _store.GetSenders().ToList())
+      {
+        if (sender.SendFilter is null)
+        {
+          continue;
+        }
+
+        var selectedObjects = sender.SendFilter.NotNull().SelectedObjectIds;
+        objectIds.AddRange(selectedObjects);
+      }
+      var unpackedObjectIds = _elementUnpacker.GetUnpackedElementIds(objectIds, doc);
+      _sendConversionCache.EvictObjects(unpackedObjectIds);
+    }
+
+    _revitIdleManager.SubscribeToIdle(nameof(CheckFilterExpiration), CheckFilterExpiration);
+    _revitIdleManager.SubscribeToIdle(nameof(RunExpirationChecks), RunExpirationChecks);
+  }
+
+  private bool HaveUnitsChanged(Document doc)
+  {
+    var docId = doc.Title + doc.PathName;
+    var unitSpecTypeIds = new List<ForgeTypeId>() // list of units we care about
+    {
+      SpecTypeId.Angle,
+      SpecTypeId.Area,
+      SpecTypeId.Distance,
+      SpecTypeId.Length,
+      SpecTypeId.Volume,
+    };
+    var units = "";
+    foreach (var typeId in unitSpecTypeIds)
+    {
+      units += doc.GetUnits().GetFormatOptions(typeId).GetUnitTypeId().TypeId;
+    }
+
+    if (_docUnitCache.TryGetValue(docId, out string? value))
+    {
+      if (value == units)
+      {
+        return false;
+      }
+      _docUnitCache[docId] = units;
+      return true;
+    }
+
+    _docUnitCache[docId] = units;
+    return false;
+  }
+
+  private async Task PostSetObjectIds()
+  {
+    var document = _revitContext.UIApplication?.ActiveUIDocument?.Document;
+    if (document == null || _refreshSender == null)
+    {
+      return;
+    }
+    foreach (var sender in _store.GetSenders().ToList())
+    {
+      await _refreshSender(sender);
+    }
+  }
+
+  /// <summary>
+  /// Notifies ui if any filters need refreshing. Currently, this only applies for view filters.
+  /// </summary>
+  private async Task CheckFilterExpiration()
+  {
+    // NOTE: below code seems like more make sense in terms of performance, but it causes unmanaged exception on Revit
+    // using var viewCollector = new FilteredElementCollector(RevitContext.UIApplication?.ActiveUIDocument.Document);
+    // var views = viewCollector.OfClass(typeof(View)).Cast<View>().Select(v => v.Id).ToList();
+    // var intersection = ChangedObjectIds.Keys.Intersect(views).ToList();
+    // if (intersection.Count != 0)
+    // {
+    //    await Commands.RefreshSendFilters();
+    // }
+    var doc = _revitContext.UIApplication?.ActiveUIDocument?.Document;
+    if (doc == null || _commands == null)
+    {
+      return;
+    }
+
+    if (ChangedObjectIds.Any(e => doc.GetElement(e) is View))
+    {
+      await _commands.RefreshSendFilters();
+    }
+  }
+
+  private async Task RunExpirationChecks()
+  {
+    var senders = _store.GetSenders().ToList();
+    var doc = _revitContext.UIApplication?.ActiveUIDocument?.Document;
+
+    if (doc == null || _commands == null)
+    {
+      return;
+    }
+
+    var objUniqueIds = new List<string>();
+    var changedIds = ChangedObjectIds.ToList();
+
+    // Handling type changes: if an element's type is changed, we need to mark as changed all objects that have that type.
+    // Step 1: get any changed types
+    var elementTypeIdsList = changedIds
+      .Select(e => doc.GetElement(e))
+      .OfType<ElementType>()
+      .Select(el => el.Id)
+      .ToHashSet(); // ToHashSet() for faster Contains
+
+    // Step 2: Find all elements of the changed types, and add them to the changed ids list.
+    if (elementTypeIdsList.Count != 0)
+    {
+      using var collector = new FilteredElementCollector(doc);
+      var collectorElements = collector
+        .WhereElementIsNotElementType()
+        .Where(e => elementTypeIdsList.Contains(e.GetTypeId()));
+      foreach (var elm in collectorElements)
+      {
+        changedIds.Add(elm.Id);
+      }
+    }
+
+    foreach (var sender in senders)
+    {
+      foreach (var changedElementId in changedIds)
+      {
+        if (sender.SendFilter?.IdMap?.TryGetValue(changedElementId.ToString(), out var id) ?? false)
+        {
+          objUniqueIds.Add(id);
+        }
+      }
+    }
+
+    var unpackedObjectIds = _elementUnpacker.GetUnpackedElementIds(objUniqueIds, doc);
+    _sendConversionCache.EvictObjects(unpackedObjectIds);
+
+    // Note: we're doing object selection and card expiry management by old school ids
+    List<string> expiredSenderIds = new();
+    foreach (SenderModelCard modelCard in senders)
+    {
+      if (modelCard.SendFilter is IRevitSendFilter viewFilter)
+      {
+        viewFilter.SetContext(_revitContext);
+      }
+
+      if (modelCard.SendFilter is null || modelCard.SendFilter.IdMap is null)
+      {
+        continue;
+      }
+
+      var selectedObjects = modelCard.SendFilter.NotNull().IdMap.NotNull().Values;
+      var intersection = selectedObjects.Intersect(objUniqueIds).ToList();
+      bool isExpired = intersection.Count != 0;
+      if (isExpired)
+      {
+        expiredSenderIds.Add(modelCard.ModelCardId.NotNull());
+      }
+    }
+
+    await _commands.SetModelsExpired(expiredSenderIds);
+    ChangedObjectIds = new();
+  }
+}

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/RoomsAndAreasHandler.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/RoomsAndAreasHandler.cs
@@ -16,6 +16,7 @@ public class RoomsAndAreasHandler
   /// This method handles the specifics of element collection but doesn't make decisions
   /// about whether rooms/areas should be appended - that's the caller's responsibility.
   /// Callers are also responsible for deduplicating against any already-collected elements.
+  /// Unplaced rooms (UpperLimit == null) and unplaced areas (Location == null) are excluded.
   /// </summary>
   public IReadOnlyList<Element> CollectRoomsAndAreas(Document document, AppendRoomsAndAreasMode mode)
   {
@@ -30,7 +31,11 @@ public class RoomsAndAreasHandler
     {
       using var roomCollector = new FilteredElementCollector(document);
       collected.AddRange(
-        roomCollector.OfClass(typeof(SpatialElement)).OfCategory(BuiltInCategory.OST_Rooms).Cast<Element>()
+        roomCollector
+          .OfClass(typeof(SpatialElement))
+          .OfCategory(BuiltInCategory.OST_Rooms)
+          .Cast<Autodesk.Revit.DB.Architecture.Room>()
+          .Where(r => r.UpperLimit != null)
       );
     }
 
@@ -38,7 +43,11 @@ public class RoomsAndAreasHandler
     {
       using var areaCollector = new FilteredElementCollector(document);
       collected.AddRange(
-        areaCollector.OfClass(typeof(SpatialElement)).OfCategory(BuiltInCategory.OST_Areas).Cast<Element>()
+        areaCollector
+          .OfClass(typeof(SpatialElement))
+          .OfCategory(BuiltInCategory.OST_Areas)
+          .Cast<SpatialElement>()
+          .Where(se => se.Location != null)
       );
     }
 

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/RoomsAndAreasHandler.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/RoomsAndAreasHandler.cs
@@ -4,19 +4,14 @@ using Speckle.Connectors.Revit.Operations.Send.Settings;
 namespace Speckle.Connectors.Revit.HostApp;
 
 /// <summary>
-/// Handles collecting rooms and/or areas from a Revit document.
-/// This class is responsible for the mechanics of retrieving spatial elements per the
-/// requested mode, but not for making decisions about whether rooms/areas should be
-/// appended (which is the responsibility of the calling code)!
+/// Collects rooms and/or areas from a Revit document. Mechanics only — the caller
+/// decides whether to append and is responsible for deduplication.
 /// </summary>
 public class RoomsAndAreasHandler
 {
   /// <summary>
-  /// Collects rooms and/or areas from the document per the requested mode.
-  /// This method handles the specifics of element collection but doesn't make decisions
-  /// about whether rooms/areas should be appended - that's the caller's responsibility.
-  /// Callers are also responsible for deduplicating against any already-collected elements.
-  /// Unplaced rooms (UpperLimit == null) and unplaced areas (Location == null) are excluded.
+  /// Collects rooms and/or areas per <paramref name="mode"/>. Unplaced rooms
+  /// (UpperLimit == null) and unplaced areas (Location == null) are excluded.
   /// </summary>
   public IReadOnlyList<Element> CollectRoomsAndAreas(Document document, AppendRoomsAndAreasMode mode)
   {

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/RoomsAndAreasHandler.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/RoomsAndAreasHandler.cs
@@ -1,0 +1,47 @@
+using Autodesk.Revit.DB;
+using Speckle.Connectors.Revit.Operations.Send.Settings;
+
+namespace Speckle.Connectors.Revit.HostApp;
+
+/// <summary>
+/// Handles collecting rooms and/or areas from a Revit document.
+/// This class is responsible for the mechanics of retrieving spatial elements per the
+/// requested mode, but not for making decisions about whether rooms/areas should be
+/// appended (which is the responsibility of the calling code)!
+/// </summary>
+public class RoomsAndAreasHandler
+{
+  /// <summary>
+  /// Collects rooms and/or areas from the document per the requested mode.
+  /// This method handles the specifics of element collection but doesn't make decisions
+  /// about whether rooms/areas should be appended - that's the caller's responsibility.
+  /// Callers are also responsible for deduplicating against any already-collected elements.
+  /// </summary>
+  public IReadOnlyList<Element> CollectRoomsAndAreas(Document document, AppendRoomsAndAreasMode mode)
+  {
+    if (mode == AppendRoomsAndAreasMode.None)
+    {
+      return [];
+    }
+
+    var collected = new List<Element>();
+
+    if (mode is AppendRoomsAndAreasMode.RoomsOnly or AppendRoomsAndAreasMode.Both)
+    {
+      using var roomCollector = new FilteredElementCollector(document);
+      collected.AddRange(
+        roomCollector.OfClass(typeof(SpatialElement)).OfCategory(BuiltInCategory.OST_Rooms).Cast<Element>()
+      );
+    }
+
+    if (mode is AppendRoomsAndAreasMode.AreasOnly or AppendRoomsAndAreasMode.Both)
+    {
+      using var areaCollector = new FilteredElementCollector(document);
+      collected.AddRange(
+        areaCollector.OfClass(typeof(SpatialElement)).OfCategory(BuiltInCategory.OST_Areas).Cast<Element>()
+      );
+    }
+
+    return collected;
+  }
+}

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/Settings/AppendRoomsAndAreasSetting.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/Settings/AppendRoomsAndAreasSetting.cs
@@ -1,0 +1,36 @@
+using System.Diagnostics.CodeAnalysis;
+using Speckle.Connectors.DUI.Settings;
+
+namespace Speckle.Connectors.Revit.Operations.Send.Settings;
+
+public enum AppendRoomsAndAreasMode
+{
+  None,
+  RoomsOnly,
+  AreasOnly,
+  Both,
+}
+
+[SuppressMessage(
+  "Usage",
+  "CA2263:Prefer generic overload when type is known",
+  Justification = "Multi-targeting friction"
+)]
+public class AppendRoomsAndAreasSetting(AppendRoomsAndAreasMode value = AppendRoomsAndAreasSetting.DEFAULT_VALUE)
+  : ICardSetting
+{
+  public const string SETTING_ID = "appendRoomsAndAreas";
+  public const AppendRoomsAndAreasMode DEFAULT_VALUE = AppendRoomsAndAreasMode.None;
+
+  public string? Id { get; set; } = SETTING_ID;
+  public string? Title { get; set; } = "Append Rooms and Areas";
+  public string? Type { get; set; } = "string";
+  public List<string>? Enum { get; set; } = System.Enum.GetNames(typeof(AppendRoomsAndAreasMode)).ToList();
+  public object? Value { get; set; } = value.ToString();
+
+  public static readonly Dictionary<string, AppendRoomsAndAreasMode> AppendRoomsAndAreasMap =
+    System
+      .Enum.GetValues(typeof(AppendRoomsAndAreasMode))
+      .Cast<AppendRoomsAndAreasMode>()
+      .ToDictionary(v => v.ToString(), v => v);
+}

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/Settings/AppendRoomsAndAreasSetting.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/Settings/AppendRoomsAndAreasSetting.cs
@@ -28,9 +28,8 @@ public class AppendRoomsAndAreasSetting(AppendRoomsAndAreasMode value = AppendRo
   public List<string>? Enum { get; set; } = System.Enum.GetNames(typeof(AppendRoomsAndAreasMode)).ToList();
   public object? Value { get; set; } = value.ToString();
 
-  public static readonly Dictionary<string, AppendRoomsAndAreasMode> AppendRoomsAndAreasMap =
-    System
-      .Enum.GetValues(typeof(AppendRoomsAndAreasMode))
-      .Cast<AppendRoomsAndAreasMode>()
-      .ToDictionary(v => v.ToString(), v => v);
+  public static readonly Dictionary<string, AppendRoomsAndAreasMode> AppendRoomsAndAreasMap = System
+    .Enum.GetValues(typeof(AppendRoomsAndAreasMode))
+    .Cast<AppendRoomsAndAreasMode>()
+    .ToDictionary(v => v.ToString(), v => v);
 }

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/Settings/AppendRoomsAndAreasSetting.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/Settings/AppendRoomsAndAreasSetting.cs
@@ -24,7 +24,8 @@ public class AppendRoomsAndAreasSetting(AppendRoomsAndAreasMode value = AppendRo
 
   public string? Id { get; set; } = SETTING_ID;
   public string? Title { get; set; } = "Append Rooms and Areas";
-  public string? Description { get; set; }
+  public string? Description { get; set; } =
+    "Intended for use with 3D views. Appends rooms and/or areas from the whole document, independent of the active filter.";
   public string? Type { get; set; } = "string";
   public List<string>? Enum { get; set; } = System.Enum.GetNames(typeof(AppendRoomsAndAreasMode)).ToList();
   public object? Value { get; set; } = value.ToString();

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/Settings/AppendRoomsAndAreasSetting.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/Settings/AppendRoomsAndAreasSetting.cs
@@ -24,6 +24,7 @@ public class AppendRoomsAndAreasSetting(AppendRoomsAndAreasMode value = AppendRo
 
   public string? Id { get; set; } = SETTING_ID;
   public string? Title { get; set; } = "Append Rooms and Areas";
+  public string? Description { get; set; }
   public string? Type { get; set; } = "string";
   public List<string>? Enum { get; set; } = System.Enum.GetNames(typeof(AppendRoomsAndAreasMode)).ToList();
   public object? Value { get; set; } = value.ToString();

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/Settings/ToSpeckleSettingsManager.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/Settings/ToSpeckleSettingsManager.cs
@@ -23,6 +23,7 @@ public class ToSpeckleSettingsManager(
   private readonly Dictionary<string, bool?> _sendLinkedModelsCache = [];
   private readonly Dictionary<string, bool?> _sendRebarsAsVolumetricCache = [];
   private readonly Dictionary<string, bool?> _sendAreasAsMeshCache = [];
+  private readonly Dictionary<string, AppendRoomsAndAreasMode> _appendRoomsAndAreasCache = [];
 
   public DetailLevelType GetDetailLevelSetting(Document document, SenderModelCard modelCard)
   {
@@ -141,6 +142,70 @@ public class ToSpeckleSettingsManager(
       _sendAreasAsMeshCache,
       "Send areas as mesh"
     );
+
+  public AppendRoomsAndAreasMode GetAppendRoomsAndAreas(Document document, SenderModelCard modelCard)
+  {
+    var valueString =
+      modelCard.Settings?.FirstOrDefault(s => s.Id == AppendRoomsAndAreasSetting.SETTING_ID)?.Value as string;
+    if (
+      valueString is not null
+      && AppendRoomsAndAreasSetting.AppendRoomsAndAreasMap.TryGetValue(valueString, out AppendRoomsAndAreasMode mode)
+    )
+    {
+      if (
+        _appendRoomsAndAreasCache.TryGetValue(modelCard.ModelCardId.NotNull(), out AppendRoomsAndAreasMode previous)
+        && previous != mode
+      )
+      {
+        EvictCacheForModelCard(document, modelCard);
+      }
+      _appendRoomsAndAreasCache[modelCard.ModelCardId.NotNull()] = mode;
+      return mode;
+    }
+
+    logger.LogWarning(
+      "Invalid appendRoomsAndAreas setting for model {ModelCardId}, using default: None",
+      modelCard.ModelCardId
+    );
+    _appendRoomsAndAreasCache[modelCard.ModelCardId.NotNull()] = AppendRoomsAndAreasMode.None;
+    return AppendRoomsAndAreasMode.None;
+  }
+
+  /// <summary>
+  /// Collects rooms and/or areas from the document per the card setting, excluding elements already present in <paramref name="existingIds"/>.
+  /// </summary>
+  public IReadOnlyList<Element> GetElementsToAppend(
+    Document document,
+    SenderModelCard modelCard,
+    HashSet<string> existingIds
+  )
+  {
+    var mode = GetAppendRoomsAndAreas(document, modelCard);
+    if (mode == AppendRoomsAndAreasMode.None)
+    {
+      return [];
+    }
+
+    var toAppend = new List<Element>();
+
+    if (mode is AppendRoomsAndAreasMode.RoomsOnly or AppendRoomsAndAreasMode.Both)
+    {
+      using var roomCollector = new FilteredElementCollector(document);
+      toAppend.AddRange(
+        roomCollector.OfClass(typeof(SpatialElement)).OfCategory(BuiltInCategory.OST_Rooms).Cast<Element>()
+      );
+    }
+
+    if (mode is AppendRoomsAndAreasMode.AreasOnly or AppendRoomsAndAreasMode.Both)
+    {
+      using var areaCollector = new FilteredElementCollector(document);
+      toAppend.AddRange(
+        areaCollector.OfClass(typeof(SpatialElement)).OfCategory(BuiltInCategory.OST_Areas).Cast<Element>()
+      );
+    }
+
+    return toAppend.Where(e => !existingIds.Contains(e.UniqueId)).ToList();
+  }
 
   /// <summary>
   /// Helper method to handle boolean settings with caching and logging

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/Settings/ToSpeckleSettingsManager.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/Settings/ToSpeckleSettingsManager.cs
@@ -25,39 +25,16 @@ public class ToSpeckleSettingsManager(
   private readonly Dictionary<string, bool?> _sendAreasAsMeshCache = [];
   private readonly Dictionary<string, AppendRoomsAndAreasMode> _appendRoomsAndAreasCache = [];
 
-  public DetailLevelType GetDetailLevelSetting(Document document, SenderModelCard modelCard)
-  {
-    var fidelityString =
-      modelCard.Settings?.FirstOrDefault(s => s.Id == DetailLevelSetting.SETTING_ID)?.Value as string;
-    if (
-      fidelityString is not null
-      && DetailLevelSetting.GeometryFidelityMap.TryGetValue(fidelityString, out DetailLevelType fidelity)
-    )
-    {
-      if (_detailLevelCache.TryGetValue(modelCard.ModelCardId.NotNull(), out DetailLevelType previousType))
-      {
-        if (previousType != fidelity)
-        {
-          EvictCacheForModelCard(document, modelCard);
-        }
-      }
-      _detailLevelCache[modelCard.ModelCardId.NotNull()] = fidelity;
-      return fidelity;
-    }
-
-    // log the issue
-    logger.LogWarning(
-      "Invalid detail level setting received: '{FidelityString}' for model {ModelCardId}, using default: {DefaultValue}",
-      fidelityString,
-      modelCard.ModelCardId,
-      DetailLevelSetting.DEFAULT_VALUE
+  public DetailLevelType GetDetailLevelSetting(Document document, SenderModelCard modelCard) =>
+    GetEnumSettingWithCache(
+      document,
+      DetailLevelSetting.SETTING_ID,
+      DetailLevelSetting.GeometryFidelityMap,
+      DetailLevelSetting.DEFAULT_VALUE,
+      modelCard,
+      _detailLevelCache,
+      "detail level"
     );
-
-    // return sensible default
-    DetailLevelType defaultValue = DetailLevelSetting.DEFAULT_VALUE;
-    _detailLevelCache[modelCard.ModelCardId.NotNull()] = defaultValue;
-    return defaultValue;
-  }
 
   public Transform? GetReferencePointSetting(Document document, ModelCard modelCard)
   {
@@ -143,33 +120,16 @@ public class ToSpeckleSettingsManager(
       "Send areas as mesh"
     );
 
-  public AppendRoomsAndAreasMode GetAppendRoomsAndAreas(Document document, SenderModelCard modelCard)
-  {
-    var valueString =
-      modelCard.Settings?.FirstOrDefault(s => s.Id == AppendRoomsAndAreasSetting.SETTING_ID)?.Value as string;
-    if (
-      valueString is not null
-      && AppendRoomsAndAreasSetting.AppendRoomsAndAreasMap.TryGetValue(valueString, out AppendRoomsAndAreasMode mode)
-    )
-    {
-      if (
-        _appendRoomsAndAreasCache.TryGetValue(modelCard.ModelCardId.NotNull(), out AppendRoomsAndAreasMode previous)
-        && previous != mode
-      )
-      {
-        EvictCacheForModelCard(document, modelCard);
-      }
-      _appendRoomsAndAreasCache[modelCard.ModelCardId.NotNull()] = mode;
-      return mode;
-    }
-
-    logger.LogWarning(
-      "Invalid appendRoomsAndAreas setting for model {ModelCardId}, using default: None",
-      modelCard.ModelCardId
+  public AppendRoomsAndAreasMode GetAppendRoomsAndAreas(Document document, SenderModelCard modelCard) =>
+    GetEnumSettingWithCache(
+      document,
+      AppendRoomsAndAreasSetting.SETTING_ID,
+      AppendRoomsAndAreasSetting.AppendRoomsAndAreasMap,
+      AppendRoomsAndAreasMode.None,
+      modelCard,
+      _appendRoomsAndAreasCache,
+      "appendRoomsAndAreas"
     );
-    _appendRoomsAndAreasCache[modelCard.ModelCardId.NotNull()] = AppendRoomsAndAreasMode.None;
-    return AppendRoomsAndAreasMode.None;
-  }
 
   /// <summary>
   /// Collects rooms and/or areas from the document per the card setting, excluding elements already present in <paramref name="existingIds"/>.
@@ -192,7 +152,11 @@ public class ToSpeckleSettingsManager(
     {
       using var roomCollector = new FilteredElementCollector(document);
       toAppend.AddRange(
-        roomCollector.OfClass(typeof(SpatialElement)).OfCategory(BuiltInCategory.OST_Rooms).Cast<Element>()
+        roomCollector
+          .OfClass(typeof(SpatialElement))
+          .OfCategory(BuiltInCategory.OST_Rooms)
+          .Cast<Element>()
+          .Where(e => !existingIds.Contains(e.UniqueId))
       );
     }
 
@@ -200,11 +164,54 @@ public class ToSpeckleSettingsManager(
     {
       using var areaCollector = new FilteredElementCollector(document);
       toAppend.AddRange(
-        areaCollector.OfClass(typeof(SpatialElement)).OfCategory(BuiltInCategory.OST_Areas).Cast<Element>()
+        areaCollector
+          .OfClass(typeof(SpatialElement))
+          .OfCategory(BuiltInCategory.OST_Areas)
+          .Cast<Element>()
+          .Where(e => !existingIds.Contains(e.UniqueId))
       );
     }
 
-    return toAppend.Where(e => !existingIds.Contains(e.UniqueId)).ToList();
+    return toAppend;
+  }
+
+  /// <summary>
+  /// Helper method to handle enum settings with string-keyed maps, per-card caching, and cache eviction on change.
+  /// </summary>
+  private TEnum GetEnumSettingWithCache<TEnum>(
+    Document document,
+    string settingId,
+    Dictionary<string, TEnum> map,
+    TEnum defaultValue,
+    SenderModelCard modelCard,
+    Dictionary<string, TEnum> cache,
+    string settingName
+  )
+    where TEnum : struct
+  {
+    var valueString = modelCard.Settings?.FirstOrDefault(s => s.Id == settingId)?.Value as string;
+    if (valueString is not null && map.TryGetValue(valueString, out TEnum value))
+    {
+      if (
+        cache.TryGetValue(modelCard.ModelCardId.NotNull(), out TEnum previous)
+        && !EqualityComparer<TEnum>.Default.Equals(previous, value)
+      )
+      {
+        EvictCacheForModelCard(document, modelCard);
+      }
+      cache[modelCard.ModelCardId.NotNull()] = value;
+      return value;
+    }
+
+    logger.LogWarning(
+      "Invalid {SettingName} setting received: '{ValueString}' for model {ModelCardId}, using default: {DefaultValue}",
+      settingName,
+      valueString,
+      modelCard.ModelCardId,
+      defaultValue
+    );
+    cache[modelCard.ModelCardId.NotNull()] = defaultValue;
+    return defaultValue;
   }
 
   /// <summary>

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/Settings/ToSpeckleSettingsManager.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/Settings/ToSpeckleSettingsManager.cs
@@ -132,50 +132,6 @@ public class ToSpeckleSettingsManager(
     );
 
   /// <summary>
-  /// Collects rooms and/or areas from the document per the card setting, excluding elements already present in <paramref name="existingIds"/>.
-  /// </summary>
-  public IReadOnlyList<Element> GetElementsToAppend(
-    Document document,
-    SenderModelCard modelCard,
-    HashSet<string> existingIds
-  )
-  {
-    var mode = GetAppendRoomsAndAreas(document, modelCard);
-    if (mode == AppendRoomsAndAreasMode.None)
-    {
-      return [];
-    }
-
-    var toAppend = new List<Element>();
-
-    if (mode is AppendRoomsAndAreasMode.RoomsOnly or AppendRoomsAndAreasMode.Both)
-    {
-      using var roomCollector = new FilteredElementCollector(document);
-      toAppend.AddRange(
-        roomCollector
-          .OfClass(typeof(SpatialElement))
-          .OfCategory(BuiltInCategory.OST_Rooms)
-          .Cast<Element>()
-          .Where(e => !existingIds.Contains(e.UniqueId))
-      );
-    }
-
-    if (mode is AppendRoomsAndAreasMode.AreasOnly or AppendRoomsAndAreasMode.Both)
-    {
-      using var areaCollector = new FilteredElementCollector(document);
-      toAppend.AddRange(
-        areaCollector
-          .OfClass(typeof(SpatialElement))
-          .OfCategory(BuiltInCategory.OST_Areas)
-          .Cast<Element>()
-          .Where(e => !existingIds.Contains(e.UniqueId))
-      );
-    }
-
-    return toAppend;
-  }
-
-  /// <summary>
   /// Helper method to handle enum settings with string-keyed maps, per-card caching, and cache eviction on change.
   /// </summary>
   private TEnum GetEnumSettingWithCache<TEnum>(

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Speckle.Connectors.RevitShared.projitems
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Speckle.Connectors.RevitShared.projitems
@@ -62,6 +62,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Operations\Send\Filters\RevitViewsFilter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Operations\Send\RevitContinuousTraversalBuilder.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Operations\Send\RevitRootObjectBuilder.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Operations\Send\Settings\AppendRoomsAndAreasSetting.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Operations\Send\Settings\LinkedModelsSetting.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Operations\Send\Settings\SendParameterNullOrEmptyStringsSetting.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Operations\Send\Settings\SendAreasAsMeshSetting.cs" />

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Speckle.Connectors.RevitShared.projitems
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Speckle.Connectors.RevitShared.projitems
@@ -28,6 +28,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)HostApp\FamilyTransformUtils.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HostApp\LevelUnpacker.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HostApp\LinkedModelHandler.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)HostApp\RoomsAndAreasHandler.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HostApp\ParameterUpdater.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HostApp\RevitFamilyBaker.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HostApp\RevitMaterialBaker.cs" />

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Speckle.Connectors.RevitShared.projitems
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Speckle.Connectors.RevitShared.projitems
@@ -29,6 +29,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)HostApp\LevelUnpacker.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HostApp\LinkedModelHandler.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HostApp\RoomsAndAreasHandler.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)HostApp\RevitSendChangeTracker.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HostApp\ParameterUpdater.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HostApp\RevitFamilyBaker.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HostApp\RevitMaterialBaker.cs" />


### PR DESCRIPTION
Adds a new **"Append Rooms and Areas"** send setting with four modes: `None`, `RoomsOnly`, `AreasOnly`, and `Both`.

When a non-`None` mode is selected, the relevant `SpatialElement`s (rooms and/or areas) are collected from the entire document and appended to the send payload *after* the active filter resolves its elements, so they are always included even if the filter wouldn't normally capture them. Duplicate elements are excluded via a `UniqueId` hash-set built from the already-collected elements.

Also refactors the repeated enum-setting-with-cache pattern in `ToSpeckleSettingsManager` into a single generic `GetEnumSettingWithCache` helper, which the existing `DetailLevelSetting` path now uses too.

<img width="332" height="251" alt="image" src="https://github.com/user-attachments/assets/92f9d56e-64af-4907-8d13-a1239f9c3638" />

<img width="1914" height="1072" alt="image" src="https://github.com/user-attachments/assets/350612dd-8342-4572-b0d8-291aded3c9a7" />
