### PR TITLE
refactor(otel): Update connectors with SDK changes

### DIFF
--- a/Connectors/Autocad/Speckle.Connectors.Autocad2023/packages.lock.json
+++ b/Connectors/Autocad/Speckle.Connectors.Autocad2023/packages.lock.json
@@ -180,8 +180,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
+        "resolved": "2026.6.0",
+        "contentHash": "rrbbe+Z8Nql/y0jHod6+B0zRitmHXq+RNw1zZnzY1heLV6NOe/8ntGbMo9JIGTnZ6Bvxg51UxntMiyAYCdvhXg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -191,14 +191,14 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.21.0",
+          "Speckle.Sdk.Dependencies": "2026.6.0",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA==",
+        "resolved": "2026.6.0",
+        "contentHash": "Nb38i5rAXRkEZlN0nkGbYe5Ph88ZBeHLqkcYCGAXolJcE7eDIPfU5hlWd2KcijFOD/E6f6CEdZJ99PinX2+Ejg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
         }
@@ -307,7 +307,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -336,7 +336,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "Microsoft.Web.WebView2": {
@@ -353,11 +353,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.21.0, )",
-        "resolved": "3.21.0",
-        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
+        "requested": "[2026.6.0, )",
+        "resolved": "2026.6.0",
+        "contentHash": "7rfwSQHjuvwxeEWJ4/dHYlIAoeZ5SdiPCCYFiF/Avz1ACp5KoDwkh0FF/5lvWDk86MoH55m5BwxYLFek2ui7Kg==",
         "dependencies": {
-          "Speckle.Sdk": "3.21.0"
+          "Speckle.Sdk": "2026.6.0"
         }
       },
       "System.Text.Json": {

--- a/Connectors/Autocad/Speckle.Connectors.Autocad2023/packages.lock.json
+++ b/Connectors/Autocad/Speckle.Connectors.Autocad2023/packages.lock.json
@@ -180,8 +180,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "jp1fle+rM6l3TtmhTwaWIlZ6HdeR7WYWFwRAxD/iazOFNXp0gWpEwYMe7Z+gBEmd6M91xQwWGAGo03x3D2XJaA==",
+        "resolved": "3.21.0",
+        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -191,14 +191,14 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.20.6",
+          "Speckle.Sdk.Dependencies": "3.21.0",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "DDRzJnBkQuDQbk1Zq76J++sZd63a+aKcY7BiYVDNvjzBSuzhtURe8PQoCfAb1H6WcYL2/K+KytOVvzK/113sGg==",
+        "resolved": "3.21.0",
+        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
         }
@@ -307,7 +307,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -336,7 +336,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "Microsoft.Web.WebView2": {
@@ -353,11 +353,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.20.6, )",
-        "resolved": "3.20.6",
-        "contentHash": "iK+Yl0VUoGzBFuOqP3yrEWQIuQDoISfwbG7vn0jNmEAgwGcRfB9yGlQ0wA4s7IgxbdEfPjhzzcKMBNcPJWkLtw==",
+        "requested": "[3.21.0, )",
+        "resolved": "3.21.0",
+        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.20.6"
+          "Speckle.Sdk": "3.21.0"
         }
       },
       "System.Text.Json": {

--- a/Connectors/Autocad/Speckle.Connectors.Autocad2024/packages.lock.json
+++ b/Connectors/Autocad/Speckle.Connectors.Autocad2024/packages.lock.json
@@ -180,8 +180,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
+        "resolved": "2026.6.0",
+        "contentHash": "rrbbe+Z8Nql/y0jHod6+B0zRitmHXq+RNw1zZnzY1heLV6NOe/8ntGbMo9JIGTnZ6Bvxg51UxntMiyAYCdvhXg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -191,14 +191,14 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.21.0",
+          "Speckle.Sdk.Dependencies": "2026.6.0",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA==",
+        "resolved": "2026.6.0",
+        "contentHash": "Nb38i5rAXRkEZlN0nkGbYe5Ph88ZBeHLqkcYCGAXolJcE7eDIPfU5hlWd2KcijFOD/E6f6CEdZJ99PinX2+Ejg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
         }
@@ -307,7 +307,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -337,7 +337,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "Microsoft.Web.WebView2": {
@@ -354,11 +354,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.21.0, )",
-        "resolved": "3.21.0",
-        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
+        "requested": "[2026.6.0, )",
+        "resolved": "2026.6.0",
+        "contentHash": "7rfwSQHjuvwxeEWJ4/dHYlIAoeZ5SdiPCCYFiF/Avz1ACp5KoDwkh0FF/5lvWDk86MoH55m5BwxYLFek2ui7Kg==",
         "dependencies": {
-          "Speckle.Sdk": "3.21.0"
+          "Speckle.Sdk": "2026.6.0"
         }
       },
       "System.Text.Json": {

--- a/Connectors/Autocad/Speckle.Connectors.Autocad2024/packages.lock.json
+++ b/Connectors/Autocad/Speckle.Connectors.Autocad2024/packages.lock.json
@@ -180,8 +180,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "jp1fle+rM6l3TtmhTwaWIlZ6HdeR7WYWFwRAxD/iazOFNXp0gWpEwYMe7Z+gBEmd6M91xQwWGAGo03x3D2XJaA==",
+        "resolved": "3.21.0",
+        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -191,14 +191,14 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.20.6",
+          "Speckle.Sdk.Dependencies": "3.21.0",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "DDRzJnBkQuDQbk1Zq76J++sZd63a+aKcY7BiYVDNvjzBSuzhtURe8PQoCfAb1H6WcYL2/K+KytOVvzK/113sGg==",
+        "resolved": "3.21.0",
+        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
         }
@@ -307,7 +307,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -337,7 +337,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "Microsoft.Web.WebView2": {
@@ -354,11 +354,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.20.6, )",
-        "resolved": "3.20.6",
-        "contentHash": "iK+Yl0VUoGzBFuOqP3yrEWQIuQDoISfwbG7vn0jNmEAgwGcRfB9yGlQ0wA4s7IgxbdEfPjhzzcKMBNcPJWkLtw==",
+        "requested": "[3.21.0, )",
+        "resolved": "3.21.0",
+        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.20.6"
+          "Speckle.Sdk": "3.21.0"
         }
       },
       "System.Text.Json": {

--- a/Connectors/Autocad/Speckle.Connectors.Autocad2025/packages.lock.json
+++ b/Connectors/Autocad/Speckle.Connectors.Autocad2025/packages.lock.json
@@ -139,8 +139,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "jp1fle+rM6l3TtmhTwaWIlZ6HdeR7WYWFwRAxD/iazOFNXp0gWpEwYMe7Z+gBEmd6M91xQwWGAGo03x3D2XJaA==",
+        "resolved": "3.21.0",
+        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -148,13 +148,13 @@
           "Microsoft.Extensions.ObjectPool": "8.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.20.6"
+          "Speckle.Sdk.Dependencies": "3.21.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "DDRzJnBkQuDQbk1Zq76J++sZd63a+aKcY7BiYVDNvjzBSuzhtURe8PQoCfAb1H6WcYL2/K+KytOVvzK/113sGg=="
+        "resolved": "3.21.0",
+        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -201,7 +201,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -231,7 +231,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "Microsoft.Web.WebView2": {
@@ -248,11 +248,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.20.6, )",
-        "resolved": "3.20.6",
-        "contentHash": "iK+Yl0VUoGzBFuOqP3yrEWQIuQDoISfwbG7vn0jNmEAgwGcRfB9yGlQ0wA4s7IgxbdEfPjhzzcKMBNcPJWkLtw==",
+        "requested": "[3.21.0, )",
+        "resolved": "3.21.0",
+        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.20.6"
+          "Speckle.Sdk": "3.21.0"
         }
       }
     },

--- a/Connectors/Autocad/Speckle.Connectors.Autocad2025/packages.lock.json
+++ b/Connectors/Autocad/Speckle.Connectors.Autocad2025/packages.lock.json
@@ -139,8 +139,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
+        "resolved": "2026.6.0",
+        "contentHash": "rrbbe+Z8Nql/y0jHod6+B0zRitmHXq+RNw1zZnzY1heLV6NOe/8ntGbMo9JIGTnZ6Bvxg51UxntMiyAYCdvhXg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -148,13 +148,13 @@
           "Microsoft.Extensions.ObjectPool": "8.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.21.0"
+          "Speckle.Sdk.Dependencies": "2026.6.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA=="
+        "resolved": "2026.6.0",
+        "contentHash": "Nb38i5rAXRkEZlN0nkGbYe5Ph88ZBeHLqkcYCGAXolJcE7eDIPfU5hlWd2KcijFOD/E6f6CEdZJ99PinX2+Ejg=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -201,7 +201,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -231,7 +231,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "Microsoft.Web.WebView2": {
@@ -248,11 +248,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.21.0, )",
-        "resolved": "3.21.0",
-        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
+        "requested": "[2026.6.0, )",
+        "resolved": "2026.6.0",
+        "contentHash": "7rfwSQHjuvwxeEWJ4/dHYlIAoeZ5SdiPCCYFiF/Avz1ACp5KoDwkh0FF/5lvWDk86MoH55m5BwxYLFek2ui7Kg==",
         "dependencies": {
-          "Speckle.Sdk": "3.21.0"
+          "Speckle.Sdk": "2026.6.0"
         }
       }
     },

--- a/Connectors/Autocad/Speckle.Connectors.Autocad2026/packages.lock.json
+++ b/Connectors/Autocad/Speckle.Connectors.Autocad2026/packages.lock.json
@@ -139,8 +139,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "jp1fle+rM6l3TtmhTwaWIlZ6HdeR7WYWFwRAxD/iazOFNXp0gWpEwYMe7Z+gBEmd6M91xQwWGAGo03x3D2XJaA==",
+        "resolved": "3.21.0",
+        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -148,13 +148,13 @@
           "Microsoft.Extensions.ObjectPool": "8.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.20.6"
+          "Speckle.Sdk.Dependencies": "3.21.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "DDRzJnBkQuDQbk1Zq76J++sZd63a+aKcY7BiYVDNvjzBSuzhtURe8PQoCfAb1H6WcYL2/K+KytOVvzK/113sGg=="
+        "resolved": "3.21.0",
+        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -201,7 +201,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -231,7 +231,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "Microsoft.Web.WebView2": {
@@ -248,11 +248,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.20.6, )",
-        "resolved": "3.20.6",
-        "contentHash": "iK+Yl0VUoGzBFuOqP3yrEWQIuQDoISfwbG7vn0jNmEAgwGcRfB9yGlQ0wA4s7IgxbdEfPjhzzcKMBNcPJWkLtw==",
+        "requested": "[3.21.0, )",
+        "resolved": "3.21.0",
+        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.20.6"
+          "Speckle.Sdk": "3.21.0"
         }
       }
     },

--- a/Connectors/Autocad/Speckle.Connectors.Autocad2026/packages.lock.json
+++ b/Connectors/Autocad/Speckle.Connectors.Autocad2026/packages.lock.json
@@ -139,8 +139,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
+        "resolved": "2026.6.0",
+        "contentHash": "rrbbe+Z8Nql/y0jHod6+B0zRitmHXq+RNw1zZnzY1heLV6NOe/8ntGbMo9JIGTnZ6Bvxg51UxntMiyAYCdvhXg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -148,13 +148,13 @@
           "Microsoft.Extensions.ObjectPool": "8.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.21.0"
+          "Speckle.Sdk.Dependencies": "2026.6.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA=="
+        "resolved": "2026.6.0",
+        "contentHash": "Nb38i5rAXRkEZlN0nkGbYe5Ph88ZBeHLqkcYCGAXolJcE7eDIPfU5hlWd2KcijFOD/E6f6CEdZJ99PinX2+Ejg=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -201,7 +201,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -231,7 +231,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "Microsoft.Web.WebView2": {
@@ -248,11 +248,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.21.0, )",
-        "resolved": "3.21.0",
-        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
+        "requested": "[2026.6.0, )",
+        "resolved": "2026.6.0",
+        "contentHash": "7rfwSQHjuvwxeEWJ4/dHYlIAoeZ5SdiPCCYFiF/Avz1ACp5KoDwkh0FF/5lvWDk86MoH55m5BwxYLFek2ui7Kg==",
         "dependencies": {
-          "Speckle.Sdk": "3.21.0"
+          "Speckle.Sdk": "2026.6.0"
         }
       }
     },

--- a/Connectors/Autocad/Speckle.Connectors.Autocad2027/packages.lock.json
+++ b/Connectors/Autocad/Speckle.Connectors.Autocad2027/packages.lock.json
@@ -140,8 +140,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "jp1fle+rM6l3TtmhTwaWIlZ6HdeR7WYWFwRAxD/iazOFNXp0gWpEwYMe7Z+gBEmd6M91xQwWGAGo03x3D2XJaA==",
+        "resolved": "3.21.0",
+        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
         "dependencies": {
           "GraphQL.Client": "6.1.0",
           "Microsoft.Data.Sqlite": "10.0.0",
@@ -149,13 +149,13 @@
           "Microsoft.Extensions.ObjectPool": "10.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.20.6"
+          "Speckle.Sdk.Dependencies": "3.21.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "DDRzJnBkQuDQbk1Zq76J++sZd63a+aKcY7BiYVDNvjzBSuzhtURe8PQoCfAb1H6WcYL2/K+KytOVvzK/113sGg=="
+        "resolved": "3.21.0",
+        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -194,7 +194,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -224,7 +224,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "Microsoft.Web.WebView2": {
@@ -241,11 +241,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.20.6, )",
-        "resolved": "3.20.6",
-        "contentHash": "iK+Yl0VUoGzBFuOqP3yrEWQIuQDoISfwbG7vn0jNmEAgwGcRfB9yGlQ0wA4s7IgxbdEfPjhzzcKMBNcPJWkLtw==",
+        "requested": "[3.21.0, )",
+        "resolved": "3.21.0",
+        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.20.6"
+          "Speckle.Sdk": "3.21.0"
         }
       }
     },

--- a/Connectors/Autocad/Speckle.Connectors.Autocad2027/packages.lock.json
+++ b/Connectors/Autocad/Speckle.Connectors.Autocad2027/packages.lock.json
@@ -140,8 +140,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
+        "resolved": "2026.6.0",
+        "contentHash": "rrbbe+Z8Nql/y0jHod6+B0zRitmHXq+RNw1zZnzY1heLV6NOe/8ntGbMo9JIGTnZ6Bvxg51UxntMiyAYCdvhXg==",
         "dependencies": {
           "GraphQL.Client": "6.1.0",
           "Microsoft.Data.Sqlite": "10.0.0",
@@ -149,13 +149,13 @@
           "Microsoft.Extensions.ObjectPool": "10.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.21.0"
+          "Speckle.Sdk.Dependencies": "2026.6.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA=="
+        "resolved": "2026.6.0",
+        "contentHash": "Nb38i5rAXRkEZlN0nkGbYe5Ph88ZBeHLqkcYCGAXolJcE7eDIPfU5hlWd2KcijFOD/E6f6CEdZJ99PinX2+Ejg=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -194,7 +194,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -224,7 +224,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "Microsoft.Web.WebView2": {
@@ -241,11 +241,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.21.0, )",
-        "resolved": "3.21.0",
-        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
+        "requested": "[2026.6.0, )",
+        "resolved": "2026.6.0",
+        "contentHash": "7rfwSQHjuvwxeEWJ4/dHYlIAoeZ5SdiPCCYFiF/Avz1ACp5KoDwkh0FF/5lvWDk86MoH55m5BwxYLFek2ui7Kg==",
         "dependencies": {
-          "Speckle.Sdk": "3.21.0"
+          "Speckle.Sdk": "2026.6.0"
         }
       }
     },

--- a/Connectors/Autocad/Speckle.Connectors.AutocadShared/HostApp/AutocadLayerUnpacker.cs
+++ b/Connectors/Autocad/Speckle.Connectors.AutocadShared/HostApp/AutocadLayerUnpacker.cs
@@ -19,7 +19,7 @@ public class AutocadLayerUnpacker
     }
     if (tr.GetObject(entity.LayerId, OpenMode.ForRead) is LayerTableRecord autocadLayer)
     {
-      speckleLayer = new Layer(layerName) { applicationId = autocadLayer.GetSpeckleApplicationId() }; // Do not use handle directly, see note in the 'GetSpeckleApplicationId' method
+      speckleLayer = new Layer { name = layerName, applicationId = autocadLayer.GetSpeckleApplicationId() }; // Do not use handle directly, see note in the 'GetSpeckleApplicationId' method
       _layerCollectionCache[layerName] = speckleLayer;
       layer = autocadLayer;
       return speckleLayer;

--- a/Connectors/Autocad/Speckle.Connectors.AutocadShared/Operations/Send/AutocadContinuousTraversalBaseBuilder.cs
+++ b/Connectors/Autocad/Speckle.Connectors.AutocadShared/Operations/Send/AutocadContinuousTraversalBaseBuilder.cs
@@ -147,7 +147,7 @@ public abstract class AutocadContinuousTraversalBaseBuilder : IRootContinuousTra
 
   public virtual (Collection, LayerTableRecord?) CreateObjectCollection(Entity entity, Transaction tr)
   {
-    return (new(), null);
+    return (new() { name = "unnamed" }, null);
   }
 
   public virtual void AddAdditionalProxiesToRoot(Collection rootCollection)

--- a/Connectors/Autocad/Speckle.Connectors.AutocadShared/Operations/Send/AutocadRootObjectBaseBuilder.cs
+++ b/Connectors/Autocad/Speckle.Connectors.AutocadShared/Operations/Send/AutocadRootObjectBaseBuilder.cs
@@ -173,7 +173,7 @@ public abstract class AutocadRootObjectBaseBuilder : IRootObjectBuilder<AutocadR
 
   public virtual (Collection, LayerTableRecord?) CreateObjectCollection(Entity entity, Transaction tr)
   {
-    return (new(), null);
+    return (new() { name = "unnamed" }, null);
   }
 
   public virtual void AddAdditionalProxiesToRoot(Collection rootCollection)

--- a/Connectors/Autocad/Speckle.Connectors.Civil3d2023/packages.lock.json
+++ b/Connectors/Autocad/Speckle.Connectors.Civil3d2023/packages.lock.json
@@ -189,8 +189,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
+        "resolved": "2026.6.0",
+        "contentHash": "rrbbe+Z8Nql/y0jHod6+B0zRitmHXq+RNw1zZnzY1heLV6NOe/8ntGbMo9JIGTnZ6Bvxg51UxntMiyAYCdvhXg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -200,14 +200,14 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.21.0",
+          "Speckle.Sdk.Dependencies": "2026.6.0",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA==",
+        "resolved": "2026.6.0",
+        "contentHash": "Nb38i5rAXRkEZlN0nkGbYe5Ph88ZBeHLqkcYCGAXolJcE7eDIPfU5hlWd2KcijFOD/E6f6CEdZJ99PinX2+Ejg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
         }
@@ -316,7 +316,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -346,7 +346,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "Microsoft.Web.WebView2": {
@@ -363,11 +363,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.21.0, )",
-        "resolved": "3.21.0",
-        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
+        "requested": "[2026.6.0, )",
+        "resolved": "2026.6.0",
+        "contentHash": "7rfwSQHjuvwxeEWJ4/dHYlIAoeZ5SdiPCCYFiF/Avz1ACp5KoDwkh0FF/5lvWDk86MoH55m5BwxYLFek2ui7Kg==",
         "dependencies": {
-          "Speckle.Sdk": "3.21.0"
+          "Speckle.Sdk": "2026.6.0"
         }
       },
       "System.Text.Json": {

--- a/Connectors/Autocad/Speckle.Connectors.Civil3d2023/packages.lock.json
+++ b/Connectors/Autocad/Speckle.Connectors.Civil3d2023/packages.lock.json
@@ -189,8 +189,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "jp1fle+rM6l3TtmhTwaWIlZ6HdeR7WYWFwRAxD/iazOFNXp0gWpEwYMe7Z+gBEmd6M91xQwWGAGo03x3D2XJaA==",
+        "resolved": "3.21.0",
+        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -200,14 +200,14 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.20.6",
+          "Speckle.Sdk.Dependencies": "3.21.0",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "DDRzJnBkQuDQbk1Zq76J++sZd63a+aKcY7BiYVDNvjzBSuzhtURe8PQoCfAb1H6WcYL2/K+KytOVvzK/113sGg==",
+        "resolved": "3.21.0",
+        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
         }
@@ -316,7 +316,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -346,7 +346,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "Microsoft.Web.WebView2": {
@@ -363,11 +363,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.20.6, )",
-        "resolved": "3.20.6",
-        "contentHash": "iK+Yl0VUoGzBFuOqP3yrEWQIuQDoISfwbG7vn0jNmEAgwGcRfB9yGlQ0wA4s7IgxbdEfPjhzzcKMBNcPJWkLtw==",
+        "requested": "[3.21.0, )",
+        "resolved": "3.21.0",
+        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.20.6"
+          "Speckle.Sdk": "3.21.0"
         }
       },
       "System.Text.Json": {

--- a/Connectors/Autocad/Speckle.Connectors.Civil3d2024/packages.lock.json
+++ b/Connectors/Autocad/Speckle.Connectors.Civil3d2024/packages.lock.json
@@ -189,8 +189,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
+        "resolved": "2026.6.0",
+        "contentHash": "rrbbe+Z8Nql/y0jHod6+B0zRitmHXq+RNw1zZnzY1heLV6NOe/8ntGbMo9JIGTnZ6Bvxg51UxntMiyAYCdvhXg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -200,14 +200,14 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.21.0",
+          "Speckle.Sdk.Dependencies": "2026.6.0",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA==",
+        "resolved": "2026.6.0",
+        "contentHash": "Nb38i5rAXRkEZlN0nkGbYe5Ph88ZBeHLqkcYCGAXolJcE7eDIPfU5hlWd2KcijFOD/E6f6CEdZJ99PinX2+Ejg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
         }
@@ -316,7 +316,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -346,7 +346,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "Microsoft.Web.WebView2": {
@@ -363,11 +363,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.21.0, )",
-        "resolved": "3.21.0",
-        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
+        "requested": "[2026.6.0, )",
+        "resolved": "2026.6.0",
+        "contentHash": "7rfwSQHjuvwxeEWJ4/dHYlIAoeZ5SdiPCCYFiF/Avz1ACp5KoDwkh0FF/5lvWDk86MoH55m5BwxYLFek2ui7Kg==",
         "dependencies": {
-          "Speckle.Sdk": "3.21.0"
+          "Speckle.Sdk": "2026.6.0"
         }
       },
       "System.Text.Json": {

--- a/Connectors/Autocad/Speckle.Connectors.Civil3d2024/packages.lock.json
+++ b/Connectors/Autocad/Speckle.Connectors.Civil3d2024/packages.lock.json
@@ -189,8 +189,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "jp1fle+rM6l3TtmhTwaWIlZ6HdeR7WYWFwRAxD/iazOFNXp0gWpEwYMe7Z+gBEmd6M91xQwWGAGo03x3D2XJaA==",
+        "resolved": "3.21.0",
+        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -200,14 +200,14 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.20.6",
+          "Speckle.Sdk.Dependencies": "3.21.0",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "DDRzJnBkQuDQbk1Zq76J++sZd63a+aKcY7BiYVDNvjzBSuzhtURe8PQoCfAb1H6WcYL2/K+KytOVvzK/113sGg==",
+        "resolved": "3.21.0",
+        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
         }
@@ -316,7 +316,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -346,7 +346,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "Microsoft.Web.WebView2": {
@@ -363,11 +363,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.20.6, )",
-        "resolved": "3.20.6",
-        "contentHash": "iK+Yl0VUoGzBFuOqP3yrEWQIuQDoISfwbG7vn0jNmEAgwGcRfB9yGlQ0wA4s7IgxbdEfPjhzzcKMBNcPJWkLtw==",
+        "requested": "[3.21.0, )",
+        "resolved": "3.21.0",
+        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.20.6"
+          "Speckle.Sdk": "3.21.0"
         }
       },
       "System.Text.Json": {

--- a/Connectors/Autocad/Speckle.Connectors.Civil3d2025/packages.lock.json
+++ b/Connectors/Autocad/Speckle.Connectors.Civil3d2025/packages.lock.json
@@ -148,8 +148,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
+        "resolved": "2026.6.0",
+        "contentHash": "rrbbe+Z8Nql/y0jHod6+B0zRitmHXq+RNw1zZnzY1heLV6NOe/8ntGbMo9JIGTnZ6Bvxg51UxntMiyAYCdvhXg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -157,13 +157,13 @@
           "Microsoft.Extensions.ObjectPool": "8.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.21.0"
+          "Speckle.Sdk.Dependencies": "2026.6.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA=="
+        "resolved": "2026.6.0",
+        "contentHash": "Nb38i5rAXRkEZlN0nkGbYe5Ph88ZBeHLqkcYCGAXolJcE7eDIPfU5hlWd2KcijFOD/E6f6CEdZJ99PinX2+Ejg=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -210,7 +210,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -241,7 +241,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "Microsoft.Web.WebView2": {
@@ -258,11 +258,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.21.0, )",
-        "resolved": "3.21.0",
-        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
+        "requested": "[2026.6.0, )",
+        "resolved": "2026.6.0",
+        "contentHash": "7rfwSQHjuvwxeEWJ4/dHYlIAoeZ5SdiPCCYFiF/Avz1ACp5KoDwkh0FF/5lvWDk86MoH55m5BwxYLFek2ui7Kg==",
         "dependencies": {
-          "Speckle.Sdk": "3.21.0"
+          "Speckle.Sdk": "2026.6.0"
         }
       }
     },

--- a/Connectors/Autocad/Speckle.Connectors.Civil3d2025/packages.lock.json
+++ b/Connectors/Autocad/Speckle.Connectors.Civil3d2025/packages.lock.json
@@ -148,8 +148,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "jp1fle+rM6l3TtmhTwaWIlZ6HdeR7WYWFwRAxD/iazOFNXp0gWpEwYMe7Z+gBEmd6M91xQwWGAGo03x3D2XJaA==",
+        "resolved": "3.21.0",
+        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -157,13 +157,13 @@
           "Microsoft.Extensions.ObjectPool": "8.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.20.6"
+          "Speckle.Sdk.Dependencies": "3.21.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "DDRzJnBkQuDQbk1Zq76J++sZd63a+aKcY7BiYVDNvjzBSuzhtURe8PQoCfAb1H6WcYL2/K+KytOVvzK/113sGg=="
+        "resolved": "3.21.0",
+        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -210,7 +210,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -241,7 +241,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "Microsoft.Web.WebView2": {
@@ -258,11 +258,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.20.6, )",
-        "resolved": "3.20.6",
-        "contentHash": "iK+Yl0VUoGzBFuOqP3yrEWQIuQDoISfwbG7vn0jNmEAgwGcRfB9yGlQ0wA4s7IgxbdEfPjhzzcKMBNcPJWkLtw==",
+        "requested": "[3.21.0, )",
+        "resolved": "3.21.0",
+        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.20.6"
+          "Speckle.Sdk": "3.21.0"
         }
       }
     },

--- a/Connectors/Autocad/Speckle.Connectors.Civil3d2026/packages.lock.json
+++ b/Connectors/Autocad/Speckle.Connectors.Civil3d2026/packages.lock.json
@@ -148,8 +148,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
+        "resolved": "2026.6.0",
+        "contentHash": "rrbbe+Z8Nql/y0jHod6+B0zRitmHXq+RNw1zZnzY1heLV6NOe/8ntGbMo9JIGTnZ6Bvxg51UxntMiyAYCdvhXg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -157,13 +157,13 @@
           "Microsoft.Extensions.ObjectPool": "8.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.21.0"
+          "Speckle.Sdk.Dependencies": "2026.6.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA=="
+        "resolved": "2026.6.0",
+        "contentHash": "Nb38i5rAXRkEZlN0nkGbYe5Ph88ZBeHLqkcYCGAXolJcE7eDIPfU5hlWd2KcijFOD/E6f6CEdZJ99PinX2+Ejg=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -210,7 +210,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -241,7 +241,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "Microsoft.Web.WebView2": {
@@ -258,11 +258,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.21.0, )",
-        "resolved": "3.21.0",
-        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
+        "requested": "[2026.6.0, )",
+        "resolved": "2026.6.0",
+        "contentHash": "7rfwSQHjuvwxeEWJ4/dHYlIAoeZ5SdiPCCYFiF/Avz1ACp5KoDwkh0FF/5lvWDk86MoH55m5BwxYLFek2ui7Kg==",
         "dependencies": {
-          "Speckle.Sdk": "3.21.0"
+          "Speckle.Sdk": "2026.6.0"
         }
       }
     },

--- a/Connectors/Autocad/Speckle.Connectors.Civil3d2026/packages.lock.json
+++ b/Connectors/Autocad/Speckle.Connectors.Civil3d2026/packages.lock.json
@@ -148,8 +148,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "jp1fle+rM6l3TtmhTwaWIlZ6HdeR7WYWFwRAxD/iazOFNXp0gWpEwYMe7Z+gBEmd6M91xQwWGAGo03x3D2XJaA==",
+        "resolved": "3.21.0",
+        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -157,13 +157,13 @@
           "Microsoft.Extensions.ObjectPool": "8.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.20.6"
+          "Speckle.Sdk.Dependencies": "3.21.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "DDRzJnBkQuDQbk1Zq76J++sZd63a+aKcY7BiYVDNvjzBSuzhtURe8PQoCfAb1H6WcYL2/K+KytOVvzK/113sGg=="
+        "resolved": "3.21.0",
+        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -210,7 +210,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -241,7 +241,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "Microsoft.Web.WebView2": {
@@ -258,11 +258,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.20.6, )",
-        "resolved": "3.20.6",
-        "contentHash": "iK+Yl0VUoGzBFuOqP3yrEWQIuQDoISfwbG7vn0jNmEAgwGcRfB9yGlQ0wA4s7IgxbdEfPjhzzcKMBNcPJWkLtw==",
+        "requested": "[3.21.0, )",
+        "resolved": "3.21.0",
+        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.20.6"
+          "Speckle.Sdk": "3.21.0"
         }
       }
     },

--- a/Connectors/Autocad/Speckle.Connectors.Civil3d2027/packages.lock.json
+++ b/Connectors/Autocad/Speckle.Connectors.Civil3d2027/packages.lock.json
@@ -149,8 +149,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "jp1fle+rM6l3TtmhTwaWIlZ6HdeR7WYWFwRAxD/iazOFNXp0gWpEwYMe7Z+gBEmd6M91xQwWGAGo03x3D2XJaA==",
+        "resolved": "3.21.0",
+        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
         "dependencies": {
           "GraphQL.Client": "6.1.0",
           "Microsoft.Data.Sqlite": "10.0.0",
@@ -158,13 +158,13 @@
           "Microsoft.Extensions.ObjectPool": "10.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.20.6"
+          "Speckle.Sdk.Dependencies": "3.21.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "DDRzJnBkQuDQbk1Zq76J++sZd63a+aKcY7BiYVDNvjzBSuzhtURe8PQoCfAb1H6WcYL2/K+KytOVvzK/113sGg=="
+        "resolved": "3.21.0",
+        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -203,7 +203,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -234,7 +234,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "Microsoft.Web.WebView2": {
@@ -251,11 +251,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.20.6, )",
-        "resolved": "3.20.6",
-        "contentHash": "iK+Yl0VUoGzBFuOqP3yrEWQIuQDoISfwbG7vn0jNmEAgwGcRfB9yGlQ0wA4s7IgxbdEfPjhzzcKMBNcPJWkLtw==",
+        "requested": "[3.21.0, )",
+        "resolved": "3.21.0",
+        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.20.6"
+          "Speckle.Sdk": "3.21.0"
         }
       }
     },

--- a/Connectors/Autocad/Speckle.Connectors.Civil3d2027/packages.lock.json
+++ b/Connectors/Autocad/Speckle.Connectors.Civil3d2027/packages.lock.json
@@ -149,8 +149,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
+        "resolved": "2026.6.0",
+        "contentHash": "rrbbe+Z8Nql/y0jHod6+B0zRitmHXq+RNw1zZnzY1heLV6NOe/8ntGbMo9JIGTnZ6Bvxg51UxntMiyAYCdvhXg==",
         "dependencies": {
           "GraphQL.Client": "6.1.0",
           "Microsoft.Data.Sqlite": "10.0.0",
@@ -158,13 +158,13 @@
           "Microsoft.Extensions.ObjectPool": "10.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.21.0"
+          "Speckle.Sdk.Dependencies": "2026.6.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA=="
+        "resolved": "2026.6.0",
+        "contentHash": "Nb38i5rAXRkEZlN0nkGbYe5Ph88ZBeHLqkcYCGAXolJcE7eDIPfU5hlWd2KcijFOD/E6f6CEdZJ99PinX2+Ejg=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -203,7 +203,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -234,7 +234,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "Microsoft.Web.WebView2": {
@@ -251,11 +251,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.21.0, )",
-        "resolved": "3.21.0",
-        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
+        "requested": "[2026.6.0, )",
+        "resolved": "2026.6.0",
+        "contentHash": "7rfwSQHjuvwxeEWJ4/dHYlIAoeZ5SdiPCCYFiF/Avz1ACp5KoDwkh0FF/5lvWDk86MoH55m5BwxYLFek2ui7Kg==",
         "dependencies": {
-          "Speckle.Sdk": "3.21.0"
+          "Speckle.Sdk": "2026.6.0"
         }
       }
     },

--- a/Connectors/Autocad/Speckle.Connectors.Plant3d2026/packages.lock.json
+++ b/Connectors/Autocad/Speckle.Connectors.Plant3d2026/packages.lock.json
@@ -148,8 +148,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
+        "resolved": "2026.6.0",
+        "contentHash": "rrbbe+Z8Nql/y0jHod6+B0zRitmHXq+RNw1zZnzY1heLV6NOe/8ntGbMo9JIGTnZ6Bvxg51UxntMiyAYCdvhXg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -157,13 +157,13 @@
           "Microsoft.Extensions.ObjectPool": "8.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.21.0"
+          "Speckle.Sdk.Dependencies": "2026.6.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA=="
+        "resolved": "2026.6.0",
+        "contentHash": "Nb38i5rAXRkEZlN0nkGbYe5Ph88ZBeHLqkcYCGAXolJcE7eDIPfU5hlWd2KcijFOD/E6f6CEdZJ99PinX2+Ejg=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -210,7 +210,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -232,7 +232,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "speckle.converters.plant3d2026": {
@@ -258,11 +258,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.21.0, )",
-        "resolved": "3.21.0",
-        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
+        "requested": "[2026.6.0, )",
+        "resolved": "2026.6.0",
+        "contentHash": "7rfwSQHjuvwxeEWJ4/dHYlIAoeZ5SdiPCCYFiF/Avz1ACp5KoDwkh0FF/5lvWDk86MoH55m5BwxYLFek2ui7Kg==",
         "dependencies": {
-          "Speckle.Sdk": "3.21.0"
+          "Speckle.Sdk": "2026.6.0"
         }
       }
     },

--- a/Connectors/Autocad/Speckle.Connectors.Plant3d2026/packages.lock.json
+++ b/Connectors/Autocad/Speckle.Connectors.Plant3d2026/packages.lock.json
@@ -148,8 +148,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "jp1fle+rM6l3TtmhTwaWIlZ6HdeR7WYWFwRAxD/iazOFNXp0gWpEwYMe7Z+gBEmd6M91xQwWGAGo03x3D2XJaA==",
+        "resolved": "3.21.0",
+        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -157,13 +157,13 @@
           "Microsoft.Extensions.ObjectPool": "8.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.20.6"
+          "Speckle.Sdk.Dependencies": "3.21.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "DDRzJnBkQuDQbk1Zq76J++sZd63a+aKcY7BiYVDNvjzBSuzhtURe8PQoCfAb1H6WcYL2/K+KytOVvzK/113sGg=="
+        "resolved": "3.21.0",
+        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -210,7 +210,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -232,7 +232,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "speckle.converters.plant3d2026": {
@@ -258,11 +258,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.20.6, )",
-        "resolved": "3.20.6",
-        "contentHash": "iK+Yl0VUoGzBFuOqP3yrEWQIuQDoISfwbG7vn0jNmEAgwGcRfB9yGlQ0wA4s7IgxbdEfPjhzzcKMBNcPJWkLtw==",
+        "requested": "[3.21.0, )",
+        "resolved": "3.21.0",
+        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.20.6"
+          "Speckle.Sdk": "3.21.0"
         }
       }
     },

--- a/Connectors/Autocad/Speckle.Connectors.Plant3d2027/packages.lock.json
+++ b/Connectors/Autocad/Speckle.Connectors.Plant3d2027/packages.lock.json
@@ -149,8 +149,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "jp1fle+rM6l3TtmhTwaWIlZ6HdeR7WYWFwRAxD/iazOFNXp0gWpEwYMe7Z+gBEmd6M91xQwWGAGo03x3D2XJaA==",
+        "resolved": "3.21.0",
+        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
         "dependencies": {
           "GraphQL.Client": "6.1.0",
           "Microsoft.Data.Sqlite": "10.0.0",
@@ -158,13 +158,13 @@
           "Microsoft.Extensions.ObjectPool": "10.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.20.6"
+          "Speckle.Sdk.Dependencies": "3.21.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "DDRzJnBkQuDQbk1Zq76J++sZd63a+aKcY7BiYVDNvjzBSuzhtURe8PQoCfAb1H6WcYL2/K+KytOVvzK/113sGg=="
+        "resolved": "3.21.0",
+        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -203,7 +203,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -225,7 +225,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "speckle.converters.plant3d2027": {
@@ -251,11 +251,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.20.6, )",
-        "resolved": "3.20.6",
-        "contentHash": "iK+Yl0VUoGzBFuOqP3yrEWQIuQDoISfwbG7vn0jNmEAgwGcRfB9yGlQ0wA4s7IgxbdEfPjhzzcKMBNcPJWkLtw==",
+        "requested": "[3.21.0, )",
+        "resolved": "3.21.0",
+        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.20.6"
+          "Speckle.Sdk": "3.21.0"
         }
       }
     },

