### PR TITLE
fix(acad-c3d-p3d): sanitize extracted properties before send serialization

### DIFF
--- a/Converters/Autocad/Speckle.Converters.AutocadShared/Speckle.Converters.AutocadShared.projitems
+++ b/Converters/Autocad/Speckle.Converters.AutocadShared/Speckle.Converters.AutocadShared.projitems
@@ -67,6 +67,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)ToSpeckle\Properties\XDataExtractor.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ToSpeckle\Properties\ExtensionDictionaryExtractor.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ToSpeckle\Properties\IPropertiesExtractor.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)ToSpeckle\Properties\PropertyValueSanitizer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ToSpeckle\Properties\PropertiesExtractor.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ToSpeckle\Raw\Solid3dToRawEncodingConverter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ToSpeckle\Raw\DBSubDMeshToSpeckleRawConverter.cs" />

--- a/Converters/Autocad/Speckle.Converters.AutocadShared/ToSpeckle/Properties/ExtensionDictionaryExtractor.cs
+++ b/Converters/Autocad/Speckle.Converters.AutocadShared/ToSpeckle/Properties/ExtensionDictionaryExtractor.cs
@@ -43,7 +43,7 @@ public class ExtensionDictionaryExtractor
           Dictionary<string, object?> entryDict = new();
           foreach (ADB.TypedValue xEntry in xRecord.Data)
           {
-            if (GetValidValue(xEntry.Value) is object val)
+            if (PropertyValueSanitizer.Sanitize(xEntry.Value) is object val)
             {
               entryDict[xEntry.TypeCode.ToString()] = val;
             }
@@ -61,7 +61,4 @@ public class ExtensionDictionaryExtractor
 
     return extensionDictionaryDict.Count > 0 ? extensionDictionaryDict : null;
   }
-
-  // xrecord values can contain invalid serialisation types like objectIds
-  private object? GetValidValue(object val) => val.GetType().IsPrimitive ? val : val.ToString();
 }

--- a/Converters/Autocad/Speckle.Converters.AutocadShared/ToSpeckle/Properties/PropertyValueSanitizer.cs
+++ b/Converters/Autocad/Speckle.Converters.AutocadShared/ToSpeckle/Properties/PropertyValueSanitizer.cs
@@ -1,0 +1,65 @@
+using System.Collections;
+
+namespace Speckle.Converters.AutocadShared.ToSpeckle;
+
+public static class PropertyValueSanitizer
+{
+  public static Dictionary<string, object?> Sanitize(Dictionary<string, object?> properties) =>
+    properties.ToDictionary(kvp => kvp.Key, kvp => Sanitize(kvp.Value));
+
+  public static object? Sanitize(object? value)
+  {
+    if (value is null)
+    {
+      return null;
+    }
+
+    if (value is ADB.ObjectId objectId)
+    {
+      return objectId == ADB.ObjectId.Null ? null : objectId.Handle.Value.ToString();
+    }
+
+    Type valueType = value.GetType();
+    if (
+      valueType.IsPrimitive
+      || value is string
+      || value is decimal
+      || value is Guid
+      || value is DateTime
+      || value is DateTimeOffset
+      || value is TimeSpan
+    )
+    {
+      return value;
+    }
+
+    if (valueType.IsEnum)
+    {
+      return value.ToString();
+    }
+
+    if (value is IDictionary dictionary)
+    {
+      Dictionary<string, object?> sanitized = new(dictionary.Count);
+      foreach (DictionaryEntry entry in dictionary)
+      {
+        sanitized[entry.Key.ToString() ?? string.Empty] = Sanitize(entry.Value);
+      }
+
+      return sanitized;
+    }
+
+    if (value is IEnumerable enumerable)
+    {
+      List<object?> sanitized = new();
+      foreach (object? item in enumerable)
+      {
+        sanitized.Add(Sanitize(item));
+      }
+
+      return sanitized;
+    }
+
+    return value.ToString();
+  }
+}

