### PR TITLE
Fix(rhino): Fix occasional extrusion fail due to area calculations returning null

### DIFF
--- a/Converters/Rhino/Speckle.Converters.RhinoShared/ToSpeckle/Raw/ExtrusionToSpeckleConverter.cs
+++ b/Converters/Rhino/Speckle.Converters.RhinoShared/ToSpeckle/Raw/ExtrusionToSpeckleConverter.cs
@@ -36,7 +36,7 @@ public class ExtrusionToSpeckleConverter : ITypedConverter<RG.Extrusion, SOG.Ext
     );
 
     // get area and volume props
-    double area = AreaMassProperties.Compute(target).Area;
+    double area = AreaMassProperties.Compute(target)?.Area ?? 0;
     double volume = 0;
     if (target.IsSolid)
     {

--- a/Converters/Rhino/Speckle.Converters.RhinoShared/ToSpeckle/Raw/MeshToSpeckleConverter.cs
+++ b/Converters/Rhino/Speckle.Converters.RhinoShared/ToSpeckle/Raw/MeshToSpeckleConverter.cs
@@ -100,7 +100,7 @@ public class MeshToSpeckleConverter : ITypedConverter<RG.Mesh, SOG.Mesh>
     }
 
     // get area and volume props
-    double area = AreaMassProperties.Compute(target).Area;
+    double area = AreaMassProperties.Compute(target)?.Area ?? 0;
     double volume = target.IsClosed ? target.Volume() : 0;
 
     return new SOG.Mesh


### PR DESCRIPTION
Fix a error I'm seeing in logs:
```
System.NullReferenceException: Object reference not set to an instance of an object.
   at Speckle.Converters.Rhino.ToSpeckle.Raw.ExtrusionToSpeckleConverter.Convert(Extrusion target) in /_/Converters/Rhino/Speckle.Converters.RhinoShared/ToSpeckle/Raw/ExtrusionToSpeckleConverter.cs:line 39
   at Speckle.Converters.Rhino.ToSpeckle.TopLevel.RhinoObjectToSpeckleTopLevelConverter`3.Convert(Object target) in /_/Converters/Rhino/Speckle.Converters.RhinoShared/ToSpeckle/TopLevel/RhinoObjectToSpeckleTopLevelConverter.cs:line 24
   at Speckle.Connectors.Rhino.Operations.Send.RhinoContinuousTraversalBuilder.ConvertRhinoObject(RhinoObject rhinoObject, Collection collectionHost, IReadOnlyDictionary`2 instanceProxies, String projectId, SendPipeline sendPipeline) in /_/Connectors/Rhino/Speckle.Connectors.RhinoShared/Operations/Send/RhinoContinousTraversalBuilder.cs:line 202
```
I'm hoping this is caused by the `AreaMassProperties.Compute` returning null.

Looking at [the source](https://github.com/mcneel/rhino3dm/blob/7ae9ec7c75cd685d3328aa878ae91f11c9c8d4bd/src/dotnet/opennurbs/opennurbs_massprop.cs#L221-L243
), it clearly can return null on faliure:
```cs
    /// <summary>
    /// Compute the AreaMassProperties for a single Surface.
    /// </summary>
    /// <param name="surface">Surface to measure.</param>
    /// <param name="area">true to calculate area.</param>
    /// <param name="firstMoments">true to calculate area first moments, area, and area centroid.</param>
    /// <param name="secondMoments">true to calculate area second moments.</param>
    /// <param name="productMoments">true to calculate area product moments.</param>
    /// <returns>The AreaMassProperties for the given Surface or null on failure.</returns>
    /// <exception cref="System.ArgumentNullException">When surface is null.</exception>
    /// <since>6.3</since>
    public static AreaMassProperties Compute(Surface surface, bool area, bool firstMoments, bool secondMoments, bool productMoments)
    {
      if (surface == null)
        throw new ArgumentNullException(nameof(surface));

      IntPtr pSurface = surface.ConstPointer();
      const double relative_tolerance = 1.0e-6;
      const double absolute_tolerance = 1.0e-6;
      IntPtr rc = UnsafeNativeMethods.ON_Surface_MassProperties(true, pSurface, area, firstMoments, secondMoments, productMoments, relative_tolerance, absolute_tolerance);
      GC.KeepAlive(surface);
      return IntPtr.Zero == rc ? null : new AreaMassProperties(rc, false);
    }
```