--- a/Connectors/Autocad/Speckle.Connectors.Plant3d2027/packages.lock.json
+++ b/Connectors/Autocad/Speckle.Connectors.Plant3d2027/packages.lock.json
@@ -149,8 +149,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
+        "resolved": "2026.6.0",
+        "contentHash": "rrbbe+Z8Nql/y0jHod6+B0zRitmHXq+RNw1zZnzY1heLV6NOe/8ntGbMo9JIGTnZ6Bvxg51UxntMiyAYCdvhXg==",
         "dependencies": {
           "GraphQL.Client": "6.1.0",
           "Microsoft.Data.Sqlite": "10.0.0",
@@ -158,13 +158,13 @@
           "Microsoft.Extensions.ObjectPool": "10.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.21.0"
+          "Speckle.Sdk.Dependencies": "2026.6.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA=="
+        "resolved": "2026.6.0",
+        "contentHash": "Nb38i5rAXRkEZlN0nkGbYe5Ph88ZBeHLqkcYCGAXolJcE7eDIPfU5hlWd2KcijFOD/E6f6CEdZJ99PinX2+Ejg=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -203,7 +203,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -225,7 +225,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "speckle.converters.plant3d2027": {
@@ -251,11 +251,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.21.0, )",
-        "resolved": "3.21.0",
-        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
+        "requested": "[2026.6.0, )",
+        "resolved": "2026.6.0",
+        "contentHash": "7rfwSQHjuvwxeEWJ4/dHYlIAoeZ5SdiPCCYFiF/Avz1ACp5KoDwkh0FF/5lvWDk86MoH55m5BwxYLFek2ui7Kg==",
         "dependencies": {
-          "Speckle.Sdk": "3.21.0"
+          "Speckle.Sdk": "2026.6.0"
         }
       }
     },

--- a/Connectors/CSi/Speckle.Connectors.CSiShared/HostApp/CsiSendCollectionManager.cs
+++ b/Connectors/CSi/Speckle.Connectors.CSiShared/HostApp/CsiSendCollectionManager.cs
@@ -39,5 +39,6 @@ public class CsiSendCollectionManager
 
   protected virtual string GetCollectionPath(Base convertedObject) => convertedObject["type"]?.ToString() ?? "Unknown";
 
-  protected virtual Collection CreateCollection(Base convertedObject) => new(GetCollectionPath(convertedObject));
+  protected virtual Collection CreateCollection(Base convertedObject) =>
+    new() { name = GetCollectionPath(convertedObject) };
 }

--- a/Connectors/CSi/Speckle.Connectors.ETABS21/packages.lock.json
+++ b/Connectors/CSi/Speckle.Connectors.ETABS21/packages.lock.json
@@ -196,8 +196,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "jp1fle+rM6l3TtmhTwaWIlZ6HdeR7WYWFwRAxD/iazOFNXp0gWpEwYMe7Z+gBEmd6M91xQwWGAGo03x3D2XJaA==",
+        "resolved": "3.21.0",
+        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -207,14 +207,14 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.20.6",
+          "Speckle.Sdk.Dependencies": "3.21.0",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "DDRzJnBkQuDQbk1Zq76J++sZd63a+aKcY7BiYVDNvjzBSuzhtURe8PQoCfAb1H6WcYL2/K+KytOVvzK/113sGg==",
+        "resolved": "3.21.0",
+        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
         }
@@ -324,7 +324,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -346,7 +346,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "speckle.converters.etabs21": {
@@ -369,11 +369,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.20.6, )",
-        "resolved": "3.20.6",
-        "contentHash": "iK+Yl0VUoGzBFuOqP3yrEWQIuQDoISfwbG7vn0jNmEAgwGcRfB9yGlQ0wA4s7IgxbdEfPjhzzcKMBNcPJWkLtw==",
+        "requested": "[3.21.0, )",
+        "resolved": "3.21.0",
+        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.20.6"
+          "Speckle.Sdk": "3.21.0"
         }
       }
     }

--- a/Connectors/CSi/Speckle.Connectors.ETABS21/packages.lock.json
+++ b/Connectors/CSi/Speckle.Connectors.ETABS21/packages.lock.json
@@ -196,8 +196,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
+        "resolved": "2026.6.0",
+        "contentHash": "rrbbe+Z8Nql/y0jHod6+B0zRitmHXq+RNw1zZnzY1heLV6NOe/8ntGbMo9JIGTnZ6Bvxg51UxntMiyAYCdvhXg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -207,14 +207,14 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.21.0",
+          "Speckle.Sdk.Dependencies": "2026.6.0",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA==",
+        "resolved": "2026.6.0",
+        "contentHash": "Nb38i5rAXRkEZlN0nkGbYe5Ph88ZBeHLqkcYCGAXolJcE7eDIPfU5hlWd2KcijFOD/E6f6CEdZJ99PinX2+Ejg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
         }
@@ -324,7 +324,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -346,7 +346,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "speckle.converters.etabs21": {
@@ -369,11 +369,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.21.0, )",
-        "resolved": "3.21.0",
-        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
+        "requested": "[2026.6.0, )",
+        "resolved": "2026.6.0",
+        "contentHash": "7rfwSQHjuvwxeEWJ4/dHYlIAoeZ5SdiPCCYFiF/Avz1ACp5KoDwkh0FF/5lvWDk86MoH55m5BwxYLFek2ui7Kg==",
         "dependencies": {
-          "Speckle.Sdk": "3.21.0"
+          "Speckle.Sdk": "2026.6.0"
         }
       }
     }

--- a/Connectors/CSi/Speckle.Connectors.ETABS22/packages.lock.json
+++ b/Connectors/CSi/Speckle.Connectors.ETABS22/packages.lock.json
@@ -139,8 +139,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
+        "resolved": "2026.6.0",
+        "contentHash": "rrbbe+Z8Nql/y0jHod6+B0zRitmHXq+RNw1zZnzY1heLV6NOe/8ntGbMo9JIGTnZ6Bvxg51UxntMiyAYCdvhXg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -148,13 +148,13 @@
           "Microsoft.Extensions.ObjectPool": "8.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.21.0"
+          "Speckle.Sdk.Dependencies": "2026.6.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA=="
+        "resolved": "2026.6.0",
+        "contentHash": "Nb38i5rAXRkEZlN0nkGbYe5Ph88ZBeHLqkcYCGAXolJcE7eDIPfU5hlWd2KcijFOD/E6f6CEdZJ99PinX2+Ejg=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -201,7 +201,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -223,7 +223,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "speckle.converters.etabs22": {
@@ -246,11 +246,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.21.0, )",
-        "resolved": "3.21.0",
-        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
+        "requested": "[2026.6.0, )",
+        "resolved": "2026.6.0",
+        "contentHash": "7rfwSQHjuvwxeEWJ4/dHYlIAoeZ5SdiPCCYFiF/Avz1ACp5KoDwkh0FF/5lvWDk86MoH55m5BwxYLFek2ui7Kg==",
         "dependencies": {
-          "Speckle.Sdk": "3.21.0"
+          "Speckle.Sdk": "2026.6.0"
         }
       }
     }

--- a/Connectors/CSi/Speckle.Connectors.ETABS22/packages.lock.json
+++ b/Connectors/CSi/Speckle.Connectors.ETABS22/packages.lock.json
@@ -139,8 +139,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "jp1fle+rM6l3TtmhTwaWIlZ6HdeR7WYWFwRAxD/iazOFNXp0gWpEwYMe7Z+gBEmd6M91xQwWGAGo03x3D2XJaA==",
+        "resolved": "3.21.0",
+        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -148,13 +148,13 @@
           "Microsoft.Extensions.ObjectPool": "8.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.20.6"
+          "Speckle.Sdk.Dependencies": "3.21.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "DDRzJnBkQuDQbk1Zq76J++sZd63a+aKcY7BiYVDNvjzBSuzhtURe8PQoCfAb1H6WcYL2/K+KytOVvzK/113sGg=="
+        "resolved": "3.21.0",
+        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -201,7 +201,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -223,7 +223,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "speckle.converters.etabs22": {
@@ -246,11 +246,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.20.6, )",
-        "resolved": "3.20.6",
-        "contentHash": "iK+Yl0VUoGzBFuOqP3yrEWQIuQDoISfwbG7vn0jNmEAgwGcRfB9yGlQ0wA4s7IgxbdEfPjhzzcKMBNcPJWkLtw==",
+        "requested": "[3.21.0, )",
+        "resolved": "3.21.0",
+        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.20.6"
+          "Speckle.Sdk": "3.21.0"
         }
       }
     }

--- a/Connectors/CSi/Speckle.Connectors.ETABSShared/HostApp/EtabsSendCollectionManager.cs
+++ b/Connectors/CSi/Speckle.Connectors.ETABSShared/HostApp/EtabsSendCollectionManager.cs
@@ -136,7 +136,7 @@ public class EtabsSendCollectionManager : CsiSendCollectionManager
       return existingCollection;
     }
 
-    var levelCollection = new Collection(level);
+    var levelCollection = new Collection { name = level };
     root.elements.Add(levelCollection);
     CollectionCache[levelKey] = levelCollection;
 
@@ -145,7 +145,7 @@ public class EtabsSendCollectionManager : CsiSendCollectionManager
 
   private Collection CreateCategoryCollection(ElementCategory category, Collection levelCollection)
   {
-    var categoryCollection = new Collection(_categoryNames[category]);
+    var categoryCollection = new Collection { name = _categoryNames[category] };
     levelCollection.elements.Add(categoryCollection);
     return categoryCollection;
   }

--- a/Connectors/Navisworks/Speckle.Connectors.Navisworks2020/packages.lock.json
+++ b/Connectors/Navisworks/Speckle.Connectors.Navisworks2020/packages.lock.json
@@ -180,8 +180,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
+        "resolved": "2026.6.0",
+        "contentHash": "rrbbe+Z8Nql/y0jHod6+B0zRitmHXq+RNw1zZnzY1heLV6NOe/8ntGbMo9JIGTnZ6Bvxg51UxntMiyAYCdvhXg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -191,14 +191,14 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.21.0",
+          "Speckle.Sdk.Dependencies": "2026.6.0",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA==",
+        "resolved": "2026.6.0",
+        "contentHash": "Nb38i5rAXRkEZlN0nkGbYe5Ph88ZBeHLqkcYCGAXolJcE7eDIPfU5hlWd2KcijFOD/E6f6CEdZJ99PinX2+Ejg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
         }
@@ -307,7 +307,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -329,7 +329,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "speckle.converters.navisworks2020": {
@@ -354,11 +354,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.21.0, )",
-        "resolved": "3.21.0",
-        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
+        "requested": "[2026.6.0, )",
+        "resolved": "2026.6.0",
+        "contentHash": "7rfwSQHjuvwxeEWJ4/dHYlIAoeZ5SdiPCCYFiF/Avz1ACp5KoDwkh0FF/5lvWDk86MoH55m5BwxYLFek2ui7Kg==",
         "dependencies": {
-          "Speckle.Sdk": "3.21.0"
+          "Speckle.Sdk": "2026.6.0"
         }
       },
       "System.Text.Json": {

--- a/Connectors/Navisworks/Speckle.Connectors.Navisworks2020/packages.lock.json
+++ b/Connectors/Navisworks/Speckle.Connectors.Navisworks2020/packages.lock.json
@@ -180,8 +180,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "jp1fle+rM6l3TtmhTwaWIlZ6HdeR7WYWFwRAxD/iazOFNXp0gWpEwYMe7Z+gBEmd6M91xQwWGAGo03x3D2XJaA==",
+        "resolved": "3.21.0",
+        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -191,14 +191,14 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.20.6",
+          "Speckle.Sdk.Dependencies": "3.21.0",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "DDRzJnBkQuDQbk1Zq76J++sZd63a+aKcY7BiYVDNvjzBSuzhtURe8PQoCfAb1H6WcYL2/K+KytOVvzK/113sGg==",
+        "resolved": "3.21.0",
+        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
         }
@@ -307,7 +307,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -329,7 +329,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "speckle.converters.navisworks2020": {
@@ -354,11 +354,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.20.6, )",
-        "resolved": "3.20.6",
-        "contentHash": "iK+Yl0VUoGzBFuOqP3yrEWQIuQDoISfwbG7vn0jNmEAgwGcRfB9yGlQ0wA4s7IgxbdEfPjhzzcKMBNcPJWkLtw==",
+        "requested": "[3.21.0, )",
+        "resolved": "3.21.0",
+        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.20.6"
+          "Speckle.Sdk": "3.21.0"
         }
       },
       "System.Text.Json": {

--- a/Connectors/Navisworks/Speckle.Connectors.Navisworks2021/packages.lock.json
+++ b/Connectors/Navisworks/Speckle.Connectors.Navisworks2021/packages.lock.json
@@ -180,8 +180,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
+        "resolved": "2026.6.0",
+        "contentHash": "rrbbe+Z8Nql/y0jHod6+B0zRitmHXq+RNw1zZnzY1heLV6NOe/8ntGbMo9JIGTnZ6Bvxg51UxntMiyAYCdvhXg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -191,14 +191,14 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.21.0",
+          "Speckle.Sdk.Dependencies": "2026.6.0",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA==",
+        "resolved": "2026.6.0",
+        "contentHash": "Nb38i5rAXRkEZlN0nkGbYe5Ph88ZBeHLqkcYCGAXolJcE7eDIPfU5hlWd2KcijFOD/E6f6CEdZJ99PinX2+Ejg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
         }
@@ -307,7 +307,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -329,7 +329,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "speckle.converters.navisworks2021": {
@@ -354,11 +354,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.21.0, )",
-        "resolved": "3.21.0",
-        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
+        "requested": "[2026.6.0, )",
+        "resolved": "2026.6.0",
+        "contentHash": "7rfwSQHjuvwxeEWJ4/dHYlIAoeZ5SdiPCCYFiF/Avz1ACp5KoDwkh0FF/5lvWDk86MoH55m5BwxYLFek2ui7Kg==",
         "dependencies": {
-          "Speckle.Sdk": "3.21.0"
+          "Speckle.Sdk": "2026.6.0"
         }
       },
       "System.Text.Json": {

--- a/Connectors/Navisworks/Speckle.Connectors.Navisworks2021/packages.lock.json
+++ b/Connectors/Navisworks/Speckle.Connectors.Navisworks2021/packages.lock.json
@@ -180,8 +180,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "jp1fle+rM6l3TtmhTwaWIlZ6HdeR7WYWFwRAxD/iazOFNXp0gWpEwYMe7Z+gBEmd6M91xQwWGAGo03x3D2XJaA==",
+        "resolved": "3.21.0",
+        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -191,14 +191,14 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.20.6",
+          "Speckle.Sdk.Dependencies": "3.21.0",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "DDRzJnBkQuDQbk1Zq76J++sZd63a+aKcY7BiYVDNvjzBSuzhtURe8PQoCfAb1H6WcYL2/K+KytOVvzK/113sGg==",
+        "resolved": "3.21.0",
+        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
         }
@@ -307,7 +307,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -329,7 +329,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "speckle.converters.navisworks2021": {
@@ -354,11 +354,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.20.6, )",
-        "resolved": "3.20.6",
-        "contentHash": "iK+Yl0VUoGzBFuOqP3yrEWQIuQDoISfwbG7vn0jNmEAgwGcRfB9yGlQ0wA4s7IgxbdEfPjhzzcKMBNcPJWkLtw==",
+        "requested": "[3.21.0, )",
+        "resolved": "3.21.0",
+        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.20.6"
+          "Speckle.Sdk": "3.21.0"
         }
       },
       "System.Text.Json": {

--- a/Connectors/Navisworks/Speckle.Connectors.Navisworks2022/packages.lock.json
+++ b/Connectors/Navisworks/Speckle.Connectors.Navisworks2022/packages.lock.json
@@ -180,8 +180,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "jp1fle+rM6l3TtmhTwaWIlZ6HdeR7WYWFwRAxD/iazOFNXp0gWpEwYMe7Z+gBEmd6M91xQwWGAGo03x3D2XJaA==",
+        "resolved": "3.21.0",
+        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -191,14 +191,14 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.20.6",
+          "Speckle.Sdk.Dependencies": "3.21.0",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "DDRzJnBkQuDQbk1Zq76J++sZd63a+aKcY7BiYVDNvjzBSuzhtURe8PQoCfAb1H6WcYL2/K+KytOVvzK/113sGg==",
+        "resolved": "3.21.0",
+        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
         }
@@ -307,7 +307,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -329,7 +329,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "speckle.converters.navisworks2022": {
@@ -354,11 +354,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.20.6, )",
-        "resolved": "3.20.6",
-        "contentHash": "iK+Yl0VUoGzBFuOqP3yrEWQIuQDoISfwbG7vn0jNmEAgwGcRfB9yGlQ0wA4s7IgxbdEfPjhzzcKMBNcPJWkLtw==",
+        "requested": "[3.21.0, )",
+        "resolved": "3.21.0",
+        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.20.6"
+          "Speckle.Sdk": "3.21.0"
         }
       },
       "System.Text.Json": {

--- a/Connectors/Navisworks/Speckle.Connectors.Navisworks2022/packages.lock.json
+++ b/Connectors/Navisworks/Speckle.Connectors.Navisworks2022/packages.lock.json
@@ -180,8 +180,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
+        "resolved": "2026.6.0",
+        "contentHash": "rrbbe+Z8Nql/y0jHod6+B0zRitmHXq+RNw1zZnzY1heLV6NOe/8ntGbMo9JIGTnZ6Bvxg51UxntMiyAYCdvhXg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -191,14 +191,14 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.21.0",
+          "Speckle.Sdk.Dependencies": "2026.6.0",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA==",
+        "resolved": "2026.6.0",
+        "contentHash": "Nb38i5rAXRkEZlN0nkGbYe5Ph88ZBeHLqkcYCGAXolJcE7eDIPfU5hlWd2KcijFOD/E6f6CEdZJ99PinX2+Ejg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
         }
@@ -307,7 +307,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -329,7 +329,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "speckle.converters.navisworks2022": {
@@ -354,11 +354,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.21.0, )",
-        "resolved": "3.21.0",
-        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
+        "requested": "[2026.6.0, )",
+        "resolved": "2026.6.0",
+        "contentHash": "7rfwSQHjuvwxeEWJ4/dHYlIAoeZ5SdiPCCYFiF/Avz1ACp5KoDwkh0FF/5lvWDk86MoH55m5BwxYLFek2ui7Kg==",
         "dependencies": {
-          "Speckle.Sdk": "3.21.0"
+          "Speckle.Sdk": "2026.6.0"
         }
       },
       "System.Text.Json": {

--- a/Connectors/Navisworks/Speckle.Connectors.Navisworks2023/packages.lock.json
+++ b/Connectors/Navisworks/Speckle.Connectors.Navisworks2023/packages.lock.json
@@ -180,8 +180,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
+        "resolved": "2026.6.0",
+        "contentHash": "rrbbe+Z8Nql/y0jHod6+B0zRitmHXq+RNw1zZnzY1heLV6NOe/8ntGbMo9JIGTnZ6Bvxg51UxntMiyAYCdvhXg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -191,14 +191,14 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.21.0",
+          "Speckle.Sdk.Dependencies": "2026.6.0",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA==",
+        "resolved": "2026.6.0",
+        "contentHash": "Nb38i5rAXRkEZlN0nkGbYe5Ph88ZBeHLqkcYCGAXolJcE7eDIPfU5hlWd2KcijFOD/E6f6CEdZJ99PinX2+Ejg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
         }
@@ -307,7 +307,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -329,7 +329,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "speckle.converters.navisworks2023": {
@@ -354,11 +354,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.21.0, )",
-        "resolved": "3.21.0",
-        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
+        "requested": "[2026.6.0, )",
+        "resolved": "2026.6.0",
+        "contentHash": "7rfwSQHjuvwxeEWJ4/dHYlIAoeZ5SdiPCCYFiF/Avz1ACp5KoDwkh0FF/5lvWDk86MoH55m5BwxYLFek2ui7Kg==",
         "dependencies": {
-          "Speckle.Sdk": "3.21.0"
+          "Speckle.Sdk": "2026.6.0"
         }
       },
       "System.Text.Json": {

--- a/Connectors/Navisworks/Speckle.Connectors.Navisworks2023/packages.lock.json
+++ b/Connectors/Navisworks/Speckle.Connectors.Navisworks2023/packages.lock.json
@@ -180,8 +180,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "jp1fle+rM6l3TtmhTwaWIlZ6HdeR7WYWFwRAxD/iazOFNXp0gWpEwYMe7Z+gBEmd6M91xQwWGAGo03x3D2XJaA==",
+        "resolved": "3.21.0",
+        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -191,14 +191,14 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.20.6",
+          "Speckle.Sdk.Dependencies": "3.21.0",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "DDRzJnBkQuDQbk1Zq76J++sZd63a+aKcY7BiYVDNvjzBSuzhtURe8PQoCfAb1H6WcYL2/K+KytOVvzK/113sGg==",
+        "resolved": "3.21.0",
+        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
         }
@@ -307,7 +307,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -329,7 +329,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "speckle.converters.navisworks2023": {
@@ -354,11 +354,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.20.6, )",
-        "resolved": "3.20.6",
-        "contentHash": "iK+Yl0VUoGzBFuOqP3yrEWQIuQDoISfwbG7vn0jNmEAgwGcRfB9yGlQ0wA4s7IgxbdEfPjhzzcKMBNcPJWkLtw==",
+        "requested": "[3.21.0, )",
+        "resolved": "3.21.0",
+        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.20.6"
+          "Speckle.Sdk": "3.21.0"
         }
       },
       "System.Text.Json": {

--- a/Connectors/Navisworks/Speckle.Connectors.Navisworks2024/packages.lock.json
+++ b/Connectors/Navisworks/Speckle.Connectors.Navisworks2024/packages.lock.json
@@ -180,8 +180,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
+        "resolved": "2026.6.0",
+        "contentHash": "rrbbe+Z8Nql/y0jHod6+B0zRitmHXq+RNw1zZnzY1heLV6NOe/8ntGbMo9JIGTnZ6Bvxg51UxntMiyAYCdvhXg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -191,14 +191,14 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.21.0",
+          "Speckle.Sdk.Dependencies": "2026.6.0",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA==",
+        "resolved": "2026.6.0",
+        "contentHash": "Nb38i5rAXRkEZlN0nkGbYe5Ph88ZBeHLqkcYCGAXolJcE7eDIPfU5hlWd2KcijFOD/E6f6CEdZJ99PinX2+Ejg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
         }
@@ -307,7 +307,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -329,7 +329,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "speckle.converters.navisworks2024": {
@@ -354,11 +354,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.21.0, )",
-        "resolved": "3.21.0",
-        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
+        "requested": "[2026.6.0, )",
+        "resolved": "2026.6.0",
+        "contentHash": "7rfwSQHjuvwxeEWJ4/dHYlIAoeZ5SdiPCCYFiF/Avz1ACp5KoDwkh0FF/5lvWDk86MoH55m5BwxYLFek2ui7Kg==",
         "dependencies": {
-          "Speckle.Sdk": "3.21.0"
+          "Speckle.Sdk": "2026.6.0"
         }
       },
       "System.Text.Json": {

--- a/Connectors/Navisworks/Speckle.Connectors.Navisworks2024/packages.lock.json
+++ b/Connectors/Navisworks/Speckle.Connectors.Navisworks2024/packages.lock.json
@@ -180,8 +180,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "jp1fle+rM6l3TtmhTwaWIlZ6HdeR7WYWFwRAxD/iazOFNXp0gWpEwYMe7Z+gBEmd6M91xQwWGAGo03x3D2XJaA==",
+        "resolved": "3.21.0",
+        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -191,14 +191,14 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.20.6",
+          "Speckle.Sdk.Dependencies": "3.21.0",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "DDRzJnBkQuDQbk1Zq76J++sZd63a+aKcY7BiYVDNvjzBSuzhtURe8PQoCfAb1H6WcYL2/K+KytOVvzK/113sGg==",
+        "resolved": "3.21.0",
+        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
         }
@@ -307,7 +307,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -329,7 +329,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "speckle.converters.navisworks2024": {
@@ -354,11 +354,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.20.6, )",
-        "resolved": "3.20.6",
-        "contentHash": "iK+Yl0VUoGzBFuOqP3yrEWQIuQDoISfwbG7vn0jNmEAgwGcRfB9yGlQ0wA4s7IgxbdEfPjhzzcKMBNcPJWkLtw==",
+        "requested": "[3.21.0, )",
+        "resolved": "3.21.0",
+        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.20.6"
+          "Speckle.Sdk": "3.21.0"
         }
       },
       "System.Text.Json": {

--- a/Connectors/Navisworks/Speckle.Connectors.Navisworks2025/packages.lock.json
+++ b/Connectors/Navisworks/Speckle.Connectors.Navisworks2025/packages.lock.json
@@ -186,8 +186,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
+        "resolved": "2026.6.0",
+        "contentHash": "rrbbe+Z8Nql/y0jHod6+B0zRitmHXq+RNw1zZnzY1heLV6NOe/8ntGbMo9JIGTnZ6Bvxg51UxntMiyAYCdvhXg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -197,14 +197,14 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.21.0",
+          "Speckle.Sdk.Dependencies": "2026.6.0",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA==",
+        "resolved": "2026.6.0",
+        "contentHash": "Nb38i5rAXRkEZlN0nkGbYe5Ph88ZBeHLqkcYCGAXolJcE7eDIPfU5hlWd2KcijFOD/E6f6CEdZJ99PinX2+Ejg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
         }
@@ -313,7 +313,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -335,7 +335,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "speckle.converters.navisworks2025": {
@@ -354,11 +354,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.21.0, )",
-        "resolved": "3.21.0",
-        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
+        "requested": "[2026.6.0, )",
+        "resolved": "2026.6.0",
+        "contentHash": "7rfwSQHjuvwxeEWJ4/dHYlIAoeZ5SdiPCCYFiF/Avz1ACp5KoDwkh0FF/5lvWDk86MoH55m5BwxYLFek2ui7Kg==",
         "dependencies": {
-          "Speckle.Sdk": "3.21.0"
+          "Speckle.Sdk": "2026.6.0"
         }
       },
       "System.Text.Json": {

--- a/Connectors/Navisworks/Speckle.Connectors.Navisworks2025/packages.lock.json
+++ b/Connectors/Navisworks/Speckle.Connectors.Navisworks2025/packages.lock.json
@@ -186,8 +186,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "jp1fle+rM6l3TtmhTwaWIlZ6HdeR7WYWFwRAxD/iazOFNXp0gWpEwYMe7Z+gBEmd6M91xQwWGAGo03x3D2XJaA==",
+        "resolved": "3.21.0",
+        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -197,14 +197,14 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.20.6",
+          "Speckle.Sdk.Dependencies": "3.21.0",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "DDRzJnBkQuDQbk1Zq76J++sZd63a+aKcY7BiYVDNvjzBSuzhtURe8PQoCfAb1H6WcYL2/K+KytOVvzK/113sGg==",
+        "resolved": "3.21.0",
+        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
         }
@@ -313,7 +313,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -335,7 +335,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "speckle.converters.navisworks2025": {
@@ -354,11 +354,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.20.6, )",
-        "resolved": "3.20.6",
-        "contentHash": "iK+Yl0VUoGzBFuOqP3yrEWQIuQDoISfwbG7vn0jNmEAgwGcRfB9yGlQ0wA4s7IgxbdEfPjhzzcKMBNcPJWkLtw==",
+        "requested": "[3.21.0, )",
+        "resolved": "3.21.0",
+        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.20.6"
+          "Speckle.Sdk": "3.21.0"
         }
       },
       "System.Text.Json": {

--- a/Connectors/Navisworks/Speckle.Connectors.Navisworks2026/packages.lock.json
+++ b/Connectors/Navisworks/Speckle.Connectors.Navisworks2026/packages.lock.json
@@ -195,8 +195,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "jp1fle+rM6l3TtmhTwaWIlZ6HdeR7WYWFwRAxD/iazOFNXp0gWpEwYMe7Z+gBEmd6M91xQwWGAGo03x3D2XJaA==",
+        "resolved": "3.21.0",
+        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -206,14 +206,14 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.20.6",
+          "Speckle.Sdk.Dependencies": "3.21.0",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "DDRzJnBkQuDQbk1Zq76J++sZd63a+aKcY7BiYVDNvjzBSuzhtURe8PQoCfAb1H6WcYL2/K+KytOVvzK/113sGg==",
+        "resolved": "3.21.0",
+        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
         }
@@ -314,7 +314,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -336,7 +336,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "speckle.converters.navisworks2026": {
@@ -356,11 +356,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.20.6, )",
-        "resolved": "3.20.6",
-        "contentHash": "iK+Yl0VUoGzBFuOqP3yrEWQIuQDoISfwbG7vn0jNmEAgwGcRfB9yGlQ0wA4s7IgxbdEfPjhzzcKMBNcPJWkLtw==",
+        "requested": "[3.21.0, )",
+        "resolved": "3.21.0",
+        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.20.6"
+          "Speckle.Sdk": "3.21.0"
         }
       },
       "System.Text.Json": {

--- a/Connectors/Navisworks/Speckle.Connectors.Navisworks2026/packages.lock.json
+++ b/Connectors/Navisworks/Speckle.Connectors.Navisworks2026/packages.lock.json
@@ -195,8 +195,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
+        "resolved": "2026.6.0",
+        "contentHash": "rrbbe+Z8Nql/y0jHod6+B0zRitmHXq+RNw1zZnzY1heLV6NOe/8ntGbMo9JIGTnZ6Bvxg51UxntMiyAYCdvhXg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -206,14 +206,14 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.21.0",
+          "Speckle.Sdk.Dependencies": "2026.6.0",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA==",
+        "resolved": "2026.6.0",
+        "contentHash": "Nb38i5rAXRkEZlN0nkGbYe5Ph88ZBeHLqkcYCGAXolJcE7eDIPfU5hlWd2KcijFOD/E6f6CEdZJ99PinX2+Ejg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
         }
@@ -314,7 +314,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -336,7 +336,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "speckle.converters.navisworks2026": {
@@ -356,11 +356,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.21.0, )",
-        "resolved": "3.21.0",
-        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
+        "requested": "[2026.6.0, )",
+        "resolved": "2026.6.0",
+        "contentHash": "7rfwSQHjuvwxeEWJ4/dHYlIAoeZ5SdiPCCYFiF/Avz1ACp5KoDwkh0FF/5lvWDk86MoH55m5BwxYLFek2ui7Kg==",
         "dependencies": {
-          "Speckle.Sdk": "3.21.0"
+          "Speckle.Sdk": "2026.6.0"
         }
       },
       "System.Text.Json": {

--- a/Connectors/Navisworks/Speckle.Connectors.Navisworks2027/packages.lock.json
+++ b/Connectors/Navisworks/Speckle.Connectors.Navisworks2027/packages.lock.json
@@ -195,8 +195,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
+        "resolved": "2026.6.0",
+        "contentHash": "rrbbe+Z8Nql/y0jHod6+B0zRitmHXq+RNw1zZnzY1heLV6NOe/8ntGbMo9JIGTnZ6Bvxg51UxntMiyAYCdvhXg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -206,14 +206,14 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.21.0",
+          "Speckle.Sdk.Dependencies": "2026.6.0",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA==",
+        "resolved": "2026.6.0",
+        "contentHash": "Nb38i5rAXRkEZlN0nkGbYe5Ph88ZBeHLqkcYCGAXolJcE7eDIPfU5hlWd2KcijFOD/E6f6CEdZJ99PinX2+Ejg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
         }
@@ -314,7 +314,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -336,7 +336,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "speckle.converters.navisworks2027": {
@@ -356,11 +356,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.21.0, )",
-        "resolved": "3.21.0",
-        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
+        "requested": "[2026.6.0, )",
+        "resolved": "2026.6.0",
+        "contentHash": "7rfwSQHjuvwxeEWJ4/dHYlIAoeZ5SdiPCCYFiF/Avz1ACp5KoDwkh0FF/5lvWDk86MoH55m5BwxYLFek2ui7Kg==",
         "dependencies": {
-          "Speckle.Sdk": "3.21.0"
+          "Speckle.Sdk": "2026.6.0"
         }
       },
       "System.Text.Json": {

--- a/Connectors/Navisworks/Speckle.Connectors.Navisworks2027/packages.lock.json
+++ b/Connectors/Navisworks/Speckle.Connectors.Navisworks2027/packages.lock.json
@@ -195,8 +195,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "jp1fle+rM6l3TtmhTwaWIlZ6HdeR7WYWFwRAxD/iazOFNXp0gWpEwYMe7Z+gBEmd6M91xQwWGAGo03x3D2XJaA==",
+        "resolved": "3.21.0",
+        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -206,14 +206,14 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.20.6",
+          "Speckle.Sdk.Dependencies": "3.21.0",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "DDRzJnBkQuDQbk1Zq76J++sZd63a+aKcY7BiYVDNvjzBSuzhtURe8PQoCfAb1H6WcYL2/K+KytOVvzK/113sGg==",
+        "resolved": "3.21.0",
+        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
         }
@@ -314,7 +314,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -336,7 +336,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "speckle.converters.navisworks2027": {
@@ -356,11 +356,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.20.6, )",
-        "resolved": "3.20.6",
-        "contentHash": "iK+Yl0VUoGzBFuOqP3yrEWQIuQDoISfwbG7vn0jNmEAgwGcRfB9yGlQ0wA4s7IgxbdEfPjhzzcKMBNcPJWkLtw==",
+        "requested": "[3.21.0, )",
+        "resolved": "3.21.0",
+        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.20.6"
+          "Speckle.Sdk": "3.21.0"
         }
       },
       "System.Text.Json": {

--- a/Connectors/Revit/Speckle.Connectors.Revit2023/packages.lock.json
+++ b/Connectors/Revit/Speckle.Connectors.Revit2023/packages.lock.json
@@ -202,8 +202,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "jp1fle+rM6l3TtmhTwaWIlZ6HdeR7WYWFwRAxD/iazOFNXp0gWpEwYMe7Z+gBEmd6M91xQwWGAGo03x3D2XJaA==",
+        "resolved": "3.21.0",
+        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -213,14 +213,14 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.20.6",
+          "Speckle.Sdk.Dependencies": "3.21.0",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "DDRzJnBkQuDQbk1Zq76J++sZd63a+aKcY7BiYVDNvjzBSuzhtURe8PQoCfAb1H6WcYL2/K+KytOVvzK/113sGg==",
+        "resolved": "3.21.0",
+        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
         }
@@ -336,7 +336,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -357,7 +357,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "speckle.converters.revit2023": {
@@ -382,11 +382,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.20.6, )",
-        "resolved": "3.20.6",
-        "contentHash": "iK+Yl0VUoGzBFuOqP3yrEWQIuQDoISfwbG7vn0jNmEAgwGcRfB9yGlQ0wA4s7IgxbdEfPjhzzcKMBNcPJWkLtw==",
+        "requested": "[3.21.0, )",
+        "resolved": "3.21.0",
+        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.20.6"
+          "Speckle.Sdk": "3.21.0"
         }
       },
       "Speckle.Revit.API": {

--- a/Connectors/Revit/Speckle.Connectors.Revit2023/packages.lock.json
+++ b/Connectors/Revit/Speckle.Connectors.Revit2023/packages.lock.json
@@ -202,8 +202,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
+        "resolved": "2026.6.0",
+        "contentHash": "rrbbe+Z8Nql/y0jHod6+B0zRitmHXq+RNw1zZnzY1heLV6NOe/8ntGbMo9JIGTnZ6Bvxg51UxntMiyAYCdvhXg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -213,14 +213,14 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.21.0",
+          "Speckle.Sdk.Dependencies": "2026.6.0",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA==",
+        "resolved": "2026.6.0",
+        "contentHash": "Nb38i5rAXRkEZlN0nkGbYe5Ph88ZBeHLqkcYCGAXolJcE7eDIPfU5hlWd2KcijFOD/E6f6CEdZJ99PinX2+Ejg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
         }
@@ -336,7 +336,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -357,7 +357,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "speckle.converters.revit2023": {
@@ -382,11 +382,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.21.0, )",
-        "resolved": "3.21.0",
-        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
+        "requested": "[2026.6.0, )",
+        "resolved": "2026.6.0",
+        "contentHash": "7rfwSQHjuvwxeEWJ4/dHYlIAoeZ5SdiPCCYFiF/Avz1ACp5KoDwkh0FF/5lvWDk86MoH55m5BwxYLFek2ui7Kg==",
         "dependencies": {
-          "Speckle.Sdk": "3.21.0"
+          "Speckle.Sdk": "2026.6.0"
         }
       },
       "Speckle.Revit.API": {

--- a/Connectors/Revit/Speckle.Connectors.Revit2024/packages.lock.json
+++ b/Connectors/Revit/Speckle.Connectors.Revit2024/packages.lock.json
@@ -202,8 +202,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
+        "resolved": "2026.6.0",
+        "contentHash": "rrbbe+Z8Nql/y0jHod6+B0zRitmHXq+RNw1zZnzY1heLV6NOe/8ntGbMo9JIGTnZ6Bvxg51UxntMiyAYCdvhXg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -213,14 +213,14 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.21.0",
+          "Speckle.Sdk.Dependencies": "2026.6.0",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA==",
+        "resolved": "2026.6.0",
+        "contentHash": "Nb38i5rAXRkEZlN0nkGbYe5Ph88ZBeHLqkcYCGAXolJcE7eDIPfU5hlWd2KcijFOD/E6f6CEdZJ99PinX2+Ejg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
         }
@@ -336,7 +336,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -357,7 +357,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "speckle.converters.revit2024": {
@@ -382,11 +382,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.21.0, )",
-        "resolved": "3.21.0",
-        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
+        "requested": "[2026.6.0, )",
+        "resolved": "2026.6.0",
+        "contentHash": "7rfwSQHjuvwxeEWJ4/dHYlIAoeZ5SdiPCCYFiF/Avz1ACp5KoDwkh0FF/5lvWDk86MoH55m5BwxYLFek2ui7Kg==",
         "dependencies": {
-          "Speckle.Sdk": "3.21.0"
+          "Speckle.Sdk": "2026.6.0"
         }
       },
       "Speckle.Revit.API": {

--- a/Connectors/Revit/Speckle.Connectors.Revit2024/packages.lock.json
+++ b/Connectors/Revit/Speckle.Connectors.Revit2024/packages.lock.json
@@ -202,8 +202,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "jp1fle+rM6l3TtmhTwaWIlZ6HdeR7WYWFwRAxD/iazOFNXp0gWpEwYMe7Z+gBEmd6M91xQwWGAGo03x3D2XJaA==",
+        "resolved": "3.21.0",
+        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -213,14 +213,14 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.20.6",
+          "Speckle.Sdk.Dependencies": "3.21.0",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "DDRzJnBkQuDQbk1Zq76J++sZd63a+aKcY7BiYVDNvjzBSuzhtURe8PQoCfAb1H6WcYL2/K+KytOVvzK/113sGg==",
+        "resolved": "3.21.0",
+        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
         }