--- a/Converters/Autocad/Speckle.Converters.AutocadShared/ToSpeckle/Properties/PropertyValueSanitizer.cs
+++ b/Converters/Autocad/Speckle.Converters.AutocadShared/ToSpeckle/Properties/PropertyValueSanitizer.cs
@@ -19,16 +19,18 @@ public static class PropertyValueSanitizer
       return objectId == ADB.ObjectId.Null ? null : objectId.Handle.Value.ToString();
     }
 
+    // decimal is not IsPrimitive and the Speckle V2 ObjectSerializer has no decimal case -> emit a serializer-safe double.
+    if (value is decimal decimalValue)
+    {
+      return (double)decimalValue;
+    }
+
     Type valueType = value.GetType();
-    if (
-      valueType.IsPrimitive
-      || value is string
-      || value is decimal
-      || value is Guid
-      || value is DateTime
-      || value is DateTimeOffset
-      || value is TimeSpan
-    )
+
+    // Pass through only types the Speckle V2 ObjectSerializer accepts directly
+    // (primitives, string, Guid, DateTime). DateTimeOffset/TimeSpan are NOT supported
+    // and fall through to ToString() at the end.
+    if (valueType.IsPrimitive || value is string || value is Guid || value is DateTime)
     {
       return value;
     }

--- a/Converters/Autocad/Speckle.Converters.AutocadShared/ToSpeckle/Properties/XDataExtractor.cs
+++ b/Converters/Autocad/Speckle.Converters.AutocadShared/ToSpeckle/Properties/XDataExtractor.cs
@@ -42,7 +42,7 @@ public class XDataExtractor
         case (int)DxfCode.ExtendedDataControlString: // this is the start and end brace code for this list of entries
           break;
         default:
-          if (GetValidValue(entry.Value) is object val)
+          if (PropertyValueSanitizer.Sanitize(entry.Value) is object val)
           {
             string key = entry.TypeCode.ToString();
             if (currentXData.TryGetValue(key, out List<object?>? value))
@@ -74,7 +74,4 @@ public class XDataExtractor
       appXData.Clear();
     }
   }
-
-  // xrecord values can contain invalid serialisation types like objectIds
-  private object? GetValidValue(object val) => val.GetType().IsPrimitive ? val : val.ToString();
 }

--- a/Converters/Civil3d/Speckle.Converters.Civil3dShared/ToSpeckle/Properties/ExtensionDictionaryExtractor.cs
+++ b/Converters/Civil3d/Speckle.Converters.Civil3dShared/ToSpeckle/Properties/ExtensionDictionaryExtractor.cs
@@ -39,9 +39,7 @@ public class ExtensionDictionaryExtractor
           Dictionary<string, object?> entryDict = new();
           foreach (ADB.TypedValue xEntry in xRecord.Data)
           {
-            if (
-              Speckle.Converters.AutocadShared.ToSpeckle.PropertyValueSanitizer.Sanitize(xEntry.Value) is object val
-            )
+            if (Speckle.Converters.AutocadShared.ToSpeckle.PropertyValueSanitizer.Sanitize(xEntry.Value) is object val)
             {
               entryDict[xEntry.TypeCode.ToString()] = val;
             }

--- a/Converters/Civil3d/Speckle.Converters.Civil3dShared/ToSpeckle/Properties/ExtensionDictionaryExtractor.cs
+++ b/Converters/Civil3d/Speckle.Converters.Civil3dShared/ToSpeckle/Properties/ExtensionDictionaryExtractor.cs
@@ -39,7 +39,12 @@ public class ExtensionDictionaryExtractor
           Dictionary<string, object?> entryDict = new();
           foreach (ADB.TypedValue xEntry in xRecord.Data)
           {
-            entryDict[xEntry.TypeCode.ToString()] = xEntry.Value;
+            if (
+              Speckle.Converters.AutocadShared.ToSpeckle.PropertyValueSanitizer.Sanitize(xEntry.Value) is object val
+            )
+            {
+              entryDict[xEntry.TypeCode.ToString()] = val;
+            }
           }
 
           if (entryDict.Count > 0)

--- a/Converters/Civil3d/Speckle.Converters.Civil3dShared/ToSpeckle/Properties/PropertiesExtractor.cs
+++ b/Converters/Civil3d/Speckle.Converters.Civil3dShared/ToSpeckle/Properties/PropertiesExtractor.cs
@@ -37,7 +37,7 @@ public class PropertiesExtractor : Speckle.Converters.AutocadShared.ToSpeckle.IP
       properties
     );
 
