### PR TITLE
feat(connectors): add tooltip to settings

### DIFF
--- a/Connectors/CSi/Speckle.Connectors.CSiShared/Settings/LoadCaseCombinationSetting.cs
+++ b/Connectors/CSi/Speckle.Connectors.CSiShared/Settings/LoadCaseCombinationSetting.cs
@@ -7,6 +7,7 @@ public class LoadCaseCombinationSetting(List<string> values, cSapModel sapModel)
 {
   public string? Id { get; set; } = "loadCasesAndCombinations";
   public string? Title { get; set; } = "Load Cases & Combinations";
+  public string? Description { get; set; }
   public string? Type { get; set; } = "array";
   public object? Value { get; set; } = values;
   public List<string>? Enum { get; set; } = LoadCaseHelper.GetLoadCasesAndCombinations(sapModel);

--- a/Connectors/CSi/Speckle.Connectors.CSiShared/Settings/ResultTypeSetting.cs
+++ b/Connectors/CSi/Speckle.Connectors.CSiShared/Settings/ResultTypeSetting.cs
@@ -7,6 +7,7 @@ public class ResultTypeSetting(List<string> values) : ICardSetting
 {
   public string? Id { get; set; } = "resultTypes";
   public string? Title { get; set; } = "Result Type";
+  public string? Description { get; set; }
   public string? Type { get; set; } = "array";
   public object? Value { get; set; } = values;
   public List<string>? Enum { get; set; } = ResultsKey.All.OrderBy(x => x).ToList();

--- a/Connectors/Navisworks/Speckle.Connectors.NavisworksShared/Operations/Send/Settings/ConvertHiddenElementsSetting.cs
+++ b/Connectors/Navisworks/Speckle.Connectors.NavisworksShared/Operations/Send/Settings/ConvertHiddenElementsSetting.cs
@@ -6,6 +6,7 @@ public class ConvertHiddenElementsSetting(bool value) : ICardSetting
 {
   public string? Id { get; set; } = "convertHiddenElements";
   public string? Title { get; set; } = "Convert Hidden Elements";
+  public string? Description { get; set; } = "Includes elements hidden in the Navisworks scene. Disabled by default.";
   public string? Type { get; set; } = "boolean";
   public List<string>? Enum { get; set; }
   public object? Value { get; set; } = value;

--- a/Connectors/Navisworks/Speckle.Connectors.NavisworksShared/Operations/Send/Settings/IncludeInternalPropertiesSetting.cs
+++ b/Connectors/Navisworks/Speckle.Connectors.NavisworksShared/Operations/Send/Settings/IncludeInternalPropertiesSetting.cs
@@ -6,7 +6,8 @@ public class IncludeInternalPropertiesSetting(bool value) : ICardSetting
 {
   public string? Id { get; set; } = "includeInternalProperties";
   public string? Title { get; set; } = "Include Internal Properties";
-  public string? Description { get; set; } = "Includes Navisworks-internal property categories. Disabled by default to keep payloads small.";
+  public string? Description { get; set; } =
+    "Includes Navisworks-internal property categories. Disabled by default to keep payloads small.";
   public string? Type { get; set; } = "boolean";
   public List<string>? Enum { get; set; }
   public object? Value { get; set; } = value;

--- a/Connectors/Navisworks/Speckle.Connectors.NavisworksShared/Operations/Send/Settings/IncludeInternalPropertiesSetting.cs
+++ b/Connectors/Navisworks/Speckle.Connectors.NavisworksShared/Operations/Send/Settings/IncludeInternalPropertiesSetting.cs
@@ -6,6 +6,7 @@ public class IncludeInternalPropertiesSetting(bool value) : ICardSetting
 {
   public string? Id { get; set; } = "includeInternalProperties";
   public string? Title { get; set; } = "Include Internal Properties";
+  public string? Description { get; set; } = "Includes Navisworks-internal property categories. Disabled by default to keep payloads small.";
   public string? Type { get; set; } = "boolean";
   public List<string>? Enum { get; set; }
   public object? Value { get; set; } = value;

--- a/Connectors/Navisworks/Speckle.Connectors.NavisworksShared/Operations/Send/Settings/OriginModeSetting.cs
+++ b/Connectors/Navisworks/Speckle.Connectors.NavisworksShared/Operations/Send/Settings/OriginModeSetting.cs
@@ -7,6 +7,7 @@ public class OriginModeSetting(OriginMode value) : ICardSetting
 {
   public string? Id { get; set; } = "originMode";
   public string? Title { get; set; } = "Origin Mode";
+  public string? Description { get; set; } = "The point used as the origin of the sent geometry.";
   public string? Type { get; set; } = "string";
   public List<string>? Enum { get; set; } = System.Enum.GetNames(typeof(OriginMode)).ToList();
   public object? Value { get; set; } = value.ToString();

--- a/Connectors/Navisworks/Speckle.Connectors.NavisworksShared/Operations/Send/Settings/PreserveModelHierarchySetting.cs
+++ b/Connectors/Navisworks/Speckle.Connectors.NavisworksShared/Operations/Send/Settings/PreserveModelHierarchySetting.cs
@@ -6,6 +6,7 @@ public class PreserveModelHierarchySetting(bool value) : ICardSetting
 {
   public string? Id { get; set; } = "preserveModelHierarchy";
   public string? Title { get; set; } = "Preserve Model Hierarchy";
+  public string? Description { get; set; } = "Mirrors the Navisworks model tree structure in the sent data. Disable to flatten to a single collection.";
   public string? Type { get; set; } = "boolean";
   public List<string>? Enum { get; set; }
   public object? Value { get; set; } = value;

--- a/Connectors/Navisworks/Speckle.Connectors.NavisworksShared/Operations/Send/Settings/PreserveModelHierarchySetting.cs
+++ b/Connectors/Navisworks/Speckle.Connectors.NavisworksShared/Operations/Send/Settings/PreserveModelHierarchySetting.cs
@@ -6,7 +6,8 @@ public class PreserveModelHierarchySetting(bool value) : ICardSetting
 {
   public string? Id { get; set; } = "preserveModelHierarchy";
   public string? Title { get; set; } = "Preserve Model Hierarchy";
-  public string? Description { get; set; } = "Mirrors the Navisworks model tree structure in the sent data. Disable to flatten to a single collection.";
+  public string? Description { get; set; } =
+    "Mirrors the Navisworks model tree structure in the sent data. Disable to flatten to a single collection.";
   public string? Type { get; set; } = "boolean";
   public List<string>? Enum { get; set; }
   public object? Value { get; set; } = value;

--- a/Connectors/Navisworks/Speckle.Connectors.NavisworksShared/Operations/Send/Settings/RevitCategoryMapping.cs
+++ b/Connectors/Navisworks/Speckle.Connectors.NavisworksShared/Operations/Send/Settings/RevitCategoryMapping.cs
@@ -6,7 +6,8 @@ public class RevitCategoryMappingSetting(bool value) : ICardSetting
 {
   public string? Id { get; set; } = "mappingToRevitCategories";
   public string? Title { get; set; } = "Map to Revit Categories";
-  public string? Description { get; set; } = "Tags elements with inferred Revit categories so they bake correctly when received in Revit.";
+  public string? Description { get; set; } =
+    "Tags elements with inferred Revit categories so they bake correctly when received in Revit.";
   public string? Type { get; set; } = "boolean";
   public List<string>? Enum { get; set; }
   public object? Value { get; set; } = value;

--- a/Connectors/Navisworks/Speckle.Connectors.NavisworksShared/Operations/Send/Settings/RevitCategoryMapping.cs
+++ b/Connectors/Navisworks/Speckle.Connectors.NavisworksShared/Operations/Send/Settings/RevitCategoryMapping.cs
@@ -6,6 +6,7 @@ public class RevitCategoryMappingSetting(bool value) : ICardSetting
 {
   public string? Id { get; set; } = "mappingToRevitCategories";
   public string? Title { get; set; } = "Map to Revit Categories";
+  public string? Description { get; set; } = "Tags elements with inferred Revit categories so they bake correctly when received in Revit.";
   public string? Type { get; set; } = "boolean";
   public List<string>? Enum { get; set; }
   public object? Value { get; set; } = value;

--- a/Connectors/Navisworks/Speckle.Connectors.NavisworksShared/Operations/Send/Settings/VisualRepresentationSetting.cs
+++ b/Connectors/Navisworks/Speckle.Connectors.NavisworksShared/Operations/Send/Settings/VisualRepresentationSetting.cs
@@ -7,7 +7,8 @@ public class VisualRepresentationSetting(RepresentationMode value) : ICardSettin
 {
   public string? Id { get; set; } = "visualRepresentation";
   public string? Title { get; set; } = "Visual Representation";
-  public string? Description { get; set; } = "Which Navisworks appearance layer to send: Active (current overrides), Permanent (saved overrides), or Original (model defaults).";
+  public string? Description { get; set; } =
+    "Which Navisworks appearance layer to send: Active (current overrides), Permanent (saved overrides), or Original (model defaults).";
   public string? Type { get; set; } = "string";
   public List<string>? Enum { get; set; } = System.Enum.GetNames(typeof(RepresentationMode)).ToList();
   public object? Value { get; set; } = value.ToString();

--- a/Connectors/Navisworks/Speckle.Connectors.NavisworksShared/Operations/Send/Settings/VisualRepresentationSetting.cs
+++ b/Connectors/Navisworks/Speckle.Connectors.NavisworksShared/Operations/Send/Settings/VisualRepresentationSetting.cs
@@ -7,6 +7,7 @@ public class VisualRepresentationSetting(RepresentationMode value) : ICardSettin
 {
   public string? Id { get; set; } = "visualRepresentation";
   public string? Title { get; set; } = "Visual Representation";
+  public string? Description { get; set; } = "Which Navisworks appearance layer to send: Active (current overrides), Permanent (saved overrides), or Original (model defaults).";
   public string? Type { get; set; } = "string";
   public List<string>? Enum { get; set; } = System.Enum.GetNames(typeof(RepresentationMode)).ToList();
   public object? Value { get; set; } = value.ToString();

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Receive/ReceiveInstancesAsFamiliesSetting.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Receive/ReceiveInstancesAsFamiliesSetting.cs
@@ -10,7 +10,8 @@ public class ReceiveInstancesAsFamiliesSetting(bool value = ReceiveInstancesAsFa
 
   public string? Id { get; set; } = SETTING_ID;
   public string? Title { get; set; } = "Receive Blocks as Families";
-  public string? Description { get; set; } = "Bake incoming blocks as Revit Families. Disable to receive them as DirectShapes for faster receive.";
+  public string? Description { get; set; } =
+    "Bake incoming blocks as Revit Families. Disable to receive them as DirectShapes for faster receive.";
   public string? Type { get; set; } = "boolean";
   public object? Value { get; set; } = value;
   public List<string>? Enum { get; set; }

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Receive/ReceiveInstancesAsFamiliesSetting.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Receive/ReceiveInstancesAsFamiliesSetting.cs
@@ -10,6 +10,7 @@ public class ReceiveInstancesAsFamiliesSetting(bool value = ReceiveInstancesAsFa
 
   public string? Id { get; set; } = SETTING_ID;
   public string? Title { get; set; } = "Receive Blocks as Families";
+  public string? Description { get; set; } = "Bake incoming blocks as Revit Families. Disable to receive them as DirectShapes for faster receive.";
   public string? Type { get; set; } = "boolean";
   public object? Value { get; set; } = value;
   public List<string>? Enum { get; set; }

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Receive/ReceiveReferencePointSetting.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Receive/ReceiveReferencePointSetting.cs
@@ -17,6 +17,7 @@ public class ReceiveReferencePointSetting(ReceiveReferencePointType value = Rece
 
   public string? Id { get; set; } = SETTING_ID;
   public string? Title { get; set; } = "Reference Point";
+  public string? Description { get; set; } = "Sets the datum used to place received geometry.";
   public string? Type { get; set; } = "string";
   public List<string>? Enum { get; set; } = System.Enum.GetNames(typeof(ReceiveReferencePointType)).ToList();
   public object? Value { get; set; } = value.ToString();

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/Settings/DetailLevelSetting.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/Settings/DetailLevelSetting.cs
@@ -16,6 +16,9 @@ public class DetailLevelSetting(DetailLevelType value = DetailLevelSetting.DEFAU
 
   public string? Id { get; set; } = SETTING_ID;
   public string? Title { get; set; } = "Detail Level";
+
+  public string? Description { get; set; } =
+    "Geometric fidelity used when converting elements. Higher levels produce more accurate geometry but larger sends.";
   public string? Type { get; set; } = "string";
   public List<string>? Enum { get; set; } = System.Enum.GetNames(typeof(DetailLevelType)).ToList();
   public object? Value { get; set; } = value.ToString();

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/Settings/LinkedModelsSetting.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/Settings/LinkedModelsSetting.cs
@@ -9,6 +9,7 @@ public class LinkedModelsSetting(bool value = LinkedModelsSetting.DEFAULT_VALUE)
 
   public string? Id { get; set; } = SETTING_ID;
   public string? Title { get; set; } = "Include Linked Models";
+  public string? Description { get; set; }
   public string? Type { get; set; } = "boolean";
   public object? Value { get; set; } = value;
   public List<string>? Enum { get; set; }

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/Settings/SendAreasAsMeshSetting.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/Settings/SendAreasAsMeshSetting.cs
@@ -9,6 +9,7 @@ public class SendAreasAsMeshSetting(bool value = SendAreasAsMeshSetting.DEFAULT_
 
   public string? Id { get; set; } = SETTING_ID;
   public string? Title { get; set; } = "Send Areas As Mesh";
+  public string? Description { get; set; } = "Sends areas as flat meshes of their boundaries.";
   public string? Type { get; set; } = "boolean";
   public object? Value { get; set; } = value;
   public List<string>? Enum { get; set; }

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/Settings/SendParameterNullOrEmptyStringsSetting.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/Settings/SendParameterNullOrEmptyStringsSetting.cs
@@ -10,6 +10,7 @@ public class SendParameterNullOrEmptyStringsSetting(bool value = SendParameterNu
 
   public string? Id { get; set; } = SETTING_ID;
   public string? Title { get; set; } = "Send null/empty parameters";
+  public string? Description { get; set; }
   public string? Type { get; set; } = "boolean";
   public List<string>? Enum { get; set; }
   public object? Value { get; set; } = value;

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/Settings/SendRebarsAsVolumetricSetting.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/Settings/SendRebarsAsVolumetricSetting.cs
@@ -8,7 +8,8 @@ public class SendRebarsAsVolumetricSetting(bool value = SendRebarsAsVolumetricSe
   public const bool DEFAULT_VALUE = false;
 
   public string? Id { get; set; } = SETTING_ID;
-  public string? Title { get; set; } = "Send Rebars As Volumetric (disable for better performance)";
+  public string? Title { get; set; } = "Send Rebars As Volumetric";
+  public string? Description { get; set; } = "Sends rebars as solid 3D geometry instead of centre-line curves. Disable for faster sends on rebar-heavy models.";
   public string? Type { get; set; } = "boolean";
   public object? Value { get; set; } = value;
   public List<string>? Enum { get; set; }

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/Settings/SendRebarsAsVolumetricSetting.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/Settings/SendRebarsAsVolumetricSetting.cs
@@ -9,7 +9,8 @@ public class SendRebarsAsVolumetricSetting(bool value = SendRebarsAsVolumetricSe
 
   public string? Id { get; set; } = SETTING_ID;
   public string? Title { get; set; } = "Send Rebars As Volumetric";
-  public string? Description { get; set; } = "Sends rebars as solid 3D geometry instead of centre-line curves. Disable for faster sends on rebar-heavy models.";
+  public string? Description { get; set; } =
+    "Sends rebars as solid 3D geometry instead of centre-line curves. Disable for faster sends on rebar-heavy models.";
   public string? Type { get; set; } = "boolean";
   public object? Value { get; set; } = value;
   public List<string>? Enum { get; set; }

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/Settings/SendReferencePointSetting.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/Settings/SendReferencePointSetting.cs
@@ -17,6 +17,7 @@ public class SendReferencePointSetting(ReferencePointType value = SendReferenceP
 
   public string? Id { get; set; } = SETTING_ID;
   public string? Title { get; set; } = "Reference Point";
+  public string? Description { get; set; } = "Sets the datum used as the origin of the sent geometry.";
   public string? Type { get; set; } = "string";
   public List<string>? Enum { get; set; } = System.Enum.GetNames(typeof(ReferencePointType)).ToList();
   public object? Value { get; set; } = value.ToString();

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/Operations/Send/Settings/AddVisualizationProperties.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/Operations/Send/Settings/AddVisualizationProperties.cs
@@ -6,7 +6,8 @@ public class AddVisualizationProperties(bool value) : ICardSetting
 {
   public string? Id { get; set; } = "addVisualizationProperties";
   public string? Title { get; set; } = "Add Mesh Visualization Properties";
-  public string? Description { get; set; } = "Embeds vertex colours and texture coordinates so meshes render as they do in Rhino. Will increase model size.";
+  public string? Description { get; set; } =
+    "Embeds vertex colours and texture coordinates so meshes render as they do in Rhino. Will increase model size.";
   public string? Type { get; set; } = "boolean";
   public object? Value { get; set; } = value;
   public List<string>? Enum { get; set; }

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/Operations/Send/Settings/AddVisualizationProperties.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/Operations/Send/Settings/AddVisualizationProperties.cs
@@ -5,7 +5,8 @@ namespace Speckle.Connectors.Rhino.Operations.Send.Settings;
 public class AddVisualizationProperties(bool value) : ICardSetting
 {
   public string? Id { get; set; } = "addVisualizationProperties";
-  public string? Title { get; set; } = "Add visualization properties for meshes (will increase model size)";
+  public string? Title { get; set; } = "Add Mesh Visualization Properties";
+  public string? Description { get; set; } = "Embeds vertex colours and texture coordinates so meshes render as they do in Rhino. Will increase model size.";
   public string? Type { get; set; } = "boolean";
   public object? Value { get; set; } = value;
   public List<string>? Enum { get; set; }

--- a/Connectors/Tekla/Speckle.Connector.TeklaShared/Operations/Send/Settings/SendRebarsAsSolidSetting.cs
+++ b/Connectors/Tekla/Speckle.Connector.TeklaShared/Operations/Send/Settings/SendRebarsAsSolidSetting.cs
@@ -6,7 +6,8 @@ public class SendRebarsAsSolidSetting(bool value) : ICardSetting
 {
   public string? Id { get; set; } = "sendRebarsAsSolid";
   public string? Title { get; set; } = "Send Rebars As Solid";
-  public string? Description { get; set; } = "Sends rebar as solid 3D geometry instead of centre-line curves. Disable for faster sends on rebar-heavy models.";
+  public string? Description { get; set; } =
+    "Sends rebar as solid 3D geometry instead of centre-line curves. Disable for faster sends on rebar-heavy models.";
   public string? Type { get; set; } = "boolean";
   public object? Value { get; set; } = value;
   public List<string>? Enum { get; set; }

--- a/Connectors/Tekla/Speckle.Connector.TeklaShared/Operations/Send/Settings/SendRebarsAsSolidSetting.cs
+++ b/Connectors/Tekla/Speckle.Connector.TeklaShared/Operations/Send/Settings/SendRebarsAsSolidSetting.cs
@@ -6,6 +6,7 @@ public class SendRebarsAsSolidSetting(bool value) : ICardSetting
 {
   public string? Id { get; set; } = "sendRebarsAsSolid";
   public string? Title { get; set; } = "Send Rebars As Solid";
+  public string? Description { get; set; } = "Sends rebar as solid 3D geometry instead of centre-line curves. Disable for faster sends on rebar-heavy models.";
   public string? Type { get; set; } = "boolean";
   public object? Value { get; set; } = value;
   public List<string>? Enum { get; set; }

--- a/DUI3/Speckle.Connectors.DUI/Settings/CardSetting.cs
+++ b/DUI3/Speckle.Connectors.DUI/Settings/CardSetting.cs
@@ -7,6 +7,7 @@ public class CardSetting : ICardSetting
 {
   public string? Id { get; set; }
   public string? Title { get; set; }
+  public string? Description { get; set; }
   public string? Type { get; set; }
   public object? Value { get; set; }
   public List<string>? Enum { get; set; }


### PR DESCRIPTION
## Description
Adds per-setting tooltips so labels can stay short while richer detail is available on hover. Fixes CNX-3378.

## User Value
Settings labels can be concise without sacrificing clarity — users get the longer explanation on demand.

## Changes:
See [feat(dui): adds tooltip to settings](https://github.com/specklesystems/speckle-connectors-dui/pull/110)

## Todo before merge
HostApp "owners" to please check placeholder descriptions:
- [ ] Navis @jsdbroughton
- [ ] Tekla @dogukankaratas 
- [ ] Revit @bimgeek 

## Checklist:
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] I have added appropriate tests.
- [x] I have updated or added relevant documentation.