### PR TITLE
fix (civil3d): keep dataobject properties on displayValue fallback bake

### DIFF
--- a/Converters/Autocad/Speckle.Converters.AutocadShared/ToHost/Geometry/DataObjectConverter.cs
+++ b/Converters/Autocad/Speckle.Converters.AutocadShared/ToHost/Geometry/DataObjectConverter.cs
@@ -82,7 +82,10 @@ public class DataObjectConverter : IToHostTopLevelConverter, ITypedConverter<Dat
     // Fallback: convert displayValue geometry
     foreach (var item in target.displayValue)
     {
-      result.AddRange(ConvertDisplayObject(item));
+      foreach (var (entity, _) in ConvertDisplayObject(item))
+      {
+        result.Add((entity, target));
+      }
     }
 
     return result;


### PR DESCRIPTION
Property sets on SAT-less DataObjects were lost on receive. The fallback path paired the entity with the display geometry instead of the DataObject, dropping its properties. Now it pairs with the DataObject.