@@ -336,7 +336,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -357,7 +357,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "speckle.converters.revit2024": {
@@ -382,11 +382,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.20.6, )",
-        "resolved": "3.20.6",
-        "contentHash": "iK+Yl0VUoGzBFuOqP3yrEWQIuQDoISfwbG7vn0jNmEAgwGcRfB9yGlQ0wA4s7IgxbdEfPjhzzcKMBNcPJWkLtw==",
+        "requested": "[3.21.0, )",
+        "resolved": "3.21.0",
+        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.20.6"
+          "Speckle.Sdk": "3.21.0"
         }
       },
       "Speckle.Revit.API": {

--- a/Connectors/Revit/Speckle.Connectors.Revit2025/packages.lock.json
+++ b/Connectors/Revit/Speckle.Connectors.Revit2025/packages.lock.json
@@ -155,8 +155,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "jp1fle+rM6l3TtmhTwaWIlZ6HdeR7WYWFwRAxD/iazOFNXp0gWpEwYMe7Z+gBEmd6M91xQwWGAGo03x3D2XJaA==",
+        "resolved": "3.21.0",
+        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -164,13 +164,13 @@
           "Microsoft.Extensions.ObjectPool": "8.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.20.6"
+          "Speckle.Sdk.Dependencies": "3.21.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "DDRzJnBkQuDQbk1Zq76J++sZd63a+aKcY7BiYVDNvjzBSuzhtURe8PQoCfAb1H6WcYL2/K+KytOVvzK/113sGg=="
+        "resolved": "3.21.0",
+        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -224,7 +224,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -245,7 +245,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "speckle.converters.revit2025": {
@@ -270,11 +270,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.20.6, )",
-        "resolved": "3.20.6",
-        "contentHash": "iK+Yl0VUoGzBFuOqP3yrEWQIuQDoISfwbG7vn0jNmEAgwGcRfB9yGlQ0wA4s7IgxbdEfPjhzzcKMBNcPJWkLtw==",
+        "requested": "[3.21.0, )",
+        "resolved": "3.21.0",
+        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.20.6"
+          "Speckle.Sdk": "3.21.0"
         }
       },
       "Speckle.Revit.API": {

--- a/Connectors/Revit/Speckle.Connectors.Revit2025/packages.lock.json
+++ b/Connectors/Revit/Speckle.Connectors.Revit2025/packages.lock.json
@@ -155,8 +155,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
+        "resolved": "2026.6.0",
+        "contentHash": "rrbbe+Z8Nql/y0jHod6+B0zRitmHXq+RNw1zZnzY1heLV6NOe/8ntGbMo9JIGTnZ6Bvxg51UxntMiyAYCdvhXg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -164,13 +164,13 @@
           "Microsoft.Extensions.ObjectPool": "8.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.21.0"
+          "Speckle.Sdk.Dependencies": "2026.6.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA=="
+        "resolved": "2026.6.0",
+        "contentHash": "Nb38i5rAXRkEZlN0nkGbYe5Ph88ZBeHLqkcYCGAXolJcE7eDIPfU5hlWd2KcijFOD/E6f6CEdZJ99PinX2+Ejg=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -224,7 +224,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -245,7 +245,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "speckle.converters.revit2025": {
@@ -270,11 +270,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.21.0, )",
-        "resolved": "3.21.0",
-        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
+        "requested": "[2026.6.0, )",
+        "resolved": "2026.6.0",
+        "contentHash": "7rfwSQHjuvwxeEWJ4/dHYlIAoeZ5SdiPCCYFiF/Avz1ACp5KoDwkh0FF/5lvWDk86MoH55m5BwxYLFek2ui7Kg==",
         "dependencies": {
-          "Speckle.Sdk": "3.21.0"
+          "Speckle.Sdk": "2026.6.0"
         }
       },
       "Speckle.Revit.API": {

--- a/Connectors/Revit/Speckle.Connectors.Revit2026/packages.lock.json
+++ b/Connectors/Revit/Speckle.Connectors.Revit2026/packages.lock.json
@@ -140,8 +140,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
+        "resolved": "2026.6.0",
+        "contentHash": "rrbbe+Z8Nql/y0jHod6+B0zRitmHXq+RNw1zZnzY1heLV6NOe/8ntGbMo9JIGTnZ6Bvxg51UxntMiyAYCdvhXg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -149,13 +149,13 @@
           "Microsoft.Extensions.ObjectPool": "8.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.21.0"
+          "Speckle.Sdk.Dependencies": "2026.6.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA=="
+        "resolved": "2026.6.0",
+        "contentHash": "Nb38i5rAXRkEZlN0nkGbYe5Ph88ZBeHLqkcYCGAXolJcE7eDIPfU5hlWd2KcijFOD/E6f6CEdZJ99PinX2+Ejg=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -209,7 +209,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -230,7 +230,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "speckle.converters.revit2026": {
@@ -255,11 +255,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.21.0, )",
-        "resolved": "3.21.0",
-        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
+        "requested": "[2026.6.0, )",
+        "resolved": "2026.6.0",
+        "contentHash": "7rfwSQHjuvwxeEWJ4/dHYlIAoeZ5SdiPCCYFiF/Avz1ACp5KoDwkh0FF/5lvWDk86MoH55m5BwxYLFek2ui7Kg==",
         "dependencies": {
-          "Speckle.Sdk": "3.21.0"
+          "Speckle.Sdk": "2026.6.0"
         }
       },
       "Speckle.Revit.API": {

--- a/Connectors/Revit/Speckle.Connectors.Revit2026/packages.lock.json
+++ b/Connectors/Revit/Speckle.Connectors.Revit2026/packages.lock.json
@@ -140,8 +140,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "jp1fle+rM6l3TtmhTwaWIlZ6HdeR7WYWFwRAxD/iazOFNXp0gWpEwYMe7Z+gBEmd6M91xQwWGAGo03x3D2XJaA==",
+        "resolved": "3.21.0",
+        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -149,13 +149,13 @@
           "Microsoft.Extensions.ObjectPool": "8.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.20.6"
+          "Speckle.Sdk.Dependencies": "3.21.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "DDRzJnBkQuDQbk1Zq76J++sZd63a+aKcY7BiYVDNvjzBSuzhtURe8PQoCfAb1H6WcYL2/K+KytOVvzK/113sGg=="
+        "resolved": "3.21.0",
+        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -209,7 +209,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -230,7 +230,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "speckle.converters.revit2026": {
@@ -255,11 +255,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.20.6, )",
-        "resolved": "3.20.6",
-        "contentHash": "iK+Yl0VUoGzBFuOqP3yrEWQIuQDoISfwbG7vn0jNmEAgwGcRfB9yGlQ0wA4s7IgxbdEfPjhzzcKMBNcPJWkLtw==",
+        "requested": "[3.21.0, )",
+        "resolved": "3.21.0",
+        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.20.6"
+          "Speckle.Sdk": "3.21.0"
         }
       },
       "Speckle.Revit.API": {

--- a/Connectors/Revit/Speckle.Connectors.Revit2027/packages.lock.json
+++ b/Connectors/Revit/Speckle.Connectors.Revit2027/packages.lock.json
@@ -140,8 +140,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "jp1fle+rM6l3TtmhTwaWIlZ6HdeR7WYWFwRAxD/iazOFNXp0gWpEwYMe7Z+gBEmd6M91xQwWGAGo03x3D2XJaA==",
+        "resolved": "3.21.0",
+        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
         "dependencies": {
           "GraphQL.Client": "6.1.0",
           "Microsoft.Data.Sqlite": "10.0.0",
@@ -149,13 +149,13 @@
           "Microsoft.Extensions.ObjectPool": "10.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.20.6"
+          "Speckle.Sdk.Dependencies": "3.21.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "DDRzJnBkQuDQbk1Zq76J++sZd63a+aKcY7BiYVDNvjzBSuzhtURe8PQoCfAb1H6WcYL2/K+KytOVvzK/113sGg=="
+        "resolved": "3.21.0",
+        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -201,7 +201,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -222,7 +222,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "speckle.converters.revit2027": {
@@ -247,11 +247,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.20.6, )",
-        "resolved": "3.20.6",
-        "contentHash": "iK+Yl0VUoGzBFuOqP3yrEWQIuQDoISfwbG7vn0jNmEAgwGcRfB9yGlQ0wA4s7IgxbdEfPjhzzcKMBNcPJWkLtw==",
+        "requested": "[3.21.0, )",
+        "resolved": "3.21.0",
+        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.20.6"
+          "Speckle.Sdk": "3.21.0"
         }
       },
       "Speckle.Revit.API": {

--- a/Connectors/Revit/Speckle.Connectors.Revit2027/packages.lock.json
+++ b/Connectors/Revit/Speckle.Connectors.Revit2027/packages.lock.json
@@ -140,8 +140,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
+        "resolved": "2026.6.0",
+        "contentHash": "rrbbe+Z8Nql/y0jHod6+B0zRitmHXq+RNw1zZnzY1heLV6NOe/8ntGbMo9JIGTnZ6Bvxg51UxntMiyAYCdvhXg==",
         "dependencies": {
           "GraphQL.Client": "6.1.0",
           "Microsoft.Data.Sqlite": "10.0.0",
@@ -149,13 +149,13 @@
           "Microsoft.Extensions.ObjectPool": "10.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.21.0"
+          "Speckle.Sdk.Dependencies": "2026.6.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA=="
+        "resolved": "2026.6.0",
+        "contentHash": "Nb38i5rAXRkEZlN0nkGbYe5Ph88ZBeHLqkcYCGAXolJcE7eDIPfU5hlWd2KcijFOD/E6f6CEdZJ99PinX2+Ejg=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -201,7 +201,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -222,7 +222,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "speckle.converters.revit2027": {
@@ -247,11 +247,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.21.0, )",
-        "resolved": "3.21.0",
-        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
+        "requested": "[2026.6.0, )",
+        "resolved": "2026.6.0",
+        "contentHash": "7rfwSQHjuvwxeEWJ4/dHYlIAoeZ5SdiPCCYFiF/Avz1ACp5KoDwkh0FF/5lvWDk86MoH55m5BwxYLFek2ui7Kg==",
         "dependencies": {
-          "Speckle.Sdk": "3.21.0"
+          "Speckle.Sdk": "2026.6.0"
         }
       },
       "Speckle.Revit.API": {

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/SendCollectionManager.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/SendCollectionManager.cs
@@ -59,7 +59,7 @@ public class SendCollectionManager
         // create main model collection if it doesn't exist yet
         if (_mainModelCollection == null)
         {
-          _mainModelCollection = new Collection(rootObject.name);
+          _mainModelCollection = new Collection { name = rootObject.name };
           rootObject.elements.Add(_mainModelCollection);
         }
 
@@ -75,7 +75,7 @@ public class SendCollectionManager
         if (!_linkedModelCollections.TryGetValue(displayName, out Collection? linkedModelCollection))
         {
           // First time seeing this model with this display name
-          linkedModelCollection = new Collection(displayName);
+          linkedModelCollection = new Collection() { name = displayName };
           rootObject.elements.Add(linkedModelCollection);
           _linkedModelCollections[displayName] = linkedModelCollection;
         }
@@ -152,7 +152,7 @@ public class SendCollectionManager
       }
       else
       {
-        childCollection = new Collection(pathItem);
+        childCollection = new Collection { name = pathItem };
         previousCollection.elements.Add(childCollection);
         _collectionCache[flatPathName] = childCollection;
       }

--- a/Connectors/Rhino/Speckle.Connectors.Grasshopper7/packages.lock.json
+++ b/Connectors/Rhino/Speckle.Connectors.Grasshopper7/packages.lock.json
@@ -213,8 +213,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
+        "resolved": "2026.6.0",
+        "contentHash": "rrbbe+Z8Nql/y0jHod6+B0zRitmHXq+RNw1zZnzY1heLV6NOe/8ntGbMo9JIGTnZ6Bvxg51UxntMiyAYCdvhXg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -224,14 +224,14 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.21.0",
+          "Speckle.Sdk.Dependencies": "2026.6.0",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA==",
+        "resolved": "2026.6.0",
+        "contentHash": "Nb38i5rAXRkEZlN0nkGbYe5Ph88ZBeHLqkcYCGAXolJcE7eDIPfU5hlWd2KcijFOD/E6f6CEdZJ99PinX2+Ejg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
         }
@@ -368,7 +368,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "speckle.connectors.logging": {
@@ -377,7 +377,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "speckle.converters.rhino7": {
@@ -395,11 +395,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.21.0, )",
-        "resolved": "3.21.0",
-        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
+        "requested": "[2026.6.0, )",
+        "resolved": "2026.6.0",
+        "contentHash": "7rfwSQHjuvwxeEWJ4/dHYlIAoeZ5SdiPCCYFiF/Avz1ACp5KoDwkh0FF/5lvWDk86MoH55m5BwxYLFek2ui7Kg==",
         "dependencies": {
-          "Speckle.Sdk": "3.21.0"
+          "Speckle.Sdk": "2026.6.0"
         }
       },
       "System.Text.Json": {

--- a/Connectors/Rhino/Speckle.Connectors.Grasshopper7/packages.lock.json
+++ b/Connectors/Rhino/Speckle.Connectors.Grasshopper7/packages.lock.json
@@ -213,8 +213,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "jp1fle+rM6l3TtmhTwaWIlZ6HdeR7WYWFwRAxD/iazOFNXp0gWpEwYMe7Z+gBEmd6M91xQwWGAGo03x3D2XJaA==",
+        "resolved": "3.21.0",
+        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -224,14 +224,14 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.20.6",
+          "Speckle.Sdk.Dependencies": "3.21.0",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "DDRzJnBkQuDQbk1Zq76J++sZd63a+aKcY7BiYVDNvjzBSuzhtURe8PQoCfAb1H6WcYL2/K+KytOVvzK/113sGg==",
+        "resolved": "3.21.0",
+        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
         }
@@ -368,7 +368,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "speckle.connectors.logging": {
@@ -377,7 +377,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "speckle.converters.rhino7": {
@@ -395,11 +395,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.20.6, )",
-        "resolved": "3.20.6",
-        "contentHash": "iK+Yl0VUoGzBFuOqP3yrEWQIuQDoISfwbG7vn0jNmEAgwGcRfB9yGlQ0wA4s7IgxbdEfPjhzzcKMBNcPJWkLtw==",
+        "requested": "[3.21.0, )",
+        "resolved": "3.21.0",
+        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.20.6"
+          "Speckle.Sdk": "3.21.0"
         }
       },
       "System.Text.Json": {

--- a/Connectors/Rhino/Speckle.Connectors.Grasshopper8/packages.lock.json
+++ b/Connectors/Rhino/Speckle.Connectors.Grasshopper8/packages.lock.json
@@ -213,8 +213,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "jp1fle+rM6l3TtmhTwaWIlZ6HdeR7WYWFwRAxD/iazOFNXp0gWpEwYMe7Z+gBEmd6M91xQwWGAGo03x3D2XJaA==",
+        "resolved": "3.21.0",
+        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -224,14 +224,14 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.20.6",
+          "Speckle.Sdk.Dependencies": "3.21.0",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "DDRzJnBkQuDQbk1Zq76J++sZd63a+aKcY7BiYVDNvjzBSuzhtURe8PQoCfAb1H6WcYL2/K+KytOVvzK/113sGg==",
+        "resolved": "3.21.0",
+        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
         }
@@ -368,7 +368,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "speckle.connectors.logging": {
@@ -377,7 +377,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "speckle.converters.rhino8": {
@@ -394,11 +394,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.20.6, )",
-        "resolved": "3.20.6",
-        "contentHash": "iK+Yl0VUoGzBFuOqP3yrEWQIuQDoISfwbG7vn0jNmEAgwGcRfB9yGlQ0wA4s7IgxbdEfPjhzzcKMBNcPJWkLtw==",
+        "requested": "[3.21.0, )",
+        "resolved": "3.21.0",
+        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.20.6"
+          "Speckle.Sdk": "3.21.0"
         }
       },
       "System.Text.Json": {

--- a/Connectors/Rhino/Speckle.Connectors.Grasshopper8/packages.lock.json
+++ b/Connectors/Rhino/Speckle.Connectors.Grasshopper8/packages.lock.json
@@ -213,8 +213,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
+        "resolved": "2026.6.0",
+        "contentHash": "rrbbe+Z8Nql/y0jHod6+B0zRitmHXq+RNw1zZnzY1heLV6NOe/8ntGbMo9JIGTnZ6Bvxg51UxntMiyAYCdvhXg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -224,14 +224,14 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.21.0",
+          "Speckle.Sdk.Dependencies": "2026.6.0",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA==",
+        "resolved": "2026.6.0",
+        "contentHash": "Nb38i5rAXRkEZlN0nkGbYe5Ph88ZBeHLqkcYCGAXolJcE7eDIPfU5hlWd2KcijFOD/E6f6CEdZJ99PinX2+Ejg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
         }
@@ -368,7 +368,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "speckle.connectors.logging": {
@@ -377,7 +377,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "speckle.converters.rhino8": {
@@ -394,11 +394,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.21.0, )",
-        "resolved": "3.21.0",
-        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
+        "requested": "[2026.6.0, )",
+        "resolved": "2026.6.0",
+        "contentHash": "7rfwSQHjuvwxeEWJ4/dHYlIAoeZ5SdiPCCYFiF/Avz1ACp5KoDwkh0FF/5lvWDk86MoH55m5BwxYLFek2ui7Kg==",
         "dependencies": {
-          "Speckle.Sdk": "3.21.0"
+          "Speckle.Sdk": "2026.6.0"
         }
       },
       "System.Text.Json": {

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Collections/CollectionsByName.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Collections/CollectionsByName.cs
@@ -231,7 +231,7 @@ public class CollectionsByName : GH_Component
         // create new child collection
         var newChild = new SpeckleCollectionWrapper
         {
-          Base = new Collection(),
+          Base = new Collection() { name = collectionName },
           Name = collectionName,
           Path = currentPath.ToList(),
           Color = null,

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Collections/CreateCollection.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Collections/CreateCollection.cs
@@ -96,7 +96,7 @@ public class CreateCollection : VariableParameterComponentBase
     var childPath = new List<string> { rootName, inputParam.NickName };
     var childCollection = new SpeckleCollectionWrapper
     {
-      Base = new Collection(),
+      Base = new Collection() { name = inputParam.NickName },
       Name = inputParam.NickName,
       Path = childPath,
       Color = null,

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Send/SendAsyncComponent.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Send/SendAsyncComponent.cs
@@ -313,7 +313,7 @@ public class SendAsyncComponent : GH_AsyncComponent<SendAsyncComponent>
 
       rootBase = new SpeckleCollectionWrapper
       {
-        Base = new Speckle.Sdk.Models.Collections.Collection(),
+        Base = new Speckle.Sdk.Models.Collections.Collection() { name = docName },
         Path = [docName],
         Color = null,
         Material = null,

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Send/SendComponent.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Send/SendComponent.cs
@@ -139,7 +139,7 @@ public class SendComponent : SpeckleTaskCapableComponent<SendComponentInput, Sen
 
       rootBase = new SpeckleCollectionWrapper
       {
-        Base = new Collection(),
+        Base = new Collection { name = docName },
         Name = docName,
         Path = [docName],
         Color = null,

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/HostApp/CollectionHelpers.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/HostApp/CollectionHelpers.cs
@@ -14,7 +14,7 @@ public static class CollectionHelpers
   public static SpeckleCollectionWrapper CreateRootCollection(string instanceGuid) =>
     new SpeckleCollectionWrapper
     {
-      Base = new Collection(),
+      Base = new Collection() { name = "Unnamed" },
       Name = "Unnamed",
       Path = new List<string> { "Unnamed" },
       Color = null,

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Operations/Receive/GrasshopperCollectionRebuilder.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Operations/Receive/GrasshopperCollectionRebuilder.cs
@@ -15,7 +15,7 @@ internal sealed class GrasshopperCollectionRebuilder
   {
     RootCollectionWrapper = new SpeckleCollectionWrapper()
     {
-      Base = new Collection(),
+      Base = new Collection { name = baseCollection.name },
       Name = baseCollection.name,
       Color = null,
       Material = null,
@@ -67,7 +67,7 @@ internal sealed class GrasshopperCollectionRebuilder
       // create and cache if needed
       SpeckleCollectionWrapper newSpeckleCollectionWrapper = new()
       {
-        Base = new Collection(),
+        Base = new Collection { name = collectionName },
         Name = collectionName,
         ApplicationId = collection.applicationId,
         Path = currentLayerPath,

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Operations/Send/GrasshopperContinuousTraversalBuilder.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Operations/Send/GrasshopperContinuousTraversalBuilder.cs
@@ -30,8 +30,9 @@ public class GrasshopperContinuousTraversalBuilder(
     // create root collection
     var rootCollectionGoo = (SpeckleRootCollectionWrapperGoo)objects[0].Duplicate();
     rootCollectionGoo.Value.Name = "Grasshopper Model";
-    RootCollection rootCollection = new(rootCollectionGoo.Value.Name)
+    RootCollection rootCollection = new()
     {
+      name = rootCollectionGoo.Value.Name,
       applicationId = rootCollectionGoo.Value.ApplicationId,
       properties = rootCollectionGoo.Value.Properties ?? new(),
     };

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Operations/Send/GrasshopperSendOperation.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Operations/Send/GrasshopperSendOperation.cs
@@ -39,8 +39,9 @@ public class GrasshopperRootObjectBuilder : IRootObjectBuilder<SpeckleCollection
     // create root collection
     var rootCollectionGoo = (SpeckleRootCollectionWrapperGoo)input[0].Duplicate();
     rootCollectionGoo.Value.Name = "Grasshopper Model";
-    RootCollection rootCollection = new(rootCollectionGoo.Value.Name)
+    RootCollection rootCollection = new()
     {
+      name = rootCollectionGoo.Value.Name,
       applicationId = rootCollectionGoo.Value.ApplicationId,
       properties = rootCollectionGoo.Value.Properties ?? new(),
     };

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/Wrappers/SpeckleCollectionWrapper.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/Wrappers/SpeckleCollectionWrapper.cs
@@ -165,7 +165,12 @@ public class SpeckleCollectionWrapper : SpeckleWrapper, ISpeckleCollectionObject
   public SpeckleCollectionWrapper DeepCopy() =>
     new()
     {
-      Base = new Collection(Collection.name) { applicationId = Collection.applicationId, id = Collection.id },
+      Base = new Collection
+      {
+        name = Collection.name,
+        applicationId = Collection.applicationId,
+        id = Collection.id,
+      },
       Color = Color,
       Material = Material,
       ApplicationId = ApplicationId,

--- a/Connectors/Rhino/Speckle.Connectors.Rhino7/packages.lock.json
+++ b/Connectors/Rhino/Speckle.Connectors.Rhino7/packages.lock.json
@@ -194,8 +194,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
+        "resolved": "2026.6.0",
+        "contentHash": "rrbbe+Z8Nql/y0jHod6+B0zRitmHXq+RNw1zZnzY1heLV6NOe/8ntGbMo9JIGTnZ6Bvxg51UxntMiyAYCdvhXg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -205,14 +205,14 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.21.0",
+          "Speckle.Sdk.Dependencies": "2026.6.0",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA==",
+        "resolved": "2026.6.0",
+        "contentHash": "Nb38i5rAXRkEZlN0nkGbYe5Ph88ZBeHLqkcYCGAXolJcE7eDIPfU5hlWd2KcijFOD/E6f6CEdZJ99PinX2+Ejg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
         }
@@ -349,7 +349,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -380,7 +380,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "speckle.converters.rhino7": {
@@ -413,11 +413,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.21.0, )",
-        "resolved": "3.21.0",
-        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
+        "requested": "[2026.6.0, )",
+        "resolved": "2026.6.0",
+        "contentHash": "7rfwSQHjuvwxeEWJ4/dHYlIAoeZ5SdiPCCYFiF/Avz1ACp5KoDwkh0FF/5lvWDk86MoH55m5BwxYLFek2ui7Kg==",
         "dependencies": {
-          "Speckle.Sdk": "3.21.0"
+          "Speckle.Sdk": "2026.6.0"
         }
       },
       "System.Resources.Extensions": {

--- a/Connectors/Rhino/Speckle.Connectors.Rhino7/packages.lock.json
+++ b/Connectors/Rhino/Speckle.Connectors.Rhino7/packages.lock.json
@@ -194,8 +194,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "jp1fle+rM6l3TtmhTwaWIlZ6HdeR7WYWFwRAxD/iazOFNXp0gWpEwYMe7Z+gBEmd6M91xQwWGAGo03x3D2XJaA==",
+        "resolved": "3.21.0",
+        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -205,14 +205,14 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.20.6",
+          "Speckle.Sdk.Dependencies": "3.21.0",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "DDRzJnBkQuDQbk1Zq76J++sZd63a+aKcY7BiYVDNvjzBSuzhtURe8PQoCfAb1H6WcYL2/K+KytOVvzK/113sGg==",
+        "resolved": "3.21.0",
+        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
         }
@@ -349,7 +349,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -380,7 +380,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "speckle.converters.rhino7": {
@@ -413,11 +413,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.20.6, )",
-        "resolved": "3.20.6",
-        "contentHash": "iK+Yl0VUoGzBFuOqP3yrEWQIuQDoISfwbG7vn0jNmEAgwGcRfB9yGlQ0wA4s7IgxbdEfPjhzzcKMBNcPJWkLtw==",
+        "requested": "[3.21.0, )",
+        "resolved": "3.21.0",
+        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.20.6"
+          "Speckle.Sdk": "3.21.0"
         }
       },
       "System.Resources.Extensions": {

--- a/Connectors/Rhino/Speckle.Connectors.Rhino8/packages.lock.json
+++ b/Connectors/Rhino/Speckle.Connectors.Rhino8/packages.lock.json
@@ -210,8 +210,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
+        "resolved": "2026.6.0",
+        "contentHash": "rrbbe+Z8Nql/y0jHod6+B0zRitmHXq+RNw1zZnzY1heLV6NOe/8ntGbMo9JIGTnZ6Bvxg51UxntMiyAYCdvhXg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -221,14 +221,14 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.21.0",
+          "Speckle.Sdk.Dependencies": "2026.6.0",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA==",
+        "resolved": "2026.6.0",
+        "contentHash": "Nb38i5rAXRkEZlN0nkGbYe5Ph88ZBeHLqkcYCGAXolJcE7eDIPfU5hlWd2KcijFOD/E6f6CEdZJ99PinX2+Ejg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
         }
@@ -366,7 +366,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -397,7 +397,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "speckle.converters.rhino8": {
@@ -429,11 +429,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.21.0, )",
-        "resolved": "3.21.0",
-        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
+        "requested": "[2026.6.0, )",
+        "resolved": "2026.6.0",
+        "contentHash": "7rfwSQHjuvwxeEWJ4/dHYlIAoeZ5SdiPCCYFiF/Avz1ACp5KoDwkh0FF/5lvWDk86MoH55m5BwxYLFek2ui7Kg==",
         "dependencies": {
-          "Speckle.Sdk": "3.21.0"
+          "Speckle.Sdk": "2026.6.0"
         }
       },
       "System.Resources.Extensions": {

--- a/Connectors/Rhino/Speckle.Connectors.Rhino8/packages.lock.json
+++ b/Connectors/Rhino/Speckle.Connectors.Rhino8/packages.lock.json
@@ -210,8 +210,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "jp1fle+rM6l3TtmhTwaWIlZ6HdeR7WYWFwRAxD/iazOFNXp0gWpEwYMe7Z+gBEmd6M91xQwWGAGo03x3D2XJaA==",
+        "resolved": "3.21.0",
+        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -221,14 +221,14 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.20.6",
+          "Speckle.Sdk.Dependencies": "3.21.0",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "DDRzJnBkQuDQbk1Zq76J++sZd63a+aKcY7BiYVDNvjzBSuzhtURe8PQoCfAb1H6WcYL2/K+KytOVvzK/113sGg==",
+        "resolved": "3.21.0",
+        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
         }
@@ -366,7 +366,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -397,7 +397,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "speckle.converters.rhino8": {
@@ -429,11 +429,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.20.6, )",
-        "resolved": "3.20.6",
-        "contentHash": "iK+Yl0VUoGzBFuOqP3yrEWQIuQDoISfwbG7vn0jNmEAgwGcRfB9yGlQ0wA4s7IgxbdEfPjhzzcKMBNcPJWkLtw==",
+        "requested": "[3.21.0, )",
+        "resolved": "3.21.0",
+        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.20.6"
+          "Speckle.Sdk": "3.21.0"
         }
       },
       "System.Resources.Extensions": {

--- a/Connectors/Rhino/Speckle.Connectors.RhinoImporter/packages.lock.json
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoImporter/packages.lock.json
@@ -19,20 +19,20 @@
       },
       "RhinoCommon": {
         "type": "Direct",
-        "requested": "[8.28.26041.11001, )",
-        "resolved": "8.28.26041.11001",
-        "contentHash": "5mByZF+IdHvRLbYvr6Ek95Pwam6otewAyVHIGSC0sUE1+OscSpd9gbrFWnzo1arfCYmUJcUdsGhf7VayW09fQA==",
+        "requested": "[8.31.26126.13431, )",
+        "resolved": "8.31.26126.13431",
+        "contentHash": "fEsA70P6K7oQxQKZ/TytKqZ7EWLa2l8394oHosSFabRJ1rJnT6Q/NsNVhtlmAWuAaOBDDDKLc46kqo0WnsOxJA==",
         "dependencies": {
           "System.Drawing.Common": "7.0.0"
         }
       },
       "RhinoWindows": {
         "type": "Direct",
-        "requested": "[8.28.26041.11001, )",
-        "resolved": "8.28.26041.11001",
-        "contentHash": "7MBG231k5c0/V/USTzbXpaTCiZCECQOuB80DnpgEvvEA3r//IQQDTbrqawDYmN9BEw/FHiFn82bsf6tV+SS5Iw==",
+        "requested": "[8.31.26126.13431, )",
+        "resolved": "8.31.26126.13431",
+        "contentHash": "KeteDrHWbzwHwJZnwYmhuT0bYed7NHPb4Fvgw6DxfPNUBK4WuYClA2M5uOpGE7Lbn8K593MrTb5ksz4ASK2VQw==",
         "dependencies": {
-          "RhinoCommon": "[8.28.26041.11001]"
+          "RhinoCommon": "[8.31.26126.13431]"
         }
       },
       "Speckle.InterfaceGenerator": {

--- a/Connectors/Rhino/Speckle.Connectors.RhinoImporter/packages.lock.json
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoImporter/packages.lock.json
@@ -156,8 +156,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "jp1fle+rM6l3TtmhTwaWIlZ6HdeR7WYWFwRAxD/iazOFNXp0gWpEwYMe7Z+gBEmd6M91xQwWGAGo03x3D2XJaA==",
+        "resolved": "3.21.0",
+        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -165,13 +165,13 @@
           "Microsoft.Extensions.ObjectPool": "8.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.20.6"
+          "Speckle.Sdk.Dependencies": "3.21.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "DDRzJnBkQuDQbk1Zq76J++sZd63a+aKcY7BiYVDNvjzBSuzhtURe8PQoCfAb1H6WcYL2/K+KytOVvzK/113sGg=="
+        "resolved": "3.21.0",
+        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -226,7 +226,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -248,7 +248,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "speckle.converters.rhino8": {
@@ -271,11 +271,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.20.6, )",
-        "resolved": "3.20.6",
-        "contentHash": "iK+Yl0VUoGzBFuOqP3yrEWQIuQDoISfwbG7vn0jNmEAgwGcRfB9yGlQ0wA4s7IgxbdEfPjhzzcKMBNcPJWkLtw==",
+        "requested": "[3.21.0, )",
+        "resolved": "3.21.0",
+        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.20.6"
+          "Speckle.Sdk": "3.21.0"
         }
       }
     },

--- a/Connectors/Rhino/Speckle.Connectors.RhinoImporter/packages.lock.json
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoImporter/packages.lock.json
@@ -156,8 +156,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
+        "resolved": "2026.6.0",
+        "contentHash": "rrbbe+Z8Nql/y0jHod6+B0zRitmHXq+RNw1zZnzY1heLV6NOe/8ntGbMo9JIGTnZ6Bvxg51UxntMiyAYCdvhXg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -165,13 +165,13 @@
           "Microsoft.Extensions.ObjectPool": "8.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.21.0"
+          "Speckle.Sdk.Dependencies": "2026.6.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA=="
+        "resolved": "2026.6.0",
+        "contentHash": "Nb38i5rAXRkEZlN0nkGbYe5Ph88ZBeHLqkcYCGAXolJcE7eDIPfU5hlWd2KcijFOD/E6f6CEdZJ99PinX2+Ejg=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -226,7 +226,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -248,7 +248,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "speckle.converters.rhino8": {
@@ -271,11 +271,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.21.0, )",
-        "resolved": "3.21.0",
-        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
+        "requested": "[2026.6.0, )",
+        "resolved": "2026.6.0",
+        "contentHash": "7rfwSQHjuvwxeEWJ4/dHYlIAoeZ5SdiPCCYFiF/Avz1ACp5KoDwkh0FF/5lvWDk86MoH55m5BwxYLFek2ui7Kg==",
         "dependencies": {
-          "Speckle.Sdk": "3.21.0"
+          "Speckle.Sdk": "2026.6.0"
         }
       }
     },

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/HostApp/RhinoLayerUnpacker.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/HostApp/RhinoLayerUnpacker.cs
@@ -83,8 +83,9 @@ public class RhinoLayerUnpacker
       }
       else
       {
-        childCollection = new SpeckleLayer(layerName)
+        childCollection = new SpeckleLayer()
         {
+          name = layerName,
           applicationId = RhinoDoc.ActiveDoc.Layers[existingLayerIndex].Id.ToString(),
         };
 

--- a/Connectors/TSD/Speckle.Connectors.TSD2027/packages.lock.json
+++ b/Connectors/TSD/Speckle.Connectors.TSD2027/packages.lock.json
@@ -171,8 +171,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
+        "resolved": "2026.6.0",
+        "contentHash": "rrbbe+Z8Nql/y0jHod6+B0zRitmHXq+RNw1zZnzY1heLV6NOe/8ntGbMo9JIGTnZ6Bvxg51UxntMiyAYCdvhXg==",
         "dependencies": {
           "GraphQL.Client": "6.1.0",
           "Microsoft.Data.Sqlite": "10.0.0",
@@ -180,13 +180,13 @@
           "Microsoft.Extensions.ObjectPool": "10.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.21.0"
+          "Speckle.Sdk.Dependencies": "2026.6.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA=="
+        "resolved": "2026.6.0",
+        "contentHash": "Nb38i5rAXRkEZlN0nkGbYe5Ph88ZBeHLqkcYCGAXolJcE7eDIPfU5hlWd2KcijFOD/E6f6CEdZJ99PinX2+Ejg=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -232,7 +232,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -254,7 +254,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "speckle.converters.tsd2027": {
@@ -284,11 +284,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.21.0, )",
-        "resolved": "3.21.0",
-        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
+        "requested": "[2026.6.0, )",
+        "resolved": "2026.6.0",
+        "contentHash": "7rfwSQHjuvwxeEWJ4/dHYlIAoeZ5SdiPCCYFiF/Avz1ACp5KoDwkh0FF/5lvWDk86MoH55m5BwxYLFek2ui7Kg==",
         "dependencies": {
-          "Speckle.Sdk": "3.21.0"
+          "Speckle.Sdk": "2026.6.0"
         }
       }
     }

--- a/Connectors/TSD/Speckle.Connectors.TSD2027/packages.lock.json
+++ b/Connectors/TSD/Speckle.Connectors.TSD2027/packages.lock.json
@@ -171,8 +171,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "jp1fle+rM6l3TtmhTwaWIlZ6HdeR7WYWFwRAxD/iazOFNXp0gWpEwYMe7Z+gBEmd6M91xQwWGAGo03x3D2XJaA==",
+        "resolved": "3.21.0",
+        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
         "dependencies": {
           "GraphQL.Client": "6.1.0",
           "Microsoft.Data.Sqlite": "10.0.0",
@@ -180,13 +180,13 @@
           "Microsoft.Extensions.ObjectPool": "10.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.20.6"
+          "Speckle.Sdk.Dependencies": "3.21.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "DDRzJnBkQuDQbk1Zq76J++sZd63a+aKcY7BiYVDNvjzBSuzhtURe8PQoCfAb1H6WcYL2/K+KytOVvzK/113sGg=="
+        "resolved": "3.21.0",
+        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -225,7 +225,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -247,7 +247,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "Microsoft.Web.WebView2": {
@@ -264,11 +264,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.20.6, )",
-        "resolved": "3.20.6",
-        "contentHash": "iK+Yl0VUoGzBFuOqP3yrEWQIuQDoISfwbG7vn0jNmEAgwGcRfB9yGlQ0wA4s7IgxbdEfPjhzzcKMBNcPJWkLtw==",
+        "requested": "[3.21.0, )",
+        "resolved": "3.21.0",
+        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.20.6"
+          "Speckle.Sdk": "3.21.0"
         }
       }
     }

--- a/Connectors/Tekla/Speckle.Connector.Tekla2023/packages.lock.json
+++ b/Connectors/Tekla/Speckle.Connector.Tekla2023/packages.lock.json
@@ -234,8 +234,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "jp1fle+rM6l3TtmhTwaWIlZ6HdeR7WYWFwRAxD/iazOFNXp0gWpEwYMe7Z+gBEmd6M91xQwWGAGo03x3D2XJaA==",
+        "resolved": "3.21.0",
+        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -245,14 +245,14 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.20.6",
+          "Speckle.Sdk.Dependencies": "3.21.0",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "DDRzJnBkQuDQbk1Zq76J++sZd63a+aKcY7BiYVDNvjzBSuzhtURe8PQoCfAb1H6WcYL2/K+KytOVvzK/113sGg==",
+        "resolved": "3.21.0",
+        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
         }
@@ -389,7 +389,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -420,7 +420,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "LibTessDotNet": {
@@ -443,11 +443,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.20.6, )",
-        "resolved": "3.20.6",
-        "contentHash": "iK+Yl0VUoGzBFuOqP3yrEWQIuQDoISfwbG7vn0jNmEAgwGcRfB9yGlQ0wA4s7IgxbdEfPjhzzcKMBNcPJWkLtw==",
+        "requested": "[3.21.0, )",
+        "resolved": "3.21.0",
+        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.20.6"
+          "Speckle.Sdk": "3.21.0"
         }
       }
     }

--- a/Connectors/Tekla/Speckle.Connector.Tekla2023/packages.lock.json
+++ b/Connectors/Tekla/Speckle.Connector.Tekla2023/packages.lock.json
@@ -234,8 +234,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
+        "resolved": "2026.6.0",
+        "contentHash": "rrbbe+Z8Nql/y0jHod6+B0zRitmHXq+RNw1zZnzY1heLV6NOe/8ntGbMo9JIGTnZ6Bvxg51UxntMiyAYCdvhXg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -245,14 +245,14 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.21.0",
+          "Speckle.Sdk.Dependencies": "2026.6.0",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA==",
+        "resolved": "2026.6.0",
+        "contentHash": "Nb38i5rAXRkEZlN0nkGbYe5Ph88ZBeHLqkcYCGAXolJcE7eDIPfU5hlWd2KcijFOD/E6f6CEdZJ99PinX2+Ejg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
         }
