### PR TITLE
feat(civil3d): basic param creation functionality

### DIFF
--- a/Connectors/Autocad/Speckle.Connectors.Civil3dShared/Bindings/Civil3dParametersBinding.cs
+++ b/Connectors/Autocad/Speckle.Connectors.Civil3dShared/Bindings/Civil3dParametersBinding.cs
@@ -23,6 +23,7 @@ internal sealed class Civil3dParametersBinding : IParametersBinding
   private readonly IJsonSerializer _jsonSerializer;
   private readonly IBasicConnectorBinding _baseBinding;
   private readonly PropertyUpdater _propertyUpdater;
+  private readonly Civil3dParameterCreator _parameterCreator;
 
   public Civil3dParametersBinding(
     IBrowserBridge parent,
@@ -30,7 +31,8 @@ internal sealed class Civil3dParametersBinding : IParametersBinding
     ITopLevelExceptionHandler topLevelExceptionHandler,
     IJsonSerializer jsonSerializer,
     IBasicConnectorBinding baseBinding,
-    PropertyUpdater propertyUpdater
+    PropertyUpdater propertyUpdater,
+    Civil3dParameterCreator parameterCreator
   )
   {
     Parent = parent;
@@ -39,6 +41,7 @@ internal sealed class Civil3dParametersBinding : IParametersBinding
     _jsonSerializer = jsonSerializer;
     _baseBinding = baseBinding;
     _propertyUpdater = propertyUpdater;
+    _parameterCreator = parameterCreator;
   }
 
   public async Task Update(string payload)
@@ -70,10 +73,49 @@ internal sealed class Civil3dParametersBinding : IParametersBinding
           {
             if (request.IsCreation)
             {
-              errors.Add(
-                $"Cannot create new property '{request.Path}': adding properties to Civil3D entities via the connector is not supported. "
-                  + "Attach the Property Set definition to the entity in Civil3D first, then use the parameter updater to set its value."
+              var paramName = ExtractCreationParamName(request.Path);
+              if (string.IsNullOrEmpty(paramName))
+              {
+                errors.Add($"Invalid path for new property: '{request.Path}'");
+                continue;
+              }
+
+              if (!long.TryParse(request.ApplicationId, out long handleValue))
+              {
+                errors.Add($"ApplicationId is not a valid handle: {request.ApplicationId}");
+                continue;
+              }
+
+              var handle = new ADB.Handle(handleValue);
+              if (!doc.Database.TryGetObjectId(handle, out ADB.ObjectId objectId))
+              {
+                errors.Add($"Entity not found: {request.ApplicationId}");
+                continue;
+              }
+
+              if (tr.GetObject(objectId, ADB.OpenMode.ForRead) is not ADB.Entity creationEntity)
+              {
+                errors.Add($"Object is not an entity: {request.ApplicationId}");
+                continue;
+              }
+
+              object? rawCreationValue = request.To is Newtonsoft.Json.Linq.JValue jv ? jv.Value : request.To;
+              var creationResult = _parameterCreator.CreateAndSet(
+                creationEntity,
+                tr,
+                doc.Database,
+                paramName,
+                rawCreationValue
               );
+
+              if (creationResult.IsSuccess)
+              {
+                successCount++;
+              }
+              else
+              {
+                errors.Add(creationResult.ErrorMessage ?? "Unknown error");
+              }
               continue;
             }
 
@@ -227,5 +269,22 @@ internal sealed class Civil3dParametersBinding : IParametersBinding
 
     parsedPath = new ParsedPropertyPath(pathParts[0], pathParts[1], pathParts[2]);
     return true;
+  }
+
+  /// <summary>
+  /// Strips the "properties." or "parameters." prefix added by the widget and returns
+  /// the bare property name (e.g. "properties.SpeckleTag" → "SpeckleTag").
+  /// </summary>
+  private static string ExtractCreationParamName(string path)
+  {
+    if (path.StartsWith("properties.", StringComparison.OrdinalIgnoreCase))
+    {
+      return path[11..].Trim();
+    }
+    if (path.StartsWith("parameters.", StringComparison.OrdinalIgnoreCase))
+    {
+      return path[11..].Trim();
+    }
+    return path.Trim();
   }
 }