-    return properties;
+    return Speckle.Converters.AutocadShared.ToSpeckle.PropertyValueSanitizer.Sanitize(properties);
   }
 
   private void AddDictionaryToPropertyDictionary(

--- a/Converters/Plant3d/Speckle.Converters.Plant3dShared/ToSpeckle/Properties/ExtensionDictionaryExtractor.cs
+++ b/Converters/Plant3d/Speckle.Converters.Plant3dShared/ToSpeckle/Properties/ExtensionDictionaryExtractor.cs
@@ -37,9 +37,7 @@ public class ExtensionDictionaryExtractor
           Dictionary<string, object?> entryDict = new();
           foreach (ADB.TypedValue xEntry in xRecord.Data)
           {
-            if (
-              Speckle.Converters.AutocadShared.ToSpeckle.PropertyValueSanitizer.Sanitize(xEntry.Value) is object val
-            )
+            if (Speckle.Converters.AutocadShared.ToSpeckle.PropertyValueSanitizer.Sanitize(xEntry.Value) is object val)
             {
               entryDict[xEntry.TypeCode.ToString()] = val;
             }

--- a/Converters/Plant3d/Speckle.Converters.Plant3dShared/ToSpeckle/Properties/ExtensionDictionaryExtractor.cs
+++ b/Converters/Plant3d/Speckle.Converters.Plant3dShared/ToSpeckle/Properties/ExtensionDictionaryExtractor.cs
@@ -37,7 +37,12 @@ public class ExtensionDictionaryExtractor
           Dictionary<string, object?> entryDict = new();
           foreach (ADB.TypedValue xEntry in xRecord.Data)
           {
-            entryDict[xEntry.TypeCode.ToString()] = xEntry.Value;
+            if (
+              Speckle.Converters.AutocadShared.ToSpeckle.PropertyValueSanitizer.Sanitize(xEntry.Value) is object val
+            )
+            {
+              entryDict[xEntry.TypeCode.ToString()] = val;
+            }
           }
 
           if (entryDict.Count > 0)


### PR DESCRIPTION
## Description

Fixes send serialization failures caused by extracted AutoCAD/Civil3D/Plant3D property values that are not supported by the Speckle object serializer.

This adds a shared property value sanitizer for AutoCAD-derived converters and applies it to XData, extension dictionary values, and Civil3D extracted properties before they are serialized.

## User Value

Users can send AutoCAD, Civil3D, and Plant3D elements without losing objects because unsupported property values caused serialization to fail.

## Changes

- Added `PropertyValueSanitizer` for serializer-safe property conversion.
- Converts unsupported values such as `ObjectId`, `decimal`, enums, dictionaries, and enumerables into supported serialized forms.
- Reused the sanitizer in AutoCAD XData and extension dictionary extraction.
- Applied the same sanitizer to Civil3D and Plant3D extension dictionary extraction.
- Sanitized Civil3D property dictionaries before returning them for send serialization.

## Validation of changes

- Confirmed the sanitizer is included in the AutoCAD shared project items.
- Existing property extraction now routes unsafe values through the sanitizer before send serialization.

<img width="844" height="821" alt="SCR-20260616-mwov" src="https://github.com/user-attachments/assets/efc80575-1613-4f17-b889-2781603195bc" />

