### PR TITLE
feat (tsd): member filtering

### DIFF
--- a/Connectors/TSD/Speckle.Connectors.TSDShared/Bindings/TSDSelectionBinding.cs
+++ b/Connectors/TSD/Speckle.Connectors.TSDShared/Bindings/TSDSelectionBinding.cs
@@ -44,7 +44,7 @@ internal sealed class TSDSelectionBinding : ISelectionBinding
       return new SelectionInfo([], "No objects selected.");
     }
 
-    var ids = entities.Select(entity => entity.Id).ToList();
+    var ids = entities.Select(entity => entity.EncodedId).ToList();
     var typeNames = string.Join(", ", entities.Select(entity => entity.TypeName).Distinct());
     return new SelectionInfo(ids, $"{ids.Count} objects ({typeNames})");
   }

--- a/Connectors/TSD/Speckle.Connectors.TSDShared/HostApp/TSDApplicationService.cs
+++ b/Connectors/TSD/Speckle.Connectors.TSDShared/HostApp/TSDApplicationService.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.Logging;
+using Speckle.Connectors.TSDShared.Utils;
 using Speckle.Sdk;
 using TSD.API.Remoting;
 using TSD.API.Remoting.Common;
@@ -95,7 +96,9 @@ internal sealed class TSDApplicationService : ITSDApplicationService, IDisposabl
         if (item is ISelectedEntity selectedEntity)
         {
           var entity = selectedEntity.Entity;
-          result.Add(new TSDSelectedEntity(entity.Id.ToString(), entity.Type.ToString()));
+          result.Add(
+            new TSDSelectedEntity(TsdObjectIdentifier.Encode(entity.Type, entity.Index), entity.Type.ToString())
+          );
         }
       }
 
@@ -129,19 +132,29 @@ internal sealed class TSDApplicationService : ITSDApplicationService, IDisposabl
         return Array.Empty<IMember>();
       }
 
-      var members = await model.GetMembersAsync(null).ConfigureAwait(false);
-      if (members is null)
+      if (objectIds.Count == 0)
+      {
+        var allMembers = await model.GetMembersAsync(null).ConfigureAwait(false);
+        return allMembers?.ToList() ?? (IReadOnlyList<IMember>)Array.Empty<IMember>();
+      }
+
+      var memberIndices = new List<int>();
+      foreach (var objectId in objectIds)
+      {
+        var (type, index) = TsdObjectIdentifier.Decode(objectId);
+        if (type == EntityType.Member)
+        {
+          memberIndices.Add(index);
+        }
+      }
+
+      if (memberIndices.Count == 0)
       {
         return Array.Empty<IMember>();
       }
 
-      if (objectIds.Count == 0)
-      {
-        return members.ToList();
-      }
-
-      var idSet = objectIds.ToHashSet();
-      return members.Where(member => idSet.Contains(member.Id.ToString())).ToList();
+      var members = await model.GetMembersAsync(memberIndices).ConfigureAwait(false);
+      return members?.ToList() ?? (IReadOnlyList<IMember>)Array.Empty<IMember>();
     }
     catch (Exception ex) when (!ex.IsFatal())
     {

--- a/Connectors/TSD/Speckle.Connectors.TSDShared/HostApp/TSDSelectedEntity.cs
+++ b/Connectors/TSD/Speckle.Connectors.TSDShared/HostApp/TSDSelectedEntity.cs
@@ -1,3 +1,3 @@
 namespace Speckle.Connectors.TSDShared.HostApp;
 
-internal sealed record TSDSelectedEntity(string Id, string TypeName);
+internal sealed record TSDSelectedEntity(string EncodedId, string TypeName);

--- a/Connectors/TSD/Speckle.Connectors.TSDShared/Speckle.Connectors.TSDShared.projitems
+++ b/Connectors/TSD/Speckle.Connectors.TSDShared/Speckle.Connectors.TSDShared.projitems
@@ -19,5 +19,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)Operations\Send\TsdRootObjectBuilder.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HostApp\TSDDocumentModelStore.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ServiceRegistration.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Utils\TsdObjectIdentifier.cs" />
   </ItemGroup>
 </Project>

--- a/Connectors/TSD/Speckle.Connectors.TSDShared/Utils/TsdObjectIdentifier.cs
+++ b/Connectors/TSD/Speckle.Connectors.TSDShared/Utils/TsdObjectIdentifier.cs
@@ -1,0 +1,24 @@
+using TSD.API.Remoting.Common;
+
+namespace Speckle.Connectors.TSDShared.Utils;
+
+internal static class TsdObjectIdentifier
+{
+  public static string Encode(EntityType entityType, int index) => $"{(int)entityType}:{index}";
+
+  public static (EntityType type, int index) Decode(string encodedId)
+  {
+    if (string.IsNullOrEmpty(encodedId))
+    {
+      throw new ArgumentException($"Invalid encoded ID: {encodedId}");
+    }
+
+    var parts = encodedId.Split(':');
+    if (parts.Length != 2 || !int.TryParse(parts[0], out int typeValue) || !int.TryParse(parts[1], out int index))
+    {
+      throw new ArgumentException($"Invalid encoded ID: {encodedId}");
+    }
+
+    return ((EntityType)typeValue, index);
+  }
+}


### PR DESCRIPTION
 Moves TSD send filtering from client-side to server-side.

Before, send fetched all members from TSD over gRPC (`GetMembersAsync(null)`) and filtered them client-side by GUID. 

Now the selection is keyed by `Type:Index`, and send asks TSD only for the selected member indices via `GetMembersAsync(indices)`.