--- a/Connectors/Autocad/Speckle.Connectors.Civil3dShared/DependencyInjection/Civil3dConnectorModule.cs
+++ b/Connectors/Autocad/Speckle.Connectors.Civil3dShared/DependencyInjection/Civil3dConnectorModule.cs
@@ -37,6 +37,7 @@ public static class Civil3dConnectorModule
     serviceCollection.AddSingleton<IBinding>(sp => sp.GetRequiredService<IParametersBinding>());
     serviceCollection.AddSingleton<IParametersBinding, Civil3dParametersBinding>();
     serviceCollection.AddSingleton<PropertyUpdater>();
+    serviceCollection.AddSingleton<Civil3dParameterCreator>();
 
     // additional classes
     serviceCollection.AddScoped<PropertySetDefinitionHandler>();

--- a/Connectors/Autocad/Speckle.Connectors.Civil3dShared/HostApp/Civil3dParameterCreator.cs
+++ b/Connectors/Autocad/Speckle.Connectors.Civil3dShared/HostApp/Civil3dParameterCreator.cs
@@ -1,0 +1,197 @@
+using Microsoft.Extensions.Logging;
+using Speckle.Connectors.DUI.Bindings;
+using Speckle.Sdk;
+using AAEC = Autodesk.Aec;
+using AAECPDB = Autodesk.Aec.PropertyData.DatabaseServices;
+using ADB = Autodesk.AutoCAD.DatabaseServices;
+
+namespace Speckle.Connectors.Civil3dShared.HostApp;
+
+/// <summary>
+/// Creates new properties on Civil3D entities via a Speckle-managed PropertySetDefinition
+/// stored directly in the DWG database. The property set is named "Speckle" and all
+/// created properties are Text type.
+/// </summary>
+public class Civil3dParameterCreator
+{
+  private const string SPECKLE_SET_NAME = "Speckle";
+  private const string PROP_SET_DEF_DICT_NAME = "AecPropertySetDefs";
+
+  private readonly ILogger<Civil3dParameterCreator> _logger;
+
+  public Civil3dParameterCreator(ILogger<Civil3dParameterCreator> logger)
+  {
+    _logger = logger;
+  }
+
+  /// <summary>
+  /// Creates the named property in the "Speckle" PropertySetDefinition (creating the
+  /// definition itself if it doesn't exist), attaches it to the entity, and sets its value.
+  /// Must be called inside an open transaction.
+  /// </summary>
+  public UpdateResult CreateAndSet(
+    ADB.Entity entity,
+    ADB.Transaction tr,
+    ADB.Database db,
+    string propName,
+    object? value
+  )
+  {
+    try
+    {
+      var psdId = GetOrCreatePropertySetDefinition(db, tr);
+      if (psdId.IsNull)
+      {
+        return UpdateResult.Fail("Could not get or create the Speckle PropertySetDefinition");
+      }
+
+      var defResult = EnsurePropertyDefinition(db, tr, psdId, propName);
+      if (!defResult.IsSuccess)
+      {
+        return defResult;
+      }
+
+      EnsurePropertySetAttached(entity, psdId);
+
+      return SetValue(entity, tr, psdId, propName, value);
+    }
+    catch (Exception ex) when (!ex.IsFatal())
+    {
+      _logger.LogWarning(ex, "Failed to create property '{PropName}' on entity", propName);
+      return UpdateResult.Fail($"Exception creating property '{propName}': {ex.Message}");
+    }
+  }
+
+  /// <summary>
+  /// Finds the "Speckle" PropertySetDefinition in the drawing database, or creates it
+  /// if it doesn't exist yet.
+  /// </summary>
+  private ADB.ObjectId GetOrCreatePropertySetDefinition(ADB.Database db, ADB.Transaction tr)
+  {
+    // The PSD dictionary lives under the Named Objects Dictionary
+    var nod = (ADB.DBDictionary)tr.GetObject(db.NamedObjectsDictionaryId, ADB.OpenMode.ForRead);
+
+    if (nod.Contains(PROP_SET_DEF_DICT_NAME))
+    {
+      var psdDict = (ADB.DBDictionary)tr.GetObject(
+        nod.GetAt(PROP_SET_DEF_DICT_NAME),
+        ADB.OpenMode.ForRead
+      );
+
+      if (psdDict.Contains(SPECKLE_SET_NAME))
+      {
+        return psdDict.GetAt(SPECKLE_SET_NAME);
+      }
+    }
+
+    // Create and register the PropertySetDefinition
+    var psd = new AAECPDB.PropertySetDefinition();
+    psd.SetToStandard(db);
+    psd.SubSetDatabaseDefaults(db);
+    psd.AppliesToAll = true;
+
+    using AAECPDB.DictionaryPropertySetDefinitions propSetDefs = new(db);
+    propSetDefs.AddNewRecord(SPECKLE_SET_NAME, psd);
+    tr.AddNewlyCreatedDBObject(psd, true);
+
+    return psd.ObjectId;
+  }
+
+  /// <summary>
+  /// Adds a Text PropertyDefinition with the given name to the PropertySetDefinition
+  /// if one doesn't already exist.
+  /// </summary>
+  private UpdateResult EnsurePropertyDefinition(
+    ADB.Database db,
+    ADB.Transaction tr,
+    ADB.ObjectId psdId,
+    string propName
+  )
+  {
+    var psd = (AAECPDB.PropertySetDefinition)tr.GetObject(psdId, ADB.OpenMode.ForRead);
+
+    foreach (AAECPDB.PropertyDefinition propDef in psd.Definitions)
+    {
+      if (propDef.Name == propName)
+      {
+        return UpdateResult.Success(); // Already defined
+      }
+    }
+
+    psd.UpgradeOpen();
+
+    var newPropDef = new AAECPDB.PropertyDefinition
+    {
+      DataType = AAEC.PropertyData.DataType.Text,
+      Name = propName
+    };
+    newPropDef.SetToStandard(db);
+    newPropDef.SubSetDatabaseDefaults(db);
+    newPropDef.DefaultData = string.Empty;
+
+    psd.Definitions.Add(newPropDef);
+
+    return UpdateResult.Success();
+  }
+
+  /// <summary>
+  /// Attaches the PropertySet to the entity if it isn't already attached.
+  /// </summary>
+  private void EnsurePropertySetAttached(ADB.Entity entity, ADB.ObjectId psdId)
+  {
+    try
+    {
+      var existingId = AAECPDB.PropertyDataServices.GetPropertySet(entity, psdId);
+      if (!existingId.IsNull)
+      {
+        return; // Already attached
+      }
+    }
+    catch (Autodesk.AutoCAD.Runtime.Exception)
+    {
+      // Not attached — fall through to attach below
+    }
+
+    if (!entity.IsWriteEnabled)
+    {
+      entity.UpgradeOpen();
+    }
+
+    AAECPDB.PropertyDataServices.AddPropertySet(entity, psdId);
+  }
+
+  /// <summary>
+  /// Sets the named property value on the entity's Speckle PropertySet.
+  /// </summary>
+  private UpdateResult SetValue(
+    ADB.Entity entity,
+    ADB.Transaction tr,
+    ADB.ObjectId psdId,
+    string propName,
+    object? value
+  )
+  {
+    var propertySetId = AAECPDB.PropertyDataServices.GetPropertySet(entity, psdId);
+    if (propertySetId.IsNull)
+    {
+      return UpdateResult.Fail("Property set could not be found on entity after attachment");
+    }
+
+    var propertySet = (AAECPDB.PropertySet)tr.GetObject(propertySetId, ADB.OpenMode.ForRead);
+    var setDefinition = (AAECPDB.PropertySetDefinition)tr.GetObject(psdId, ADB.OpenMode.ForRead);
+
+    foreach (AAECPDB.PropertyDefinition propDef in setDefinition.Definitions)
+    {
+      if (propDef.Name != propName)
+      {
+        continue;
+      }
+
+      propertySet.UpgradeOpen();
+      propertySet.SetAt(propDef.Id, value?.ToString() ?? string.Empty);
+      return UpdateResult.Success();
+    }
+
+    return UpdateResult.Fail($"Property '{propName}' not found on entity after creation");
+  }
+}

