### PR TITLE
feat(rhino): extend parameter updater support

### DIFF
--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/Bindings/RhinoParametersBinding.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/Bindings/RhinoParametersBinding.cs
@@ -1,0 +1,184 @@
+using Microsoft.Extensions.Logging;
+using Rhino;
+using Rhino.DocObjects;
+using Speckle.Connectors.DUI.Bindings;
+using Speckle.Connectors.DUI.Bridge;
+using Speckle.Connectors.DUI.Utils;
+using Speckle.Connectors.Rhino.HostApp;
+using Speckle.Sdk;
+
+namespace Speckle.Connectors.Rhino.Bindings;
+
+internal sealed class RhinoParametersBinding : IParametersBinding
+{
+  public string Name => "parametersBinding";
+  public IBrowserBridge Parent { get; }
+
+  private readonly ITopLevelExceptionHandler _topLevelExceptionHandler;
+  private readonly RhinoPropertyUpdater _propertyUpdater;
+  private readonly IJsonSerializer _jsonSerializer;
+  private readonly IBasicConnectorBinding _baseBinding;
+  private readonly ILogger<RhinoParametersBinding> _logger;
+
+  public RhinoParametersBinding(
+    IBrowserBridge parent,
+    ITopLevelExceptionHandler topLevelExceptionHandler,
+    RhinoPropertyUpdater propertyUpdater,
+    IJsonSerializer jsonSerializer,
+    IBasicConnectorBinding baseBinding,
+    ILogger<RhinoParametersBinding> logger
+  )
+  {
+    Parent = parent;
+    _topLevelExceptionHandler = topLevelExceptionHandler;
+    _propertyUpdater = propertyUpdater;
+    _jsonSerializer = jsonSerializer;
+    _baseBinding = baseBinding;
+    _logger = logger;
+  }
+
+  public async Task Update(string payload)
+  {
+    try
+    {
+      var wrapper = _jsonSerializer.Deserialize<ParameterChangesWrapper>(payload);
+      var requests = wrapper?.Changes;
+
+      if (requests is null || requests.Count == 0)
+      {
+        return;
+      }
+
+      var doc = RhinoDoc.ActiveDoc ?? throw new SpeckleException("Unable to retrieve active Rhino document");
+
+      int successCount = 0;
+      List<string> errors = [];
+
+      uint undoRecord = doc.BeginUndoRecord("Speckle: Apply Parameter Changes");
+      try
+      {
+        foreach (var request in requests)
+        {
+          if (!TryValidateAndParseRequest(doc, request, out var rhinoObject, out var pathParts, out var errorMessage))
+          {
+            errors.Add(errorMessage!);
+            continue;
+          }
+
+          object? rawValue = request.To is Newtonsoft.Json.Linq.JValue jValue ? jValue.Value : request.To;
+
+          var result = _propertyUpdater.Update(rhinoObject!, pathParts!, rawValue);
+          if (result.IsSuccess)
+          {
+            successCount++;
+          }
+          else
+          {
+            errors.Add(result.ErrorMessage ?? "Unknown error");
+          }
+        }
+      }
+      finally
+      {
+        doc.EndUndoRecord(undoRecord);
+      }
+
+      if (errors.Count > 0)
+      {
+        var groupedErrors = errors.GroupBy(e => e).Select(g => $"{g.Count()} x {g.Key}");
+        var errorString = string.Join(", ", groupedErrors);
+
+        if (successCount > 0)
+        {
+          await _baseBinding.Commands.SetGlobalNotification(
+            ToastNotificationType.WARNING,
+            "Parameters updated with errors",
+            $"Applied {successCount} updates. Encountered {errors.Count} errors: {errorString}",
+            autoClose: false
+          );
+        }
+        else
+        {
+          await _baseBinding.Commands.SetGlobalNotification(
+            ToastNotificationType.DANGER,
+            "No parameters updated",
+            $"All {errors.Count} updates failed: {errorString}",
+            autoClose: false
+          );
+        }
+      }
+      else if (successCount > 0)
+      {
+        await _baseBinding.Commands.SetGlobalNotification(
+          ToastNotificationType.SUCCESS,
+          "All parameters updated",
+          $"Successfully applied {successCount} updates."
+        );
+      }
+    }
+    catch (Exception ex) when (!ex.IsFatal())
+    {
+      _topLevelExceptionHandler.CatchUnhandled(() =>
+        throw new SpeckleException("Failed to apply parameter updates", ex)
+      );
+    }
+  }
+
+  private bool TryValidateAndParseRequest(
+    RhinoDoc doc,
+    ParameterChangeRequest request,
+    out RhinoObject? rhinoObject,
+    out string[]? pathParts,
+    out string? errorMessage
+  )
+  {
+    rhinoObject = null;
+    pathParts = null;
+    errorMessage = null;
+
+    if (string.IsNullOrEmpty(request.ApplicationId))
+    {
+      errorMessage = "Missing ApplicationId";
+      return false;
+    }
+
+    if (!Guid.TryParse(request.ApplicationId, out var objectId))
+    {
+      errorMessage = $"ApplicationId is not a valid GUID: {request.ApplicationId}";
+      return false;
+    }
+
+    rhinoObject = doc.Objects.FindId(objectId);
+    if (rhinoObject is null)
+    {
+      errorMessage = $"Object not found: {request.ApplicationId}";
+      return false;
+    }
+
+    var rawPath = request.Path;
+    if (string.IsNullOrEmpty(rawPath))
+    {
+      _logger.LogError("Widget / DUI payload error: parameter path missing");
+      errorMessage = "Parameter path is missing";
+      return false;
+    }
+
+    if (rawPath.StartsWith("properties.", StringComparison.InvariantCultureIgnoreCase))
+    {
+      rawPath = rawPath[11..];
+    }
+    else if (rawPath.StartsWith("parameters.", StringComparison.InvariantCultureIgnoreCase))
+    {
+      rawPath = rawPath[11..];
+    }
+
+    if (string.IsNullOrEmpty(rawPath))
+    {
+      errorMessage = "Parameter path is empty after prefix stripping";
+      return false;
+    }
+
+    pathParts = rawPath.Split('.');
+    return true;
+  }
+}

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/HostApp/RhinoPropertyUpdater.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/HostApp/RhinoPropertyUpdater.cs
@@ -45,9 +45,7 @@ public class RhinoPropertyUpdater
 
         if (!SetNestedDictValue(attributes.UserDictionary, pathParts, 1, newValue))
         {
-          return UpdateResult.Fail(
-            $"Failed to set User Dictionary path '{string.Join(".", pathParts)}'"
-          );
+          return UpdateResult.Fail($"Failed to set User Dictionary path '{string.Join(".", pathParts)}'");
         }
       }
       else

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/HostApp/RhinoPropertyUpdater.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/HostApp/RhinoPropertyUpdater.cs
@@ -1,0 +1,130 @@
+using Microsoft.Extensions.Logging;
+using Rhino;
+using Rhino.Collections;
+using Rhino.DocObjects;
+using Speckle.Connectors.DUI.Bindings;
+using Speckle.Sdk;
+
+namespace Speckle.Connectors.Rhino.HostApp;
+
+/// <summary>
+/// Updates property values on Rhino objects via the user strings and user dictionary.
+/// </summary>
+public class RhinoPropertyUpdater
+{
+  private const string USER_DICTIONARY_KEY = "User Dictionary";
+
+  private readonly ILogger<RhinoPropertyUpdater> _logger;
+
+  public RhinoPropertyUpdater(ILogger<RhinoPropertyUpdater> logger)
+  {
+    _logger = logger;
+  }
+
+  public UpdateResult Update(RhinoObject rhinoObject, string[] pathParts, object? newValue)
+  {
+    if (pathParts.Length == 0)
+    {
+      return UpdateResult.Fail("Property path is empty");
+    }
+
+    try
+    {
+      var attributes = rhinoObject.Attributes.Duplicate();
+
+      if (pathParts.Length == 1)
+      {
+        attributes.SetUserString(pathParts[0], newValue?.ToString() ?? string.Empty);
+      }
+      else if (pathParts[0] == USER_DICTIONARY_KEY)
+      {
+        if (pathParts.Length < 2)
+        {
+          return UpdateResult.Fail("'User Dictionary' path requires at least one key segment");
+        }
+
+        if (!SetNestedDictValue(attributes.UserDictionary, pathParts, 1, newValue))
+        {
+          return UpdateResult.Fail(
+            $"Failed to set User Dictionary path '{string.Join(".", pathParts)}'"
+          );
+        }
+      }
+      else
+      {
+        return UpdateResult.Fail(
+          $"Unsupported path '{string.Join(".", pathParts)}'. Supported: a single user string key, or 'User Dictionary.<key>'."
+        );
+      }
+
+      if (!RhinoDoc.ActiveDoc.Objects.ModifyAttributes(rhinoObject, attributes, quiet: false))
+      {
+        return UpdateResult.Fail($"Rhino rejected attribute modification for object {rhinoObject.Id}");
+      }
+
+      return UpdateResult.Success();
+    }
+    catch (Exception ex) when (!ex.IsFatal())
+    {
+      _logger.LogWarning(ex, "Failed to update property on object {ObjectId}", rhinoObject.Id);
+      return UpdateResult.Fail($"Exception: {ex.Message}");
+    }
+  }
+
+  /// <summary>
+  /// Recursively navigates/creates intermediate ArchivableDictionary nodes, then sets the leaf value.
+  /// Uses an index into the shared path array to avoid allocating sub-arrays on each recursion.
+  /// Always writes intermediate nodes back so the change propagates regardless of copy/reference semantics.
+  /// </summary>
+  private bool SetNestedDictValue(ArchivableDictionary dict, string[] path, int index, object? newValue)
+  {
+    if (index >= path.Length)
+    {
+      return false;
+    }
+
+    if (index == path.Length - 1)
+    {
+      SetDictValue(dict, path[index], newValue);
+      return true;
+    }
+
+    var intermediate =
+      dict.ContainsKey(path[index]) && dict[path[index]] is ArchivableDictionary existing
+        ? existing
+        : new ArchivableDictionary();
+
+    if (!SetNestedDictValue(intermediate, path, index + 1, newValue))
+    {
+      return false;
+    }
+
+    dict.Set(path[index], intermediate);
+    return true;
+  }
+
+  private static void SetDictValue(ArchivableDictionary dict, string key, object? value)
+  {
+    if (value is null)
+    {
+      dict.Remove(key);
+      return;
+    }
+
+    switch (value)
+    {
+      case bool b:
+        dict.Set(key, b);
+        break;
+      case int i:
+        dict.Set(key, i);
+        break;
+      case double d:
+        dict.Set(key, d);
+        break;
+      default:
+        dict.Set(key, value.ToString());
+        break;
+    }
+  }
+}

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/Registration/ServiceRegistration.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/Registration/ServiceRegistration.cs
@@ -55,6 +55,10 @@ public static class ServiceRegistration
     serviceCollection.AddSingleton<IBinding, RhinoReceiveBinding>();
     serviceCollection.AddSingleton<IBinding, RhinoMapperBinding>();
 
