### PR TITLE
fix(rhino): add volume and area to RhinoDataObject

### DIFF
--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/HostApp/Properties/PropertiesExtractor.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/HostApp/Properties/PropertiesExtractor.cs
@@ -2,7 +2,9 @@ using Rhino;
 using Rhino.Collections;
 using Rhino.DocObjects;
 using Speckle.Connectors.Rhino.Mapper.Revit;
+using Speckle.Objects;
 using Speckle.Sdk;
+using Speckle.Sdk.Models;
 
 namespace Speckle.Connectors.Rhino.HostApp.Properties;
 
@@ -29,6 +31,29 @@ public class PropertiesExtractor
     }
 
     return properties;
+  }
+
+  public void AddGeometryProperties(Dictionary<string, object?> properties, Base geometry, string units)
+  {
+    if (geometry is IHasArea hasArea)
+    {
+      properties["area"] = new Dictionary<string, object?>
+      {
+        ["name"] = "area",
+        ["value"] = hasArea.area,
+        ["units"] = $"{units}²",
+      };
+    }
+
+    if (geometry is IHasVolume hasVolume)
+    {
+      properties["volume"] = new Dictionary<string, object?>
+      {
+        ["name"] = "volume",
+        ["value"] = hasVolume.volume,
+        ["units"] = $"{units}³",
+      };
+    }
   }
 
   private Dictionary<string, object?> GetUserDict(RhinoObject rhObject)

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/Operations/Send/RhinoContinousTraversalBuilder.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/Operations/Send/RhinoContinousTraversalBuilder.cs
@@ -218,12 +218,15 @@ public class RhinoContinuousTraversalBuilder : IRootContinuousTraversalBuilder<R
           displayMeshes = [rawGeometry];
         }
 
+        var properties = _propertiesExtractor.GetProperties(rhinoObject);
+        _propertiesExtractor.AddGeometryProperties(properties, rawGeometry, _converterSettings.Current.SpeckleUnits);
+
         converted = new RhinoDataObject
         {
           name = !string.IsNullOrEmpty(rhinoObject.Attributes.Name) ? rhinoObject.Attributes.Name : sourceType,
           type = sourceType,
           displayValue = displayMeshes,
-          properties = _propertiesExtractor.GetProperties(rhinoObject),
+          properties = properties,
           units = _converterSettings.Current.SpeckleUnits,
           applicationId = applicationId,
           rawEncoding = rawEncoding,

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/Operations/Send/RhinoRootObjectBuilder.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/Operations/Send/RhinoRootObjectBuilder.cs
@@ -210,12 +210,15 @@ public class RhinoRootObjectBuilder : IRootObjectBuilder<RhinoObject>
           displayMeshes = [rawGeometry];
         }
 
+        var properties = _propertiesExtractor.GetProperties(rhinoObject);
+        _propertiesExtractor.AddGeometryProperties(properties, rawGeometry, _converterSettings.Current.SpeckleUnits);
+
         converted = new RhinoDataObject
         {
           name = !string.IsNullOrEmpty(rhinoObject.Attributes.Name) ? rhinoObject.Attributes.Name : sourceType,
           type = sourceType,
           displayValue = displayMeshes,
-          properties = _propertiesExtractor.GetProperties(rhinoObject),
+          properties = properties,
           units = _converterSettings.Current.SpeckleUnits,
           applicationId = applicationId,
           rawEncoding = rawEncoding,


### PR DESCRIPTION
The BrepX → RhinoDataObject change dropped the area and volume values from properties. This adds them back into the object's properties as { name, value, units }.

<img width="1041" height="804" alt="image" src="https://github.com/user-attachments/assets/1ad5e24e-9fa3-4333-bf46-c7a83db2736f" />
