### PR TITLE
ci(github actions): lint & comply with linter findings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,5 @@ updates:
     directory: "/" # search in .github/workflows under root `/`
     schedule:
       interval: "weekly" # check for action update every week
+    cooldown:
+      default-days: 7

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -5,22 +5,30 @@ on:
   push:
     branches: ["main"]
 
+permissions: {} # We will use fine-grained permissions for each job, so we start with no permissions at all and then add them back as needed.
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true # other running workflows get cancelled on the same branch
+
 jobs:
   test:
+    name: Test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
         with:
           dotnet-version: 10.0.2xx # Align with global.json (including roll forward rules)
 
       - name: Cache Nuget
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.nuget/packages
           key: ${{ runner.os }}-nuget-${{ hashFiles('**/packages.lock.json') }}
@@ -28,11 +36,13 @@ jobs:
       - name: ⚒️ Run Test
         run: ./build.sh test-and-pack
 
-      - name: Upload coverage reports to Codecov with GitHub Action
-        uses: codecov/codecov-action@v6
-        with:
-          files: Converters/**/coverage.xml
-          token: ${{ secrets.CODECOV_TOKEN }}
+      # Skipping codecov due to https://github.com/codecov/codecov-action/issues/1956 and fix being less than cooldown period
+
+      # - name: Upload coverage reports to Codecov with GitHub Action
+      #   uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
+      #   with:
+      #     files: Converters/**/coverage.xml
+      #     token: ${{ secrets.CODECOV_TOKEN }}
 
       # Disabling this code for now, since we no longer need to publish nugets from this repo
       # But keeping it around incase we ever need in the future.
@@ -40,3 +50,20 @@ jobs:
 #      - name: Push to nuget.org
 #        if: ${{ inputs.deployNugets }}
 #        run: dotnet nuget push output/*.nupkg --source "https://api.nuget.org/v3/index.json" --api-key ${{ secrets.CONNECTORS_NUGET_TOKEN }}
+
+  lint-github-actions:
+    name: Lint GitHub Actions
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # only needed for private or internal repos
+      actions: read # only needed for private or internal repos
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor 🌈
+        uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
+        with:
+          advanced-security: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,8 +5,15 @@ on:
     branches: ["main", "installer-test/**"]
     tags: ["v3.*.*"] # Manual delivery on every 3.x tag
 
+permissions: {} # We will use fine-grained permissions for each job, so we start with no permissions at all and then add them back as needed.
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true # other running workflows get cancelled on the same branch
+
 jobs:
   build-connectors:
+    name: Build Connectors
     runs-on: windows-latest # Keeping on windows for now, for cross platform building of exe projects, we need to use dotnet publish
     env:
       SEMVER: "unset"
@@ -14,28 +21,28 @@ jobs:
     outputs:
       semver: ${{ steps.set-version.outputs.semver }}
       file_version: ${{ steps.set-version.outputs.file_version }}
+    permissions:
+      contents: read
+
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
         with:
           dotnet-version: 10.0.2xx # Align with global.json (including roll forward rules)
 