@@ -389,7 +389,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -420,7 +420,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "LibTessDotNet": {
@@ -443,11 +443,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.21.0, )",
-        "resolved": "3.21.0",
-        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
+        "requested": "[2026.6.0, )",
+        "resolved": "2026.6.0",
+        "contentHash": "7rfwSQHjuvwxeEWJ4/dHYlIAoeZ5SdiPCCYFiF/Avz1ACp5KoDwkh0FF/5lvWDk86MoH55m5BwxYLFek2ui7Kg==",
         "dependencies": {
-          "Speckle.Sdk": "3.21.0"
+          "Speckle.Sdk": "2026.6.0"
         }
       }
     }

--- a/Connectors/Tekla/Speckle.Connector.Tekla2024/packages.lock.json
+++ b/Connectors/Tekla/Speckle.Connector.Tekla2024/packages.lock.json
@@ -253,8 +253,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
+        "resolved": "2026.6.0",
+        "contentHash": "rrbbe+Z8Nql/y0jHod6+B0zRitmHXq+RNw1zZnzY1heLV6NOe/8ntGbMo9JIGTnZ6Bvxg51UxntMiyAYCdvhXg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -264,14 +264,14 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.21.0",
+          "Speckle.Sdk.Dependencies": "2026.6.0",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA==",
+        "resolved": "2026.6.0",
+        "contentHash": "Nb38i5rAXRkEZlN0nkGbYe5Ph88ZBeHLqkcYCGAXolJcE7eDIPfU5hlWd2KcijFOD/E6f6CEdZJ99PinX2+Ejg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
         }
@@ -470,7 +470,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -501,7 +501,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "LibTessDotNet": {
@@ -524,11 +524,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.21.0, )",
-        "resolved": "3.21.0",
-        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
+        "requested": "[2026.6.0, )",
+        "resolved": "2026.6.0",
+        "contentHash": "7rfwSQHjuvwxeEWJ4/dHYlIAoeZ5SdiPCCYFiF/Avz1ACp5KoDwkh0FF/5lvWDk86MoH55m5BwxYLFek2ui7Kg==",
         "dependencies": {
-          "Speckle.Sdk": "3.21.0"
+          "Speckle.Sdk": "2026.6.0"
         }
       }
     }

--- a/Connectors/Tekla/Speckle.Connector.Tekla2024/packages.lock.json
+++ b/Connectors/Tekla/Speckle.Connector.Tekla2024/packages.lock.json
@@ -253,8 +253,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "jp1fle+rM6l3TtmhTwaWIlZ6HdeR7WYWFwRAxD/iazOFNXp0gWpEwYMe7Z+gBEmd6M91xQwWGAGo03x3D2XJaA==",
+        "resolved": "3.21.0",
+        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -264,14 +264,14 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.20.6",
+          "Speckle.Sdk.Dependencies": "3.21.0",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "DDRzJnBkQuDQbk1Zq76J++sZd63a+aKcY7BiYVDNvjzBSuzhtURe8PQoCfAb1H6WcYL2/K+KytOVvzK/113sGg==",
+        "resolved": "3.21.0",
+        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
         }
@@ -470,7 +470,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -501,7 +501,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "LibTessDotNet": {
@@ -524,11 +524,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.20.6, )",
-        "resolved": "3.20.6",
-        "contentHash": "iK+Yl0VUoGzBFuOqP3yrEWQIuQDoISfwbG7vn0jNmEAgwGcRfB9yGlQ0wA4s7IgxbdEfPjhzzcKMBNcPJWkLtw==",
+        "requested": "[3.21.0, )",
+        "resolved": "3.21.0",
+        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.20.6"
+          "Speckle.Sdk": "3.21.0"
         }
       }
     }

--- a/Connectors/Tekla/Speckle.Connector.Tekla2025/packages.lock.json
+++ b/Connectors/Tekla/Speckle.Connector.Tekla2025/packages.lock.json
@@ -253,8 +253,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
+        "resolved": "2026.6.0",
+        "contentHash": "rrbbe+Z8Nql/y0jHod6+B0zRitmHXq+RNw1zZnzY1heLV6NOe/8ntGbMo9JIGTnZ6Bvxg51UxntMiyAYCdvhXg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -264,14 +264,14 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.21.0",
+          "Speckle.Sdk.Dependencies": "2026.6.0",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA==",
+        "resolved": "2026.6.0",
+        "contentHash": "Nb38i5rAXRkEZlN0nkGbYe5Ph88ZBeHLqkcYCGAXolJcE7eDIPfU5hlWd2KcijFOD/E6f6CEdZJ99PinX2+Ejg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
         }
@@ -470,7 +470,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -501,7 +501,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "LibTessDotNet": {
@@ -524,11 +524,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.21.0, )",
-        "resolved": "3.21.0",
-        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
+        "requested": "[2026.6.0, )",
+        "resolved": "2026.6.0",
+        "contentHash": "7rfwSQHjuvwxeEWJ4/dHYlIAoeZ5SdiPCCYFiF/Avz1ACp5KoDwkh0FF/5lvWDk86MoH55m5BwxYLFek2ui7Kg==",
         "dependencies": {
-          "Speckle.Sdk": "3.21.0"
+          "Speckle.Sdk": "2026.6.0"
         }
       }
     }

--- a/Connectors/Tekla/Speckle.Connector.Tekla2025/packages.lock.json
+++ b/Connectors/Tekla/Speckle.Connector.Tekla2025/packages.lock.json
@@ -253,8 +253,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "jp1fle+rM6l3TtmhTwaWIlZ6HdeR7WYWFwRAxD/iazOFNXp0gWpEwYMe7Z+gBEmd6M91xQwWGAGo03x3D2XJaA==",
+        "resolved": "3.21.0",
+        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -264,14 +264,14 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.20.6",
+          "Speckle.Sdk.Dependencies": "3.21.0",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "DDRzJnBkQuDQbk1Zq76J++sZd63a+aKcY7BiYVDNvjzBSuzhtURe8PQoCfAb1H6WcYL2/K+KytOVvzK/113sGg==",
+        "resolved": "3.21.0",
+        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
         }
@@ -470,7 +470,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -501,7 +501,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "LibTessDotNet": {
@@ -524,11 +524,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.20.6, )",
-        "resolved": "3.20.6",
-        "contentHash": "iK+Yl0VUoGzBFuOqP3yrEWQIuQDoISfwbG7vn0jNmEAgwGcRfB9yGlQ0wA4s7IgxbdEfPjhzzcKMBNcPJWkLtw==",
+        "requested": "[3.21.0, )",
+        "resolved": "3.21.0",
+        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.20.6"
+          "Speckle.Sdk": "3.21.0"
         }
       }
     }

--- a/Connectors/Tekla/Speckle.Connector.TeklaShared/HostApp/SendCollectionManager.cs
+++ b/Connectors/Tekla/Speckle.Connector.TeklaShared/HostApp/SendCollectionManager.cs
@@ -22,7 +22,7 @@ public class SendCollectionManager
     // NOTE: As this point, we need to create a suitable collection
     // This would be done using a recursive approach to see where to add collection
     // However, since data structure is flat, this returns quick (Ref: Revit ;) )
-    Collection childCollection = new(path);
+    Collection childCollection = new() { name = path };
     rootObject.elements.Add(childCollection);
     _collectionCache[path] = childCollection;
 

--- a/Converters/Autocad/Speckle.Converters.Autocad2023/packages.lock.json
+++ b/Converters/Autocad/Speckle.Converters.Autocad2023/packages.lock.json
@@ -180,8 +180,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "jp1fle+rM6l3TtmhTwaWIlZ6HdeR7WYWFwRAxD/iazOFNXp0gWpEwYMe7Z+gBEmd6M91xQwWGAGo03x3D2XJaA==",
+        "resolved": "3.21.0",
+        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -191,14 +191,14 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.20.6",
+          "Speckle.Sdk.Dependencies": "3.21.0",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "DDRzJnBkQuDQbk1Zq76J++sZd63a+aKcY7BiYVDNvjzBSuzhtURe8PQoCfAb1H6WcYL2/K+KytOVvzK/113sGg==",
+        "resolved": "3.21.0",
+        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
         }
@@ -305,7 +305,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "Speckle.DoubleNumerics": {
@@ -316,11 +316,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.20.6, )",
-        "resolved": "3.20.6",
-        "contentHash": "iK+Yl0VUoGzBFuOqP3yrEWQIuQDoISfwbG7vn0jNmEAgwGcRfB9yGlQ0wA4s7IgxbdEfPjhzzcKMBNcPJWkLtw==",
+        "requested": "[3.21.0, )",
+        "resolved": "3.21.0",
+        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.20.6"
+          "Speckle.Sdk": "3.21.0"
         }
       },
       "System.Text.Json": {

--- a/Converters/Autocad/Speckle.Converters.Autocad2023/packages.lock.json
+++ b/Converters/Autocad/Speckle.Converters.Autocad2023/packages.lock.json
@@ -180,8 +180,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
+        "resolved": "2026.6.0",
+        "contentHash": "rrbbe+Z8Nql/y0jHod6+B0zRitmHXq+RNw1zZnzY1heLV6NOe/8ntGbMo9JIGTnZ6Bvxg51UxntMiyAYCdvhXg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -191,14 +191,14 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.21.0",
+          "Speckle.Sdk.Dependencies": "2026.6.0",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA==",
+        "resolved": "2026.6.0",
+        "contentHash": "Nb38i5rAXRkEZlN0nkGbYe5Ph88ZBeHLqkcYCGAXolJcE7eDIPfU5hlWd2KcijFOD/E6f6CEdZJ99PinX2+Ejg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
         }
@@ -305,7 +305,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "Speckle.DoubleNumerics": {
@@ -316,11 +316,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.21.0, )",
-        "resolved": "3.21.0",
-        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
+        "requested": "[2026.6.0, )",
+        "resolved": "2026.6.0",
+        "contentHash": "7rfwSQHjuvwxeEWJ4/dHYlIAoeZ5SdiPCCYFiF/Avz1ACp5KoDwkh0FF/5lvWDk86MoH55m5BwxYLFek2ui7Kg==",
         "dependencies": {
-          "Speckle.Sdk": "3.21.0"
+          "Speckle.Sdk": "2026.6.0"
         }
       },
       "System.Text.Json": {

--- a/Converters/Autocad/Speckle.Converters.Autocad2024/packages.lock.json
+++ b/Converters/Autocad/Speckle.Converters.Autocad2024/packages.lock.json
@@ -180,8 +180,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
+        "resolved": "2026.6.0",
+        "contentHash": "rrbbe+Z8Nql/y0jHod6+B0zRitmHXq+RNw1zZnzY1heLV6NOe/8ntGbMo9JIGTnZ6Bvxg51UxntMiyAYCdvhXg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -191,14 +191,14 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.21.0",
+          "Speckle.Sdk.Dependencies": "2026.6.0",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA==",
+        "resolved": "2026.6.0",
+        "contentHash": "Nb38i5rAXRkEZlN0nkGbYe5Ph88ZBeHLqkcYCGAXolJcE7eDIPfU5hlWd2KcijFOD/E6f6CEdZJ99PinX2+Ejg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
         }
@@ -307,7 +307,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -329,7 +329,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "Microsoft.Web.WebView2": {
@@ -346,11 +346,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.21.0, )",
-        "resolved": "3.21.0",
-        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
+        "requested": "[2026.6.0, )",
+        "resolved": "2026.6.0",
+        "contentHash": "7rfwSQHjuvwxeEWJ4/dHYlIAoeZ5SdiPCCYFiF/Avz1ACp5KoDwkh0FF/5lvWDk86MoH55m5BwxYLFek2ui7Kg==",
         "dependencies": {
-          "Speckle.Sdk": "3.21.0"
+          "Speckle.Sdk": "2026.6.0"
         }
       },
       "System.Text.Json": {

--- a/Converters/Autocad/Speckle.Converters.Autocad2024/packages.lock.json
+++ b/Converters/Autocad/Speckle.Converters.Autocad2024/packages.lock.json
@@ -180,8 +180,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "jp1fle+rM6l3TtmhTwaWIlZ6HdeR7WYWFwRAxD/iazOFNXp0gWpEwYMe7Z+gBEmd6M91xQwWGAGo03x3D2XJaA==",
+        "resolved": "3.21.0",
+        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -191,14 +191,14 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.20.6",
+          "Speckle.Sdk.Dependencies": "3.21.0",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "DDRzJnBkQuDQbk1Zq76J++sZd63a+aKcY7BiYVDNvjzBSuzhtURe8PQoCfAb1H6WcYL2/K+KytOVvzK/113sGg==",
+        "resolved": "3.21.0",
+        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
         }
@@ -307,7 +307,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -329,7 +329,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "Microsoft.Web.WebView2": {
@@ -346,11 +346,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.20.6, )",
-        "resolved": "3.20.6",
-        "contentHash": "iK+Yl0VUoGzBFuOqP3yrEWQIuQDoISfwbG7vn0jNmEAgwGcRfB9yGlQ0wA4s7IgxbdEfPjhzzcKMBNcPJWkLtw==",
+        "requested": "[3.21.0, )",
+        "resolved": "3.21.0",
+        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.20.6"
+          "Speckle.Sdk": "3.21.0"
         }
       },
       "System.Text.Json": {

--- a/Converters/Autocad/Speckle.Converters.Autocad2025/packages.lock.json
+++ b/Converters/Autocad/Speckle.Converters.Autocad2025/packages.lock.json
@@ -139,8 +139,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "jp1fle+rM6l3TtmhTwaWIlZ6HdeR7WYWFwRAxD/iazOFNXp0gWpEwYMe7Z+gBEmd6M91xQwWGAGo03x3D2XJaA==",
+        "resolved": "3.21.0",
+        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -148,13 +148,13 @@
           "Microsoft.Extensions.ObjectPool": "8.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.20.6"
+          "Speckle.Sdk.Dependencies": "3.21.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "DDRzJnBkQuDQbk1Zq76J++sZd63a+aKcY7BiYVDNvjzBSuzhtURe8PQoCfAb1H6WcYL2/K+KytOVvzK/113sGg=="
+        "resolved": "3.21.0",
+        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -201,7 +201,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -223,7 +223,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "Microsoft.Web.WebView2": {
@@ -240,11 +240,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.20.6, )",
-        "resolved": "3.20.6",
-        "contentHash": "iK+Yl0VUoGzBFuOqP3yrEWQIuQDoISfwbG7vn0jNmEAgwGcRfB9yGlQ0wA4s7IgxbdEfPjhzzcKMBNcPJWkLtw==",
+        "requested": "[3.21.0, )",
+        "resolved": "3.21.0",
+        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.20.6"
+          "Speckle.Sdk": "3.21.0"
         }
       }
     }

--- a/Converters/Autocad/Speckle.Converters.Autocad2025/packages.lock.json
+++ b/Converters/Autocad/Speckle.Converters.Autocad2025/packages.lock.json
@@ -139,8 +139,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
+        "resolved": "2026.6.0",
+        "contentHash": "rrbbe+Z8Nql/y0jHod6+B0zRitmHXq+RNw1zZnzY1heLV6NOe/8ntGbMo9JIGTnZ6Bvxg51UxntMiyAYCdvhXg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -148,13 +148,13 @@
           "Microsoft.Extensions.ObjectPool": "8.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.21.0"
+          "Speckle.Sdk.Dependencies": "2026.6.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA=="
+        "resolved": "2026.6.0",
+        "contentHash": "Nb38i5rAXRkEZlN0nkGbYe5Ph88ZBeHLqkcYCGAXolJcE7eDIPfU5hlWd2KcijFOD/E6f6CEdZJ99PinX2+Ejg=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -201,7 +201,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -223,7 +223,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "Microsoft.Web.WebView2": {
@@ -240,11 +240,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.21.0, )",
-        "resolved": "3.21.0",
-        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
+        "requested": "[2026.6.0, )",
+        "resolved": "2026.6.0",
+        "contentHash": "7rfwSQHjuvwxeEWJ4/dHYlIAoeZ5SdiPCCYFiF/Avz1ACp5KoDwkh0FF/5lvWDk86MoH55m5BwxYLFek2ui7Kg==",
         "dependencies": {
-          "Speckle.Sdk": "3.21.0"
+          "Speckle.Sdk": "2026.6.0"
         }
       }
     }

--- a/Converters/Autocad/Speckle.Converters.Autocad2026/packages.lock.json
+++ b/Converters/Autocad/Speckle.Converters.Autocad2026/packages.lock.json
@@ -139,8 +139,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "jp1fle+rM6l3TtmhTwaWIlZ6HdeR7WYWFwRAxD/iazOFNXp0gWpEwYMe7Z+gBEmd6M91xQwWGAGo03x3D2XJaA==",
+        "resolved": "3.21.0",
+        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -148,13 +148,13 @@
           "Microsoft.Extensions.ObjectPool": "8.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.20.6"
+          "Speckle.Sdk.Dependencies": "3.21.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "DDRzJnBkQuDQbk1Zq76J++sZd63a+aKcY7BiYVDNvjzBSuzhtURe8PQoCfAb1H6WcYL2/K+KytOVvzK/113sGg=="
+        "resolved": "3.21.0",
+        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -201,7 +201,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -223,7 +223,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "Microsoft.Web.WebView2": {
@@ -240,11 +240,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.20.6, )",
-        "resolved": "3.20.6",
-        "contentHash": "iK+Yl0VUoGzBFuOqP3yrEWQIuQDoISfwbG7vn0jNmEAgwGcRfB9yGlQ0wA4s7IgxbdEfPjhzzcKMBNcPJWkLtw==",
+        "requested": "[3.21.0, )",
+        "resolved": "3.21.0",
+        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.20.6"
+          "Speckle.Sdk": "3.21.0"
         }
       }
     }

--- a/Converters/Autocad/Speckle.Converters.Autocad2026/packages.lock.json
+++ b/Converters/Autocad/Speckle.Converters.Autocad2026/packages.lock.json
@@ -139,8 +139,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
+        "resolved": "2026.6.0",
+        "contentHash": "rrbbe+Z8Nql/y0jHod6+B0zRitmHXq+RNw1zZnzY1heLV6NOe/8ntGbMo9JIGTnZ6Bvxg51UxntMiyAYCdvhXg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -148,13 +148,13 @@
           "Microsoft.Extensions.ObjectPool": "8.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.21.0"
+          "Speckle.Sdk.Dependencies": "2026.6.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA=="
+        "resolved": "2026.6.0",
+        "contentHash": "Nb38i5rAXRkEZlN0nkGbYe5Ph88ZBeHLqkcYCGAXolJcE7eDIPfU5hlWd2KcijFOD/E6f6CEdZJ99PinX2+Ejg=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -201,7 +201,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -223,7 +223,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "Microsoft.Web.WebView2": {
@@ -240,11 +240,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.21.0, )",
-        "resolved": "3.21.0",
-        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
+        "requested": "[2026.6.0, )",
+        "resolved": "2026.6.0",
+        "contentHash": "7rfwSQHjuvwxeEWJ4/dHYlIAoeZ5SdiPCCYFiF/Avz1ACp5KoDwkh0FF/5lvWDk86MoH55m5BwxYLFek2ui7Kg==",
         "dependencies": {
-          "Speckle.Sdk": "3.21.0"
+          "Speckle.Sdk": "2026.6.0"
         }
       }
     }

--- a/Converters/Autocad/Speckle.Converters.Autocad2027/packages.lock.json
+++ b/Converters/Autocad/Speckle.Converters.Autocad2027/packages.lock.json
@@ -140,8 +140,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "jp1fle+rM6l3TtmhTwaWIlZ6HdeR7WYWFwRAxD/iazOFNXp0gWpEwYMe7Z+gBEmd6M91xQwWGAGo03x3D2XJaA==",
+        "resolved": "3.21.0",
+        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
         "dependencies": {
           "GraphQL.Client": "6.1.0",
           "Microsoft.Data.Sqlite": "10.0.0",
@@ -149,13 +149,13 @@
           "Microsoft.Extensions.ObjectPool": "10.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.20.6"
+          "Speckle.Sdk.Dependencies": "3.21.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "DDRzJnBkQuDQbk1Zq76J++sZd63a+aKcY7BiYVDNvjzBSuzhtURe8PQoCfAb1H6WcYL2/K+KytOVvzK/113sGg=="
+        "resolved": "3.21.0",
+        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -194,7 +194,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -216,7 +216,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "Microsoft.Web.WebView2": {
@@ -233,11 +233,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.20.6, )",
-        "resolved": "3.20.6",
-        "contentHash": "iK+Yl0VUoGzBFuOqP3yrEWQIuQDoISfwbG7vn0jNmEAgwGcRfB9yGlQ0wA4s7IgxbdEfPjhzzcKMBNcPJWkLtw==",
+        "requested": "[3.21.0, )",
+        "resolved": "3.21.0",
+        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.20.6"
+          "Speckle.Sdk": "3.21.0"
         }
       }
     }

--- a/Converters/Autocad/Speckle.Converters.Autocad2027/packages.lock.json
+++ b/Converters/Autocad/Speckle.Converters.Autocad2027/packages.lock.json
@@ -140,8 +140,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
+        "resolved": "2026.6.0",
+        "contentHash": "rrbbe+Z8Nql/y0jHod6+B0zRitmHXq+RNw1zZnzY1heLV6NOe/8ntGbMo9JIGTnZ6Bvxg51UxntMiyAYCdvhXg==",
         "dependencies": {
           "GraphQL.Client": "6.1.0",
           "Microsoft.Data.Sqlite": "10.0.0",
@@ -149,13 +149,13 @@
           "Microsoft.Extensions.ObjectPool": "10.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.21.0"
+          "Speckle.Sdk.Dependencies": "2026.6.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA=="
+        "resolved": "2026.6.0",
+        "contentHash": "Nb38i5rAXRkEZlN0nkGbYe5Ph88ZBeHLqkcYCGAXolJcE7eDIPfU5hlWd2KcijFOD/E6f6CEdZJ99PinX2+Ejg=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -194,7 +194,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -216,7 +216,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "Microsoft.Web.WebView2": {
@@ -233,11 +233,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.21.0, )",
-        "resolved": "3.21.0",
-        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
+        "requested": "[2026.6.0, )",
+        "resolved": "2026.6.0",
+        "contentHash": "7rfwSQHjuvwxeEWJ4/dHYlIAoeZ5SdiPCCYFiF/Avz1ACp5KoDwkh0FF/5lvWDk86MoH55m5BwxYLFek2ui7Kg==",
         "dependencies": {
-          "Speckle.Sdk": "3.21.0"
+          "Speckle.Sdk": "2026.6.0"
         }
       }
     }

--- a/Converters/CSi/Speckle.Converters.ETABS21/packages.lock.json
+++ b/Converters/CSi/Speckle.Converters.ETABS21/packages.lock.json
@@ -180,8 +180,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "jp1fle+rM6l3TtmhTwaWIlZ6HdeR7WYWFwRAxD/iazOFNXp0gWpEwYMe7Z+gBEmd6M91xQwWGAGo03x3D2XJaA==",
+        "resolved": "3.21.0",
+        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -191,14 +191,14 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.20.6",
+          "Speckle.Sdk.Dependencies": "3.21.0",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "DDRzJnBkQuDQbk1Zq76J++sZd63a+aKcY7BiYVDNvjzBSuzhtURe8PQoCfAb1H6WcYL2/K+KytOVvzK/113sGg==",
+        "resolved": "3.21.0",
+        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
         }
@@ -305,7 +305,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "Speckle.DoubleNumerics": {
@@ -316,11 +316,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.20.6, )",
-        "resolved": "3.20.6",
-        "contentHash": "iK+Yl0VUoGzBFuOqP3yrEWQIuQDoISfwbG7vn0jNmEAgwGcRfB9yGlQ0wA4s7IgxbdEfPjhzzcKMBNcPJWkLtw==",
+        "requested": "[3.21.0, )",
+        "resolved": "3.21.0",
+        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.20.6"
+          "Speckle.Sdk": "3.21.0"
         }
       },
       "System.Text.Json": {

--- a/Converters/CSi/Speckle.Converters.ETABS21/packages.lock.json
+++ b/Converters/CSi/Speckle.Converters.ETABS21/packages.lock.json
@@ -180,8 +180,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
+        "resolved": "2026.6.0",
+        "contentHash": "rrbbe+Z8Nql/y0jHod6+B0zRitmHXq+RNw1zZnzY1heLV6NOe/8ntGbMo9JIGTnZ6Bvxg51UxntMiyAYCdvhXg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -191,14 +191,14 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.21.0",
+          "Speckle.Sdk.Dependencies": "2026.6.0",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA==",
+        "resolved": "2026.6.0",
+        "contentHash": "Nb38i5rAXRkEZlN0nkGbYe5Ph88ZBeHLqkcYCGAXolJcE7eDIPfU5hlWd2KcijFOD/E6f6CEdZJ99PinX2+Ejg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
         }
@@ -305,7 +305,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "Speckle.DoubleNumerics": {
@@ -316,11 +316,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.21.0, )",
-        "resolved": "3.21.0",
-        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
+        "requested": "[2026.6.0, )",
+        "resolved": "2026.6.0",
+        "contentHash": "7rfwSQHjuvwxeEWJ4/dHYlIAoeZ5SdiPCCYFiF/Avz1ACp5KoDwkh0FF/5lvWDk86MoH55m5BwxYLFek2ui7Kg==",
         "dependencies": {
-          "Speckle.Sdk": "3.21.0"
+          "Speckle.Sdk": "2026.6.0"
         }
       },
       "System.Text.Json": {

--- a/Converters/CSi/Speckle.Converters.ETABS22/packages.lock.json
+++ b/Converters/CSi/Speckle.Converters.ETABS22/packages.lock.json
@@ -139,8 +139,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
+        "resolved": "2026.6.0",
+        "contentHash": "rrbbe+Z8Nql/y0jHod6+B0zRitmHXq+RNw1zZnzY1heLV6NOe/8ntGbMo9JIGTnZ6Bvxg51UxntMiyAYCdvhXg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -148,13 +148,13 @@
           "Microsoft.Extensions.ObjectPool": "8.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.21.0"
+          "Speckle.Sdk.Dependencies": "2026.6.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA=="
+        "resolved": "2026.6.0",
+        "contentHash": "Nb38i5rAXRkEZlN0nkGbYe5Ph88ZBeHLqkcYCGAXolJcE7eDIPfU5hlWd2KcijFOD/E6f6CEdZJ99PinX2+Ejg=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -199,7 +199,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "Speckle.DoubleNumerics": {
@@ -210,11 +210,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.21.0, )",
-        "resolved": "3.21.0",
-        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
+        "requested": "[2026.6.0, )",
+        "resolved": "2026.6.0",
+        "contentHash": "7rfwSQHjuvwxeEWJ4/dHYlIAoeZ5SdiPCCYFiF/Avz1ACp5KoDwkh0FF/5lvWDk86MoH55m5BwxYLFek2ui7Kg==",
         "dependencies": {
-          "Speckle.Sdk": "3.21.0"
+          "Speckle.Sdk": "2026.6.0"
         }
       }
     }

--- a/Converters/CSi/Speckle.Converters.ETABS22/packages.lock.json
+++ b/Converters/CSi/Speckle.Converters.ETABS22/packages.lock.json
@@ -139,8 +139,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "jp1fle+rM6l3TtmhTwaWIlZ6HdeR7WYWFwRAxD/iazOFNXp0gWpEwYMe7Z+gBEmd6M91xQwWGAGo03x3D2XJaA==",
+        "resolved": "3.21.0",
+        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -148,13 +148,13 @@
           "Microsoft.Extensions.ObjectPool": "8.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.20.6"
+          "Speckle.Sdk.Dependencies": "3.21.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "DDRzJnBkQuDQbk1Zq76J++sZd63a+aKcY7BiYVDNvjzBSuzhtURe8PQoCfAb1H6WcYL2/K+KytOVvzK/113sGg=="
+        "resolved": "3.21.0",
+        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -199,7 +199,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "Speckle.DoubleNumerics": {
@@ -210,11 +210,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.20.6, )",
-        "resolved": "3.20.6",
-        "contentHash": "iK+Yl0VUoGzBFuOqP3yrEWQIuQDoISfwbG7vn0jNmEAgwGcRfB9yGlQ0wA4s7IgxbdEfPjhzzcKMBNcPJWkLtw==",
+        "requested": "[3.21.0, )",
+        "resolved": "3.21.0",
+        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.20.6"
+          "Speckle.Sdk": "3.21.0"
         }
       }
     }

--- a/Converters/Civil3d/Speckle.Converters.Civil3d2023/packages.lock.json
+++ b/Converters/Civil3d/Speckle.Converters.Civil3d2023/packages.lock.json
@@ -189,8 +189,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
+        "resolved": "2026.6.0",
+        "contentHash": "rrbbe+Z8Nql/y0jHod6+B0zRitmHXq+RNw1zZnzY1heLV6NOe/8ntGbMo9JIGTnZ6Bvxg51UxntMiyAYCdvhXg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -200,14 +200,14 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.21.0",
+          "Speckle.Sdk.Dependencies": "2026.6.0",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA==",
+        "resolved": "2026.6.0",
+        "contentHash": "Nb38i5rAXRkEZlN0nkGbYe5Ph88ZBeHLqkcYCGAXolJcE7eDIPfU5hlWd2KcijFOD/E6f6CEdZJ99PinX2+Ejg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
         }
@@ -314,7 +314,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "Speckle.DoubleNumerics": {
@@ -325,11 +325,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.21.0, )",
-        "resolved": "3.21.0",
-        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
+        "requested": "[2026.6.0, )",
+        "resolved": "2026.6.0",
+        "contentHash": "7rfwSQHjuvwxeEWJ4/dHYlIAoeZ5SdiPCCYFiF/Avz1ACp5KoDwkh0FF/5lvWDk86MoH55m5BwxYLFek2ui7Kg==",
         "dependencies": {
-          "Speckle.Sdk": "3.21.0"
+          "Speckle.Sdk": "2026.6.0"
         }
       },
       "System.Text.Json": {

--- a/Converters/Civil3d/Speckle.Converters.Civil3d2023/packages.lock.json
+++ b/Converters/Civil3d/Speckle.Converters.Civil3d2023/packages.lock.json
@@ -189,8 +189,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "jp1fle+rM6l3TtmhTwaWIlZ6HdeR7WYWFwRAxD/iazOFNXp0gWpEwYMe7Z+gBEmd6M91xQwWGAGo03x3D2XJaA==",
+        "resolved": "3.21.0",
+        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -200,14 +200,14 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.20.6",
+          "Speckle.Sdk.Dependencies": "3.21.0",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "DDRzJnBkQuDQbk1Zq76J++sZd63a+aKcY7BiYVDNvjzBSuzhtURe8PQoCfAb1H6WcYL2/K+KytOVvzK/113sGg==",
+        "resolved": "3.21.0",
+        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
         }
@@ -314,7 +314,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "Speckle.DoubleNumerics": {
@@ -325,11 +325,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.20.6, )",
-        "resolved": "3.20.6",
-        "contentHash": "iK+Yl0VUoGzBFuOqP3yrEWQIuQDoISfwbG7vn0jNmEAgwGcRfB9yGlQ0wA4s7IgxbdEfPjhzzcKMBNcPJWkLtw==",
+        "requested": "[3.21.0, )",
+        "resolved": "3.21.0",
+        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.20.6"
+          "Speckle.Sdk": "3.21.0"
         }
       },
       "System.Text.Json": {

--- a/Converters/Civil3d/Speckle.Converters.Civil3d2024/packages.lock.json
+++ b/Converters/Civil3d/Speckle.Converters.Civil3d2024/packages.lock.json
@@ -189,8 +189,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
+        "resolved": "2026.6.0",
+        "contentHash": "rrbbe+Z8Nql/y0jHod6+B0zRitmHXq+RNw1zZnzY1heLV6NOe/8ntGbMo9JIGTnZ6Bvxg51UxntMiyAYCdvhXg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -200,14 +200,14 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.21.0",
+          "Speckle.Sdk.Dependencies": "2026.6.0",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA==",
+        "resolved": "2026.6.0",
+        "contentHash": "Nb38i5rAXRkEZlN0nkGbYe5Ph88ZBeHLqkcYCGAXolJcE7eDIPfU5hlWd2KcijFOD/E6f6CEdZJ99PinX2+Ejg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
         }
@@ -314,7 +314,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "Speckle.DoubleNumerics": {
@@ -325,11 +325,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.21.0, )",
-        "resolved": "3.21.0",
-        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
+        "requested": "[2026.6.0, )",
+        "resolved": "2026.6.0",
+        "contentHash": "7rfwSQHjuvwxeEWJ4/dHYlIAoeZ5SdiPCCYFiF/Avz1ACp5KoDwkh0FF/5lvWDk86MoH55m5BwxYLFek2ui7Kg==",
         "dependencies": {
-          "Speckle.Sdk": "3.21.0"
+          "Speckle.Sdk": "2026.6.0"
         }
       },
       "System.Text.Json": {

--- a/Converters/Civil3d/Speckle.Converters.Civil3d2024/packages.lock.json
+++ b/Converters/Civil3d/Speckle.Converters.Civil3d2024/packages.lock.json
@@ -189,8 +189,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "jp1fle+rM6l3TtmhTwaWIlZ6HdeR7WYWFwRAxD/iazOFNXp0gWpEwYMe7Z+gBEmd6M91xQwWGAGo03x3D2XJaA==",
+        "resolved": "3.21.0",
+        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -200,14 +200,14 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.20.6",
+          "Speckle.Sdk.Dependencies": "3.21.0",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "DDRzJnBkQuDQbk1Zq76J++sZd63a+aKcY7BiYVDNvjzBSuzhtURe8PQoCfAb1H6WcYL2/K+KytOVvzK/113sGg==",
+        "resolved": "3.21.0",
+        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
         }
@@ -314,7 +314,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "Speckle.DoubleNumerics": {
@@ -325,11 +325,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.20.6, )",
-        "resolved": "3.20.6",
-        "contentHash": "iK+Yl0VUoGzBFuOqP3yrEWQIuQDoISfwbG7vn0jNmEAgwGcRfB9yGlQ0wA4s7IgxbdEfPjhzzcKMBNcPJWkLtw==",
+        "requested": "[3.21.0, )",
+        "resolved": "3.21.0",
+        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.20.6"
+          "Speckle.Sdk": "3.21.0"
         }
       },
       "System.Text.Json": {

--- a/Converters/Civil3d/Speckle.Converters.Civil3d2025/packages.lock.json
+++ b/Converters/Civil3d/Speckle.Converters.Civil3d2025/packages.lock.json
@@ -148,8 +148,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
+        "resolved": "2026.6.0",
+        "contentHash": "rrbbe+Z8Nql/y0jHod6+B0zRitmHXq+RNw1zZnzY1heLV6NOe/8ntGbMo9JIGTnZ6Bvxg51UxntMiyAYCdvhXg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -157,13 +157,13 @@
           "Microsoft.Extensions.ObjectPool": "8.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.21.0"
+          "Speckle.Sdk.Dependencies": "2026.6.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA=="
+        "resolved": "2026.6.0",
+        "contentHash": "Nb38i5rAXRkEZlN0nkGbYe5Ph88ZBeHLqkcYCGAXolJcE7eDIPfU5hlWd2KcijFOD/E6f6CEdZJ99PinX2+Ejg=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -210,7 +210,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -232,7 +232,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "Microsoft.Web.WebView2": {
@@ -249,11 +249,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.21.0, )",
-        "resolved": "3.21.0",
-        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
+        "requested": "[2026.6.0, )",
+        "resolved": "2026.6.0",
+        "contentHash": "7rfwSQHjuvwxeEWJ4/dHYlIAoeZ5SdiPCCYFiF/Avz1ACp5KoDwkh0FF/5lvWDk86MoH55m5BwxYLFek2ui7Kg==",
         "dependencies": {
-          "Speckle.Sdk": "3.21.0"
+          "Speckle.Sdk": "2026.6.0"
         }
       }
     }

--- a/Converters/Civil3d/Speckle.Converters.Civil3d2025/packages.lock.json
+++ b/Converters/Civil3d/Speckle.Converters.Civil3d2025/packages.lock.json
@@ -148,8 +148,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "jp1fle+rM6l3TtmhTwaWIlZ6HdeR7WYWFwRAxD/iazOFNXp0gWpEwYMe7Z+gBEmd6M91xQwWGAGo03x3D2XJaA==",
+        "resolved": "3.21.0",
+        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -157,13 +157,13 @@
           "Microsoft.Extensions.ObjectPool": "8.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.20.6"
+          "Speckle.Sdk.Dependencies": "3.21.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "DDRzJnBkQuDQbk1Zq76J++sZd63a+aKcY7BiYVDNvjzBSuzhtURe8PQoCfAb1H6WcYL2/K+KytOVvzK/113sGg=="
+        "resolved": "3.21.0",
+        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -210,7 +210,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -232,7 +232,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "Microsoft.Web.WebView2": {
@@ -249,11 +249,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.20.6, )",
-        "resolved": "3.20.6",
-        "contentHash": "iK+Yl0VUoGzBFuOqP3yrEWQIuQDoISfwbG7vn0jNmEAgwGcRfB9yGlQ0wA4s7IgxbdEfPjhzzcKMBNcPJWkLtw==",
+        "requested": "[3.21.0, )",
+        "resolved": "3.21.0",
+        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.20.6"
+          "Speckle.Sdk": "3.21.0"
         }
       }
     }

--- a/Converters/Civil3d/Speckle.Converters.Civil3d2026/packages.lock.json
+++ b/Converters/Civil3d/Speckle.Converters.Civil3d2026/packages.lock.json
@@ -148,8 +148,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
+        "resolved": "2026.6.0",
+        "contentHash": "rrbbe+Z8Nql/y0jHod6+B0zRitmHXq+RNw1zZnzY1heLV6NOe/8ntGbMo9JIGTnZ6Bvxg51UxntMiyAYCdvhXg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -157,13 +157,13 @@
           "Microsoft.Extensions.ObjectPool": "8.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.21.0"
+          "Speckle.Sdk.Dependencies": "2026.6.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA=="
+        "resolved": "2026.6.0",
+        "contentHash": "Nb38i5rAXRkEZlN0nkGbYe5Ph88ZBeHLqkcYCGAXolJcE7eDIPfU5hlWd2KcijFOD/E6f6CEdZJ99PinX2+Ejg=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -210,7 +210,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -232,7 +232,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "Microsoft.Web.WebView2": {
@@ -249,11 +249,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.21.0, )",
-        "resolved": "3.21.0",
-        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
+        "requested": "[2026.6.0, )",
+        "resolved": "2026.6.0",
+        "contentHash": "7rfwSQHjuvwxeEWJ4/dHYlIAoeZ5SdiPCCYFiF/Avz1ACp5KoDwkh0FF/5lvWDk86MoH55m5BwxYLFek2ui7Kg==",
         "dependencies": {
-          "Speckle.Sdk": "3.21.0"
+          "Speckle.Sdk": "2026.6.0"
         }
       }
     }

