### PR TITLE
fix(ci): fix release.yml semv ver env var

### DIFF
--- a/.github/workflows/extended-ci-test.yml
+++ b/.github/workflows/extended-ci-test.yml
@@ -17,3 +17,5 @@ jobs:
     uses: './.github/workflows/release.yml'
     permissions:
       contents: read
+    secrets:
+      CONNECTORS_GH_TOKEN: ${{ secrets.CONNECTORS_GH_TOKEN }}

--- a/.github/workflows/extended-ci-test.yml
+++ b/.github/workflows/extended-ci-test.yml
@@ -14,6 +14,6 @@ concurrency:
 
 jobs:
   test-deploy-pipeline:
-    uses: './release.yml'
+    uses: './.github/workflows/release.yml'
     permissions:
       contents: read

--- a/.github/workflows/extended-ci-test.yml
+++ b/.github/workflows/extended-ci-test.yml
@@ -5,13 +5,12 @@ on:
     paths:
       - 'build/**'
       - '.github/**'
-      - '.github/**'
     
 permissions: {} # We will use fine-grained permissions for each job, so we start with no permissions at all and then add them back as needed.
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true # other running workflows get cancelled on the same branch
+  cancel-in-progress: true
 
 jobs:
   test-deploy-pipeline:

--- a/.github/workflows/extended-ci-test.yml
+++ b/.github/workflows/extended-ci-test.yml
@@ -1,0 +1,20 @@
+name: Extended CI Test
+
+on:
+  push:
+    paths:
+      - 'build/**'
+      - '.github/**'
+      - '.github/**'
+    
+permissions: {} # We will use fine-grained permissions for each job, so we start with no permissions at all and then add them back as needed.
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true # other running workflows get cancelled on the same branch
+
+jobs:
+  test-deploy-pipeline:
+    uses: './release.yml'
+    permissions:
+      contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ on:
 permissions: {} # We will use fine-grained permissions for each job, so we start with no permissions at all and then add them back as needed.
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow_ref }}-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true # other running workflows get cancelled on the same branch
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,11 +58,11 @@ jobs:
       - id: set-version
         name: Set version to output 
         run: |
-          echo "semver=${{ env.SEMVER }}"
-          echo "file_version=${{ env.FILE_VERSION }}"
+          echo "semver=$env:SEMVER"
+          echo "file_version=$env:FILE_VERSION"
           
-          echo "semver=${{ env.SEMVER }}" >> "$Env:GITHUB_OUTPUT"
-          echo "file_version=${{ env.FILE_VERSION }}" >> "$Env:GITHUB_OUTPUT"
+          echo "semver=$env:SEMVER" >> "$Env:GITHUB_OUTPUT"
+          echo "file_version=$env:FILE_VERSION" >> "$Env:GITHUB_OUTPUT"
 
   deploy-installers:
     name: Deploy Installers

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,8 +44,8 @@ jobs:
         id: build-and-zip
         run: |
           ./build.ps1 zip
-          echo "semver=${SEMVER}" >> "$Env:GITHUB_OUTPUT"
-          echo "file_version=${FILE_VERSION}" >> "$Env:GITHUB_OUTPUT"
+          echo "semver=$Env:SEMVER" >> "$Env:GITHUB_OUTPUT"
+          echo "file_version=$Env:FILE_VERSION" >> "$Env:GITHUB_OUTPUT"
 
       - name: ⬆️ Upload artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,9 +15,6 @@ jobs:
   build-connectors:
     name: Build Connectors
     runs-on: windows-latest # Keeping on windows for now, for cross platform building of exe projects, we need to use dotnet publish
-    env:
-      SEMVER: "unset"
-      FILE_VERSION: "unset"
     outputs:
       semver: ${{ steps.build-and-zip.outputs.semver }}
       file_version: ${{ steps.build-and-zip.outputs.file_version }}
@@ -48,7 +45,7 @@ jobs:
       - name: ⬆️ Upload artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: output-${{ env.SEMVER }}