-      - name: Cache Nuget
-        uses: actions/cache@v5
-        with:
-          path: ~/.nuget/packages
-          key: ${{ runner.os }}-nuget-${{ hashFiles('**/packages.lock.json') }}
+      # we are purposefully not caching releases when publishing artefacts, see https://docs.zizmor.sh/audits/#cache-poisoning
 
       - name: ⚒️ Run build and zip connectors
         run: ./build.ps1 zip
 
       - name: ⬆️ Upload artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # 7.0.1
         with:
           name: output-${{ env.SEMVER }}
           path: output/*.*
@@ -46,21 +53,25 @@ jobs:
       - id: set-version
         name: Set version to output
         run: |
-          echo "semver=${{ env.SEMVER }}" >> "$Env:GITHUB_OUTPUT"
-          echo "file_version=${{ env.FILE_VERSION }}" >> "$Env:GITHUB_OUTPUT"
+          echo "semver=${SEMVER}" >> "$Env:GITHUB_OUTPUT"
+          echo "file_version=${FILE_VERSION}" >> "$Env:GITHUB_OUTPUT"
+        env:
+          SEMVER: ${{ steps.get-version.outputs.semver }}
+          FILE_VERSION: ${{ steps.get-version.outputs.file_version }}
 
   deploy-installers:
+    name: Deploy Installers
     runs-on: ubuntu-latest
     needs: build-connectors
     env:
       IS_PUBLIC_RELEASE: ${{ github.ref_type == 'tag' }}
     steps:
       - name: 🔫 Trigger Build Installers
-        uses: benc-uk/workflow-dispatch@v1
+        uses: benc-uk/workflow-dispatch@31e2b3319479a63f0ab15bf800eff9e913504e26 # 1.3.2
         with:
           workflow: Build Installers
           repo: specklesystems/connector-installers
-          token: ${{ secrets.CONNECTORS_GH_TOKEN }}
+          token: ${{ secrets.CONNECTORS_GH_TOKEN }} # zizmor: ignore[secrets-outside-env]
           inputs: '{
             "run_id": "${{ github.run_id }}",
             "semver": "${{ needs.build-connectors.outputs.semver }}",
@@ -74,6 +85,6 @@ jobs:
         timeout-minutes: 15
 
       # Allows us to inspect the artifacts of failed builds, since this below step will be skipped if the above step fails
-      - uses: geekyeggo/delete-artifact@v6
+      - uses: geekyeggo/delete-artifact@176a747ab7e287e3ff4787bf8a148716375ca118 # 6.0.0
         with:
           name: output-*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
         run: ./build.ps1 zip
 
       - name: ⬆️ Upload artifacts
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # 7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: output-${{ env.SEMVER }}
           path: output/*.*
@@ -67,7 +67,7 @@ jobs:
       IS_PUBLIC_RELEASE: ${{ github.ref_type == 'tag' }}
     steps:
       - name: 🔫 Trigger Build Installers
-        uses: benc-uk/workflow-dispatch@31e2b3319479a63f0ab15bf800eff9e913504e26 # 1.3.2
+        uses: benc-uk/workflow-dispatch@31e2b3319479a63f0ab15bf800eff9e913504e26 # v1.3.2
         with:
           workflow: Build Installers
           repo: specklesystems/connector-installers
@@ -85,6 +85,6 @@ jobs:
         timeout-minutes: 15
 
       # Allows us to inspect the artifacts of failed builds, since this below step will be skipped if the above step fails
-      - uses: geekyeggo/delete-artifact@176a747ab7e287e3ff4787bf8a148716375ca118 # 6.0.0
+      - uses: geekyeggo/delete-artifact@176a747ab7e287e3ff4787bf8a148716375ca118 # v6.0.0
         with:
           name: output-*


### PR DESCRIPTION
## Description

Introduces a linter for GitHub Actions (zizmor), and updates the dependabot & GitHub Actions files to comply with Zizmor's recommendations.

## User Value

- CI only; improves security


## Changes:

- introduces a new job in the PR pipeline to lint github actions
- removes caching in release pipeline to prevent cache poisoning attacks
- pins all github actions to a commit sha to prevent supply-chain attacks
- introduces a 7 day cooldown period for dependabot updates to mitigate supply-chain attacks
- ignores the requirement to ensure all secrets are from environments. Ensures we can continue to use repository level secret
- temporarily disables codecov
  - CodeCov is currently breaking on GPG verification in our CI. This seems to be because CodeCov lost access to their GPG key account. https://github.com/codecov/codecov-action/issues/1956 Codecov have a patch, but that is less than our cooldown period. Out of caution, we'll disable CodeCov until the fix is older than our cooldown period.

## To-do before merge:

<!---

(Optional -- remove this section if not needed)

Include any notes about things that need to happen before this PR is merged, e.g.:

- [ ] Change the base branch

- [ ] Ensure PR #56 is merged

-->

## Validation of changes:

It works, see: https://github.com/specklesystems/speckle-sharp-connectors/actions/runs/27148670998/job/80133438281

<img width="1068" height="988" alt="Screenshot 2026-06-08 at 16 41 39" src="https://github.com/user-attachments/assets/2dd613eb-3166-4976-a0bb-e53c50b24db9" />

## Checklist:

<!---

This checklist is a useful reminder of related tasks to uphold our repo quality. Amend this list as needed for the pr.

-->
- [ ] My commits are related to the pull request and do not amend unrelated code or documentation.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.