--- a/Converters/Civil3d/Speckle.Converters.Civil3d2026/packages.lock.json
+++ b/Converters/Civil3d/Speckle.Converters.Civil3d2026/packages.lock.json
@@ -148,8 +148,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "jp1fle+rM6l3TtmhTwaWIlZ6HdeR7WYWFwRAxD/iazOFNXp0gWpEwYMe7Z+gBEmd6M91xQwWGAGo03x3D2XJaA==",
+        "resolved": "3.21.0",
+        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -157,13 +157,13 @@
           "Microsoft.Extensions.ObjectPool": "8.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.20.6"
+          "Speckle.Sdk.Dependencies": "3.21.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "DDRzJnBkQuDQbk1Zq76J++sZd63a+aKcY7BiYVDNvjzBSuzhtURe8PQoCfAb1H6WcYL2/K+KytOVvzK/113sGg=="
+        "resolved": "3.21.0",
+        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -210,7 +210,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -232,7 +232,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "Microsoft.Web.WebView2": {
@@ -249,11 +249,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.20.6, )",
-        "resolved": "3.20.6",
-        "contentHash": "iK+Yl0VUoGzBFuOqP3yrEWQIuQDoISfwbG7vn0jNmEAgwGcRfB9yGlQ0wA4s7IgxbdEfPjhzzcKMBNcPJWkLtw==",
+        "requested": "[3.21.0, )",
+        "resolved": "3.21.0",
+        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.20.6"
+          "Speckle.Sdk": "3.21.0"
         }
       }
     }

--- a/Converters/Civil3d/Speckle.Converters.Civil3d2027/packages.lock.json
+++ b/Converters/Civil3d/Speckle.Converters.Civil3d2027/packages.lock.json
@@ -149,8 +149,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "jp1fle+rM6l3TtmhTwaWIlZ6HdeR7WYWFwRAxD/iazOFNXp0gWpEwYMe7Z+gBEmd6M91xQwWGAGo03x3D2XJaA==",
+        "resolved": "3.21.0",
+        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
         "dependencies": {
           "GraphQL.Client": "6.1.0",
           "Microsoft.Data.Sqlite": "10.0.0",
@@ -158,13 +158,13 @@
           "Microsoft.Extensions.ObjectPool": "10.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.20.6"
+          "Speckle.Sdk.Dependencies": "3.21.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "DDRzJnBkQuDQbk1Zq76J++sZd63a+aKcY7BiYVDNvjzBSuzhtURe8PQoCfAb1H6WcYL2/K+KytOVvzK/113sGg=="
+        "resolved": "3.21.0",
+        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -203,7 +203,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -225,7 +225,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "Microsoft.Web.WebView2": {
@@ -242,11 +242,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.20.6, )",
-        "resolved": "3.20.6",
-        "contentHash": "iK+Yl0VUoGzBFuOqP3yrEWQIuQDoISfwbG7vn0jNmEAgwGcRfB9yGlQ0wA4s7IgxbdEfPjhzzcKMBNcPJWkLtw==",
+        "requested": "[3.21.0, )",
+        "resolved": "3.21.0",
+        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.20.6"
+          "Speckle.Sdk": "3.21.0"
         }
       }
     }

--- a/Converters/Civil3d/Speckle.Converters.Civil3d2027/packages.lock.json
+++ b/Converters/Civil3d/Speckle.Converters.Civil3d2027/packages.lock.json
@@ -149,8 +149,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
+        "resolved": "2026.6.0",
+        "contentHash": "rrbbe+Z8Nql/y0jHod6+B0zRitmHXq+RNw1zZnzY1heLV6NOe/8ntGbMo9JIGTnZ6Bvxg51UxntMiyAYCdvhXg==",
         "dependencies": {
           "GraphQL.Client": "6.1.0",
           "Microsoft.Data.Sqlite": "10.0.0",
@@ -158,13 +158,13 @@
           "Microsoft.Extensions.ObjectPool": "10.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.21.0"
+          "Speckle.Sdk.Dependencies": "2026.6.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA=="
+        "resolved": "2026.6.0",
+        "contentHash": "Nb38i5rAXRkEZlN0nkGbYe5Ph88ZBeHLqkcYCGAXolJcE7eDIPfU5hlWd2KcijFOD/E6f6CEdZJ99PinX2+Ejg=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -203,7 +203,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -225,7 +225,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "Microsoft.Web.WebView2": {
@@ -242,11 +242,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.21.0, )",
-        "resolved": "3.21.0",
-        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
+        "requested": "[2026.6.0, )",
+        "resolved": "2026.6.0",
+        "contentHash": "7rfwSQHjuvwxeEWJ4/dHYlIAoeZ5SdiPCCYFiF/Avz1ACp5KoDwkh0FF/5lvWDk86MoH55m5BwxYLFek2ui7Kg==",
         "dependencies": {
-          "Speckle.Sdk": "3.21.0"
+          "Speckle.Sdk": "2026.6.0"
         }
       }
     }

--- a/Converters/Navisworks/Speckle.Converters.Navisworks2020/packages.lock.json
+++ b/Converters/Navisworks/Speckle.Converters.Navisworks2020/packages.lock.json
@@ -180,8 +180,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "jp1fle+rM6l3TtmhTwaWIlZ6HdeR7WYWFwRAxD/iazOFNXp0gWpEwYMe7Z+gBEmd6M91xQwWGAGo03x3D2XJaA==",
+        "resolved": "3.21.0",
+        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -191,14 +191,14 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.20.6",
+          "Speckle.Sdk.Dependencies": "3.21.0",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "DDRzJnBkQuDQbk1Zq76J++sZd63a+aKcY7BiYVDNvjzBSuzhtURe8PQoCfAb1H6WcYL2/K+KytOVvzK/113sGg==",
+        "resolved": "3.21.0",
+        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
         }
@@ -307,7 +307,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -322,7 +322,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "Speckle.DoubleNumerics": {
@@ -333,11 +333,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.20.6, )",
-        "resolved": "3.20.6",
-        "contentHash": "iK+Yl0VUoGzBFuOqP3yrEWQIuQDoISfwbG7vn0jNmEAgwGcRfB9yGlQ0wA4s7IgxbdEfPjhzzcKMBNcPJWkLtw==",
+        "requested": "[3.21.0, )",
+        "resolved": "3.21.0",
+        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.20.6"
+          "Speckle.Sdk": "3.21.0"
         }
       },
       "System.Text.Json": {

--- a/Converters/Navisworks/Speckle.Converters.Navisworks2020/packages.lock.json
+++ b/Converters/Navisworks/Speckle.Converters.Navisworks2020/packages.lock.json
@@ -180,8 +180,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
+        "resolved": "2026.6.0",
+        "contentHash": "rrbbe+Z8Nql/y0jHod6+B0zRitmHXq+RNw1zZnzY1heLV6NOe/8ntGbMo9JIGTnZ6Bvxg51UxntMiyAYCdvhXg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -191,14 +191,14 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.21.0",
+          "Speckle.Sdk.Dependencies": "2026.6.0",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA==",
+        "resolved": "2026.6.0",
+        "contentHash": "Nb38i5rAXRkEZlN0nkGbYe5Ph88ZBeHLqkcYCGAXolJcE7eDIPfU5hlWd2KcijFOD/E6f6CEdZJ99PinX2+Ejg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
         }
@@ -307,7 +307,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -322,7 +322,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "Speckle.DoubleNumerics": {
@@ -333,11 +333,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.21.0, )",
-        "resolved": "3.21.0",
-        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
+        "requested": "[2026.6.0, )",
+        "resolved": "2026.6.0",
+        "contentHash": "7rfwSQHjuvwxeEWJ4/dHYlIAoeZ5SdiPCCYFiF/Avz1ACp5KoDwkh0FF/5lvWDk86MoH55m5BwxYLFek2ui7Kg==",
         "dependencies": {
-          "Speckle.Sdk": "3.21.0"
+          "Speckle.Sdk": "2026.6.0"
         }
       },
       "System.Text.Json": {

--- a/Converters/Navisworks/Speckle.Converters.Navisworks2021/packages.lock.json
+++ b/Converters/Navisworks/Speckle.Converters.Navisworks2021/packages.lock.json
@@ -180,8 +180,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "jp1fle+rM6l3TtmhTwaWIlZ6HdeR7WYWFwRAxD/iazOFNXp0gWpEwYMe7Z+gBEmd6M91xQwWGAGo03x3D2XJaA==",
+        "resolved": "3.21.0",
+        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -191,14 +191,14 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.20.6",
+          "Speckle.Sdk.Dependencies": "3.21.0",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "DDRzJnBkQuDQbk1Zq76J++sZd63a+aKcY7BiYVDNvjzBSuzhtURe8PQoCfAb1H6WcYL2/K+KytOVvzK/113sGg==",
+        "resolved": "3.21.0",
+        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
         }
@@ -307,7 +307,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -322,7 +322,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "Speckle.DoubleNumerics": {
@@ -333,11 +333,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.20.6, )",
-        "resolved": "3.20.6",
-        "contentHash": "iK+Yl0VUoGzBFuOqP3yrEWQIuQDoISfwbG7vn0jNmEAgwGcRfB9yGlQ0wA4s7IgxbdEfPjhzzcKMBNcPJWkLtw==",
+        "requested": "[3.21.0, )",
+        "resolved": "3.21.0",
+        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.20.6"
+          "Speckle.Sdk": "3.21.0"
         }
       },
       "System.Text.Json": {

--- a/Converters/Navisworks/Speckle.Converters.Navisworks2021/packages.lock.json
+++ b/Converters/Navisworks/Speckle.Converters.Navisworks2021/packages.lock.json
@@ -180,8 +180,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
+        "resolved": "2026.6.0",
+        "contentHash": "rrbbe+Z8Nql/y0jHod6+B0zRitmHXq+RNw1zZnzY1heLV6NOe/8ntGbMo9JIGTnZ6Bvxg51UxntMiyAYCdvhXg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -191,14 +191,14 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.21.0",
+          "Speckle.Sdk.Dependencies": "2026.6.0",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA==",
+        "resolved": "2026.6.0",
+        "contentHash": "Nb38i5rAXRkEZlN0nkGbYe5Ph88ZBeHLqkcYCGAXolJcE7eDIPfU5hlWd2KcijFOD/E6f6CEdZJ99PinX2+Ejg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
         }
@@ -307,7 +307,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -322,7 +322,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "Speckle.DoubleNumerics": {
@@ -333,11 +333,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.21.0, )",
-        "resolved": "3.21.0",
-        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
+        "requested": "[2026.6.0, )",
+        "resolved": "2026.6.0",
+        "contentHash": "7rfwSQHjuvwxeEWJ4/dHYlIAoeZ5SdiPCCYFiF/Avz1ACp5KoDwkh0FF/5lvWDk86MoH55m5BwxYLFek2ui7Kg==",
         "dependencies": {
-          "Speckle.Sdk": "3.21.0"
+          "Speckle.Sdk": "2026.6.0"
         }
       },
       "System.Text.Json": {

--- a/Converters/Navisworks/Speckle.Converters.Navisworks2022/packages.lock.json
+++ b/Converters/Navisworks/Speckle.Converters.Navisworks2022/packages.lock.json
@@ -180,8 +180,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "jp1fle+rM6l3TtmhTwaWIlZ6HdeR7WYWFwRAxD/iazOFNXp0gWpEwYMe7Z+gBEmd6M91xQwWGAGo03x3D2XJaA==",
+        "resolved": "3.21.0",
+        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -191,14 +191,14 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.20.6",
+          "Speckle.Sdk.Dependencies": "3.21.0",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "DDRzJnBkQuDQbk1Zq76J++sZd63a+aKcY7BiYVDNvjzBSuzhtURe8PQoCfAb1H6WcYL2/K+KytOVvzK/113sGg==",
+        "resolved": "3.21.0",
+        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
         }
@@ -307,7 +307,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -322,7 +322,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "Speckle.DoubleNumerics": {
@@ -333,11 +333,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.20.6, )",
-        "resolved": "3.20.6",
-        "contentHash": "iK+Yl0VUoGzBFuOqP3yrEWQIuQDoISfwbG7vn0jNmEAgwGcRfB9yGlQ0wA4s7IgxbdEfPjhzzcKMBNcPJWkLtw==",
+        "requested": "[3.21.0, )",
+        "resolved": "3.21.0",
+        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.20.6"
+          "Speckle.Sdk": "3.21.0"
         }
       },
       "System.Text.Json": {

--- a/Converters/Navisworks/Speckle.Converters.Navisworks2022/packages.lock.json
+++ b/Converters/Navisworks/Speckle.Converters.Navisworks2022/packages.lock.json
@@ -180,8 +180,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
+        "resolved": "2026.6.0",
+        "contentHash": "rrbbe+Z8Nql/y0jHod6+B0zRitmHXq+RNw1zZnzY1heLV6NOe/8ntGbMo9JIGTnZ6Bvxg51UxntMiyAYCdvhXg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -191,14 +191,14 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.21.0",
+          "Speckle.Sdk.Dependencies": "2026.6.0",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA==",
+        "resolved": "2026.6.0",
+        "contentHash": "Nb38i5rAXRkEZlN0nkGbYe5Ph88ZBeHLqkcYCGAXolJcE7eDIPfU5hlWd2KcijFOD/E6f6CEdZJ99PinX2+Ejg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
         }
@@ -307,7 +307,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -322,7 +322,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "Speckle.DoubleNumerics": {
@@ -333,11 +333,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.21.0, )",
-        "resolved": "3.21.0",
-        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
+        "requested": "[2026.6.0, )",
+        "resolved": "2026.6.0",
+        "contentHash": "7rfwSQHjuvwxeEWJ4/dHYlIAoeZ5SdiPCCYFiF/Avz1ACp5KoDwkh0FF/5lvWDk86MoH55m5BwxYLFek2ui7Kg==",
         "dependencies": {
-          "Speckle.Sdk": "3.21.0"
+          "Speckle.Sdk": "2026.6.0"
         }
       },
       "System.Text.Json": {

--- a/Converters/Navisworks/Speckle.Converters.Navisworks2023/packages.lock.json
+++ b/Converters/Navisworks/Speckle.Converters.Navisworks2023/packages.lock.json
@@ -180,8 +180,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "jp1fle+rM6l3TtmhTwaWIlZ6HdeR7WYWFwRAxD/iazOFNXp0gWpEwYMe7Z+gBEmd6M91xQwWGAGo03x3D2XJaA==",
+        "resolved": "3.21.0",
+        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -191,14 +191,14 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.20.6",
+          "Speckle.Sdk.Dependencies": "3.21.0",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "DDRzJnBkQuDQbk1Zq76J++sZd63a+aKcY7BiYVDNvjzBSuzhtURe8PQoCfAb1H6WcYL2/K+KytOVvzK/113sGg==",
+        "resolved": "3.21.0",
+        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
         }
@@ -307,7 +307,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -322,7 +322,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "Speckle.DoubleNumerics": {
@@ -333,11 +333,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.20.6, )",
-        "resolved": "3.20.6",
-        "contentHash": "iK+Yl0VUoGzBFuOqP3yrEWQIuQDoISfwbG7vn0jNmEAgwGcRfB9yGlQ0wA4s7IgxbdEfPjhzzcKMBNcPJWkLtw==",
+        "requested": "[3.21.0, )",
+        "resolved": "3.21.0",
+        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.20.6"
+          "Speckle.Sdk": "3.21.0"
         }
       },
       "System.Text.Json": {

--- a/Converters/Navisworks/Speckle.Converters.Navisworks2023/packages.lock.json
+++ b/Converters/Navisworks/Speckle.Converters.Navisworks2023/packages.lock.json
@@ -180,8 +180,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
+        "resolved": "2026.6.0",
+        "contentHash": "rrbbe+Z8Nql/y0jHod6+B0zRitmHXq+RNw1zZnzY1heLV6NOe/8ntGbMo9JIGTnZ6Bvxg51UxntMiyAYCdvhXg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -191,14 +191,14 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.21.0",
+          "Speckle.Sdk.Dependencies": "2026.6.0",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA==",
+        "resolved": "2026.6.0",
+        "contentHash": "Nb38i5rAXRkEZlN0nkGbYe5Ph88ZBeHLqkcYCGAXolJcE7eDIPfU5hlWd2KcijFOD/E6f6CEdZJ99PinX2+Ejg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
         }
@@ -307,7 +307,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -322,7 +322,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "Speckle.DoubleNumerics": {
@@ -333,11 +333,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.21.0, )",
-        "resolved": "3.21.0",
-        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
+        "requested": "[2026.6.0, )",
+        "resolved": "2026.6.0",
+        "contentHash": "7rfwSQHjuvwxeEWJ4/dHYlIAoeZ5SdiPCCYFiF/Avz1ACp5KoDwkh0FF/5lvWDk86MoH55m5BwxYLFek2ui7Kg==",
         "dependencies": {
-          "Speckle.Sdk": "3.21.0"
+          "Speckle.Sdk": "2026.6.0"
         }
       },
       "System.Text.Json": {

--- a/Converters/Navisworks/Speckle.Converters.Navisworks2024/packages.lock.json
+++ b/Converters/Navisworks/Speckle.Converters.Navisworks2024/packages.lock.json
@@ -180,8 +180,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "jp1fle+rM6l3TtmhTwaWIlZ6HdeR7WYWFwRAxD/iazOFNXp0gWpEwYMe7Z+gBEmd6M91xQwWGAGo03x3D2XJaA==",
+        "resolved": "3.21.0",
+        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -191,14 +191,14 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.20.6",
+          "Speckle.Sdk.Dependencies": "3.21.0",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "DDRzJnBkQuDQbk1Zq76J++sZd63a+aKcY7BiYVDNvjzBSuzhtURe8PQoCfAb1H6WcYL2/K+KytOVvzK/113sGg==",
+        "resolved": "3.21.0",
+        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
         }
@@ -307,7 +307,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -322,7 +322,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "Speckle.DoubleNumerics": {
@@ -333,11 +333,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.20.6, )",
-        "resolved": "3.20.6",
-        "contentHash": "iK+Yl0VUoGzBFuOqP3yrEWQIuQDoISfwbG7vn0jNmEAgwGcRfB9yGlQ0wA4s7IgxbdEfPjhzzcKMBNcPJWkLtw==",
+        "requested": "[3.21.0, )",
+        "resolved": "3.21.0",
+        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.20.6"
+          "Speckle.Sdk": "3.21.0"
         }
       },
       "System.Text.Json": {

--- a/Converters/Navisworks/Speckle.Converters.Navisworks2024/packages.lock.json
+++ b/Converters/Navisworks/Speckle.Converters.Navisworks2024/packages.lock.json
@@ -180,8 +180,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
+        "resolved": "2026.6.0",
+        "contentHash": "rrbbe+Z8Nql/y0jHod6+B0zRitmHXq+RNw1zZnzY1heLV6NOe/8ntGbMo9JIGTnZ6Bvxg51UxntMiyAYCdvhXg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -191,14 +191,14 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.21.0",
+          "Speckle.Sdk.Dependencies": "2026.6.0",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA==",
+        "resolved": "2026.6.0",
+        "contentHash": "Nb38i5rAXRkEZlN0nkGbYe5Ph88ZBeHLqkcYCGAXolJcE7eDIPfU5hlWd2KcijFOD/E6f6CEdZJ99PinX2+Ejg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
         }
@@ -307,7 +307,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -322,7 +322,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "Speckle.DoubleNumerics": {
@@ -333,11 +333,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.21.0, )",
-        "resolved": "3.21.0",
-        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
+        "requested": "[2026.6.0, )",
+        "resolved": "2026.6.0",
+        "contentHash": "7rfwSQHjuvwxeEWJ4/dHYlIAoeZ5SdiPCCYFiF/Avz1ACp5KoDwkh0FF/5lvWDk86MoH55m5BwxYLFek2ui7Kg==",
         "dependencies": {
-          "Speckle.Sdk": "3.21.0"
+          "Speckle.Sdk": "2026.6.0"
         }
       },
       "System.Text.Json": {

--- a/Converters/Navisworks/Speckle.Converters.Navisworks2025/packages.lock.json
+++ b/Converters/Navisworks/Speckle.Converters.Navisworks2025/packages.lock.json
@@ -180,8 +180,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "jp1fle+rM6l3TtmhTwaWIlZ6HdeR7WYWFwRAxD/iazOFNXp0gWpEwYMe7Z+gBEmd6M91xQwWGAGo03x3D2XJaA==",
+        "resolved": "3.21.0",
+        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -191,14 +191,14 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.20.6",
+          "Speckle.Sdk.Dependencies": "3.21.0",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "DDRzJnBkQuDQbk1Zq76J++sZd63a+aKcY7BiYVDNvjzBSuzhtURe8PQoCfAb1H6WcYL2/K+KytOVvzK/113sGg==",
+        "resolved": "3.21.0",
+        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
         }
@@ -307,7 +307,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -322,7 +322,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "Speckle.DoubleNumerics": {
@@ -333,11 +333,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.20.6, )",
-        "resolved": "3.20.6",
-        "contentHash": "iK+Yl0VUoGzBFuOqP3yrEWQIuQDoISfwbG7vn0jNmEAgwGcRfB9yGlQ0wA4s7IgxbdEfPjhzzcKMBNcPJWkLtw==",
+        "requested": "[3.21.0, )",
+        "resolved": "3.21.0",
+        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.20.6"
+          "Speckle.Sdk": "3.21.0"
         }
       },
       "System.Text.Json": {

--- a/Converters/Navisworks/Speckle.Converters.Navisworks2025/packages.lock.json
+++ b/Converters/Navisworks/Speckle.Converters.Navisworks2025/packages.lock.json
@@ -180,8 +180,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
+        "resolved": "2026.6.0",
+        "contentHash": "rrbbe+Z8Nql/y0jHod6+B0zRitmHXq+RNw1zZnzY1heLV6NOe/8ntGbMo9JIGTnZ6Bvxg51UxntMiyAYCdvhXg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -191,14 +191,14 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.21.0",
+          "Speckle.Sdk.Dependencies": "2026.6.0",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA==",
+        "resolved": "2026.6.0",
+        "contentHash": "Nb38i5rAXRkEZlN0nkGbYe5Ph88ZBeHLqkcYCGAXolJcE7eDIPfU5hlWd2KcijFOD/E6f6CEdZJ99PinX2+Ejg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
         }
@@ -307,7 +307,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -322,7 +322,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "Speckle.DoubleNumerics": {
@@ -333,11 +333,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.21.0, )",
-        "resolved": "3.21.0",
-        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
+        "requested": "[2026.6.0, )",
+        "resolved": "2026.6.0",
+        "contentHash": "7rfwSQHjuvwxeEWJ4/dHYlIAoeZ5SdiPCCYFiF/Avz1ACp5KoDwkh0FF/5lvWDk86MoH55m5BwxYLFek2ui7Kg==",
         "dependencies": {
-          "Speckle.Sdk": "3.21.0"
+          "Speckle.Sdk": "2026.6.0"
         }
       },
       "System.Text.Json": {

--- a/Converters/Navisworks/Speckle.Converters.Navisworks2026/packages.lock.json
+++ b/Converters/Navisworks/Speckle.Converters.Navisworks2026/packages.lock.json
@@ -189,8 +189,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
+        "resolved": "2026.6.0",
+        "contentHash": "rrbbe+Z8Nql/y0jHod6+B0zRitmHXq+RNw1zZnzY1heLV6NOe/8ntGbMo9JIGTnZ6Bvxg51UxntMiyAYCdvhXg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -200,14 +200,14 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.21.0",
+          "Speckle.Sdk.Dependencies": "2026.6.0",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA==",
+        "resolved": "2026.6.0",
+        "contentHash": "Nb38i5rAXRkEZlN0nkGbYe5Ph88ZBeHLqkcYCGAXolJcE7eDIPfU5hlWd2KcijFOD/E6f6CEdZJ99PinX2+Ejg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
         }
@@ -308,7 +308,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -323,7 +323,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "Speckle.DoubleNumerics": {
@@ -334,11 +334,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.21.0, )",
-        "resolved": "3.21.0",
-        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
+        "requested": "[2026.6.0, )",
+        "resolved": "2026.6.0",
+        "contentHash": "7rfwSQHjuvwxeEWJ4/dHYlIAoeZ5SdiPCCYFiF/Avz1ACp5KoDwkh0FF/5lvWDk86MoH55m5BwxYLFek2ui7Kg==",
         "dependencies": {
-          "Speckle.Sdk": "3.21.0"
+          "Speckle.Sdk": "2026.6.0"
         }
       },
       "System.Text.Json": {

--- a/Converters/Navisworks/Speckle.Converters.Navisworks2026/packages.lock.json
+++ b/Converters/Navisworks/Speckle.Converters.Navisworks2026/packages.lock.json
@@ -189,8 +189,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "jp1fle+rM6l3TtmhTwaWIlZ6HdeR7WYWFwRAxD/iazOFNXp0gWpEwYMe7Z+gBEmd6M91xQwWGAGo03x3D2XJaA==",
+        "resolved": "3.21.0",
+        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -200,14 +200,14 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.20.6",
+          "Speckle.Sdk.Dependencies": "3.21.0",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "DDRzJnBkQuDQbk1Zq76J++sZd63a+aKcY7BiYVDNvjzBSuzhtURe8PQoCfAb1H6WcYL2/K+KytOVvzK/113sGg==",
+        "resolved": "3.21.0",
+        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
         }
@@ -308,7 +308,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -323,7 +323,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "Speckle.DoubleNumerics": {
@@ -334,11 +334,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.20.6, )",
-        "resolved": "3.20.6",
-        "contentHash": "iK+Yl0VUoGzBFuOqP3yrEWQIuQDoISfwbG7vn0jNmEAgwGcRfB9yGlQ0wA4s7IgxbdEfPjhzzcKMBNcPJWkLtw==",
+        "requested": "[3.21.0, )",
+        "resolved": "3.21.0",
+        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.20.6"
+          "Speckle.Sdk": "3.21.0"
         }
       },
       "System.Text.Json": {

--- a/Converters/Navisworks/Speckle.Converters.Navisworks2027/packages.lock.json
+++ b/Converters/Navisworks/Speckle.Converters.Navisworks2027/packages.lock.json
@@ -189,8 +189,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
+        "resolved": "2026.6.0",
+        "contentHash": "rrbbe+Z8Nql/y0jHod6+B0zRitmHXq+RNw1zZnzY1heLV6NOe/8ntGbMo9JIGTnZ6Bvxg51UxntMiyAYCdvhXg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -200,14 +200,14 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.21.0",
+          "Speckle.Sdk.Dependencies": "2026.6.0",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA==",
+        "resolved": "2026.6.0",
+        "contentHash": "Nb38i5rAXRkEZlN0nkGbYe5Ph88ZBeHLqkcYCGAXolJcE7eDIPfU5hlWd2KcijFOD/E6f6CEdZJ99PinX2+Ejg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
         }
@@ -308,7 +308,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -323,7 +323,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "Speckle.DoubleNumerics": {
@@ -334,11 +334,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.21.0, )",
-        "resolved": "3.21.0",
-        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
+        "requested": "[2026.6.0, )",
+        "resolved": "2026.6.0",
+        "contentHash": "7rfwSQHjuvwxeEWJ4/dHYlIAoeZ5SdiPCCYFiF/Avz1ACp5KoDwkh0FF/5lvWDk86MoH55m5BwxYLFek2ui7Kg==",
         "dependencies": {
-          "Speckle.Sdk": "3.21.0"
+          "Speckle.Sdk": "2026.6.0"
         }
       },
       "System.Text.Json": {

--- a/Converters/Navisworks/Speckle.Converters.Navisworks2027/packages.lock.json
+++ b/Converters/Navisworks/Speckle.Converters.Navisworks2027/packages.lock.json
@@ -189,8 +189,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "jp1fle+rM6l3TtmhTwaWIlZ6HdeR7WYWFwRAxD/iazOFNXp0gWpEwYMe7Z+gBEmd6M91xQwWGAGo03x3D2XJaA==",
+        "resolved": "3.21.0",
+        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -200,14 +200,14 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.20.6",
+          "Speckle.Sdk.Dependencies": "3.21.0",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "DDRzJnBkQuDQbk1Zq76J++sZd63a+aKcY7BiYVDNvjzBSuzhtURe8PQoCfAb1H6WcYL2/K+KytOVvzK/113sGg==",
+        "resolved": "3.21.0",
+        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
         }
@@ -308,7 +308,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -323,7 +323,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "Speckle.DoubleNumerics": {
@@ -334,11 +334,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.20.6, )",
-        "resolved": "3.20.6",
-        "contentHash": "iK+Yl0VUoGzBFuOqP3yrEWQIuQDoISfwbG7vn0jNmEAgwGcRfB9yGlQ0wA4s7IgxbdEfPjhzzcKMBNcPJWkLtw==",
+        "requested": "[3.21.0, )",
+        "resolved": "3.21.0",
+        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.20.6"
+          "Speckle.Sdk": "3.21.0"
         }
       },
       "System.Text.Json": {

--- a/Converters/Plant3d/Speckle.Converters.Plant3d2026/packages.lock.json
+++ b/Converters/Plant3d/Speckle.Converters.Plant3d2026/packages.lock.json
@@ -148,8 +148,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
+        "resolved": "2026.6.0",
+        "contentHash": "rrbbe+Z8Nql/y0jHod6+B0zRitmHXq+RNw1zZnzY1heLV6NOe/8ntGbMo9JIGTnZ6Bvxg51UxntMiyAYCdvhXg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -157,13 +157,13 @@
           "Microsoft.Extensions.ObjectPool": "8.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.21.0"
+          "Speckle.Sdk.Dependencies": "2026.6.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA=="
+        "resolved": "2026.6.0",
+        "contentHash": "Nb38i5rAXRkEZlN0nkGbYe5Ph88ZBeHLqkcYCGAXolJcE7eDIPfU5hlWd2KcijFOD/E6f6CEdZJ99PinX2+Ejg=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -210,7 +210,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -232,7 +232,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "Microsoft.Web.WebView2": {
@@ -249,11 +249,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.21.0, )",
-        "resolved": "3.21.0",
-        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
+        "requested": "[2026.6.0, )",
+        "resolved": "2026.6.0",
+        "contentHash": "7rfwSQHjuvwxeEWJ4/dHYlIAoeZ5SdiPCCYFiF/Avz1ACp5KoDwkh0FF/5lvWDk86MoH55m5BwxYLFek2ui7Kg==",
         "dependencies": {
-          "Speckle.Sdk": "3.21.0"
+          "Speckle.Sdk": "2026.6.0"
         }
       }
     }

--- a/Converters/Plant3d/Speckle.Converters.Plant3d2026/packages.lock.json
+++ b/Converters/Plant3d/Speckle.Converters.Plant3d2026/packages.lock.json
@@ -148,8 +148,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "jp1fle+rM6l3TtmhTwaWIlZ6HdeR7WYWFwRAxD/iazOFNXp0gWpEwYMe7Z+gBEmd6M91xQwWGAGo03x3D2XJaA==",
+        "resolved": "3.21.0",
+        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -157,13 +157,13 @@
           "Microsoft.Extensions.ObjectPool": "8.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.20.6"
+          "Speckle.Sdk.Dependencies": "3.21.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "DDRzJnBkQuDQbk1Zq76J++sZd63a+aKcY7BiYVDNvjzBSuzhtURe8PQoCfAb1H6WcYL2/K+KytOVvzK/113sGg=="
+        "resolved": "3.21.0",
+        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -210,7 +210,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -232,7 +232,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "Microsoft.Web.WebView2": {
@@ -249,11 +249,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.20.6, )",
-        "resolved": "3.20.6",
-        "contentHash": "iK+Yl0VUoGzBFuOqP3yrEWQIuQDoISfwbG7vn0jNmEAgwGcRfB9yGlQ0wA4s7IgxbdEfPjhzzcKMBNcPJWkLtw==",
+        "requested": "[3.21.0, )",
+        "resolved": "3.21.0",
+        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.20.6"
+          "Speckle.Sdk": "3.21.0"
         }
       }
     }

--- a/Converters/Plant3d/Speckle.Converters.Plant3d2027/packages.lock.json
+++ b/Converters/Plant3d/Speckle.Converters.Plant3d2027/packages.lock.json
@@ -149,8 +149,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "jp1fle+rM6l3TtmhTwaWIlZ6HdeR7WYWFwRAxD/iazOFNXp0gWpEwYMe7Z+gBEmd6M91xQwWGAGo03x3D2XJaA==",
+        "resolved": "3.21.0",
+        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
         "dependencies": {
           "GraphQL.Client": "6.1.0",
           "Microsoft.Data.Sqlite": "10.0.0",
@@ -158,13 +158,13 @@
           "Microsoft.Extensions.ObjectPool": "10.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.20.6"
+          "Speckle.Sdk.Dependencies": "3.21.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "DDRzJnBkQuDQbk1Zq76J++sZd63a+aKcY7BiYVDNvjzBSuzhtURe8PQoCfAb1H6WcYL2/K+KytOVvzK/113sGg=="
+        "resolved": "3.21.0",
+        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -203,7 +203,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -225,7 +225,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "Microsoft.Web.WebView2": {
@@ -242,11 +242,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.20.6, )",
-        "resolved": "3.20.6",
-        "contentHash": "iK+Yl0VUoGzBFuOqP3yrEWQIuQDoISfwbG7vn0jNmEAgwGcRfB9yGlQ0wA4s7IgxbdEfPjhzzcKMBNcPJWkLtw==",
+        "requested": "[3.21.0, )",
+        "resolved": "3.21.0",
+        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.20.6"
+          "Speckle.Sdk": "3.21.0"
         }
       }
     }

--- a/Converters/Plant3d/Speckle.Converters.Plant3d2027/packages.lock.json
+++ b/Converters/Plant3d/Speckle.Converters.Plant3d2027/packages.lock.json
@@ -149,8 +149,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
+        "resolved": "2026.6.0",
+        "contentHash": "rrbbe+Z8Nql/y0jHod6+B0zRitmHXq+RNw1zZnzY1heLV6NOe/8ntGbMo9JIGTnZ6Bvxg51UxntMiyAYCdvhXg==",
         "dependencies": {
           "GraphQL.Client": "6.1.0",
           "Microsoft.Data.Sqlite": "10.0.0",
@@ -158,13 +158,13 @@
           "Microsoft.Extensions.ObjectPool": "10.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.21.0"
+          "Speckle.Sdk.Dependencies": "2026.6.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA=="
+        "resolved": "2026.6.0",
+        "contentHash": "Nb38i5rAXRkEZlN0nkGbYe5Ph88ZBeHLqkcYCGAXolJcE7eDIPfU5hlWd2KcijFOD/E6f6CEdZJ99PinX2+Ejg=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -203,7 +203,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -225,7 +225,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "Microsoft.Web.WebView2": {
@@ -242,11 +242,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.21.0, )",
-        "resolved": "3.21.0",
-        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
+        "requested": "[2026.6.0, )",
+        "resolved": "2026.6.0",
+        "contentHash": "7rfwSQHjuvwxeEWJ4/dHYlIAoeZ5SdiPCCYFiF/Avz1ACp5KoDwkh0FF/5lvWDk86MoH55m5BwxYLFek2ui7Kg==",
         "dependencies": {
-          "Speckle.Sdk": "3.21.0"
+          "Speckle.Sdk": "2026.6.0"
         }
       }
     }

--- a/Converters/Revit/Speckle.Converters.Revit2023/packages.lock.json
+++ b/Converters/Revit/Speckle.Converters.Revit2023/packages.lock.json
@@ -180,8 +180,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "jp1fle+rM6l3TtmhTwaWIlZ6HdeR7WYWFwRAxD/iazOFNXp0gWpEwYMe7Z+gBEmd6M91xQwWGAGo03x3D2XJaA==",
+        "resolved": "3.21.0",
+        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -191,14 +191,14 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.20.6",
+          "Speckle.Sdk.Dependencies": "3.21.0",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "DDRzJnBkQuDQbk1Zq76J++sZd63a+aKcY7BiYVDNvjzBSuzhtURe8PQoCfAb1H6WcYL2/K+KytOVvzK/113sGg==",
+        "resolved": "3.21.0",
+        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
         }
@@ -312,7 +312,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "LibTessDotNet": {
@@ -329,11 +329,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.20.6, )",
-        "resolved": "3.20.6",
-        "contentHash": "iK+Yl0VUoGzBFuOqP3yrEWQIuQDoISfwbG7vn0jNmEAgwGcRfB9yGlQ0wA4s7IgxbdEfPjhzzcKMBNcPJWkLtw==",
+        "requested": "[3.21.0, )",
+        "resolved": "3.21.0",
+        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.20.6"
+          "Speckle.Sdk": "3.21.0"
         }
       },
       "System.Text.Json": {

--- a/Converters/Revit/Speckle.Converters.Revit2023/packages.lock.json
+++ b/Converters/Revit/Speckle.Converters.Revit2023/packages.lock.json
@@ -180,8 +180,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
+        "resolved": "2026.6.0",
+        "contentHash": "rrbbe+Z8Nql/y0jHod6+B0zRitmHXq+RNw1zZnzY1heLV6NOe/8ntGbMo9JIGTnZ6Bvxg51UxntMiyAYCdvhXg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -191,14 +191,14 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.21.0",
+          "Speckle.Sdk.Dependencies": "2026.6.0",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA==",
+        "resolved": "2026.6.0",
+        "contentHash": "Nb38i5rAXRkEZlN0nkGbYe5Ph88ZBeHLqkcYCGAXolJcE7eDIPfU5hlWd2KcijFOD/E6f6CEdZJ99PinX2+Ejg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
         }
@@ -312,7 +312,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "LibTessDotNet": {
@@ -329,11 +329,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.21.0, )",
-        "resolved": "3.21.0",
-        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
+        "requested": "[2026.6.0, )",
+        "resolved": "2026.6.0",
+        "contentHash": "7rfwSQHjuvwxeEWJ4/dHYlIAoeZ5SdiPCCYFiF/Avz1ACp5KoDwkh0FF/5lvWDk86MoH55m5BwxYLFek2ui7Kg==",
         "dependencies": {
-          "Speckle.Sdk": "3.21.0"
+          "Speckle.Sdk": "2026.6.0"
         }
       },
       "System.Text.Json": {

--- a/Converters/Revit/Speckle.Converters.Revit2024/packages.lock.json
+++ b/Converters/Revit/Speckle.Converters.Revit2024/packages.lock.json
@@ -180,8 +180,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "jp1fle+rM6l3TtmhTwaWIlZ6HdeR7WYWFwRAxD/iazOFNXp0gWpEwYMe7Z+gBEmd6M91xQwWGAGo03x3D2XJaA==",
+        "resolved": "3.21.0",
+        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -191,14 +191,14 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.20.6",
+          "Speckle.Sdk.Dependencies": "3.21.0",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "DDRzJnBkQuDQbk1Zq76J++sZd63a+aKcY7BiYVDNvjzBSuzhtURe8PQoCfAb1H6WcYL2/K+KytOVvzK/113sGg==",
+        "resolved": "3.21.0",
+        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
         }
