### PR TITLE
fix(civil3d): prevent host crash when sending an empty TinSurface

### DIFF
--- a/Converters/Civil3d/Speckle.Converters.Civil3dShared/ToSpeckle/Raw/TinSurfaceToSpeckleMeshRawConverter.cs
+++ b/Converters/Civil3d/Speckle.Converters.Civil3dShared/ToSpeckle/Raw/TinSurfaceToSpeckleMeshRawConverter.cs
@@ -2,6 +2,7 @@ using Autodesk.AutoCAD.Geometry;
 using Speckle.Converters.Autocad;
 using Speckle.Converters.Common;
 using Speckle.Converters.Common.Objects;
+using Speckle.Sdk;
 
 namespace Speckle.Converters.Civil3dShared.ToSpeckle.Raw;
 
@@ -23,6 +24,27 @@ public class TinSurfaceToSpeckleMeshRawConverter : ITypedConverter<CDB.TinSurfac
 
   public SOG.Mesh Convert(CDB.TinSurface target)
   {
+    // An empty / no-data TinSurface has no built triangle network. Calling GetTriangles() on it reads
+    // protected native memory -> AccessViolationException -> fatal host crash that cannot be caught
+    // (corrupted-state exception; never delivered to managed catch on .NET 8). Probe the TIN
+    // definition first via GetTinProperties(), a safe managed call that does not touch the native
+    // triangle buffer. If the probe fails, the network is inaccessible and GetTriangles() would crash,
+    // so we throw a catchable SpeckleException -> reported as a per-object conversion error upstream.
+    try
+    {
+      _ = target.GetTinProperties();
+    }
+    // Catch any non-fatal failure to read the TIN definition (the broken surface throws a managed
+    // InvalidOperationException here): the network is inaccessible, so skip the surface rather than
+    // risk the native crash. IsFatal() still lets true corrupted-state exceptions propagate.
+    catch (Exception ex) when (!ex.IsFatal())
+    {
+      throw new SpeckleException(
+        $"TinSurface '{target.DisplayName}' has no accessible triangle data and cannot be converted safely.",
+        ex
+      );
+    }
+
     List<double> vertices = new();
     List<int> faces = new();
     Dictionary<Point3d, int> indices = new();


### PR DESCRIPTION
## Description

Publishing a Civil 3D selection that contains an **empty / no-data `TinSurface`** crashes the host with a fatal `System.AccessViolationException`. Reproducible via `Ctrl+A` (SELECTALL grabs the empty surface), but not via cursor/window selection (which only grabs displayed geometry).

### Root cause

The AVE originates in **native Civil 3D code** — `TinSurfaceTriangleEnumerator.MoveNext()`, reached from `TinSurfaceToSpeckleMeshRawConverter.Convert` at the `foreach (var triangle in target.GetTriangles(false))` loop. On a surface with no built triangle network, `GetTriangles(false)` dereferences freed/protected native memory.

It **cannot be caught**: an `AccessViolationException` is a Corrupted State Exception that the CLR does not deliver to managed `catch` handlers on .NET 8 (the process fast-fails), and Speckle's `IsFatal()` classifies it as fatal regardless. So the existing `catch (...) when (!ex.IsFatal())` in `AutocadContinuousTraversalBaseBuilder` never runs. The only fix is to **prevent** the native call on a surface that would crash.

The reliable, *safe* signal is that `GetTinProperties()` — a pure managed query that never touches the native triangle buffer — throws for the broken surface, whereas `IsOutOfDate` and `Visible` are useless as guards (both report healthy values).

## Changes

- Add a targeted guard at the crash site in `TinSurfaceToSpeckleMeshRawConverter.Convert`, before the `GetTriangles()` loop. It probes the TIN definition via `GetTinProperties()`; if that throws a non-fatal exception, the triangle network is inaccessible and `GetTriangles()` would crash, so we throw a catchable `SpeckleException` instead.
- Add `using Speckle.Sdk;` for `SpeckleException` / `IsFatal()`.

The `SpeckleException` propagates up through display-value extraction into the existing `catch (...) when (!ex.IsFatal())` in the builder, which records the surface as `Status.ERROR` and continues with the remaining objects. No host crash.

### Why this location / scope

- It's the exact point of danger and is Civil-aware.
- Display-value extraction runs before property extraction, so excluding the surface here also avoids the latent unguarded `GetGeneralProperties()` call in `ClassPropertiesExtractor` — a single guard suffices.
- This is **not** a generic "has no geometry" filter. A legitimately empty but *queryable* surface won't crash, so we leave it alone — we guard only the specific known crash.

### Screen recordings
#### Before
https://github.com/user-attachments/assets/baa966d5-c233-4792-902e-ccd856d6c93b

#### After
https://github.com/user-attachments/assets/e7be7cdf-256b-4e7c-a8eb-6f9481c99d8c

## To test

1. Open the drawing containing the empty Tin Surface in Civil 3D 2026.
2. `Ctrl+A` to select all (~899 entities) and Publish to Speckle.
3. **Expected:** no host crash; publish completes; the empty TinSurface appears in the send report as a single error ("…has no accessible triangle data…"); remaining objects publish.
4. **Regression:** cursor-select the normal set (~782) and publish — still succeeds with valid surface meshes (the probe succeeds for healthy surfaces and doesn't alter their conversion).

> Note: no straightforward unit test — the failure path depends on the native Civil 3D enumerator and an empty-surface database object, so verification is manual in-host.
