### PR TITLE
feat(parameter-updater): basic parameter creation for Revit

### DIFF
--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Bindings/RevitParametersBinding.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Bindings/RevitParametersBinding.cs
@@ -33,6 +33,7 @@ internal sealed class RevitParametersBinding : IParametersBinding
   private readonly ITopLevelExceptionHandler _topLevelExceptionHandler;
   private readonly IRevitTask _revitTask;
   private readonly ParameterUpdater _parameterUpdater;
+  private readonly RevitParameterCreator _parameterCreator;
   private readonly IJsonSerializer _jsonSerializer;
   private readonly IBasicConnectorBinding _baseBinding;
   private readonly ILogger<RevitParametersBinding> _logger;
@@ -43,6 +44,7 @@ internal sealed class RevitParametersBinding : IParametersBinding
     ITopLevelExceptionHandler topLevelExceptionHandler,
     IRevitTask revitTask,
     ParameterUpdater parameterUpdater,
+    RevitParameterCreator parameterCreator,
     IJsonSerializer jsonSerializer,
     IBasicConnectorBinding baseBinding,
     ILogger<RevitParametersBinding> logger
@@ -53,6 +55,7 @@ internal sealed class RevitParametersBinding : IParametersBinding
     _topLevelExceptionHandler = topLevelExceptionHandler;
     _revitTask = revitTask;
     _parameterUpdater = parameterUpdater;
+    _parameterCreator = parameterCreator;
     _jsonSerializer = jsonSerializer;
     _baseBinding = baseBinding;
     _logger = logger;
@@ -94,10 +97,38 @@ internal sealed class RevitParametersBinding : IParametersBinding
           {
             if (request.IsCreation)
             {
-              errors.Add(
-                $"Cannot create new parameter '{request.Path}': adding parameters to Revit elements via the connector is not supported. "
-                  + "Create a shared or project parameter in Revit first, then use the parameter updater to set its value."
-              );
+              var paramName = ExtractCreationParamName(request.Path);
+              if (string.IsNullOrEmpty(paramName))
+              {
+                errors.Add($"Invalid path for new parameter: '{request.Path}'");
+                continue;
+              }
+
+              if (ContainsLinkedModelTransformHash(request.ApplicationId))
+              {
+                errors.Add("Cannot modify elements from a linked model");
+                continue;
+              }
+
+              var elementId = ElementIdHelper.GetElementIdFromUniqueId(doc, request.ApplicationId);
+              var creationElement = elementId is not null ? doc.GetElement(elementId) : null;
+              if (creationElement is null)
+              {
+                errors.Add($"Element not found: {request.ApplicationId}");
+                continue;
+              }
+
+              object? rawCreationValue = request.To is Newtonsoft.Json.Linq.JValue jv ? jv.Value : request.To;
+              var creationResult = _parameterCreator.CreateAndSet(doc, creationElement, paramName, rawCreationValue);
+
+              if (creationResult.IsSuccess)
+              {
+                successCount++;
+              }
+              else
+              {
+                errors.Add(creationResult.ErrorMessage ?? "Unknown error");
+              }
               continue;
             }
 
@@ -252,4 +283,21 @@ internal sealed class RevitParametersBinding : IParametersBinding
   private static bool ContainsLinkedModelTransformHash(string applicationId) =>
     // Evaluates if the ID contains the standard transform hash for linked elements
     System.Text.RegularExpressions.Regex.IsMatch(applicationId, @"_t[a-f0-9]+$");
+
+  /// <summary>
+  /// Strips the "properties." or "parameters." prefix added by the widget and returns
+  /// the bare parameter name (e.g. "properties.SpeckleTag" → "SpeckleTag").
+  /// </summary>
+  private static string ExtractCreationParamName(string path)
+  {
+    if (path.StartsWith("properties.", StringComparison.OrdinalIgnoreCase))
+    {
+      return path[11..].Trim();
+    }
+    if (path.StartsWith("parameters.", StringComparison.OrdinalIgnoreCase))
+    {
+      return path[11..].Trim();
+    }
+    return path.Trim();
+  }
 }

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/DependencyInjection/RevitConnectorModule.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/DependencyInjection/RevitConnectorModule.cs
@@ -70,6 +70,7 @@ public static class ServiceRegistration
     serviceCollection.AddSingleton<LinkedModelHandler>();
     serviceCollection.AddSingleton<RoomsAndAreasHandler>();
     serviceCollection.AddSingleton<ParameterUpdater>();