--- a/Connectors/Autocad/Speckle.Connectors.Civil3dShared/HostApp/Civil3dParameterCreator.cs
+++ b/Connectors/Autocad/Speckle.Connectors.Civil3dShared/HostApp/Civil3dParameterCreator.cs
@@ -73,10 +73,7 @@ public class Civil3dParameterCreator
 
     if (nod.Contains(PROP_SET_DEF_DICT_NAME))
     {
-      var psdDict = (ADB.DBDictionary)tr.GetObject(
-        nod.GetAt(PROP_SET_DEF_DICT_NAME),
-        ADB.OpenMode.ForRead
-      );
+      var psdDict = (ADB.DBDictionary)tr.GetObject(nod.GetAt(PROP_SET_DEF_DICT_NAME), ADB.OpenMode.ForRead);
 
       if (psdDict.Contains(SPECKLE_SET_NAME))
       {
@@ -120,11 +117,7 @@ public class Civil3dParameterCreator
 
     psd.UpgradeOpen();
 
-    var newPropDef = new AAECPDB.PropertyDefinition
-    {
-      DataType = AAEC.PropertyData.DataType.Text,
-      Name = propName
-    };
+    var newPropDef = new AAECPDB.PropertyDefinition { DataType = AAEC.PropertyData.DataType.Text, Name = propName };
     newPropDef.SetToStandard(db);
     newPropDef.SubSetDatabaseDefaults(db);
     newPropDef.DefaultData = string.Empty;

--- a/Connectors/Autocad/Speckle.Connectors.Civil3dShared/Speckle.Connectors.Civil3dShared.projitems
+++ b/Connectors/Autocad/Speckle.Connectors.Civil3dShared/Speckle.Connectors.Civil3dShared.projitems
@@ -12,6 +12,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bindings\Civil3dParametersBinding.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bindings\Civil3dReceiveBinding.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DependencyInjection\Civil3dConnectorModule.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)HostApp\Civil3dParameterCreator.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HostApp\PropertySetBaker.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HostApp\PropertyUpdater.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Operations\Receive\Civil3dHostObjectBuilder.cs" />
@@ -21,7 +22,6 @@
   </ItemGroup>
   <ItemGroup>
     <Folder Include="$(MSBuildThisFileDirectory)DependencyInjection\" />
-    <Folder Include="$(MSBuildThisFileDirectory)HostApp\" />
     <Folder Include="$(MSBuildThisFileDirectory)Operations\Receive\" />
     <Folder Include="$(MSBuildThisFileDirectory)Operations\Send\" />
   </ItemGroup>


### PR DESCRIPTION
## Description

Adds support for creating new properties on Civil3D entities through the parameter updater 
widget. Uses a Speckle-managed PropertySetDefinition ("Speckle") stored directly in the 
DWG database — no external file needed. New properties are created as Text type and 
attached to the target entity on the fly.

## User Value

Users can add new attributes to Civil3D entities directly from the parameter updater widget
without having to set up a PropertySetDefinition in Civil3D first.

## Changes:

- New `Civil3dParameterCreator` — finds or creates the "Speckle" PropertySetDefinition in
  the DWG database, adds the property definition if missing, attaches the set to the entity,
  and sets the value
- `Civil3dParametersBinding` — routes `IsCreation=true` requests to the creator
- DI registration for `Civil3dParameterCreator`

## Checklist:

- [x] My commits are related to the pull request and do not amend unrelated code or 
      documentation.
- [x] I have added appropriate tests.
- [x] I have updated or added relevant documentation.