### PR TITLE
fix(tsd): adds slab materials

### DIFF
--- a/Connectors/TSD/Speckle.Connectors.TSDShared/HostApp/ITSDApplicationService.cs
+++ b/Connectors/TSD/Speckle.Connectors.TSDShared/HostApp/ITSDApplicationService.cs
@@ -1,5 +1,6 @@
 using TSD.API.Remoting;
 using TSD.API.Remoting.Common;
+using TSD.API.Remoting.Structure;
 using TSD.API.Remoting.Units;
 
 namespace Speckle.Connectors.TSDShared.HostApp;
@@ -20,6 +21,8 @@ internal interface ITSDApplicationService
   Task<IReadOnlyList<TSDSelectedEntity>> GetSelectedEntitiesAsync();
 
   Task<IReadOnlyList<IEntity>> GetObjectsForSendAsync(IReadOnlyList<string> objectIds);
+
+  Task<IReadOnlyDictionary<int, ISlabData>> GetSlabDataAsync(IEnumerable<int> slabIndices);
 
   Task<IReadOnlyDictionary<Quantity, IUnitBase>> GetUnitsAsync(IEnumerable<Quantity> quantities);
 

--- a/Connectors/TSD/Speckle.Connectors.TSDShared/HostApp/TSDApplicationService.cs
+++ b/Connectors/TSD/Speckle.Connectors.TSDShared/HostApp/TSDApplicationService.cs
@@ -208,6 +208,52 @@ internal sealed class TSDApplicationService : ITSDApplicationService, IDisposabl
     }
   }
 
+  public async Task<IReadOnlyDictionary<int, ISlabData>> GetSlabDataAsync(IEnumerable<int> slabIndices)
+  {
+    var result = new Dictionary<int, ISlabData>();
+    if (Application is null)
+    {
+      return result;
+    }
+
+    var indices = slabIndices.Distinct().ToList();
+    if (indices.Count == 0)
+    {
+      return result;
+    }
+
+    try
+    {
+      var document = await Application.GetDocumentAsync().ConfigureAwait(false);
+      var model = document is null ? null : await document.GetModelAsync().ConfigureAwait(false);
+      if (model is null)
+      {
+        return result;
+      }
+
+      var slabs = await model.GetSlabsAsync(indices).ConfigureAwait(false);
+      if (slabs is null)
+      {
+        return result;
+      }
+
+      foreach (var slab in slabs)
+      {
+        var data = slab.SlabData.Value;
+        if (data is not null)
+        {
+          result[slab.Index] = data;
+        }
+      }
+    }
+    catch (Exception ex) when (!ex.IsFatal())
+    {
+      _logger.LogError(ex, "Failed to read TSD slab data");
+    }
+
+    return result;
+  }
+
   public async Task<IReadOnlyDictionary<Quantity, IUnitBase>> GetUnitsAsync(IEnumerable<Quantity> quantities)
   {
     var result = new Dictionary<Quantity, IUnitBase>();

--- a/Connectors/TSD/Speckle.Connectors.TSDShared/Operations/Send/TsdDisplayValueExtractor.cs
+++ b/Connectors/TSD/Speckle.Connectors.TSDShared/Operations/Send/TsdDisplayValueExtractor.cs
@@ -12,6 +12,7 @@ namespace Speckle.Connectors.TSDShared.Operations.Send;
 internal sealed class TsdDisplayValueExtractor
 {
   private readonly ITSDApplicationService _applicationService;
+  private readonly MeshGenerator _meshGenerator = new(new BaseTransformer(), new LibTessTriangulator());
 
   public TsdDisplayValueExtractor(ITSDApplicationService applicationService)
   {
@@ -108,11 +109,7 @@ internal sealed class TsdDisplayValueExtractor
       {
         var polygons = new List<Poly3> { new(outer) };
         polygons.AddRange(holes.Select(hole => new Poly3(hole)));
-        AddTriangles(
-          baseVertices,
-          faces,
-          new MeshGenerator(new BaseTransformer(), new LibTessTriangulator()).TriangulateSurface(polygons)
-        );
+        AddTriangles(baseVertices, faces, _meshGenerator.TriangulateSurface(polygons));
       }
     }
 
@@ -137,13 +134,15 @@ internal sealed class TsdDisplayValueExtractor
         continue;
       }
 
-      var quad = new List<Vector3>
-      {
-        ToVector(bottom.GetPoint(Location.Start)),
-        ToVector(bottom.GetPoint(Location.End)),
-        ToVector(top.GetPoint(Location.End)),
-        ToVector(top.GetPoint(Location.Start)),
-      };
+      var bottomStart = ToVector(bottom.GetPoint(Location.Start));
+      var bottomEnd = ToVector(bottom.GetPoint(Location.End));
+      var topA = ToVector(top.GetPoint(Location.Start));
+      var topB = ToVector(top.GetPoint(Location.End));
+
+      var (topNearStart, topNearEnd) =
+        (topA - bottomStart).Length() <= (topB - bottomStart).Length() ? (topA, topB) : (topB, topA);
+
+      var quad = new List<Vector3> { bottomStart, bottomEnd, topNearEnd, topNearStart };
 
       AddNgonFace(baseVertices, faces, quad);
     }