+    serviceCollection.AddSingleton<RevitParameterCreator>();
     serviceCollection.AddSingleton<RevitSendChangeTracker>();
 
     // receive operation and dependencies

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/RevitParameterCreator.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/RevitParameterCreator.cs
@@ -117,8 +117,7 @@ public class RevitParameterCreator
 
   private ExternalDefinition? GetOrCreateDefinition(DefinitionFile defFile, string paramName)
   {
-    var group =
-      defFile.Groups.get_Item(SPECKLE_GROUP_NAME) ?? defFile.Groups.Create(SPECKLE_GROUP_NAME);
+    var group = defFile.Groups.get_Item(SPECKLE_GROUP_NAME) ?? defFile.Groups.Create(SPECKLE_GROUP_NAME);
 
     if (group.Definitions.get_Item(paramName) is ExternalDefinition existing)
     {
@@ -128,7 +127,7 @@ public class RevitParameterCreator
     var opts = new ExternalDefinitionCreationOptions(paramName, SpecTypeId.String.Text)
     {
       UserModifiable = true,
-      Visible = true
+      Visible = true,
     };
 
     return group.Definitions.Create(opts) as ExternalDefinition;

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/RevitParameterCreator.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/RevitParameterCreator.cs
@@ -1,0 +1,183 @@
+using System.IO;
+using Autodesk.Revit.DB;
+using Microsoft.Extensions.Logging;
+using Speckle.Connectors.DUI.Bindings;
+using Speckle.Converters.RevitShared.Helpers;
+using Speckle.Sdk;
+
+namespace Speckle.Connectors.Revit.HostApp;
+
+/// <summary>
+/// Creates new shared parameters on Revit elements and sets their value in one step.
+/// Parameters are defined under a "Speckle" group in a Speckle-managed shared parameter
+/// file, bound as Instance Text parameters under the PG_DATA ("Data") group.
+/// </summary>
+public class RevitParameterCreator
+{
+  private const string SPECKLE_GROUP_NAME = "Speckle";
+  private const string SHARED_PARAMS_FILENAME = "SpeckleSharedParameters.txt";
+
+  private readonly RevitContext _revitContext;
+  private readonly ILogger<RevitParameterCreator> _logger;
+
+  public RevitParameterCreator(RevitContext revitContext, ILogger<RevitParameterCreator> logger)
+  {
+    _revitContext = revitContext;
+    _logger = logger;
+  }
+
+  /// <summary>
+  /// Creates the named parameter on the element's category (if it does not already exist)
+  /// and sets its value. Must be called inside an open Revit transaction.
+  /// </summary>
+  public UpdateResult CreateAndSet(Document doc, Element element, string paramName, object? value)
+  {
+    var app = _revitContext.UIApplication?.Application;
+    if (app is null)
+    {
+      return UpdateResult.Fail("Could not access Revit application");
+    }
+
+    var specklePath = GetSpeckleSharedParamsPath();
+    if (!File.Exists(specklePath))
+    {
+      File.WriteAllText(specklePath, string.Empty);
+    }
+
+    // Keep SharedParametersFilename pointing at our file for the entire creation
+    // flow — including EnsureCategoryBinding — then restore it unconditionally.
+    var previousPath = app.SharedParametersFilename;
+    app.SharedParametersFilename = specklePath;
+    try
+    {
+      return CreateAndSetCore(app, doc, element, paramName, value);
+    }
+    catch (Exception ex) when (!ex.IsFatal())
+    {
+      _logger.LogWarning(ex, "Failed to create parameter '{ParamName}' on element", paramName);
+      return UpdateResult.Fail($"Exception creating parameter '{paramName}': {ex.Message}");
+    }
+    finally
+    {
+      app.SharedParametersFilename = previousPath;
+    }
+  }
+
+  private UpdateResult CreateAndSetCore(
+    Autodesk.Revit.ApplicationServices.Application app,
+    Document doc,
+    Element element,
+    string paramName,
+    object? value
+  )
+  {
+    var defFile = app.OpenSharedParameterFile();
+    if (defFile is null)
+    {
+      return UpdateResult.Fail("Could not open or create the Speckle shared parameter file");
+    }
+
+    var definition = GetOrCreateDefinition(defFile, paramName);
+    if (definition is null)
+    {
+      return UpdateResult.Fail($"Could not create parameter definition for '{paramName}'");
+    }
+
+    var bindResult = EnsureCategoryBinding(doc, definition, element);
+    if (!bindResult.IsSuccess)
+    {
+      return bindResult;
+    }
+
+    var parameter = element.LookupParameter(paramName);
+    if (parameter is null)
+    {
+      return UpdateResult.Fail(
+        $"Parameter '{paramName}' was registered but could not be found on element — try again after reloading the document"
+      );
+    }
+
+    if (parameter.IsReadOnly)
+    {
+      return UpdateResult.Fail($"Parameter '{paramName}' is read-only");
+    }
+
+    return parameter.Set(value?.ToString() ?? string.Empty)
+      ? UpdateResult.Success()
+      : UpdateResult.Fail($"Failed to set value for parameter '{paramName}'");
+  }
+
+  private static string GetSpeckleSharedParamsPath()
+  {
+    var appData = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+    var speckleDir = Path.Combine(appData, "Speckle");
+    Directory.CreateDirectory(speckleDir);
+    return Path.Combine(speckleDir, SHARED_PARAMS_FILENAME);
+  }
+
+  private ExternalDefinition? GetOrCreateDefinition(DefinitionFile defFile, string paramName)
+  {
+    var group =
+      defFile.Groups.get_Item(SPECKLE_GROUP_NAME) ?? defFile.Groups.Create(SPECKLE_GROUP_NAME);
+
+    if (group.Definitions.get_Item(paramName) is ExternalDefinition existing)
+    {
+      return existing;
+    }
+
+    var opts = new ExternalDefinitionCreationOptions(paramName, SpecTypeId.String.Text)
+    {
+      UserModifiable = true,
+      Visible = true
+    };
+
+    return group.Definitions.Create(opts) as ExternalDefinition;
+  }
+
+  private UpdateResult EnsureCategoryBinding(Document doc, ExternalDefinition definition, Element element)
+  {
+    var category = element.Category;
+    if (category is null)
+    {
+      return UpdateResult.Fail("Element has no category — cannot bind parameter");
+    }
+
+    var bindingMap = doc.ParameterBindings;
+
+    // Walk existing bindings: if this definition is already registered, expand the
+    // category set if needed rather than inserting a duplicate.
+    var iterator = bindingMap.ForwardIterator();
+    while (iterator.MoveNext())
+    {
+      if (iterator.Key?.Name != definition.Name)
+      {
+        continue;
+      }
+
+      if (iterator.Current is not InstanceBinding existingBinding)
+      {
+        continue;
+      }
+
+      if (existingBinding.Categories.Contains(category))
+      {
+        return UpdateResult.Success();
+      }
+
+      existingBinding.Categories.Insert(category);
+      bindingMap.ReInsert(definition, existingBinding, GroupTypeId.Data);
+      return UpdateResult.Success();
+    }
+
+    // No binding yet — insert a fresh one scoped to this element's category.
+    var categorySet = new CategorySet();
+    categorySet.Insert(category);
+    var binding = new InstanceBinding(categorySet);
+
+    return bindingMap.Insert(definition, binding, GroupTypeId.Data)
+      ? UpdateResult.Success()
+      : UpdateResult.Fail(
+        $"Revit rejected the parameter binding for '{definition.Name}' on category '{category.Name}'"
+      );
+  }
+}

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Speckle.Connectors.RevitShared.projitems
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Speckle.Connectors.RevitShared.projitems
@@ -28,6 +28,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)HostApp\FamilyTransformUtils.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HostApp\LevelUnpacker.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HostApp\LinkedModelHandler.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)HostApp\RevitParameterCreator.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HostApp\RoomsAndAreasHandler.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HostApp\RevitSendChangeTracker.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HostApp\ParameterUpdater.cs" />


### PR DESCRIPTION
## Description

Adds support for creating new parameters on Revit elements through the parameter updater widget. Uses a Speckle-managed shared parameter file (`%APPDATA%\Speckle\SpeckleSharedParameters.txt`) to register new `Text` instance parameters under the `Data` group, scoped to the element's category.

## User Value

Users can now add new attributes to Revit elements directly from the parameter updater widget, without having to pre-create the parameter in Revit first.

## Changes:

- New `RevitParameterCreator` — handles shared param file bootstrap, definition creation, category binding, and value set in one shot
- `RevitParametersBinding` — routes `IsCreation=true` requests to the creator instead of returning an error
- DI registration for `RevitParameterCreator`

## Checklist:

- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] I have added appropriate tests.
- [x] I have updated or added relevant documentation.