@@ -312,7 +312,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "LibTessDotNet": {
@@ -329,11 +329,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.20.6, )",
-        "resolved": "3.20.6",
-        "contentHash": "iK+Yl0VUoGzBFuOqP3yrEWQIuQDoISfwbG7vn0jNmEAgwGcRfB9yGlQ0wA4s7IgxbdEfPjhzzcKMBNcPJWkLtw==",
+        "requested": "[3.21.0, )",
+        "resolved": "3.21.0",
+        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.20.6"
+          "Speckle.Sdk": "3.21.0"
         }
       },
       "System.Text.Json": {

--- a/Converters/Revit/Speckle.Converters.Revit2024/packages.lock.json
+++ b/Converters/Revit/Speckle.Converters.Revit2024/packages.lock.json
@@ -180,8 +180,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
+        "resolved": "2026.6.0",
+        "contentHash": "rrbbe+Z8Nql/y0jHod6+B0zRitmHXq+RNw1zZnzY1heLV6NOe/8ntGbMo9JIGTnZ6Bvxg51UxntMiyAYCdvhXg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -191,14 +191,14 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.21.0",
+          "Speckle.Sdk.Dependencies": "2026.6.0",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA==",
+        "resolved": "2026.6.0",
+        "contentHash": "Nb38i5rAXRkEZlN0nkGbYe5Ph88ZBeHLqkcYCGAXolJcE7eDIPfU5hlWd2KcijFOD/E6f6CEdZJ99PinX2+Ejg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
         }
@@ -312,7 +312,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "LibTessDotNet": {
@@ -329,11 +329,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.21.0, )",
-        "resolved": "3.21.0",
-        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
+        "requested": "[2026.6.0, )",
+        "resolved": "2026.6.0",
+        "contentHash": "7rfwSQHjuvwxeEWJ4/dHYlIAoeZ5SdiPCCYFiF/Avz1ACp5KoDwkh0FF/5lvWDk86MoH55m5BwxYLFek2ui7Kg==",
         "dependencies": {
-          "Speckle.Sdk": "3.21.0"
+          "Speckle.Sdk": "2026.6.0"
         }
       },
       "System.Text.Json": {

--- a/Converters/Revit/Speckle.Converters.Revit2025/packages.lock.json
+++ b/Converters/Revit/Speckle.Converters.Revit2025/packages.lock.json
@@ -139,8 +139,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "jp1fle+rM6l3TtmhTwaWIlZ6HdeR7WYWFwRAxD/iazOFNXp0gWpEwYMe7Z+gBEmd6M91xQwWGAGo03x3D2XJaA==",
+        "resolved": "3.21.0",
+        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -148,13 +148,13 @@
           "Microsoft.Extensions.ObjectPool": "8.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.20.6"
+          "Speckle.Sdk.Dependencies": "3.21.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "DDRzJnBkQuDQbk1Zq76J++sZd63a+aKcY7BiYVDNvjzBSuzhtURe8PQoCfAb1H6WcYL2/K+KytOVvzK/113sGg=="
+        "resolved": "3.21.0",
+        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -206,7 +206,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "LibTessDotNet": {
@@ -223,11 +223,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.20.6, )",
-        "resolved": "3.20.6",
-        "contentHash": "iK+Yl0VUoGzBFuOqP3yrEWQIuQDoISfwbG7vn0jNmEAgwGcRfB9yGlQ0wA4s7IgxbdEfPjhzzcKMBNcPJWkLtw==",
+        "requested": "[3.21.0, )",
+        "resolved": "3.21.0",
+        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.20.6"
+          "Speckle.Sdk": "3.21.0"
         }
       }
     }

--- a/Converters/Revit/Speckle.Converters.Revit2025/packages.lock.json
+++ b/Converters/Revit/Speckle.Converters.Revit2025/packages.lock.json
@@ -139,8 +139,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
+        "resolved": "2026.6.0",
+        "contentHash": "rrbbe+Z8Nql/y0jHod6+B0zRitmHXq+RNw1zZnzY1heLV6NOe/8ntGbMo9JIGTnZ6Bvxg51UxntMiyAYCdvhXg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -148,13 +148,13 @@
           "Microsoft.Extensions.ObjectPool": "8.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.21.0"
+          "Speckle.Sdk.Dependencies": "2026.6.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA=="
+        "resolved": "2026.6.0",
+        "contentHash": "Nb38i5rAXRkEZlN0nkGbYe5Ph88ZBeHLqkcYCGAXolJcE7eDIPfU5hlWd2KcijFOD/E6f6CEdZJ99PinX2+Ejg=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -206,7 +206,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "LibTessDotNet": {
@@ -223,11 +223,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.21.0, )",
-        "resolved": "3.21.0",
-        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
+        "requested": "[2026.6.0, )",
+        "resolved": "2026.6.0",
+        "contentHash": "7rfwSQHjuvwxeEWJ4/dHYlIAoeZ5SdiPCCYFiF/Avz1ACp5KoDwkh0FF/5lvWDk86MoH55m5BwxYLFek2ui7Kg==",
         "dependencies": {
-          "Speckle.Sdk": "3.21.0"
+          "Speckle.Sdk": "2026.6.0"
         }
       }
     }

--- a/Converters/Revit/Speckle.Converters.Revit2026/packages.lock.json
+++ b/Converters/Revit/Speckle.Converters.Revit2026/packages.lock.json
@@ -139,8 +139,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "jp1fle+rM6l3TtmhTwaWIlZ6HdeR7WYWFwRAxD/iazOFNXp0gWpEwYMe7Z+gBEmd6M91xQwWGAGo03x3D2XJaA==",
+        "resolved": "3.21.0",
+        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -148,13 +148,13 @@
           "Microsoft.Extensions.ObjectPool": "8.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.20.6"
+          "Speckle.Sdk.Dependencies": "3.21.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "DDRzJnBkQuDQbk1Zq76J++sZd63a+aKcY7BiYVDNvjzBSuzhtURe8PQoCfAb1H6WcYL2/K+KytOVvzK/113sGg=="
+        "resolved": "3.21.0",
+        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -206,7 +206,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "LibTessDotNet": {
@@ -223,11 +223,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.20.6, )",
-        "resolved": "3.20.6",
-        "contentHash": "iK+Yl0VUoGzBFuOqP3yrEWQIuQDoISfwbG7vn0jNmEAgwGcRfB9yGlQ0wA4s7IgxbdEfPjhzzcKMBNcPJWkLtw==",
+        "requested": "[3.21.0, )",
+        "resolved": "3.21.0",
+        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.20.6"
+          "Speckle.Sdk": "3.21.0"
         }
       }
     }

--- a/Converters/Revit/Speckle.Converters.Revit2026/packages.lock.json
+++ b/Converters/Revit/Speckle.Converters.Revit2026/packages.lock.json
@@ -139,8 +139,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
+        "resolved": "2026.6.0",
+        "contentHash": "rrbbe+Z8Nql/y0jHod6+B0zRitmHXq+RNw1zZnzY1heLV6NOe/8ntGbMo9JIGTnZ6Bvxg51UxntMiyAYCdvhXg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -148,13 +148,13 @@
           "Microsoft.Extensions.ObjectPool": "8.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.21.0"
+          "Speckle.Sdk.Dependencies": "2026.6.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA=="
+        "resolved": "2026.6.0",
+        "contentHash": "Nb38i5rAXRkEZlN0nkGbYe5Ph88ZBeHLqkcYCGAXolJcE7eDIPfU5hlWd2KcijFOD/E6f6CEdZJ99PinX2+Ejg=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -206,7 +206,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "LibTessDotNet": {
@@ -223,11 +223,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.21.0, )",
-        "resolved": "3.21.0",
-        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
+        "requested": "[2026.6.0, )",
+        "resolved": "2026.6.0",
+        "contentHash": "7rfwSQHjuvwxeEWJ4/dHYlIAoeZ5SdiPCCYFiF/Avz1ACp5KoDwkh0FF/5lvWDk86MoH55m5BwxYLFek2ui7Kg==",
         "dependencies": {
-          "Speckle.Sdk": "3.21.0"
+          "Speckle.Sdk": "2026.6.0"
         }
       }
     }

--- a/Converters/Revit/Speckle.Converters.Revit2027/packages.lock.json
+++ b/Converters/Revit/Speckle.Converters.Revit2027/packages.lock.json
@@ -140,8 +140,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "jp1fle+rM6l3TtmhTwaWIlZ6HdeR7WYWFwRAxD/iazOFNXp0gWpEwYMe7Z+gBEmd6M91xQwWGAGo03x3D2XJaA==",
+        "resolved": "3.21.0",
+        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
         "dependencies": {
           "GraphQL.Client": "6.1.0",
           "Microsoft.Data.Sqlite": "10.0.0",
@@ -149,13 +149,13 @@
           "Microsoft.Extensions.ObjectPool": "10.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.20.6"
+          "Speckle.Sdk.Dependencies": "3.21.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "DDRzJnBkQuDQbk1Zq76J++sZd63a+aKcY7BiYVDNvjzBSuzhtURe8PQoCfAb1H6WcYL2/K+KytOVvzK/113sGg=="
+        "resolved": "3.21.0",
+        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -199,7 +199,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "LibTessDotNet": {
@@ -216,11 +216,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.20.6, )",
-        "resolved": "3.20.6",
-        "contentHash": "iK+Yl0VUoGzBFuOqP3yrEWQIuQDoISfwbG7vn0jNmEAgwGcRfB9yGlQ0wA4s7IgxbdEfPjhzzcKMBNcPJWkLtw==",
+        "requested": "[3.21.0, )",
+        "resolved": "3.21.0",
+        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.20.6"
+          "Speckle.Sdk": "3.21.0"
         }
       }
     }

--- a/Converters/Revit/Speckle.Converters.Revit2027/packages.lock.json
+++ b/Converters/Revit/Speckle.Converters.Revit2027/packages.lock.json
@@ -140,8 +140,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
+        "resolved": "2026.6.0",
+        "contentHash": "rrbbe+Z8Nql/y0jHod6+B0zRitmHXq+RNw1zZnzY1heLV6NOe/8ntGbMo9JIGTnZ6Bvxg51UxntMiyAYCdvhXg==",
         "dependencies": {
           "GraphQL.Client": "6.1.0",
           "Microsoft.Data.Sqlite": "10.0.0",
@@ -149,13 +149,13 @@
           "Microsoft.Extensions.ObjectPool": "10.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.21.0"
+          "Speckle.Sdk.Dependencies": "2026.6.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA=="
+        "resolved": "2026.6.0",
+        "contentHash": "Nb38i5rAXRkEZlN0nkGbYe5Ph88ZBeHLqkcYCGAXolJcE7eDIPfU5hlWd2KcijFOD/E6f6CEdZJ99PinX2+Ejg=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -199,7 +199,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "LibTessDotNet": {
@@ -216,11 +216,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.21.0, )",
-        "resolved": "3.21.0",
-        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
+        "requested": "[2026.6.0, )",
+        "resolved": "2026.6.0",
+        "contentHash": "7rfwSQHjuvwxeEWJ4/dHYlIAoeZ5SdiPCCYFiF/Avz1ACp5KoDwkh0FF/5lvWDk86MoH55m5BwxYLFek2ui7Kg==",
         "dependencies": {
-          "Speckle.Sdk": "3.21.0"
+          "Speckle.Sdk": "2026.6.0"
         }
       }
     }

--- a/Converters/Rhino/Speckle.Converters.Rhino7/packages.lock.json
+++ b/Converters/Rhino/Speckle.Converters.Rhino7/packages.lock.json
@@ -180,8 +180,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "jp1fle+rM6l3TtmhTwaWIlZ6HdeR7WYWFwRAxD/iazOFNXp0gWpEwYMe7Z+gBEmd6M91xQwWGAGo03x3D2XJaA==",
+        "resolved": "3.21.0",
+        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -191,14 +191,14 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.20.6",
+          "Speckle.Sdk.Dependencies": "3.21.0",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "DDRzJnBkQuDQbk1Zq76J++sZd63a+aKcY7BiYVDNvjzBSuzhtURe8PQoCfAb1H6WcYL2/K+KytOVvzK/113sGg==",
+        "resolved": "3.21.0",
+        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
         }
@@ -305,7 +305,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "Speckle.DoubleNumerics": {
@@ -316,11 +316,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.20.6, )",
-        "resolved": "3.20.6",
-        "contentHash": "iK+Yl0VUoGzBFuOqP3yrEWQIuQDoISfwbG7vn0jNmEAgwGcRfB9yGlQ0wA4s7IgxbdEfPjhzzcKMBNcPJWkLtw==",
+        "requested": "[3.21.0, )",
+        "resolved": "3.21.0",
+        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.20.6"
+          "Speckle.Sdk": "3.21.0"
         }
       },
       "System.Text.Json": {

--- a/Converters/Rhino/Speckle.Converters.Rhino7/packages.lock.json
+++ b/Converters/Rhino/Speckle.Converters.Rhino7/packages.lock.json
@@ -180,8 +180,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
+        "resolved": "2026.6.0",
+        "contentHash": "rrbbe+Z8Nql/y0jHod6+B0zRitmHXq+RNw1zZnzY1heLV6NOe/8ntGbMo9JIGTnZ6Bvxg51UxntMiyAYCdvhXg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -191,14 +191,14 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.21.0",
+          "Speckle.Sdk.Dependencies": "2026.6.0",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA==",
+        "resolved": "2026.6.0",
+        "contentHash": "Nb38i5rAXRkEZlN0nkGbYe5Ph88ZBeHLqkcYCGAXolJcE7eDIPfU5hlWd2KcijFOD/E6f6CEdZJ99PinX2+Ejg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
         }
@@ -305,7 +305,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "Speckle.DoubleNumerics": {
@@ -316,11 +316,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.21.0, )",
-        "resolved": "3.21.0",
-        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
+        "requested": "[2026.6.0, )",
+        "resolved": "2026.6.0",
+        "contentHash": "7rfwSQHjuvwxeEWJ4/dHYlIAoeZ5SdiPCCYFiF/Avz1ACp5KoDwkh0FF/5lvWDk86MoH55m5BwxYLFek2ui7Kg==",
         "dependencies": {
-          "Speckle.Sdk": "3.21.0"
+          "Speckle.Sdk": "2026.6.0"
         }
       },
       "System.Text.Json": {

--- a/Converters/Rhino/Speckle.Converters.Rhino8/packages.lock.json
+++ b/Converters/Rhino/Speckle.Converters.Rhino8/packages.lock.json
@@ -358,9 +358,9 @@
       },
       "RhinoCommon": {
         "type": "Direct",
-        "requested": "[8.28.26041.11001, )",
-        "resolved": "8.28.26041.11001",
-        "contentHash": "5mByZF+IdHvRLbYvr6Ek95Pwam6otewAyVHIGSC0sUE1+OscSpd9gbrFWnzo1arfCYmUJcUdsGhf7VayW09fQA==",
+        "requested": "[8.31.26126.13431, )",
+        "resolved": "8.31.26126.13431",
+        "contentHash": "fEsA70P6K7oQxQKZ/TytKqZ7EWLa2l8394oHosSFabRJ1rJnT6Q/NsNVhtlmAWuAaOBDDDKLc46kqo0WnsOxJA==",
         "dependencies": {
           "System.Drawing.Common": "7.0.0"
         }
@@ -515,10 +515,7 @@
       "SQLitePCLRaw.core": {
         "type": "Transitive",
         "resolved": "2.1.4",
-        "contentHash": "inBjvSHo9UDKneGNzfUfDjK08JzlcIhn1+SP5Y3m6cgXpCxXKCJDy6Mka7LpgSV+UZmKSnC8rTwB0SQ0xKu5pA==",
-        "dependencies": {
-          "System.Memory": "4.5.3"
-        }
+        "contentHash": "inBjvSHo9UDKneGNzfUfDjK08JzlcIhn1+SP5Y3m6cgXpCxXKCJDy6Mka7LpgSV+UZmKSnC8rTwB0SQ0xKu5pA=="
       },
       "SQLitePCLRaw.lib.e_sqlite3": {
         "type": "Transitive",
@@ -540,11 +537,6 @@
         "dependencies": {
           "Microsoft.Win32.SystemEvents": "7.0.0"
         }
-      },
-      "System.Memory": {
-        "type": "Transitive",
-        "resolved": "4.5.3",
-        "contentHash": "3oDzvc/zzetpTKWMShs1AADwZjQ/36HnsufHRPcOjyRAAMLDlu2iD33MBI2opxnezcVUtXyqDXXjoFMOU9c7SA=="
       },
       "System.Reactive": {
         "type": "Transitive",

--- a/Converters/Rhino/Speckle.Converters.Rhino8/packages.lock.json
+++ b/Converters/Rhino/Speckle.Converters.Rhino8/packages.lock.json
@@ -180,8 +180,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
+        "resolved": "2026.6.0",
+        "contentHash": "rrbbe+Z8Nql/y0jHod6+B0zRitmHXq+RNw1zZnzY1heLV6NOe/8ntGbMo9JIGTnZ6Bvxg51UxntMiyAYCdvhXg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -191,14 +191,14 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.21.0",
+          "Speckle.Sdk.Dependencies": "2026.6.0",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA==",
+        "resolved": "2026.6.0",
+        "contentHash": "Nb38i5rAXRkEZlN0nkGbYe5Ph88ZBeHLqkcYCGAXolJcE7eDIPfU5hlWd2KcijFOD/E6f6CEdZJ99PinX2+Ejg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
         }
@@ -305,7 +305,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "Speckle.DoubleNumerics": {
@@ -316,11 +316,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.21.0, )",
-        "resolved": "3.21.0",
-        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
+        "requested": "[2026.6.0, )",
+        "resolved": "2026.6.0",
+        "contentHash": "7rfwSQHjuvwxeEWJ4/dHYlIAoeZ5SdiPCCYFiF/Avz1ACp5KoDwkh0FF/5lvWDk86MoH55m5BwxYLFek2ui7Kg==",
         "dependencies": {
-          "Speckle.Sdk": "3.21.0"
+          "Speckle.Sdk": "2026.6.0"
         }
       },
       "System.Text.Json": {
@@ -486,8 +486,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
+        "resolved": "2026.6.0",
+        "contentHash": "rrbbe+Z8Nql/y0jHod6+B0zRitmHXq+RNw1zZnzY1heLV6NOe/8ntGbMo9JIGTnZ6Bvxg51UxntMiyAYCdvhXg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -495,13 +495,13 @@
           "Microsoft.Extensions.ObjectPool": "8.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.21.0"
+          "Speckle.Sdk.Dependencies": "2026.6.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA=="
+        "resolved": "2026.6.0",
+        "contentHash": "Nb38i5rAXRkEZlN0nkGbYe5Ph88ZBeHLqkcYCGAXolJcE7eDIPfU5hlWd2KcijFOD/E6f6CEdZJ99PinX2+Ejg=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -515,10 +515,7 @@
       "SQLitePCLRaw.core": {
         "type": "Transitive",
         "resolved": "2.1.4",
-        "contentHash": "inBjvSHo9UDKneGNzfUfDjK08JzlcIhn1+SP5Y3m6cgXpCxXKCJDy6Mka7LpgSV+UZmKSnC8rTwB0SQ0xKu5pA==",
-        "dependencies": {
-          "System.Memory": "4.5.3"
-        }
+        "contentHash": "inBjvSHo9UDKneGNzfUfDjK08JzlcIhn1+SP5Y3m6cgXpCxXKCJDy6Mka7LpgSV+UZmKSnC8rTwB0SQ0xKu5pA=="
       },
       "SQLitePCLRaw.lib.e_sqlite3": {
         "type": "Transitive",
@@ -541,11 +538,6 @@
           "Microsoft.Win32.SystemEvents": "7.0.0"
         }
       },
-      "System.Memory": {
-        "type": "Transitive",
-        "resolved": "4.5.3",
-        "contentHash": "3oDzvc/zzetpTKWMShs1AADwZjQ/36HnsufHRPcOjyRAAMLDlu2iD33MBI2opxnezcVUtXyqDXXjoFMOU9c7SA=="
-      },
       "System.Reactive": {
         "type": "Transitive",
         "resolved": "5.0.0",
@@ -554,7 +546,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "Speckle.DoubleNumerics": {
@@ -565,11 +557,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.21.0, )",
-        "resolved": "3.21.0",
-        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
+        "requested": "[2026.6.0, )",
+        "resolved": "2026.6.0",
+        "contentHash": "7rfwSQHjuvwxeEWJ4/dHYlIAoeZ5SdiPCCYFiF/Avz1ACp5KoDwkh0FF/5lvWDk86MoH55m5BwxYLFek2ui7Kg==",
         "dependencies": {
-          "Speckle.Sdk": "3.21.0"
+          "Speckle.Sdk": "2026.6.0"
         }
       }
     }

--- a/Converters/Rhino/Speckle.Converters.Rhino8/packages.lock.json
+++ b/Converters/Rhino/Speckle.Converters.Rhino8/packages.lock.json
@@ -180,8 +180,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "jp1fle+rM6l3TtmhTwaWIlZ6HdeR7WYWFwRAxD/iazOFNXp0gWpEwYMe7Z+gBEmd6M91xQwWGAGo03x3D2XJaA==",
+        "resolved": "3.21.0",
+        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -191,14 +191,14 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.20.6",
+          "Speckle.Sdk.Dependencies": "3.21.0",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "DDRzJnBkQuDQbk1Zq76J++sZd63a+aKcY7BiYVDNvjzBSuzhtURe8PQoCfAb1H6WcYL2/K+KytOVvzK/113sGg==",
+        "resolved": "3.21.0",
+        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
         }
@@ -305,7 +305,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "Speckle.DoubleNumerics": {
@@ -316,11 +316,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.20.6, )",
-        "resolved": "3.20.6",
-        "contentHash": "iK+Yl0VUoGzBFuOqP3yrEWQIuQDoISfwbG7vn0jNmEAgwGcRfB9yGlQ0wA4s7IgxbdEfPjhzzcKMBNcPJWkLtw==",
+        "requested": "[3.21.0, )",
+        "resolved": "3.21.0",
+        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.20.6"
+          "Speckle.Sdk": "3.21.0"
         }
       },
       "System.Text.Json": {
@@ -486,8 +486,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "jp1fle+rM6l3TtmhTwaWIlZ6HdeR7WYWFwRAxD/iazOFNXp0gWpEwYMe7Z+gBEmd6M91xQwWGAGo03x3D2XJaA==",
+        "resolved": "3.21.0",
+        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -495,13 +495,13 @@
           "Microsoft.Extensions.ObjectPool": "8.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.20.6"
+          "Speckle.Sdk.Dependencies": "3.21.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "DDRzJnBkQuDQbk1Zq76J++sZd63a+aKcY7BiYVDNvjzBSuzhtURe8PQoCfAb1H6WcYL2/K+KytOVvzK/113sGg=="
+        "resolved": "3.21.0",
+        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -546,7 +546,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "Speckle.DoubleNumerics": {
@@ -557,11 +557,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.20.6, )",
-        "resolved": "3.20.6",
-        "contentHash": "iK+Yl0VUoGzBFuOqP3yrEWQIuQDoISfwbG7vn0jNmEAgwGcRfB9yGlQ0wA4s7IgxbdEfPjhzzcKMBNcPJWkLtw==",
+        "requested": "[3.21.0, )",
+        "resolved": "3.21.0",
+        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.20.6"
+          "Speckle.Sdk": "3.21.0"
         }
       }
     }

--- a/Converters/Rhino/Speckle.Converters.Rhino8/packages.lock.json
+++ b/Converters/Rhino/Speckle.Converters.Rhino8/packages.lock.json
@@ -515,7 +515,10 @@
       "SQLitePCLRaw.core": {
         "type": "Transitive",
         "resolved": "2.1.4",
-        "contentHash": "inBjvSHo9UDKneGNzfUfDjK08JzlcIhn1+SP5Y3m6cgXpCxXKCJDy6Mka7LpgSV+UZmKSnC8rTwB0SQ0xKu5pA=="
+        "contentHash": "inBjvSHo9UDKneGNzfUfDjK08JzlcIhn1+SP5Y3m6cgXpCxXKCJDy6Mka7LpgSV+UZmKSnC8rTwB0SQ0xKu5pA==",
+        "dependencies": {
+          "System.Memory": "4.5.3"
+        }
       },
       "SQLitePCLRaw.lib.e_sqlite3": {
         "type": "Transitive",
@@ -537,6 +540,11 @@
         "dependencies": {
           "Microsoft.Win32.SystemEvents": "7.0.0"
         }
+      },
+      "System.Memory": {
+        "type": "Transitive",
+        "resolved": "4.5.3",
+        "contentHash": "3oDzvc/zzetpTKWMShs1AADwZjQ/36HnsufHRPcOjyRAAMLDlu2iD33MBI2opxnezcVUtXyqDXXjoFMOU9c7SA=="
       },
       "System.Reactive": {
         "type": "Transitive",

--- a/Converters/TSD/Speckle.Converters.TSD2027/packages.lock.json
+++ b/Converters/TSD/Speckle.Converters.TSD2027/packages.lock.json
@@ -171,8 +171,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "jp1fle+rM6l3TtmhTwaWIlZ6HdeR7WYWFwRAxD/iazOFNXp0gWpEwYMe7Z+gBEmd6M91xQwWGAGo03x3D2XJaA==",
+        "resolved": "2026.6.0",
+        "contentHash": "rrbbe+Z8Nql/y0jHod6+B0zRitmHXq+RNw1zZnzY1heLV6NOe/8ntGbMo9JIGTnZ6Bvxg51UxntMiyAYCdvhXg==",
         "dependencies": {
           "GraphQL.Client": "6.1.0",
           "Microsoft.Data.Sqlite": "10.0.0",
@@ -180,13 +180,13 @@
           "Microsoft.Extensions.ObjectPool": "10.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.20.6"
+          "Speckle.Sdk.Dependencies": "2026.6.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "DDRzJnBkQuDQbk1Zq76J++sZd63a+aKcY7BiYVDNvjzBSuzhtURe8PQoCfAb1H6WcYL2/K+KytOVvzK/113sGg=="
+        "resolved": "2026.6.0",
+        "contentHash": "Nb38i5rAXRkEZlN0nkGbYe5Ph88ZBeHLqkcYCGAXolJcE7eDIPfU5hlWd2KcijFOD/E6f6CEdZJ99PinX2+Ejg=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -230,7 +230,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "LibTessDotNet": {
@@ -247,11 +247,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.20.6, )",
-        "resolved": "3.20.6",
-        "contentHash": "iK+Yl0VUoGzBFuOqP3yrEWQIuQDoISfwbG7vn0jNmEAgwGcRfB9yGlQ0wA4s7IgxbdEfPjhzzcKMBNcPJWkLtw==",
+        "requested": "[2026.6.0, )",
+        "resolved": "2026.6.0",
+        "contentHash": "7rfwSQHjuvwxeEWJ4/dHYlIAoeZ5SdiPCCYFiF/Avz1ACp5KoDwkh0FF/5lvWDk86MoH55m5BwxYLFek2ui7Kg==",
         "dependencies": {
-          "Speckle.Sdk": "3.20.6"
+          "Speckle.Sdk": "2026.6.0"
         }
       }
     }

--- a/Converters/Tekla/Speckle.Converter.Tekla2023/packages.lock.json
+++ b/Converters/Tekla/Speckle.Converter.Tekla2023/packages.lock.json
@@ -197,8 +197,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "jp1fle+rM6l3TtmhTwaWIlZ6HdeR7WYWFwRAxD/iazOFNXp0gWpEwYMe7Z+gBEmd6M91xQwWGAGo03x3D2XJaA==",
+        "resolved": "3.21.0",
+        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -208,14 +208,14 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.20.6",
+          "Speckle.Sdk.Dependencies": "3.21.0",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "DDRzJnBkQuDQbk1Zq76J++sZd63a+aKcY7BiYVDNvjzBSuzhtURe8PQoCfAb1H6WcYL2/K+KytOVvzK/113sGg==",
+        "resolved": "3.21.0",
+        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
         }
@@ -349,7 +349,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "LibTessDotNet": {
@@ -366,11 +366,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.20.6, )",
-        "resolved": "3.20.6",
-        "contentHash": "iK+Yl0VUoGzBFuOqP3yrEWQIuQDoISfwbG7vn0jNmEAgwGcRfB9yGlQ0wA4s7IgxbdEfPjhzzcKMBNcPJWkLtw==",
+        "requested": "[3.21.0, )",
+        "resolved": "3.21.0",
+        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.20.6"
+          "Speckle.Sdk": "3.21.0"
         }
       },
       "System.Text.Json": {

--- a/Converters/Tekla/Speckle.Converter.Tekla2023/packages.lock.json
+++ b/Converters/Tekla/Speckle.Converter.Tekla2023/packages.lock.json
@@ -197,8 +197,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
+        "resolved": "2026.6.0",
+        "contentHash": "rrbbe+Z8Nql/y0jHod6+B0zRitmHXq+RNw1zZnzY1heLV6NOe/8ntGbMo9JIGTnZ6Bvxg51UxntMiyAYCdvhXg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -208,14 +208,14 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.21.0",
+          "Speckle.Sdk.Dependencies": "2026.6.0",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA==",
+        "resolved": "2026.6.0",
+        "contentHash": "Nb38i5rAXRkEZlN0nkGbYe5Ph88ZBeHLqkcYCGAXolJcE7eDIPfU5hlWd2KcijFOD/E6f6CEdZJ99PinX2+Ejg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
         }
@@ -349,7 +349,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "LibTessDotNet": {
@@ -366,11 +366,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.21.0, )",
-        "resolved": "3.21.0",
-        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
+        "requested": "[2026.6.0, )",
+        "resolved": "2026.6.0",
+        "contentHash": "7rfwSQHjuvwxeEWJ4/dHYlIAoeZ5SdiPCCYFiF/Avz1ACp5KoDwkh0FF/5lvWDk86MoH55m5BwxYLFek2ui7Kg==",
         "dependencies": {
-          "Speckle.Sdk": "3.21.0"
+          "Speckle.Sdk": "2026.6.0"
         }
       },
       "System.Text.Json": {

--- a/Converters/Tekla/Speckle.Converter.Tekla2024/packages.lock.json
+++ b/Converters/Tekla/Speckle.Converter.Tekla2024/packages.lock.json
@@ -207,8 +207,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
+        "resolved": "2026.6.0",
+        "contentHash": "rrbbe+Z8Nql/y0jHod6+B0zRitmHXq+RNw1zZnzY1heLV6NOe/8ntGbMo9JIGTnZ6Bvxg51UxntMiyAYCdvhXg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -218,14 +218,14 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.21.0",
+          "Speckle.Sdk.Dependencies": "2026.6.0",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA==",
+        "resolved": "2026.6.0",
+        "contentHash": "Nb38i5rAXRkEZlN0nkGbYe5Ph88ZBeHLqkcYCGAXolJcE7eDIPfU5hlWd2KcijFOD/E6f6CEdZJ99PinX2+Ejg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
         }
@@ -390,7 +390,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "LibTessDotNet": {
@@ -407,11 +407,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.21.0, )",
-        "resolved": "3.21.0",
-        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
+        "requested": "[2026.6.0, )",
+        "resolved": "2026.6.0",
+        "contentHash": "7rfwSQHjuvwxeEWJ4/dHYlIAoeZ5SdiPCCYFiF/Avz1ACp5KoDwkh0FF/5lvWDk86MoH55m5BwxYLFek2ui7Kg==",
         "dependencies": {
-          "Speckle.Sdk": "3.21.0"
+          "Speckle.Sdk": "2026.6.0"
         }
       },
       "System.Text.Json": {

--- a/Converters/Tekla/Speckle.Converter.Tekla2024/packages.lock.json
+++ b/Converters/Tekla/Speckle.Converter.Tekla2024/packages.lock.json
@@ -207,8 +207,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "jp1fle+rM6l3TtmhTwaWIlZ6HdeR7WYWFwRAxD/iazOFNXp0gWpEwYMe7Z+gBEmd6M91xQwWGAGo03x3D2XJaA==",
+        "resolved": "3.21.0",
+        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -218,14 +218,14 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.20.6",
+          "Speckle.Sdk.Dependencies": "3.21.0",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "DDRzJnBkQuDQbk1Zq76J++sZd63a+aKcY7BiYVDNvjzBSuzhtURe8PQoCfAb1H6WcYL2/K+KytOVvzK/113sGg==",
+        "resolved": "3.21.0",
+        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
         }
@@ -390,7 +390,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "LibTessDotNet": {
@@ -407,11 +407,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.20.6, )",
-        "resolved": "3.20.6",
-        "contentHash": "iK+Yl0VUoGzBFuOqP3yrEWQIuQDoISfwbG7vn0jNmEAgwGcRfB9yGlQ0wA4s7IgxbdEfPjhzzcKMBNcPJWkLtw==",
+        "requested": "[3.21.0, )",
+        "resolved": "3.21.0",
+        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.20.6"
+          "Speckle.Sdk": "3.21.0"
         }
       },
       "System.Text.Json": {

--- a/Converters/Tekla/Speckle.Converter.Tekla2025/packages.lock.json
+++ b/Converters/Tekla/Speckle.Converter.Tekla2025/packages.lock.json
@@ -207,8 +207,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
+        "resolved": "2026.6.0",
+        "contentHash": "rrbbe+Z8Nql/y0jHod6+B0zRitmHXq+RNw1zZnzY1heLV6NOe/8ntGbMo9JIGTnZ6Bvxg51UxntMiyAYCdvhXg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -218,14 +218,14 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.21.0",
+          "Speckle.Sdk.Dependencies": "2026.6.0",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA==",
+        "resolved": "2026.6.0",
+        "contentHash": "Nb38i5rAXRkEZlN0nkGbYe5Ph88ZBeHLqkcYCGAXolJcE7eDIPfU5hlWd2KcijFOD/E6f6CEdZJ99PinX2+Ejg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
         }
@@ -390,7 +390,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "LibTessDotNet": {
@@ -407,11 +407,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.21.0, )",
-        "resolved": "3.21.0",
-        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
+        "requested": "[2026.6.0, )",
+        "resolved": "2026.6.0",
+        "contentHash": "7rfwSQHjuvwxeEWJ4/dHYlIAoeZ5SdiPCCYFiF/Avz1ACp5KoDwkh0FF/5lvWDk86MoH55m5BwxYLFek2ui7Kg==",
         "dependencies": {
-          "Speckle.Sdk": "3.21.0"
+          "Speckle.Sdk": "2026.6.0"
         }
       },
       "System.Text.Json": {

--- a/Converters/Tekla/Speckle.Converter.Tekla2025/packages.lock.json
+++ b/Converters/Tekla/Speckle.Converter.Tekla2025/packages.lock.json
@@ -207,8 +207,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "jp1fle+rM6l3TtmhTwaWIlZ6HdeR7WYWFwRAxD/iazOFNXp0gWpEwYMe7Z+gBEmd6M91xQwWGAGo03x3D2XJaA==",
+        "resolved": "3.21.0",
+        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -218,14 +218,14 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.20.6",
+          "Speckle.Sdk.Dependencies": "3.21.0",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "DDRzJnBkQuDQbk1Zq76J++sZd63a+aKcY7BiYVDNvjzBSuzhtURe8PQoCfAb1H6WcYL2/K+KytOVvzK/113sGg==",
+        "resolved": "3.21.0",
+        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
         }
@@ -390,7 +390,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "LibTessDotNet": {
@@ -407,11 +407,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.20.6, )",
-        "resolved": "3.20.6",
-        "contentHash": "iK+Yl0VUoGzBFuOqP3yrEWQIuQDoISfwbG7vn0jNmEAgwGcRfB9yGlQ0wA4s7IgxbdEfPjhzzcKMBNcPJWkLtw==",
+        "requested": "[3.21.0, )",
+        "resolved": "3.21.0",
+        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.20.6"
+          "Speckle.Sdk": "3.21.0"
         }
       },
       "System.Text.Json": {

--- a/DUI3/Speckle.Connectors.DUI.Tests/packages.lock.json
+++ b/DUI3/Speckle.Connectors.DUI.Tests/packages.lock.json
@@ -271,8 +271,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
+        "resolved": "2026.6.0",
+        "contentHash": "rrbbe+Z8Nql/y0jHod6+B0zRitmHXq+RNw1zZnzY1heLV6NOe/8ntGbMo9JIGTnZ6Bvxg51UxntMiyAYCdvhXg==",
         "dependencies": {
           "GraphQL.Client": "6.1.0",
           "Microsoft.Data.Sqlite": "10.0.0",
@@ -280,13 +280,13 @@
           "Microsoft.Extensions.ObjectPool": "10.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.21.0"
+          "Speckle.Sdk.Dependencies": "2026.6.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA=="
+        "resolved": "2026.6.0",
+        "contentHash": "Nb38i5rAXRkEZlN0nkGbYe5Ph88ZBeHLqkcYCGAXolJcE7eDIPfU5hlWd2KcijFOD/E6f6CEdZJ99PinX2+Ejg=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -330,7 +330,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -345,7 +345,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "speckle.testing": {
@@ -353,7 +353,7 @@
         "dependencies": {
           "Moq": "[4.20.70, )",
           "NUnit": "[4.5.1, )",
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "Speckle.DoubleNumerics": {
@@ -364,11 +364,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.21.0, )",
-        "resolved": "3.21.0",
-        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
+        "requested": "[2026.6.0, )",
+        "resolved": "2026.6.0",
+        "contentHash": "7rfwSQHjuvwxeEWJ4/dHYlIAoeZ5SdiPCCYFiF/Avz1ACp5KoDwkh0FF/5lvWDk86MoH55m5BwxYLFek2ui7Kg==",
         "dependencies": {
-          "Speckle.Sdk": "3.21.0"
+          "Speckle.Sdk": "2026.6.0"
         }
       }
     }

--- a/DUI3/Speckle.Connectors.DUI.Tests/packages.lock.json
+++ b/DUI3/Speckle.Connectors.DUI.Tests/packages.lock.json
@@ -271,8 +271,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "jp1fle+rM6l3TtmhTwaWIlZ6HdeR7WYWFwRAxD/iazOFNXp0gWpEwYMe7Z+gBEmd6M91xQwWGAGo03x3D2XJaA==",
+        "resolved": "3.21.0",
+        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
         "dependencies": {
           "GraphQL.Client": "6.1.0",
           "Microsoft.Data.Sqlite": "10.0.0",
@@ -280,13 +280,13 @@
           "Microsoft.Extensions.ObjectPool": "10.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.20.6"
+          "Speckle.Sdk.Dependencies": "3.21.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "DDRzJnBkQuDQbk1Zq76J++sZd63a+aKcY7BiYVDNvjzBSuzhtURe8PQoCfAb1H6WcYL2/K+KytOVvzK/113sGg=="
+        "resolved": "3.21.0",
+        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -330,7 +330,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -345,7 +345,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "speckle.testing": {
@@ -353,7 +353,7 @@
         "dependencies": {
           "Moq": "[4.20.70, )",
           "NUnit": "[4.5.1, )",
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "Speckle.DoubleNumerics": {
@@ -364,11 +364,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.20.6, )",
-        "resolved": "3.20.6",
-        "contentHash": "iK+Yl0VUoGzBFuOqP3yrEWQIuQDoISfwbG7vn0jNmEAgwGcRfB9yGlQ0wA4s7IgxbdEfPjhzzcKMBNcPJWkLtw==",
+        "requested": "[3.21.0, )",
+        "resolved": "3.21.0",
+        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.20.6"
+          "Speckle.Sdk": "3.21.0"
         }
       }
     }

--- a/DUI3/Speckle.Connectors.DUI.WebView/packages.lock.json
+++ b/DUI3/Speckle.Connectors.DUI.WebView/packages.lock.json
@@ -180,8 +180,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
+        "resolved": "2026.6.0",
+        "contentHash": "rrbbe+Z8Nql/y0jHod6+B0zRitmHXq+RNw1zZnzY1heLV6NOe/8ntGbMo9JIGTnZ6Bvxg51UxntMiyAYCdvhXg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -191,14 +191,14 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.21.0",
+          "Speckle.Sdk.Dependencies": "2026.6.0",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA==",
+        "resolved": "2026.6.0",
+        "contentHash": "Nb38i5rAXRkEZlN0nkGbYe5Ph88ZBeHLqkcYCGAXolJcE7eDIPfU5hlWd2KcijFOD/E6f6CEdZJ99PinX2+Ejg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
         }