--- a/Connectors/TSD/Speckle.Connectors.TSDShared/Operations/Send/TsdRootObjectBuilder.cs
+++ b/Connectors/TSD/Speckle.Connectors.TSDShared/Operations/Send/TsdRootObjectBuilder.cs
@@ -71,6 +71,8 @@ internal sealed class TsdRootObjectBuilder : IRootObjectBuilder<IEntity>
     };
     rootObjectCollection["units"] = speckleUnits;
 
+    var slabDataByIndex = await GetSlabDataAsync(entities).ConfigureAwait(false);
+
     List<SendConversionResult> results = new(entities.Count);
     List<Dictionary<string, object?>> propertyTrees = new(entities.Count);
     int count = 0;
@@ -79,7 +81,8 @@ internal sealed class TsdRootObjectBuilder : IRootObjectBuilder<IEntity>
     {
       cancellationToken.ThrowIfCancellationRequested();
 
-      var (result, converted) = await ConvertEntityAsync(entity, lengthUnit, speckleUnits).ConfigureAwait(false);
+      var (result, converted) = await ConvertEntityAsync(entity, slabDataByIndex, lengthUnit, speckleUnits)
+        .ConfigureAwait(false);
       results.Add(result);
       if (converted is not null)
       {
@@ -106,6 +109,7 @@ internal sealed class TsdRootObjectBuilder : IRootObjectBuilder<IEntity>
 
   private async Task<(SendConversionResult result, Base? converted)> ConvertEntityAsync(
     IEntity entity,
+    IReadOnlyDictionary<int, ISlabData> slabDataByIndex,
     IUnitBase? unit,
     string speckleUnits
   )
@@ -118,7 +122,8 @@ internal sealed class TsdRootObjectBuilder : IRootObjectBuilder<IEntity>
       var (displayValue, properties) = entity switch
       {
         IMember member => await ConvertMemberAsync(member, unit, speckleUnits).ConfigureAwait(false),
-        ISlabItem slabItem => await ConvertSlabAsync(slabItem, unit, speckleUnits).ConfigureAwait(false),
+        ISlabItem slabItem => await ConvertSlabAsync(slabItem, slabDataByIndex, unit, speckleUnits)
+          .ConfigureAwait(false),
         IStructuralWall wall => await ConvertWallAsync(wall, unit, speckleUnits).ConfigureAwait(false),
         _ => (new List<Base>(), new Dictionary<string, object?>()),
       };
@@ -176,6 +181,7 @@ internal sealed class TsdRootObjectBuilder : IRootObjectBuilder<IEntity>
 
   private async Task<(List<Base>, Dictionary<string, object?>)> ConvertSlabAsync(
     ISlabItem slabItem,
+    IReadOnlyDictionary<int, ISlabData> slabDataByIndex,
     IUnitBase? unit,
     string speckleUnits
   )
@@ -183,8 +189,44 @@ internal sealed class TsdRootObjectBuilder : IRootObjectBuilder<IEntity>
     var displayValue = await _displayValueExtractor
       .GetSlabDisplayValueAsync(slabItem, unit, speckleUnits)
       .ConfigureAwait(false);
-    var properties = _slabPropertyExtractor.Extract(slabItem);
+
+    ISlabData? slabData = null;
+    if (TryGetSlabIndex(slabItem) is int slabIndex)
+    {
+      slabDataByIndex.TryGetValue(slabIndex, out slabData);
+    }
+
+    var properties = _slabPropertyExtractor.Extract(slabItem, slabData);
     return (displayValue, properties);
+  }
+
+  private async Task<IReadOnlyDictionary<int, ISlabData>> GetSlabDataAsync(IReadOnlyList<IEntity> entities)
+  {
+    var slabIndices = new HashSet<int>();
+    foreach (var slabItem in entities.OfType<ISlabItem>())
+    {
+      if (TryGetSlabIndex(slabItem) is int slabIndex)
+      {
+        slabIndices.Add(slabIndex);
+      }
+    }
+
+    return slabIndices.Count == 0
+      ? new Dictionary<int, ISlabData>()
+      : await _applicationService.GetSlabDataAsync(slabIndices).ConfigureAwait(false);
+  }
+
+  private int? TryGetSlabIndex(ISlabItem slabItem)
+  {
+    try
+    {
+      return slabItem.SlabIndex.Value;
+    }
+    catch (Exception ex) when (!ex.IsFatal())
+    {
+      _logger.LogDebug(ex, "Failed to read TSD slab index");
+      return null;
+    }
   }
 
   private async Task<(List<Base>, Dictionary<string, object?>)> ConvertWallAsync(

--- a/Connectors/TSD/Speckle.Connectors.TSDShared/Operations/Send/TsdSlabPropertyExtractor.cs
+++ b/Connectors/TSD/Speckle.Connectors.TSDShared/Operations/Send/TsdSlabPropertyExtractor.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.Logging;
 using Speckle.Sdk;
 using TSD.API.Remoting.Common;
+using TSD.API.Remoting.Materials;
 using TSD.API.Remoting.Structure;
 
 namespace Speckle.Connectors.TSDShared.Operations.Send;
@@ -14,7 +15,7 @@ internal sealed class TsdSlabPropertyExtractor
     _logger = logger;
   }
 
-  public Dictionary<string, object?> Extract(ISlabItem slabItem)
+  public Dictionary<string, object?> Extract(ISlabItem slabItem, ISlabData? slabData)
   {
     ISlabItemData? data = null;
     try
@@ -60,7 +61,29 @@ internal sealed class TsdSlabPropertyExtractor
       }
     }
 
+    if (slabData is not null)
+    {
+      var material = new Dictionary<string, object?>();
+      TryAdd(material, "Slab Type", () => slabData.SlabType.Value.ToString());
+      TryAdd(material, "Concrete Type", () => slabData.ConcreteType.Value.ToString());
+      TryAdd(material, "Material", () => ExtractMaterial(slabData.Material.Value));
+      if (material.Count > 0)
+      {
+        properties["Material"] = material;
+      }
+    }
+
     return properties;
+  }
+
+  private static Dictionary<string, object?>? ExtractMaterial(IMaterial? material)
+  {
+    if (material is null)
+    {
+      return null;
+    }
+
+    return new Dictionary<string, object?> { ["Name"] = material.Name, ["Type"] = material.Type.ToString() };
   }
 
   private void AddDimension(Dictionary<string, object?> target, string key, Func<double> getter)


### PR DESCRIPTION
- Walls: fixed possible self-intersecting mesh.
- Slabs: MeshGenerator is now created once and reused instead of per contour.
- Slabs: added material info (Slab Type, Concrete Type, Material), fetched from the parent slab via a new GetSlabDataAsync.