+    serviceCollection.AddSingleton<IBinding>(sp => sp.GetRequiredService<IParametersBinding>());
+    serviceCollection.AddSingleton<IParametersBinding, RhinoParametersBinding>();
+    serviceCollection.AddSingleton<RhinoPropertyUpdater>();
+
     // register send filters
     serviceCollection.AddScoped<ISendFilter, RhinoSelectionFilter>();
     serviceCollection.AddScoped<IHostObjectBuilder, RhinoHostObjectBuilder>();

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/Speckle.Connectors.RhinoShared.projitems
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/Speckle.Connectors.RhinoShared.projitems
@@ -19,12 +19,14 @@
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)Bindings\RhinoBasicConnectorBinding.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bindings\RhinoMapperBinding.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bindings\RhinoParametersBinding.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bindings\RhinoReceiveBinding.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bindings\RhinoSendBinding.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bindings\RhinoSelectionBinding.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\AttributeExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HostApp\DataObjectInstanceGrouper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HostApp\Properties\PropertiesExtractor.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)HostApp\RhinoPropertyUpdater.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HostApp\RhinoViewUnpacker.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HostApp\RhinoViewBaker.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HostApp\RhinoIdleManager.cs" />


### PR DESCRIPTION
## Description

Extends the Parameter Updater to Rhino. We already had the infrastructure in place for Revit and Civil3D — Rhino just needed to follow the same pattern and plug in its own property update mechanism (user strings + user dictionary via `ArchivableDictionary`).

## User Value

Users can now update model parameters directly from Speckle on Rhino objects and pull those changes back into their Rhino workflows.

## To-do before merge:
- [x] Merge https://github.com/specklesystems/bashboards/pull/361

## Changes:

- Added `RhinoPropertyUpdater` — handles the Rhino-specific attribute API (user strings and nested user dictionary entries)
- Added `RhinoParametersBinding` — wires `IParametersBinding` into the DUI bridge for Rhino, with undo record support and toast notifications

## Validation of changes:

https://github.com/user-attachments/assets/f5b8547e-1a98-498a-8e8b-cda81f83ee37

## Checklist:
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] I have added appropriate tests.
- [x] I have updated or added relevant documentation.