@@ -307,7 +307,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -322,7 +322,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "Speckle.DoubleNumerics": {
@@ -333,11 +333,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.21.0, )",
-        "resolved": "3.21.0",
-        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
+        "requested": "[2026.6.0, )",
+        "resolved": "2026.6.0",
+        "contentHash": "7rfwSQHjuvwxeEWJ4/dHYlIAoeZ5SdiPCCYFiF/Avz1ACp5KoDwkh0FF/5lvWDk86MoH55m5BwxYLFek2ui7Kg==",
         "dependencies": {
-          "Speckle.Sdk": "3.21.0"
+          "Speckle.Sdk": "2026.6.0"
         }
       },
       "System.Text.Json": {
@@ -496,8 +496,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
+        "resolved": "2026.6.0",
+        "contentHash": "rrbbe+Z8Nql/y0jHod6+B0zRitmHXq+RNw1zZnzY1heLV6NOe/8ntGbMo9JIGTnZ6Bvxg51UxntMiyAYCdvhXg==",
         "dependencies": {
           "GraphQL.Client": "6.1.0",
           "Microsoft.Data.Sqlite": "10.0.0",
@@ -505,13 +505,13 @@
           "Microsoft.Extensions.ObjectPool": "10.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.21.0"
+          "Speckle.Sdk.Dependencies": "2026.6.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA=="
+        "resolved": "2026.6.0",
+        "contentHash": "Nb38i5rAXRkEZlN0nkGbYe5Ph88ZBeHLqkcYCGAXolJcE7eDIPfU5hlWd2KcijFOD/E6f6CEdZJ99PinX2+Ejg=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -550,7 +550,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -565,7 +565,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "Speckle.DoubleNumerics": {
@@ -576,11 +576,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.21.0, )",
-        "resolved": "3.21.0",
-        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
+        "requested": "[2026.6.0, )",
+        "resolved": "2026.6.0",
+        "contentHash": "7rfwSQHjuvwxeEWJ4/dHYlIAoeZ5SdiPCCYFiF/Avz1ACp5KoDwkh0FF/5lvWDk86MoH55m5BwxYLFek2ui7Kg==",
         "dependencies": {
-          "Speckle.Sdk": "3.21.0"
+          "Speckle.Sdk": "2026.6.0"
         }
       }
     },
@@ -722,8 +722,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
+        "resolved": "2026.6.0",
+        "contentHash": "rrbbe+Z8Nql/y0jHod6+B0zRitmHXq+RNw1zZnzY1heLV6NOe/8ntGbMo9JIGTnZ6Bvxg51UxntMiyAYCdvhXg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -731,13 +731,13 @@
           "Microsoft.Extensions.ObjectPool": "8.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.21.0"
+          "Speckle.Sdk.Dependencies": "2026.6.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA=="
+        "resolved": "2026.6.0",
+        "contentHash": "Nb38i5rAXRkEZlN0nkGbYe5Ph88ZBeHLqkcYCGAXolJcE7eDIPfU5hlWd2KcijFOD/E6f6CEdZJ99PinX2+Ejg=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -776,7 +776,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -791,7 +791,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "Speckle.DoubleNumerics": {
@@ -802,11 +802,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.21.0, )",
-        "resolved": "3.21.0",
-        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
+        "requested": "[2026.6.0, )",
+        "resolved": "2026.6.0",
+        "contentHash": "7rfwSQHjuvwxeEWJ4/dHYlIAoeZ5SdiPCCYFiF/Avz1ACp5KoDwkh0FF/5lvWDk86MoH55m5BwxYLFek2ui7Kg==",
         "dependencies": {
-          "Speckle.Sdk": "3.21.0"
+          "Speckle.Sdk": "2026.6.0"
         }
       }
     }

--- a/DUI3/Speckle.Connectors.DUI.WebView/packages.lock.json
+++ b/DUI3/Speckle.Connectors.DUI.WebView/packages.lock.json
@@ -180,8 +180,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "jp1fle+rM6l3TtmhTwaWIlZ6HdeR7WYWFwRAxD/iazOFNXp0gWpEwYMe7Z+gBEmd6M91xQwWGAGo03x3D2XJaA==",
+        "resolved": "3.21.0",
+        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -191,14 +191,14 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.20.6",
+          "Speckle.Sdk.Dependencies": "3.21.0",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "DDRzJnBkQuDQbk1Zq76J++sZd63a+aKcY7BiYVDNvjzBSuzhtURe8PQoCfAb1H6WcYL2/K+KytOVvzK/113sGg==",
+        "resolved": "3.21.0",
+        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
         }
@@ -307,7 +307,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -322,7 +322,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "Speckle.DoubleNumerics": {
@@ -333,11 +333,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.20.6, )",
-        "resolved": "3.20.6",
-        "contentHash": "iK+Yl0VUoGzBFuOqP3yrEWQIuQDoISfwbG7vn0jNmEAgwGcRfB9yGlQ0wA4s7IgxbdEfPjhzzcKMBNcPJWkLtw==",
+        "requested": "[3.21.0, )",
+        "resolved": "3.21.0",
+        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.20.6"
+          "Speckle.Sdk": "3.21.0"
         }
       },
       "System.Text.Json": {
@@ -496,8 +496,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "jp1fle+rM6l3TtmhTwaWIlZ6HdeR7WYWFwRAxD/iazOFNXp0gWpEwYMe7Z+gBEmd6M91xQwWGAGo03x3D2XJaA==",
+        "resolved": "3.21.0",
+        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
         "dependencies": {
           "GraphQL.Client": "6.1.0",
           "Microsoft.Data.Sqlite": "10.0.0",
@@ -505,13 +505,13 @@
           "Microsoft.Extensions.ObjectPool": "10.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.20.6"
+          "Speckle.Sdk.Dependencies": "3.21.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "DDRzJnBkQuDQbk1Zq76J++sZd63a+aKcY7BiYVDNvjzBSuzhtURe8PQoCfAb1H6WcYL2/K+KytOVvzK/113sGg=="
+        "resolved": "3.21.0",
+        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -550,7 +550,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -565,7 +565,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "Speckle.DoubleNumerics": {
@@ -576,11 +576,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.20.6, )",
-        "resolved": "3.20.6",
-        "contentHash": "iK+Yl0VUoGzBFuOqP3yrEWQIuQDoISfwbG7vn0jNmEAgwGcRfB9yGlQ0wA4s7IgxbdEfPjhzzcKMBNcPJWkLtw==",
+        "requested": "[3.21.0, )",
+        "resolved": "3.21.0",
+        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.20.6"
+          "Speckle.Sdk": "3.21.0"
         }
       }
     },
@@ -722,8 +722,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "jp1fle+rM6l3TtmhTwaWIlZ6HdeR7WYWFwRAxD/iazOFNXp0gWpEwYMe7Z+gBEmd6M91xQwWGAGo03x3D2XJaA==",
+        "resolved": "3.21.0",
+        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -731,13 +731,13 @@
           "Microsoft.Extensions.ObjectPool": "8.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.20.6"
+          "Speckle.Sdk.Dependencies": "3.21.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "DDRzJnBkQuDQbk1Zq76J++sZd63a+aKcY7BiYVDNvjzBSuzhtURe8PQoCfAb1H6WcYL2/K+KytOVvzK/113sGg=="
+        "resolved": "3.21.0",
+        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -776,7 +776,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -791,7 +791,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "Speckle.DoubleNumerics": {
@@ -802,11 +802,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.20.6, )",
-        "resolved": "3.20.6",
-        "contentHash": "iK+Yl0VUoGzBFuOqP3yrEWQIuQDoISfwbG7vn0jNmEAgwGcRfB9yGlQ0wA4s7IgxbdEfPjhzzcKMBNcPJWkLtw==",
+        "requested": "[3.21.0, )",
+        "resolved": "3.21.0",
+        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.20.6"
+          "Speckle.Sdk": "3.21.0"
         }
       }
     }

--- a/DUI3/Speckle.Connectors.DUI/packages.lock.json
+++ b/DUI3/Speckle.Connectors.DUI/packages.lock.json
@@ -174,8 +174,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "jp1fle+rM6l3TtmhTwaWIlZ6HdeR7WYWFwRAxD/iazOFNXp0gWpEwYMe7Z+gBEmd6M91xQwWGAGo03x3D2XJaA==",
+        "resolved": "3.21.0",
+        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -185,14 +185,14 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.20.6",
+          "Speckle.Sdk.Dependencies": "3.21.0",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "DDRzJnBkQuDQbk1Zq76J++sZd63a+aKcY7BiYVDNvjzBSuzhtURe8PQoCfAb1H6WcYL2/K+KytOVvzK/113sGg==",
+        "resolved": "3.21.0",
+        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
         }
@@ -301,7 +301,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "speckle.connectors.logging": {
@@ -310,7 +310,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "Speckle.DoubleNumerics": {
@@ -321,11 +321,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.20.6, )",
-        "resolved": "3.20.6",
-        "contentHash": "iK+Yl0VUoGzBFuOqP3yrEWQIuQDoISfwbG7vn0jNmEAgwGcRfB9yGlQ0wA4s7IgxbdEfPjhzzcKMBNcPJWkLtw==",
+        "requested": "[3.21.0, )",
+        "resolved": "3.21.0",
+        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.20.6"
+          "Speckle.Sdk": "3.21.0"
         }
       },
       "System.Text.Json": {
@@ -478,8 +478,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "jp1fle+rM6l3TtmhTwaWIlZ6HdeR7WYWFwRAxD/iazOFNXp0gWpEwYMe7Z+gBEmd6M91xQwWGAGo03x3D2XJaA==",
+        "resolved": "3.21.0",
+        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
         "dependencies": {
           "GraphQL.Client": "6.1.0",
           "Microsoft.Data.Sqlite": "10.0.0",
@@ -487,13 +487,13 @@
           "Microsoft.Extensions.ObjectPool": "10.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.20.6"
+          "Speckle.Sdk.Dependencies": "3.21.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "DDRzJnBkQuDQbk1Zq76J++sZd63a+aKcY7BiYVDNvjzBSuzhtURe8PQoCfAb1H6WcYL2/K+KytOVvzK/113sGg=="
+        "resolved": "3.21.0",
+        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -532,7 +532,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "speckle.connectors.logging": {
@@ -541,7 +541,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "Speckle.DoubleNumerics": {
@@ -552,11 +552,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.20.6, )",
-        "resolved": "3.20.6",
-        "contentHash": "iK+Yl0VUoGzBFuOqP3yrEWQIuQDoISfwbG7vn0jNmEAgwGcRfB9yGlQ0wA4s7IgxbdEfPjhzzcKMBNcPJWkLtw==",
+        "requested": "[3.21.0, )",
+        "resolved": "3.21.0",
+        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.20.6"
+          "Speckle.Sdk": "3.21.0"
         }
       }
     },
@@ -692,8 +692,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "jp1fle+rM6l3TtmhTwaWIlZ6HdeR7WYWFwRAxD/iazOFNXp0gWpEwYMe7Z+gBEmd6M91xQwWGAGo03x3D2XJaA==",
+        "resolved": "3.21.0",
+        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -701,13 +701,13 @@
           "Microsoft.Extensions.ObjectPool": "8.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.20.6"
+          "Speckle.Sdk.Dependencies": "3.21.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "DDRzJnBkQuDQbk1Zq76J++sZd63a+aKcY7BiYVDNvjzBSuzhtURe8PQoCfAb1H6WcYL2/K+KytOVvzK/113sGg=="
+        "resolved": "3.21.0",
+        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -746,7 +746,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "speckle.connectors.logging": {
@@ -755,7 +755,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "Speckle.DoubleNumerics": {
@@ -766,11 +766,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.20.6, )",
-        "resolved": "3.20.6",
-        "contentHash": "iK+Yl0VUoGzBFuOqP3yrEWQIuQDoISfwbG7vn0jNmEAgwGcRfB9yGlQ0wA4s7IgxbdEfPjhzzcKMBNcPJWkLtw==",
+        "requested": "[3.21.0, )",
+        "resolved": "3.21.0",
+        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.20.6"
+          "Speckle.Sdk": "3.21.0"
         }
       }
     }

--- a/DUI3/Speckle.Connectors.DUI/packages.lock.json
+++ b/DUI3/Speckle.Connectors.DUI/packages.lock.json
@@ -174,8 +174,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
+        "resolved": "2026.6.0",
+        "contentHash": "rrbbe+Z8Nql/y0jHod6+B0zRitmHXq+RNw1zZnzY1heLV6NOe/8ntGbMo9JIGTnZ6Bvxg51UxntMiyAYCdvhXg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -185,14 +185,14 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.21.0",
+          "Speckle.Sdk.Dependencies": "2026.6.0",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA==",
+        "resolved": "2026.6.0",
+        "contentHash": "Nb38i5rAXRkEZlN0nkGbYe5Ph88ZBeHLqkcYCGAXolJcE7eDIPfU5hlWd2KcijFOD/E6f6CEdZJ99PinX2+Ejg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
         }
@@ -301,7 +301,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "speckle.connectors.logging": {
@@ -310,7 +310,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "Speckle.DoubleNumerics": {
@@ -321,11 +321,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.21.0, )",
-        "resolved": "3.21.0",
-        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
+        "requested": "[2026.6.0, )",
+        "resolved": "2026.6.0",
+        "contentHash": "7rfwSQHjuvwxeEWJ4/dHYlIAoeZ5SdiPCCYFiF/Avz1ACp5KoDwkh0FF/5lvWDk86MoH55m5BwxYLFek2ui7Kg==",
         "dependencies": {
-          "Speckle.Sdk": "3.21.0"
+          "Speckle.Sdk": "2026.6.0"
         }
       },
       "System.Text.Json": {
@@ -478,8 +478,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
+        "resolved": "2026.6.0",
+        "contentHash": "rrbbe+Z8Nql/y0jHod6+B0zRitmHXq+RNw1zZnzY1heLV6NOe/8ntGbMo9JIGTnZ6Bvxg51UxntMiyAYCdvhXg==",
         "dependencies": {
           "GraphQL.Client": "6.1.0",
           "Microsoft.Data.Sqlite": "10.0.0",
@@ -487,13 +487,13 @@
           "Microsoft.Extensions.ObjectPool": "10.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.21.0"
+          "Speckle.Sdk.Dependencies": "2026.6.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA=="
+        "resolved": "2026.6.0",
+        "contentHash": "Nb38i5rAXRkEZlN0nkGbYe5Ph88ZBeHLqkcYCGAXolJcE7eDIPfU5hlWd2KcijFOD/E6f6CEdZJ99PinX2+Ejg=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -532,7 +532,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "speckle.connectors.logging": {
@@ -541,7 +541,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "Speckle.DoubleNumerics": {
@@ -552,11 +552,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.21.0, )",
-        "resolved": "3.21.0",
-        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
+        "requested": "[2026.6.0, )",
+        "resolved": "2026.6.0",
+        "contentHash": "7rfwSQHjuvwxeEWJ4/dHYlIAoeZ5SdiPCCYFiF/Avz1ACp5KoDwkh0FF/5lvWDk86MoH55m5BwxYLFek2ui7Kg==",
         "dependencies": {
-          "Speckle.Sdk": "3.21.0"
+          "Speckle.Sdk": "2026.6.0"
         }
       }
     },
@@ -692,8 +692,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
+        "resolved": "2026.6.0",
+        "contentHash": "rrbbe+Z8Nql/y0jHod6+B0zRitmHXq+RNw1zZnzY1heLV6NOe/8ntGbMo9JIGTnZ6Bvxg51UxntMiyAYCdvhXg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -701,13 +701,13 @@
           "Microsoft.Extensions.ObjectPool": "8.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.21.0"
+          "Speckle.Sdk.Dependencies": "2026.6.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA=="
+        "resolved": "2026.6.0",
+        "contentHash": "Nb38i5rAXRkEZlN0nkGbYe5Ph88ZBeHLqkcYCGAXolJcE7eDIPfU5hlWd2KcijFOD/E6f6CEdZJ99PinX2+Ejg=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -746,7 +746,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "speckle.connectors.logging": {
@@ -755,7 +755,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "Speckle.DoubleNumerics": {
@@ -766,11 +766,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.21.0, )",
-        "resolved": "3.21.0",
-        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
+        "requested": "[2026.6.0, )",
+        "resolved": "2026.6.0",
+        "contentHash": "7rfwSQHjuvwxeEWJ4/dHYlIAoeZ5SdiPCCYFiF/Avz1ACp5KoDwkh0FF/5lvWDk86MoH55m5BwxYLFek2ui7Kg==",
         "dependencies": {
-          "Speckle.Sdk": "3.21.0"
+          "Speckle.Sdk": "2026.6.0"
         }
       }
     }

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -38,6 +38,11 @@
     </NoWarn>
   </PropertyGroup>
   
+  <ItemGroup>
+    <!--Waiting for microsoft to update Microsoft.Data.Sqlite-->
+    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-2m69-gcr7-jv3q" />
+  </ItemGroup>
+  
   <PropertyGroup Label="Repo Info">
     <RepositoryUrl>https://github.com/specklesystems/speckle-sharp-connectors</RepositoryUrl>
     <RepositoryType>git</RepositoryType>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -50,7 +50,7 @@
     <PackageVersion Include="Speckle.Civil3D.API" Version="2022.0.2" />
     <PackageVersion Include="Speckle.Revit.API" Version="2023.0.0" />
     <PackageVersion Include="Speckle.Navisworks.API" Version="2024.0.0" />
-    <PackageVersion Include="Speckle.Objects" Version="3.20.6" />
+    <PackageVersion Include="Speckle.Objects" Version="3.21.0" />
     <PackageVersion Include="SimpleExec" Version="12.0.0" />
     <GlobalPackageReference Include="PolySharp" Version="1.15.0" />
     <GlobalPackageReference Include="Speckle.InterfaceGenerator" Version="0.9.6" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -50,7 +50,7 @@
     <PackageVersion Include="Speckle.Civil3D.API" Version="2022.0.2" />
     <PackageVersion Include="Speckle.Revit.API" Version="2023.0.0" />
     <PackageVersion Include="Speckle.Navisworks.API" Version="2024.0.0" />
-    <PackageVersion Include="Speckle.Objects" Version="3.21.0" />
+    <PackageVersion Include="Speckle.Objects" Version="2026.6.0" />
     <PackageVersion Include="SimpleExec" Version="12.0.0" />
     <GlobalPackageReference Include="PolySharp" Version="1.15.0" />
     <GlobalPackageReference Include="Speckle.InterfaceGenerator" Version="0.9.6" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -22,10 +22,10 @@
     <PackageVersion Include="NUnit.Analyzers" Version="4.12.0" />
     <PackageVersion Include="NUnit3TestAdapter" version="6.2.0" />
     <PackageVersion Include="Revit.Async" Version="2.1.1" />
-    <PackageVersion Include="RhinoCommon" Version="8.28.26041.11001" />
+    <PackageVersion Include="RhinoCommon" Version="8.31.26126.13431" />
     <PackageVersion Include="Rhino.Inside" Version="8.0.7-beta" />
-    <PackageVersion Include="Grasshopper" Version="8.28.26041.11001" />
-    <PackageVersion Include="RhinoWindows" Version="8.28.26041.11001" />
+    <PackageVersion Include="Grasshopper" Version="8.31.26126.13431" />
+    <PackageVersion Include="RhinoWindows" Version="8.31.26126.13431" />
     <PackageVersion Include="Semver" Version="3.0.0" />
     <PackageVersion Include="Serilog.Formatting.Compact" Version="3.0.0" />
     <PackageVersion Include="Speckle.CSI.API" Version="2.4.0" />

--- a/Importers/Rhino/Speckle.Importers.JobProcessor/Domain/FileimportPayload.cs
+++ b/Importers/Rhino/Speckle.Importers.JobProcessor/Domain/FileimportPayload.cs
@@ -28,4 +28,7 @@ internal sealed class TraceContext
 {
   [JsonPropertyName("traceparent")]
   public string? TraceParent { get; init; }
+
+  [JsonPropertyName("tracestate")]
+  public string? TraceState { get; init; }
 }

--- a/Importers/Rhino/Speckle.Importers.JobProcessor/JobHandlers/IPCModels.cs
+++ b/Importers/Rhino/Speckle.Importers.JobProcessor/JobHandlers/IPCModels.cs
@@ -12,7 +12,8 @@ internal readonly struct ImporterArgs
   public required string BlobId { get; init; }
   public required int Attempt { get; init; }
   public required string ResultsPath { get; init; }
-  public required string? TraceContext { get; init; }
+  public required string? TraceParent { get; init; }
+  public required string? TraceState { get; init; }
   public required Project Project { get; init; }
   public required ModelIngestion Ingestion { get; init; }
   public required Account Account { get; init; }

--- a/Importers/Rhino/Speckle.Importers.JobProcessor/JobHandlers/IPCModels.cs
+++ b/Importers/Rhino/Speckle.Importers.JobProcessor/JobHandlers/IPCModels.cs
@@ -12,7 +12,11 @@ internal readonly struct ImporterArgs
   public required string BlobId { get; init; }
   public required int Attempt { get; init; }
   public required string ResultsPath { get; init; }
+
+  /// <summary>W3C <c>traceparent</c> header</summary>
   public required string? TraceParent { get; init; }
+
+  /// <summary>W3C <c>tracestate</c> header</summary>
   public required string? TraceState { get; init; }
   public required Project Project { get; init; }
   public required ModelIngestion Ingestion { get; init; }

--- a/Importers/Rhino/Speckle.Importers.JobProcessor/JobHandlers/RhinoJobHandler.cs
+++ b/Importers/Rhino/Speckle.Importers.JobProcessor/JobHandlers/RhinoJobHandler.cs
@@ -63,7 +63,8 @@ internal sealed class RhinoJobHandler(
       {
         FilePath = file.FileInfo.FullName,
         ResultsPath = resultsPath,
-        TraceContext = $"00-{activity?.TraceId}-{activity?.SpanId}-01",
+        TraceParent = activity?.TraceParent,
+        TraceState = activity?.TraceState,
         Account = client.Account,
         Project = project,
         Ingestion = ingestion,

--- a/Importers/Rhino/Speckle.Importers.JobProcessor/JobProcessor.cs
+++ b/Importers/Rhino/Speckle.Importers.JobProcessor/JobProcessor.cs
@@ -72,7 +72,12 @@ internal sealed class JobProcessorInstance(
       );
 
       using var activity = job.Payload.TraceContext?.TraceParent is not null
-        ? activityFactory.StartRemote(job.Payload.TraceContext.TraceParent, SdkActivityKind.Consumer, "Picked up a job")
+        ? activityFactory.StartRemote(
+          job.Payload.TraceContext.TraceParent,
+          job.Payload.TraceContext.TraceState,
+          SdkActivityKind.Consumer,
+          "Picked up a job"
+        )
         : activityFactory.Start("Picked up a job", SdkActivityKind.Consumer);
 
       using var scopeJobId = ActivityScope.SetTag("jobId", job.Id);

--- a/Importers/Rhino/Speckle.Importers.JobProcessor/packages.lock.json
+++ b/Importers/Rhino/Speckle.Importers.JobProcessor/packages.lock.json
@@ -425,8 +425,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
+        "resolved": "2026.6.0",
+        "contentHash": "rrbbe+Z8Nql/y0jHod6+B0zRitmHXq+RNw1zZnzY1heLV6NOe/8ntGbMo9JIGTnZ6Bvxg51UxntMiyAYCdvhXg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -434,13 +434,13 @@
           "Microsoft.Extensions.ObjectPool": "8.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.21.0"
+          "Speckle.Sdk.Dependencies": "2026.6.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA=="
+        "resolved": "2026.6.0",
+        "contentHash": "Nb38i5rAXRkEZlN0nkGbYe5Ph88ZBeHLqkcYCGAXolJcE7eDIPfU5hlWd2KcijFOD/E6f6CEdZJ99PinX2+Ejg=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -515,7 +515,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -545,7 +545,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "speckle.converters.rhino8": {
@@ -592,11 +592,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.21.0, )",
-        "resolved": "3.21.0",
-        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
+        "requested": "[2026.6.0, )",
+        "resolved": "2026.6.0",
+        "contentHash": "7rfwSQHjuvwxeEWJ4/dHYlIAoeZ5SdiPCCYFiF/Avz1ACp5KoDwkh0FF/5lvWDk86MoH55m5BwxYLFek2ui7Kg==",
         "dependencies": {
-          "Speckle.Sdk": "3.21.0"
+          "Speckle.Sdk": "2026.6.0"
         }
       },
       "System.Text.Json": {

--- a/Importers/Rhino/Speckle.Importers.JobProcessor/packages.lock.json
+++ b/Importers/Rhino/Speckle.Importers.JobProcessor/packages.lock.json
@@ -425,8 +425,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "jp1fle+rM6l3TtmhTwaWIlZ6HdeR7WYWFwRAxD/iazOFNXp0gWpEwYMe7Z+gBEmd6M91xQwWGAGo03x3D2XJaA==",
+        "resolved": "3.21.0",
+        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -434,13 +434,13 @@
           "Microsoft.Extensions.ObjectPool": "8.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.20.6"
+          "Speckle.Sdk.Dependencies": "3.21.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "DDRzJnBkQuDQbk1Zq76J++sZd63a+aKcY7BiYVDNvjzBSuzhtURe8PQoCfAb1H6WcYL2/K+KytOVvzK/113sGg=="
+        "resolved": "3.21.0",
+        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -515,7 +515,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -545,7 +545,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "speckle.converters.rhino8": {
@@ -592,11 +592,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.20.6, )",
-        "resolved": "3.20.6",
-        "contentHash": "iK+Yl0VUoGzBFuOqP3yrEWQIuQDoISfwbG7vn0jNmEAgwGcRfB9yGlQ0wA4s7IgxbdEfPjhzzcKMBNcPJWkLtw==",
+        "requested": "[3.21.0, )",
+        "resolved": "3.21.0",
+        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.20.6"
+          "Speckle.Sdk": "3.21.0"
         }
       },
       "System.Text.Json": {

--- a/Importers/Rhino/Speckle.Importers.Rhino/Internal/IPCModels.cs
+++ b/Importers/Rhino/Speckle.Importers.Rhino/Internal/IPCModels.cs
@@ -12,7 +12,8 @@ internal readonly struct ImporterArgs
   public required string BlobId { get; init; }
   public required int Attempt { get; init; }
   public required string ResultsPath { get; init; }
-  public required string? TraceContext { get; init; }
+  public required string? TraceParent { get; init; }
+  public required string? TraceState { get; init; }
   public required Project Project { get; init; }
   public required ModelIngestion Ingestion { get; init; }
   public required Account Account { get; init; }

--- a/Importers/Rhino/Speckle.Importers.Rhino/Program.cs
+++ b/Importers/Rhino/Speckle.Importers.Rhino/Program.cs
@@ -44,8 +44,8 @@ internal static class Program
         logger.LogCritical(eventArgs.Exception, "Unobserved Task Exception");
 
       ISdkActivityFactory activityFactory = serviceProvider.GetRequiredService<ISdkActivityFactory>();
-      using var activity = importerArgs.TraceContext is not null
-        ? activityFactory.StartRemote(importerArgs.TraceContext, SdkActivityKind.Consumer)
+      using var activity = importerArgs.TraceParent is not null
+        ? activityFactory.StartRemote(importerArgs.TraceParent, importerArgs.TraceState, SdkActivityKind.Consumer)
         : activityFactory.Start();
 
       var factory = serviceProvider.GetRequiredService<ImporterInstanceFactory>();

--- a/Importers/Rhino/Speckle.Importers.Rhino/packages.lock.json
+++ b/Importers/Rhino/Speckle.Importers.Rhino/packages.lock.json
@@ -4,11 +4,11 @@
     "net8.0-windows7.0": {
       "Grasshopper": {
         "type": "Direct",
-        "requested": "[8.28.26041.11001, )",
-        "resolved": "8.28.26041.11001",
-        "contentHash": "xlLD67F4/c5quwUrLxtAXT3M4Xam7GnhXyepC8/AblIBFcWbKEBzfOv85FlzO0ZPmDJwNjM5kRYML/sAStktZg==",
+        "requested": "[8.31.26126.13431, )",
+        "resolved": "8.31.26126.13431",
+        "contentHash": "LkUwPx8kNsUItW5UgvjuK65/NpuXrLu0Ffb+CzMRRTcP9QwbUriyYk0Qr9G8VYg92E9LE2k+ddyc5J6CZi5fVg==",
         "dependencies": {
-          "RhinoCommon": "[8.28.26041.11001]"
+          "RhinoCommon": "[8.31.26126.13431]"
         }
       },
       "Microsoft.NETFramework.ReferenceAssemblies": {
@@ -38,20 +38,20 @@
       },
       "RhinoCommon": {
         "type": "Direct",
-        "requested": "[8.28.26041.11001, )",
-        "resolved": "8.28.26041.11001",
-        "contentHash": "5mByZF+IdHvRLbYvr6Ek95Pwam6otewAyVHIGSC0sUE1+OscSpd9gbrFWnzo1arfCYmUJcUdsGhf7VayW09fQA==",
+        "requested": "[8.31.26126.13431, )",
+        "resolved": "8.31.26126.13431",
+        "contentHash": "fEsA70P6K7oQxQKZ/TytKqZ7EWLa2l8394oHosSFabRJ1rJnT6Q/NsNVhtlmAWuAaOBDDDKLc46kqo0WnsOxJA==",
         "dependencies": {
           "System.Drawing.Common": "7.0.0"
         }
       },
       "RhinoWindows": {
         "type": "Direct",
-        "requested": "[8.28.26041.11001, )",
-        "resolved": "8.28.26041.11001",
-        "contentHash": "7MBG231k5c0/V/USTzbXpaTCiZCECQOuB80DnpgEvvEA3r//IQQDTbrqawDYmN9BEw/FHiFn82bsf6tV+SS5Iw==",
+        "requested": "[8.31.26126.13431, )",
+        "resolved": "8.31.26126.13431",
+        "contentHash": "KeteDrHWbzwHwJZnwYmhuT0bYed7NHPb4Fvgw6DxfPNUBK4WuYClA2M5uOpGE7Lbn8K593MrTb5ksz4ASK2VQw==",
         "dependencies": {
-          "RhinoCommon": "[8.28.26041.11001]"
+          "RhinoCommon": "[8.31.26126.13431]"
         }
       },
       "Speckle.InterfaceGenerator": {

--- a/Importers/Rhino/Speckle.Importers.Rhino/packages.lock.json
+++ b/Importers/Rhino/Speckle.Importers.Rhino/packages.lock.json
@@ -175,8 +175,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "jp1fle+rM6l3TtmhTwaWIlZ6HdeR7WYWFwRAxD/iazOFNXp0gWpEwYMe7Z+gBEmd6M91xQwWGAGo03x3D2XJaA==",
+        "resolved": "3.21.0",
+        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -184,13 +184,13 @@
           "Microsoft.Extensions.ObjectPool": "8.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.20.6"
+          "Speckle.Sdk.Dependencies": "3.21.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "DDRzJnBkQuDQbk1Zq76J++sZd63a+aKcY7BiYVDNvjzBSuzhtURe8PQoCfAb1H6WcYL2/K+KytOVvzK/113sGg=="
+        "resolved": "3.21.0",
+        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -245,7 +245,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -275,7 +275,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "speckle.converters.rhino8": {
@@ -298,11 +298,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.20.6, )",
-        "resolved": "3.20.6",
-        "contentHash": "iK+Yl0VUoGzBFuOqP3yrEWQIuQDoISfwbG7vn0jNmEAgwGcRfB9yGlQ0wA4s7IgxbdEfPjhzzcKMBNcPJWkLtw==",
+        "requested": "[3.21.0, )",
+        "resolved": "3.21.0",
+        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.20.6"
+          "Speckle.Sdk": "3.21.0"
         }
       }
     }

--- a/Importers/Rhino/Speckle.Importers.Rhino/packages.lock.json
+++ b/Importers/Rhino/Speckle.Importers.Rhino/packages.lock.json
@@ -175,8 +175,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
+        "resolved": "2026.6.0",
+        "contentHash": "rrbbe+Z8Nql/y0jHod6+B0zRitmHXq+RNw1zZnzY1heLV6NOe/8ntGbMo9JIGTnZ6Bvxg51UxntMiyAYCdvhXg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -184,13 +184,13 @@
           "Microsoft.Extensions.ObjectPool": "8.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.21.0"
+          "Speckle.Sdk.Dependencies": "2026.6.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA=="
+        "resolved": "2026.6.0",
+        "contentHash": "Nb38i5rAXRkEZlN0nkGbYe5Ph88ZBeHLqkcYCGAXolJcE7eDIPfU5hlWd2KcijFOD/E6f6CEdZJ99PinX2+Ejg=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -245,7 +245,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "speckle.connectors.dui": {
@@ -275,7 +275,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "speckle.converters.rhino8": {
@@ -298,11 +298,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.21.0, )",
-        "resolved": "3.21.0",
-        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
+        "requested": "[2026.6.0, )",
+        "resolved": "2026.6.0",
+        "contentHash": "7rfwSQHjuvwxeEWJ4/dHYlIAoeZ5SdiPCCYFiF/Avz1ACp5KoDwkh0FF/5lvWDk86MoH55m5BwxYLFek2ui7Kg==",
         "dependencies": {
-          "Speckle.Sdk": "3.21.0"
+          "Speckle.Sdk": "2026.6.0"
         }
       }
     }