+          name: output-${{ steps.build-and-zip.outputs.semver }}
           path: output/*.*
           if-no-files-found: error
           retention-days: 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,8 +19,8 @@ jobs:
       SEMVER: "unset"
       FILE_VERSION: "unset"
     outputs:
-      semver: ${{ steps.set-version.outputs.semver }}
-      file_version: ${{ steps.set-version.outputs.file_version }}
+      semver: ${{ steps.build-and-zip.outputs.semver }}
+      file_version: ${{ steps.build-and-zip.outputs.file_version }}
     permissions:
       contents: read
 
@@ -39,7 +39,11 @@ jobs:
       # we are purposefully not caching releases when publishing artefacts, see https://docs.zizmor.sh/audits/#cache-poisoning
 
       - name: ⚒️ Run build and zip connectors
-        run: ./build.ps1 zip
+        id: build-and-zip
+        run: |
+          ./build.ps1 zip
+          echo "semver=${SEMVER}" >> "$Env:GITHUB_OUTPUT"
+          echo "file_version=${FILE_VERSION}" >> "$Env:GITHUB_OUTPUT"
 
       - name: ⬆️ Upload artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -49,15 +53,6 @@ jobs:
           if-no-files-found: error
           retention-days: 1
           compression-level: 0 # no compression
-
-      - id: set-version
-        name: Set version to output
-        run: |
-          echo "semver=${SEMVER}" >> "$Env:GITHUB_OUTPUT"
-          echo "file_version=${FILE_VERSION}" >> "$Env:GITHUB_OUTPUT"
-        env:
-          SEMVER: ${{ steps.get-version.outputs.semver }}
-          FILE_VERSION: ${{ steps.get-version.outputs.file_version }}
 
   deploy-installers:
     name: Deploy Installers

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,8 +4,10 @@ on:
   push:
     branches: ["main", "installer-test/**"]
     tags: ["v3.*.*"] # Manual delivery on every 3.x tag
-  workflow_dispatch: {}
-  workflow_call: {}
+  workflow_call: 
+    secrets:
+      CONNECTORS_GH_TOKEN:
+        required: true
   
 permissions: {} # We will use fine-grained permissions for each job, so we start with no permissions at all and then add them back as needed.
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,6 +58,9 @@ jobs:
       - id: set-version
         name: Set version to output 
         run: |
+          echo "semver=${SEMVER}"
+          echo "file_version=${FILE_VERSION}"
+          
           echo "semver=${SEMVER}" >> "$Env:GITHUB_OUTPUT"
           echo "file_version=${FILE_VERSION}" >> "$Env:GITHUB_OUTPUT"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,9 @@ on:
   push:
     branches: ["main", "installer-test/**"]
     tags: ["v3.*.*"] # Manual delivery on every 3.x tag
-
+  workflow_dispatch: {}
+  workflow_call: {}
+  
 permissions: {} # We will use fine-grained permissions for each job, so we start with no permissions at all and then add them back as needed.
 
 concurrency:
@@ -15,6 +17,9 @@ jobs:
   build-connectors:
     name: Build Connectors
     runs-on: windows-latest # Keeping on windows for now, for cross platform building of exe projects, we need to use dotnet publish
+    env:
+      SEMVER: "unset"
+      FILE_VERSION: "unset"
     outputs:
       semver: ${{ steps.build-and-zip.outputs.semver }}
       file_version: ${{ steps.build-and-zip.outputs.file_version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,8 +21,8 @@ jobs:
       SEMVER: "unset"
       FILE_VERSION: "unset"
     outputs:
-      semver: ${{ steps.build-and-zip.outputs.semver }}
-      file_version: ${{ steps.build-and-zip.outputs.file_version }}
+      semver: ${{ steps.set-version.outputs.semver }}
+      file_version: ${{ steps.set-version.outputs.file_version }}
     permissions:
       contents: read
 
@@ -41,20 +41,23 @@ jobs:
       # we are purposefully not caching releases when publishing artefacts, see https://docs.zizmor.sh/audits/#cache-poisoning
 
       - name: ⚒️ Run build and zip connectors
-        id: build-and-zip
-        run: |
-          ./build.ps1 zip
-          echo "semver=$Env:SEMVER" >> "$Env:GITHUB_OUTPUT"
-          echo "file_version=$Env:FILE_VERSION" >> "$Env:GITHUB_OUTPUT"
-
+        run: ./build.ps1 zip  
+        
       - name: ⬆️ Upload artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: output-${{ steps.build-and-zip.outputs.semver }}
+          name: output-${{ env.SEMVER }}
           path: output/*.*
           if-no-files-found: error
           retention-days: 1
           compression-level: 0 # no compression
+          
+      # build step will write SEMVER and FILE_VERSION to GITHUB_ENV, here we'll forward those to the output
+      - id: set-version
+        name: Set version to output 
+        run: |
+          echo "semver=${SEMVER}" >> "$Env:GITHUB_OUTPUT"
+          echo "file_version=${FILE_VERSION}" >> "$Env:GITHUB_OUTPUT"
 
   deploy-installers:
     name: Deploy Installers

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,11 +58,11 @@ jobs:
       - id: set-version
         name: Set version to output 
         run: |
-          echo "semver=${SEMVER}"
-          echo "file_version=${FILE_VERSION}"
+          echo "semver=${{ env.SEMVER }}"
+          echo "file_version=${{ env.FILE_VERSION }}"
           
-          echo "semver=${SEMVER}" >> "$Env:GITHUB_OUTPUT"
-          echo "file_version=${FILE_VERSION}" >> "$Env:GITHUB_OUTPUT"
+          echo "semver=${{ env.SEMVER }}" >> "$Env:GITHUB_OUTPUT"
+          echo "file_version=${{ env.FILE_VERSION }}" >> "$Env:GITHUB_OUTPUT"
 
   deploy-installers:
     name: Deploy Installers

--- a/Build/Program.cs
+++ b/Build/Program.cs
@@ -271,12 +271,10 @@ Target(
       ZipFile.CreateFromDirectory(slugDir, outputPath);
     }
 
-    // string githubEnv = Environment.GetEnvironmentVariable("GITHUB_ENV") ?? "Unset";
-    // Console.WriteLine($"GITHUB_ENV: {githubEnv}");
-    Environment.SetEnvironmentVariable("SEMVER", version.ToString(), EnvironmentVariableTarget.User);
-    Environment.SetEnvironmentVariable("FILE_VERSION", fileVersion, EnvironmentVariableTarget.User);
-    // File.AppendAllText(githubEnv, $"SEMVER={version}{Environment.NewLine}");
-    // File.AppendAllText(githubEnv, $"FILE_VERSION={fileVersion}{Environment.NewLine}");
+    string githubEnv = Environment.GetEnvironmentVariable("GITHUB_ENV") ?? "Unset";
+    Console.WriteLine($"GITHUB_ENV: {githubEnv}");
+    File.AppendAllText(githubEnv, $"SEMVER={version}{Environment.NewLine}");
+    File.AppendAllText(githubEnv, $"FILE_VERSION={fileVersion}{Environment.NewLine}");
   }
 );
 

--- a/Build/Program.cs
+++ b/Build/Program.cs
@@ -271,10 +271,12 @@ Target(
       ZipFile.CreateFromDirectory(slugDir, outputPath);
     }
 
-    string githubEnv = Environment.GetEnvironmentVariable("GITHUB_ENV") ?? "Unset";
-    Console.WriteLine($"GITHUB_ENV: {githubEnv}");
-    File.AppendAllText(githubEnv, $"SEMVER={version}{Environment.NewLine}");
-    File.AppendAllText(githubEnv, $"FILE_VERSION={fileVersion}{Environment.NewLine}");
+    // string githubEnv = Environment.GetEnvironmentVariable("GITHUB_ENV") ?? "Unset";
+    // Console.WriteLine($"GITHUB_ENV: {githubEnv}");
+    Environment.SetEnvironmentVariable("SEMVER", version.ToString(), EnvironmentVariableTarget.User);
+    Environment.SetEnvironmentVariable("FILE_VERSION", fileVersion, EnvironmentVariableTarget.User);
+    // File.AppendAllText(githubEnv, $"SEMVER={version}{Environment.NewLine}");
+    // File.AppendAllText(githubEnv, $"FILE_VERSION={fileVersion}{Environment.NewLine}");
   }
 );
 

--- a/Speckle.Connectors.slnx
+++ b/Speckle.Connectors.slnx
@@ -6,6 +6,7 @@
   </Configurations>
   <Folder Name="/Build/">
     <Project Path="Build\Build.csproj" />
+    <File Path=".github/workflows/extended-ci-test.yml" />
     <File Path=".github\workflows\pr.yml" />
     <File Path=".github\workflows\release.yml" />
   </Folder>


### PR DESCRIPTION
The build step would inexplicitly output the semver as an the env var.
Because it wasn't explicit, it was broken with #1420

This PR fixes the logic, and makes the output explicit.

Also added a workflow to ensure that the test-installer CI pipeline is tested when changes are made to the workflows or build project 