--- a/Sdk/Speckle.Connectors.Common.Tests/packages.lock.json
+++ b/Sdk/Speckle.Connectors.Common.Tests/packages.lock.json
@@ -256,8 +256,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "jp1fle+rM6l3TtmhTwaWIlZ6HdeR7WYWFwRAxD/iazOFNXp0gWpEwYMe7Z+gBEmd6M91xQwWGAGo03x3D2XJaA==",
+        "resolved": "3.21.0",
+        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
         "dependencies": {
           "GraphQL.Client": "6.1.0",
           "Microsoft.Data.Sqlite": "10.0.0",
@@ -265,13 +265,13 @@
           "Microsoft.Extensions.ObjectPool": "10.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.20.6"
+          "Speckle.Sdk.Dependencies": "3.21.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "DDRzJnBkQuDQbk1Zq76J++sZd63a+aKcY7BiYVDNvjzBSuzhtURe8PQoCfAb1H6WcYL2/K+KytOVvzK/113sGg=="
+        "resolved": "3.21.0",
+        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -315,7 +315,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "speckle.connectors.logging": {
@@ -324,7 +324,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "speckle.testing": {
@@ -332,7 +332,7 @@
         "dependencies": {
           "Moq": "[4.20.70, )",
           "NUnit": "[4.5.1, )",
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "Moq": {
@@ -358,11 +358,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.20.6, )",
-        "resolved": "3.20.6",
-        "contentHash": "iK+Yl0VUoGzBFuOqP3yrEWQIuQDoISfwbG7vn0jNmEAgwGcRfB9yGlQ0wA4s7IgxbdEfPjhzzcKMBNcPJWkLtw==",
+        "requested": "[3.21.0, )",
+        "resolved": "3.21.0",
+        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.20.6"
+          "Speckle.Sdk": "3.21.0"
         }
       }
     }

--- a/Sdk/Speckle.Connectors.Common.Tests/packages.lock.json
+++ b/Sdk/Speckle.Connectors.Common.Tests/packages.lock.json
@@ -256,8 +256,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
+        "resolved": "2026.6.0",
+        "contentHash": "rrbbe+Z8Nql/y0jHod6+B0zRitmHXq+RNw1zZnzY1heLV6NOe/8ntGbMo9JIGTnZ6Bvxg51UxntMiyAYCdvhXg==",
         "dependencies": {
           "GraphQL.Client": "6.1.0",
           "Microsoft.Data.Sqlite": "10.0.0",
@@ -265,13 +265,13 @@
           "Microsoft.Extensions.ObjectPool": "10.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.21.0"
+          "Speckle.Sdk.Dependencies": "2026.6.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA=="
+        "resolved": "2026.6.0",
+        "contentHash": "Nb38i5rAXRkEZlN0nkGbYe5Ph88ZBeHLqkcYCGAXolJcE7eDIPfU5hlWd2KcijFOD/E6f6CEdZJ99PinX2+Ejg=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -315,7 +315,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "speckle.connectors.logging": {
@@ -324,7 +324,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "speckle.testing": {
@@ -332,7 +332,7 @@
         "dependencies": {
           "Moq": "[4.20.70, )",
           "NUnit": "[4.5.1, )",
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "Moq": {
@@ -358,11 +358,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.21.0, )",
-        "resolved": "3.21.0",
-        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
+        "requested": "[2026.6.0, )",
+        "resolved": "2026.6.0",
+        "contentHash": "7rfwSQHjuvwxeEWJ4/dHYlIAoeZ5SdiPCCYFiF/Avz1ACp5KoDwkh0FF/5lvWDk86MoH55m5BwxYLFek2ui7Kg==",
         "dependencies": {
-          "Speckle.Sdk": "3.21.0"
+          "Speckle.Sdk": "2026.6.0"
         }
       }
     }

--- a/Sdk/Speckle.Connectors.Common/ConnectorActivityFactory.cs
+++ b/Sdk/Speckle.Connectors.Common/ConnectorActivityFactory.cs
@@ -3,17 +3,25 @@ using Speckle.Sdk.Logging;
 
 namespace Speckle.Connectors.Common;
 
+/// <summary>
+/// Provides <see cref="Speckle.Sdk"/> with an implementation of <see cref="ISdkActivityFactory"/>
+/// that wraps <see cref="ISdkActivity"/> with an underlying <see cref="LoggingActivity"/>
+/// </summary>
 public sealed class ConnectorActivityFactory : ISdkActivityFactory
 {
   private readonly LoggingActivityFactory _loggingActivityFactory = new();
 
-  public void SetTag(string key, object? value) => _loggingActivityFactory.SetTag(key, value);
-
   public void Dispose() => _loggingActivityFactory.Dispose();
 
-  public ISdkActivity? Start(string? name, SdkActivityKind kind, string source)
+  public ISdkActivity? Start(
+    string? name = null,
+    SdkActivityKind kind = SdkActivityKind.Internal,
+    IReadOnlyDictionary<string, object?>? tags = null,
+    DateTimeOffset startTime = default,
+    string source = ""
+  )
   {
-    LoggingActivity? activity = _loggingActivityFactory.Start(name ?? source, ToLoggingType(kind));
+    LoggingActivity? activity = _loggingActivityFactory.Start(name ?? source, ToLoggingType(kind), tags, startTime);
     if (activity is null)
     {
       return null;
@@ -22,13 +30,24 @@ public sealed class ConnectorActivityFactory : ISdkActivityFactory
     return new ConnectorActivity(activity.Value);
   }
 
-  /// <param name="traceContext">W3C trace context header</param>
-  /// <param name="kind"></param>
-  /// <param name="name"></param>
-  /// <returns></returns>
-  public ISdkActivity? StartRemote(string traceContext, SdkActivityKind kind, string? name, string source)
+  public ISdkActivity? StartRemote(
+    string? traceParent,
+    string? traceState,
+    SdkActivityKind kind,
+    string? name = null,
+    IReadOnlyDictionary<string, object?>? tags = null,
+    DateTimeOffset startTime = default,
+    string source = ""
+  )
   {
-    LoggingActivity? activity = _loggingActivityFactory.StartRemote(name ?? source, traceContext, ToLoggingType(kind));
+    LoggingActivity? activity = _loggingActivityFactory.StartRemote(
+      name ?? source,
+      traceParent,
+      traceState,
+      ToLoggingType(kind),
+      tags,
+      startTime
+    );
     if (activity is null)
     {
       return null;
@@ -36,7 +55,6 @@ public sealed class ConnectorActivityFactory : ISdkActivityFactory
     return new ConnectorActivity(activity.Value);
   }
 
-  //We need to do this gymnastics due to ILRepack
   private static LoggingActivityKind ToLoggingType(SdkActivityKind kind) =>
     kind switch
     {
@@ -56,6 +74,11 @@ public sealed class ConnectorActivityFactory : ISdkActivityFactory
 
     public void RecordException(Exception e) => activity.RecordException(e);
 
+    /// <inheritdoc />
+    public string TraceParent => activity.TraceParent;
+
+    /// <inheritdoc />
+    public string? TraceState => activity.TraceState;
     public string TraceId => activity.TraceId;
     public string SpanId => activity.SpanId;
 

--- a/Sdk/Speckle.Connectors.Common/ConnectorActivityFactory.cs
+++ b/Sdk/Speckle.Connectors.Common/ConnectorActivityFactory.cs
@@ -5,8 +5,17 @@ namespace Speckle.Connectors.Common;
 
 /// <summary>
 /// Provides <see cref="Speckle.Sdk"/> with an implementation of <see cref="ISdkActivityFactory"/>
-/// that wraps <see cref="ISdkActivity"/> with an underlying <see cref="LoggingActivity"/>
+/// that wraps <see cref="ISdkActivity"/> with an underlying <see cref="LoggingActivity"/>.
 /// </summary>
+/// <remarks>
+/// We have several layers of abstraction via interfaces and wrappers:<br/>
+/// <c>System.Diagnostics.DiagnosticSource.Activity</c> is wrapped by
+/// <see cref="LoggingActivity"/> is wrapped by
+/// <see cref="ConnectorActivityFactory"/> implements the sdk abstraction <see cref="ISdkActivityFactory"/>.
+/// <br/>
+/// This is done so that the  .NET Standard 2.0 target of the <see cref="Speckle.Sdk"/> (and therefore consumers e.g. .NET framework connectors) can avoid a
+/// dependency on <c>System.Diagnostics.DiagnosticSource</c>.
+/// </remarks>
 public sealed class ConnectorActivityFactory : ISdkActivityFactory
 {
   private readonly LoggingActivityFactory _loggingActivityFactory = new();
@@ -71,6 +80,8 @@ public sealed class ConnectorActivityFactory : ISdkActivityFactory
     public void Dispose() => activity.Dispose();
 
     public void SetTag(string key, object? value) => activity.SetTag(key, value);
+
+    public void SetBaggage(string key, string? value) => activity.SetBaggage(key, value);
 
     public void RecordException(Exception e) => activity.RecordException(e);
 

--- a/Sdk/Speckle.Connectors.Common/packages.lock.json
+++ b/Sdk/Speckle.Connectors.Common/packages.lock.json
@@ -25,11 +25,11 @@
       },
       "Speckle.Objects": {
         "type": "Direct",
-        "requested": "[3.21.0, )",
-        "resolved": "3.21.0",
-        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
+        "requested": "[2026.6.0, )",
+        "resolved": "2026.6.0",
+        "contentHash": "7rfwSQHjuvwxeEWJ4/dHYlIAoeZ5SdiPCCYFiF/Avz1ACp5KoDwkh0FF/5lvWDk86MoH55m5BwxYLFek2ui7Kg==",
         "dependencies": {
-          "Speckle.Sdk": "3.21.0"
+          "Speckle.Sdk": "2026.6.0"
         }
       },
       "GraphQL.Client": {
@@ -183,8 +183,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
+        "resolved": "2026.6.0",
+        "contentHash": "rrbbe+Z8Nql/y0jHod6+B0zRitmHXq+RNw1zZnzY1heLV6NOe/8ntGbMo9JIGTnZ6Bvxg51UxntMiyAYCdvhXg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -194,14 +194,14 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.21.0",
+          "Speckle.Sdk.Dependencies": "2026.6.0",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA==",
+        "resolved": "2026.6.0",
+        "contentHash": "Nb38i5rAXRkEZlN0nkGbYe5Ph88ZBeHLqkcYCGAXolJcE7eDIPfU5hlWd2KcijFOD/E6f6CEdZJ99PinX2+Ejg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
         }
@@ -311,7 +311,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "Speckle.DoubleNumerics": {
@@ -361,11 +361,11 @@
       },
       "Speckle.Objects": {
         "type": "Direct",
-        "requested": "[3.21.0, )",
-        "resolved": "3.21.0",
-        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
+        "requested": "[2026.6.0, )",
+        "resolved": "2026.6.0",
+        "contentHash": "7rfwSQHjuvwxeEWJ4/dHYlIAoeZ5SdiPCCYFiF/Avz1ACp5KoDwkh0FF/5lvWDk86MoH55m5BwxYLFek2ui7Kg==",
         "dependencies": {
-          "Speckle.Sdk": "3.21.0"
+          "Speckle.Sdk": "2026.6.0"
         }
       },
       "GraphQL.Client": {
@@ -479,8 +479,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
+        "resolved": "2026.6.0",
+        "contentHash": "rrbbe+Z8Nql/y0jHod6+B0zRitmHXq+RNw1zZnzY1heLV6NOe/8ntGbMo9JIGTnZ6Bvxg51UxntMiyAYCdvhXg==",
         "dependencies": {
           "GraphQL.Client": "6.1.0",
           "Microsoft.Data.Sqlite": "10.0.0",
@@ -488,13 +488,13 @@
           "Microsoft.Extensions.ObjectPool": "10.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.21.0"
+          "Speckle.Sdk.Dependencies": "2026.6.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA=="
+        "resolved": "2026.6.0",
+        "contentHash": "Nb38i5rAXRkEZlN0nkGbYe5Ph88ZBeHLqkcYCGAXolJcE7eDIPfU5hlWd2KcijFOD/E6f6CEdZJ99PinX2+Ejg=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -534,7 +534,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "Speckle.DoubleNumerics": {
@@ -568,11 +568,11 @@
       },
       "Speckle.Objects": {
         "type": "Direct",
-        "requested": "[3.21.0, )",
-        "resolved": "3.21.0",
-        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
+        "requested": "[2026.6.0, )",
+        "resolved": "2026.6.0",
+        "contentHash": "7rfwSQHjuvwxeEWJ4/dHYlIAoeZ5SdiPCCYFiF/Avz1ACp5KoDwkh0FF/5lvWDk86MoH55m5BwxYLFek2ui7Kg==",
         "dependencies": {
-          "Speckle.Sdk": "3.21.0"
+          "Speckle.Sdk": "2026.6.0"
         }
       },
       "GraphQL.Client": {
@@ -685,8 +685,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
+        "resolved": "2026.6.0",
+        "contentHash": "rrbbe+Z8Nql/y0jHod6+B0zRitmHXq+RNw1zZnzY1heLV6NOe/8ntGbMo9JIGTnZ6Bvxg51UxntMiyAYCdvhXg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -694,13 +694,13 @@
           "Microsoft.Extensions.ObjectPool": "8.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.21.0"
+          "Speckle.Sdk.Dependencies": "2026.6.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA=="
+        "resolved": "2026.6.0",
+        "contentHash": "Nb38i5rAXRkEZlN0nkGbYe5Ph88ZBeHLqkcYCGAXolJcE7eDIPfU5hlWd2KcijFOD/E6f6CEdZJ99PinX2+Ejg=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -740,7 +740,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "Speckle.DoubleNumerics": {

--- a/Sdk/Speckle.Connectors.Common/packages.lock.json
+++ b/Sdk/Speckle.Connectors.Common/packages.lock.json
@@ -25,11 +25,11 @@
       },
       "Speckle.Objects": {
         "type": "Direct",
-        "requested": "[3.20.6, )",
-        "resolved": "3.20.6",
-        "contentHash": "iK+Yl0VUoGzBFuOqP3yrEWQIuQDoISfwbG7vn0jNmEAgwGcRfB9yGlQ0wA4s7IgxbdEfPjhzzcKMBNcPJWkLtw==",
+        "requested": "[3.21.0, )",
+        "resolved": "3.21.0",
+        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.20.6"
+          "Speckle.Sdk": "3.21.0"
         }
       },
       "GraphQL.Client": {
@@ -183,8 +183,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "jp1fle+rM6l3TtmhTwaWIlZ6HdeR7WYWFwRAxD/iazOFNXp0gWpEwYMe7Z+gBEmd6M91xQwWGAGo03x3D2XJaA==",
+        "resolved": "3.21.0",
+        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -194,14 +194,14 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.20.6",
+          "Speckle.Sdk.Dependencies": "3.21.0",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "DDRzJnBkQuDQbk1Zq76J++sZd63a+aKcY7BiYVDNvjzBSuzhtURe8PQoCfAb1H6WcYL2/K+KytOVvzK/113sGg==",
+        "resolved": "3.21.0",
+        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
         }
@@ -311,7 +311,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "Speckle.DoubleNumerics": {
@@ -361,11 +361,11 @@
       },
       "Speckle.Objects": {
         "type": "Direct",
-        "requested": "[3.20.6, )",
-        "resolved": "3.20.6",
-        "contentHash": "iK+Yl0VUoGzBFuOqP3yrEWQIuQDoISfwbG7vn0jNmEAgwGcRfB9yGlQ0wA4s7IgxbdEfPjhzzcKMBNcPJWkLtw==",
+        "requested": "[3.21.0, )",
+        "resolved": "3.21.0",
+        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.20.6"
+          "Speckle.Sdk": "3.21.0"
         }
       },
       "GraphQL.Client": {
@@ -479,8 +479,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "jp1fle+rM6l3TtmhTwaWIlZ6HdeR7WYWFwRAxD/iazOFNXp0gWpEwYMe7Z+gBEmd6M91xQwWGAGo03x3D2XJaA==",
+        "resolved": "3.21.0",
+        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
         "dependencies": {
           "GraphQL.Client": "6.1.0",
           "Microsoft.Data.Sqlite": "10.0.0",
@@ -488,13 +488,13 @@
           "Microsoft.Extensions.ObjectPool": "10.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.20.6"
+          "Speckle.Sdk.Dependencies": "3.21.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "DDRzJnBkQuDQbk1Zq76J++sZd63a+aKcY7BiYVDNvjzBSuzhtURe8PQoCfAb1H6WcYL2/K+KytOVvzK/113sGg=="
+        "resolved": "3.21.0",
+        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -534,7 +534,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "Speckle.DoubleNumerics": {
@@ -568,11 +568,11 @@
       },
       "Speckle.Objects": {
         "type": "Direct",
-        "requested": "[3.20.6, )",
-        "resolved": "3.20.6",
-        "contentHash": "iK+Yl0VUoGzBFuOqP3yrEWQIuQDoISfwbG7vn0jNmEAgwGcRfB9yGlQ0wA4s7IgxbdEfPjhzzcKMBNcPJWkLtw==",
+        "requested": "[3.21.0, )",
+        "resolved": "3.21.0",
+        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.20.6"
+          "Speckle.Sdk": "3.21.0"
         }
       },
       "GraphQL.Client": {
@@ -685,8 +685,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "jp1fle+rM6l3TtmhTwaWIlZ6HdeR7WYWFwRAxD/iazOFNXp0gWpEwYMe7Z+gBEmd6M91xQwWGAGo03x3D2XJaA==",
+        "resolved": "3.21.0",
+        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -694,13 +694,13 @@
           "Microsoft.Extensions.ObjectPool": "8.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.20.6"
+          "Speckle.Sdk.Dependencies": "3.21.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "DDRzJnBkQuDQbk1Zq76J++sZd63a+aKcY7BiYVDNvjzBSuzhtURe8PQoCfAb1H6WcYL2/K+KytOVvzK/113sGg=="
+        "resolved": "3.21.0",
+        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -740,7 +740,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "Speckle.DoubleNumerics": {

--- a/Sdk/Speckle.Connectors.Logging/ActivityScopeActivityProcessor.cs
+++ b/Sdk/Speckle.Connectors.Logging/ActivityScopeActivityProcessor.cs
@@ -3,6 +3,9 @@ using OpenTelemetry;
 
 namespace Speckle.Connectors.Logging;
 
+/// <summary>
+/// Adds <see cref="ActivityScope"/> tags to <see cref="Activity"/>
+/// </summary>
 internal sealed class ActivityScopeActivityProcessor : BaseProcessor<Activity>
 {
   public override void OnEnd(Activity data)

--- a/Sdk/Speckle.Connectors.Logging/ActivityScopeExtensions.cs
+++ b/Sdk/Speckle.Connectors.Logging/ActivityScopeExtensions.cs
@@ -1,5 +1,13 @@
 namespace Speckle.Connectors.Logging;
 
+/// <summary>
+/// Creates context that is scoped to an <see cref="AsyncLocal{T}"/> state machine.
+/// The tags are added to both logs and traces via <see cref="ActivityScopeLogProcessor"/> and <see cref="ActivityScopeActivityProcessor"/>
+/// </summary>
+/// <remarks>
+/// The only thing that makes this useful is it adds info to traces and logs
+/// OTEL would traces already inherit scoped context without the help of this class...
+/// </remarks>
 public static class ActivityScope
 {
   private static readonly AsyncLocal<Dictionary<string, object?>> s_tags = new() { Value = new() };

--- a/Sdk/Speckle.Connectors.Logging/ActivityScopeLogProcessor.cs
+++ b/Sdk/Speckle.Connectors.Logging/ActivityScopeLogProcessor.cs
@@ -3,6 +3,9 @@ using OpenTelemetry.Logs;
 
 namespace Speckle.Connectors.Logging;
 
+/// <summary>
+/// Adds <see cref="ActivityScope"/> tags to <see cref="LogRecord"/>s
+/// </summary>
 internal sealed class ActivityScopeLogProcessor : BaseProcessor<LogRecord>
 {
   public override void OnEnd(LogRecord data)

--- a/Sdk/Speckle.Connectors.Logging/Internal/LogBuilder.cs
+++ b/Sdk/Speckle.Connectors.Logging/Internal/LogBuilder.cs
@@ -58,6 +58,9 @@ internal static class LogBuilder
                 "Initialized logger inside {applicationAndVersion}/{connectorVersion}. Path info {userApplicationDataPath} {installApplicationDataPath}."
               );
           }
+
+          //TODO: test this is safe
+          //loggingBuilder.AddSerilog(serilogLogger, true);
         }
       }
 

--- a/Sdk/Speckle.Connectors.Logging/LoggingActivity.cs
+++ b/Sdk/Speckle.Connectors.Logging/LoggingActivity.cs
@@ -25,6 +25,8 @@ public readonly struct LoggingActivity
 
   public void SetTag(string key, object? value) => _activity.SetTag(key, value);
 
+  public void SetBaggage(string key, string? value) => _activity.SetBaggage(key, value);
+
   public void RecordException(Exception e) => _activity.AddException(e);
 
   /// <summary>W3C <c>tracestate</c> header</summary>

--- a/Sdk/Speckle.Connectors.Logging/LoggingActivity.cs
+++ b/Sdk/Speckle.Connectors.Logging/LoggingActivity.cs
@@ -2,6 +2,16 @@
 
 namespace Speckle.Connectors.Logging;
 
+/// <summary>
+/// Provides a wrapper around <see cref="Activity"/>.
+/// Since <see cref="Activity"/> is ILRepacked and thus the type is not not accessible by consumers
+/// </summary>
+/// <remarks>
+/// The reason we're ilrepacking is to avoid .NET framework connectors from
+/// having a dependency on <see cref="System.Diagnostics.DiagnosticSource"/>
+/// To avoid any potential DLL conflicts.
+/// However, I recall this was done to "play safe" rather than avoid any known conflicts.
+/// </remarks>
 public readonly struct LoggingActivity
 {
   private readonly Activity _activity;
@@ -16,6 +26,12 @@ public readonly struct LoggingActivity
   public void SetTag(string key, object? value) => _activity.SetTag(key, value);
 
   public void RecordException(Exception e) => _activity.AddException(e);
+
+  /// <summary>W3C <c>tracestate</c> header</summary>
+  public string? TraceState => _activity.TraceStateString;
+
+  /// <summary>W3C <c>traceparent</c> header</summary>
+  public string TraceParent => $"00-{TraceId}-{SpanId}-{checked((byte)_activity.ActivityTraceFlags):X2}";
 
   public string TraceId => _activity.TraceId.ToString();
   public string SpanId => _activity.SpanId.ToString();
@@ -32,10 +48,15 @@ public readonly struct LoggingActivity
       }
     );
 
-  public void InjectHeaders(Action<string, string> header) =>
+  /// <summary>
+  /// <paramref name="headerHandler"/> will be called to handle each trace values
+  /// stored in the <see cref="Activity"/> object
+  /// so it can be injected into the headers of an HTTP request.
+  /// </summary>
+  public void InjectHeaders(Action<string, string> headerHandler) =>
     DistributedContextPropagator.Current.Inject(
       _activity,
-      header,
+      headerHandler,
       static (carrier, key, value) =>
       {
         if (carrier is Action<string, string> request)

--- a/Sdk/Speckle.Connectors.Logging/LoggingActivityFactory.cs
+++ b/Sdk/Speckle.Connectors.Logging/LoggingActivityFactory.cs
@@ -10,19 +10,25 @@ public sealed class LoggingActivityFactory : IDisposable
     Consts.GetPackageVersion(Assembly.GetExecutingAssembly())
   );
 
-  private readonly Dictionary<string, object?> _tags = new();
-
-  public void SetTag(string key, object? value) => _tags[key] = value;
-
-  public LoggingActivity? StartRemote(string name, string traceContext, LoggingActivityKind activityKind)
+  public LoggingActivity? StartRemote(
+    string name,
+    string? traceParent,
+    string? traceState,
+    LoggingActivityKind kind,
+    IReadOnlyDictionary<string, object?>? tags,
+    DateTimeOffset startTime
+  )
   {
-    if (!ActivityContext.TryParse(traceContext, null, true, out ActivityContext context))
+    if (!ActivityContext.TryParse(traceParent, traceState, true, out ActivityContext context))
     {
-      throw new ArgumentException("traceContext was not parsable to a valid W3C Header", nameof(traceContext));
+      throw new ArgumentException(
+        "traceContext was not parsable to a valid W3C traceParent or traceState Header",
+        nameof(traceParent)
+      );
     }
 
     //If you get a MissingManifestResourceException, Likely source or name is empty string, which is no good.
-    var activity = _activitySource.StartActivity(name, ToOtelType(activityKind), context, _tags);
+    var activity = _activitySource.StartActivity(name, ToOtelType(kind), context, tags, null, startTime);
     if (activity is null)
     {
       return null;
@@ -30,10 +36,15 @@ public sealed class LoggingActivityFactory : IDisposable
     return new LoggingActivity(activity);
   }
 
-  public LoggingActivity? Start(string name, LoggingActivityKind activityKind)
+  public LoggingActivity? Start(
+    string name,
+    LoggingActivityKind kind,
+    IReadOnlyDictionary<string, object?>? tags,
+    DateTimeOffset startTime
+  )
   {
     //If you get a MissingManifestResourceException, Likely source or name is empty string, which is no good.
-    var activity = _activitySource.StartActivity(ToOtelType(activityKind), tags: _tags, name: name);
+    var activity = _activitySource.StartActivity(name, ToOtelType(kind), null, tags, null, startTime);
     if (activity is null)
     {
       return null;

--- a/Sdk/Speckle.Converters.Common.Tests/packages.lock.json
+++ b/Sdk/Speckle.Converters.Common.Tests/packages.lock.json
@@ -271,8 +271,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "jp1fle+rM6l3TtmhTwaWIlZ6HdeR7WYWFwRAxD/iazOFNXp0gWpEwYMe7Z+gBEmd6M91xQwWGAGo03x3D2XJaA==",
+        "resolved": "3.21.0",
+        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
         "dependencies": {
           "GraphQL.Client": "6.1.0",
           "Microsoft.Data.Sqlite": "10.0.0",
@@ -280,13 +280,13 @@
           "Microsoft.Extensions.ObjectPool": "10.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.20.6"
+          "Speckle.Sdk.Dependencies": "3.21.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "DDRzJnBkQuDQbk1Zq76J++sZd63a+aKcY7BiYVDNvjzBSuzhtURe8PQoCfAb1H6WcYL2/K+KytOVvzK/113sGg=="
+        "resolved": "3.21.0",
+        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -328,7 +328,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "speckle.testing": {
@@ -336,7 +336,7 @@
         "dependencies": {
           "Moq": "[4.20.70, )",
           "NUnit": "[4.5.1, )",
-          "Speckle.Objects": "[3.20.6, )"
+          "Speckle.Objects": "[3.21.0, )"
         }
       },
       "Speckle.DoubleNumerics": {
@@ -347,11 +347,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.20.6, )",
-        "resolved": "3.20.6",
-        "contentHash": "iK+Yl0VUoGzBFuOqP3yrEWQIuQDoISfwbG7vn0jNmEAgwGcRfB9yGlQ0wA4s7IgxbdEfPjhzzcKMBNcPJWkLtw==",
+        "requested": "[3.21.0, )",
+        "resolved": "3.21.0",
+        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.20.6"
+          "Speckle.Sdk": "3.21.0"
         }
       }
     }

--- a/Sdk/Speckle.Converters.Common.Tests/packages.lock.json
+++ b/Sdk/Speckle.Converters.Common.Tests/packages.lock.json
@@ -271,8 +271,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
+        "resolved": "2026.6.0",
+        "contentHash": "rrbbe+Z8Nql/y0jHod6+B0zRitmHXq+RNw1zZnzY1heLV6NOe/8ntGbMo9JIGTnZ6Bvxg51UxntMiyAYCdvhXg==",
         "dependencies": {
           "GraphQL.Client": "6.1.0",
           "Microsoft.Data.Sqlite": "10.0.0",
@@ -280,13 +280,13 @@
           "Microsoft.Extensions.ObjectPool": "10.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.21.0"
+          "Speckle.Sdk.Dependencies": "2026.6.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA=="
+        "resolved": "2026.6.0",
+        "contentHash": "Nb38i5rAXRkEZlN0nkGbYe5Ph88ZBeHLqkcYCGAXolJcE7eDIPfU5hlWd2KcijFOD/E6f6CEdZJ99PinX2+Ejg=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -328,7 +328,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "speckle.testing": {
@@ -336,7 +336,7 @@
         "dependencies": {
           "Moq": "[4.20.70, )",
           "NUnit": "[4.5.1, )",
-          "Speckle.Objects": "[3.21.0, )"
+          "Speckle.Objects": "[2026.6.0, )"
         }
       },
       "Speckle.DoubleNumerics": {
@@ -347,11 +347,11 @@
       },
       "Speckle.Objects": {
         "type": "CentralTransitive",
-        "requested": "[3.21.0, )",
-        "resolved": "3.21.0",
-        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
+        "requested": "[2026.6.0, )",
+        "resolved": "2026.6.0",
+        "contentHash": "7rfwSQHjuvwxeEWJ4/dHYlIAoeZ5SdiPCCYFiF/Avz1ACp5KoDwkh0FF/5lvWDk86MoH55m5BwxYLFek2ui7Kg==",
         "dependencies": {
-          "Speckle.Sdk": "3.21.0"
+          "Speckle.Sdk": "2026.6.0"
         }
       }
     }

--- a/Sdk/Speckle.Converters.Common/packages.lock.json
+++ b/Sdk/Speckle.Converters.Common/packages.lock.json
@@ -25,11 +25,11 @@
       },
       "Speckle.Objects": {
         "type": "Direct",
-        "requested": "[3.20.6, )",
-        "resolved": "3.20.6",
-        "contentHash": "iK+Yl0VUoGzBFuOqP3yrEWQIuQDoISfwbG7vn0jNmEAgwGcRfB9yGlQ0wA4s7IgxbdEfPjhzzcKMBNcPJWkLtw==",
+        "requested": "[3.21.0, )",
+        "resolved": "3.21.0",
+        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.20.6"
+          "Speckle.Sdk": "3.21.0"
         }
       },
       "GraphQL.Client": {
@@ -183,8 +183,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "jp1fle+rM6l3TtmhTwaWIlZ6HdeR7WYWFwRAxD/iazOFNXp0gWpEwYMe7Z+gBEmd6M91xQwWGAGo03x3D2XJaA==",
+        "resolved": "3.21.0",
+        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -194,14 +194,14 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.20.6",
+          "Speckle.Sdk.Dependencies": "3.21.0",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "DDRzJnBkQuDQbk1Zq76J++sZd63a+aKcY7BiYVDNvjzBSuzhtURe8PQoCfAb1H6WcYL2/K+KytOVvzK/113sGg==",
+        "resolved": "3.21.0",
+        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
         }
@@ -352,11 +352,11 @@
       },
       "Speckle.Objects": {
         "type": "Direct",
-        "requested": "[3.20.6, )",
-        "resolved": "3.20.6",
-        "contentHash": "iK+Yl0VUoGzBFuOqP3yrEWQIuQDoISfwbG7vn0jNmEAgwGcRfB9yGlQ0wA4s7IgxbdEfPjhzzcKMBNcPJWkLtw==",
+        "requested": "[3.21.0, )",
+        "resolved": "3.21.0",
+        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.20.6"
+          "Speckle.Sdk": "3.21.0"
         }
       },
       "GraphQL.Client": {
@@ -470,8 +470,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "jp1fle+rM6l3TtmhTwaWIlZ6HdeR7WYWFwRAxD/iazOFNXp0gWpEwYMe7Z+gBEmd6M91xQwWGAGo03x3D2XJaA==",
+        "resolved": "3.21.0",
+        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
         "dependencies": {
           "GraphQL.Client": "6.1.0",
           "Microsoft.Data.Sqlite": "10.0.0",
@@ -479,13 +479,13 @@
           "Microsoft.Extensions.ObjectPool": "10.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.20.6"
+          "Speckle.Sdk.Dependencies": "3.21.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "DDRzJnBkQuDQbk1Zq76J++sZd63a+aKcY7BiYVDNvjzBSuzhtURe8PQoCfAb1H6WcYL2/K+KytOVvzK/113sGg=="
+        "resolved": "3.21.0",
+        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -550,11 +550,11 @@
       },
       "Speckle.Objects": {
         "type": "Direct",
-        "requested": "[3.20.6, )",
-        "resolved": "3.20.6",
-        "contentHash": "iK+Yl0VUoGzBFuOqP3yrEWQIuQDoISfwbG7vn0jNmEAgwGcRfB9yGlQ0wA4s7IgxbdEfPjhzzcKMBNcPJWkLtw==",
+        "requested": "[3.21.0, )",
+        "resolved": "3.21.0",
+        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.20.6"
+          "Speckle.Sdk": "3.21.0"
         }
       },
       "GraphQL.Client": {
@@ -667,8 +667,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "jp1fle+rM6l3TtmhTwaWIlZ6HdeR7WYWFwRAxD/iazOFNXp0gWpEwYMe7Z+gBEmd6M91xQwWGAGo03x3D2XJaA==",
+        "resolved": "3.21.0",
+        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -676,13 +676,13 @@
           "Microsoft.Extensions.ObjectPool": "8.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.20.6"
+          "Speckle.Sdk.Dependencies": "3.21.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "DDRzJnBkQuDQbk1Zq76J++sZd63a+aKcY7BiYVDNvjzBSuzhtURe8PQoCfAb1H6WcYL2/K+KytOVvzK/113sGg=="
+        "resolved": "3.21.0",
+        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",

--- a/Sdk/Speckle.Converters.Common/packages.lock.json
+++ b/Sdk/Speckle.Converters.Common/packages.lock.json
@@ -25,11 +25,11 @@
       },
       "Speckle.Objects": {
         "type": "Direct",
-        "requested": "[3.21.0, )",
-        "resolved": "3.21.0",
-        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
+        "requested": "[2026.6.0, )",
+        "resolved": "2026.6.0",
+        "contentHash": "7rfwSQHjuvwxeEWJ4/dHYlIAoeZ5SdiPCCYFiF/Avz1ACp5KoDwkh0FF/5lvWDk86MoH55m5BwxYLFek2ui7Kg==",
         "dependencies": {
-          "Speckle.Sdk": "3.21.0"
+          "Speckle.Sdk": "2026.6.0"
         }
       },
       "GraphQL.Client": {
@@ -183,8 +183,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
+        "resolved": "2026.6.0",
+        "contentHash": "rrbbe+Z8Nql/y0jHod6+B0zRitmHXq+RNw1zZnzY1heLV6NOe/8ntGbMo9JIGTnZ6Bvxg51UxntMiyAYCdvhXg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -194,14 +194,14 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.21.0",
+          "Speckle.Sdk.Dependencies": "2026.6.0",
           "System.Text.Json": "5.0.2"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA==",
+        "resolved": "2026.6.0",
+        "contentHash": "Nb38i5rAXRkEZlN0nkGbYe5Ph88ZBeHLqkcYCGAXolJcE7eDIPfU5hlWd2KcijFOD/E6f6CEdZJ99PinX2+Ejg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.4"
         }
@@ -352,11 +352,11 @@
       },
       "Speckle.Objects": {
         "type": "Direct",
-        "requested": "[3.21.0, )",
-        "resolved": "3.21.0",
-        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
+        "requested": "[2026.6.0, )",
+        "resolved": "2026.6.0",
+        "contentHash": "7rfwSQHjuvwxeEWJ4/dHYlIAoeZ5SdiPCCYFiF/Avz1ACp5KoDwkh0FF/5lvWDk86MoH55m5BwxYLFek2ui7Kg==",
         "dependencies": {
-          "Speckle.Sdk": "3.21.0"
+          "Speckle.Sdk": "2026.6.0"
         }
       },
       "GraphQL.Client": {
@@ -470,8 +470,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
+        "resolved": "2026.6.0",
+        "contentHash": "rrbbe+Z8Nql/y0jHod6+B0zRitmHXq+RNw1zZnzY1heLV6NOe/8ntGbMo9JIGTnZ6Bvxg51UxntMiyAYCdvhXg==",
         "dependencies": {
           "GraphQL.Client": "6.1.0",
           "Microsoft.Data.Sqlite": "10.0.0",
@@ -479,13 +479,13 @@
           "Microsoft.Extensions.ObjectPool": "10.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.21.0"
+          "Speckle.Sdk.Dependencies": "2026.6.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA=="
+        "resolved": "2026.6.0",
+        "contentHash": "Nb38i5rAXRkEZlN0nkGbYe5Ph88ZBeHLqkcYCGAXolJcE7eDIPfU5hlWd2KcijFOD/E6f6CEdZJ99PinX2+Ejg=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -550,11 +550,11 @@
       },
       "Speckle.Objects": {
         "type": "Direct",
-        "requested": "[3.21.0, )",
-        "resolved": "3.21.0",
-        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
+        "requested": "[2026.6.0, )",
+        "resolved": "2026.6.0",
+        "contentHash": "7rfwSQHjuvwxeEWJ4/dHYlIAoeZ5SdiPCCYFiF/Avz1ACp5KoDwkh0FF/5lvWDk86MoH55m5BwxYLFek2ui7Kg==",
         "dependencies": {
-          "Speckle.Sdk": "3.21.0"
+          "Speckle.Sdk": "2026.6.0"
         }
       },
       "GraphQL.Client": {
@@ -667,8 +667,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
+        "resolved": "2026.6.0",
+        "contentHash": "rrbbe+Z8Nql/y0jHod6+B0zRitmHXq+RNw1zZnzY1heLV6NOe/8ntGbMo9JIGTnZ6Bvxg51UxntMiyAYCdvhXg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -676,13 +676,13 @@
           "Microsoft.Extensions.ObjectPool": "8.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.21.0"
+          "Speckle.Sdk.Dependencies": "2026.6.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA=="
+        "resolved": "2026.6.0",
+        "contentHash": "Nb38i5rAXRkEZlN0nkGbYe5Ph88ZBeHLqkcYCGAXolJcE7eDIPfU5hlWd2KcijFOD/E6f6CEdZJ99PinX2+Ejg=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",

--- a/Sdk/Speckle.Testing/packages.lock.json
+++ b/Sdk/Speckle.Testing/packages.lock.json
@@ -40,11 +40,11 @@
       },
       "Speckle.Objects": {
         "type": "Direct",
-        "requested": "[3.21.0, )",
-        "resolved": "3.21.0",
-        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
+        "requested": "[2026.6.0, )",
+        "resolved": "2026.6.0",
+        "contentHash": "7rfwSQHjuvwxeEWJ4/dHYlIAoeZ5SdiPCCYFiF/Avz1ACp5KoDwkh0FF/5lvWDk86MoH55m5BwxYLFek2ui7Kg==",
         "dependencies": {
-          "Speckle.Sdk": "3.21.0"
+          "Speckle.Sdk": "2026.6.0"
         }
       },
       "Castle.Core": {
@@ -166,8 +166,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
+        "resolved": "2026.6.0",
+        "contentHash": "rrbbe+Z8Nql/y0jHod6+B0zRitmHXq+RNw1zZnzY1heLV6NOe/8ntGbMo9JIGTnZ6Bvxg51UxntMiyAYCdvhXg==",
         "dependencies": {
           "GraphQL.Client": "6.1.0",
           "Microsoft.Data.Sqlite": "10.0.0",
@@ -175,13 +175,13 @@
           "Microsoft.Extensions.ObjectPool": "10.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.21.0"
+          "Speckle.Sdk.Dependencies": "2026.6.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.21.0",
-        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA=="
+        "resolved": "2026.6.0",
+        "contentHash": "Nb38i5rAXRkEZlN0nkGbYe5Ph88ZBeHLqkcYCGAXolJcE7eDIPfU5hlWd2KcijFOD/E6f6CEdZJ99PinX2+Ejg=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",

--- a/Sdk/Speckle.Testing/packages.lock.json
+++ b/Sdk/Speckle.Testing/packages.lock.json
@@ -40,11 +40,11 @@
       },
       "Speckle.Objects": {
         "type": "Direct",
-        "requested": "[3.20.6, )",
-        "resolved": "3.20.6",
-        "contentHash": "iK+Yl0VUoGzBFuOqP3yrEWQIuQDoISfwbG7vn0jNmEAgwGcRfB9yGlQ0wA4s7IgxbdEfPjhzzcKMBNcPJWkLtw==",
+        "requested": "[3.21.0, )",
+        "resolved": "3.21.0",
+        "contentHash": "PAgujvXyS8A3IdYw1Kgu5ybYdmtfGKKVMOEv5/+JstiGizrOrH6C3hLJOngaEVhYNn2pyry+3vdjg+Au5rpJGQ==",
         "dependencies": {
-          "Speckle.Sdk": "3.20.6"
+          "Speckle.Sdk": "3.21.0"
         }
       },
       "Castle.Core": {
@@ -166,8 +166,8 @@
       },
       "Speckle.Sdk": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "jp1fle+rM6l3TtmhTwaWIlZ6HdeR7WYWFwRAxD/iazOFNXp0gWpEwYMe7Z+gBEmd6M91xQwWGAGo03x3D2XJaA==",
+        "resolved": "3.21.0",
+        "contentHash": "HOhzhYCit47/V9MsQF0eajMLDCYH6eH+32WQ39G261d1HrgqcTQABv6Dob41sq6B428ABItD2VNZ03SoEVz2VA==",
         "dependencies": {
           "GraphQL.Client": "6.1.0",
           "Microsoft.Data.Sqlite": "10.0.0",
@@ -175,13 +175,13 @@
           "Microsoft.Extensions.ObjectPool": "10.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "3.20.6"
+          "Speckle.Sdk.Dependencies": "3.21.0"
         }
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "3.20.6",
-        "contentHash": "DDRzJnBkQuDQbk1Zq76J++sZd63a+aKcY7BiYVDNvjzBSuzhtURe8PQoCfAb1H6WcYL2/K+KytOVvzK/113sGg=="
+        "resolved": "3.21.0",
+        "contentHash": "6mc7AJf+ycu5LUTP/NdQtrZ8s6RyaJ5TJMqzYoJ7SeQbeTaBzmlcQa1HBW1s3p9WgcB5tAfxv+WoA2Hk0KYrlA=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",


### PR DESCRIPTION
This PR updates the connector use of activities to match the changes made to the SDK to enable proper tracing in ODA importers.

This PR also allows the rhino importer to propagate `tracestate` aswell as `traceparent` header.

---

Also we changed the `Collection` class to require the name property in a reliable way.