### PR TITLE
Fix(ci): fix extended ci test

### DIFF
--- a/.github/workflows/extended-ci-test.yml
+++ b/.github/workflows/extended-ci-test.yml
@@ -17,5 +17,4 @@ jobs:
     uses: './.github/workflows/release.yml'
     permissions:
       contents: read
-    secrets:
-      CONNECTORS_GH_TOKEN: ${{ secrets.CONNECTORS_GH_TOKEN }}
+    secrets: inherit

--- a/.github/workflows/extended-ci-test.yml
+++ b/.github/workflows/extended-ci-test.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   test-deploy-pipeline:
-    uses: './.github/workflows/release.yml'
+    uses: './.github/workflows/release.yml' # zizmor: ignore[secrets-inherit] zizmor's suggested fix here doesn't work
     permissions:
       contents: read
     secrets: inherit


### PR DESCRIPTION
The extended CI tests were failing:
```
  Run benc-uk/workflow-dispatch@31e2b3319479a63f0ab15bf800eff9e913504e26                                                                                                                                                                                                                                            
    with:                                                                                                                                                                                                                                                                                                           
      workflow: Build Installers                                                                                                                                                                                                                                                                                    
      repo: specklesystems/connector-installers                                                                                                                                                                                                                                                                     
      inputs: { "run_id": "28599508266", "semver": "3.24.1-9-g12f3f4bd", "file_version": "3.24.1.0", "repo": "specklesystems/speckle-sharp-connectors", "is_public_release": false }                                                                                                                                
      ref: main                                                                                                                                                                                                                                                                                                     
      wait-for-completion: true                                                                                                                                                                                                                                                                                     
      sync-status: true                                                                                                                                                                                                                                                                                             
      wait-timeout-seconds: 900                                                                                                                                                                                                                                                                                     
      wait-interval-seconds: 5                                                                                                                                                                                                                                                                                      
    env:                                                                                                                                                                                                                                                                                                            
      IS_PUBLIC_RELEASE: false                                                                                                                                                                                                                                                                                      
  🏃 Workflow Dispatch Action v1.3.2                                                                                                                                                                                                                                                                                
  Error: Parameter token or opts.auth is required                                                                                                                                                                                                                                                                   
```


Inherit rather than pass secrets through to calling worklofw
It seems zizmor's suggestion to pass secrets explicitly between calling workflows doesn't properly work in this case.

Claude suggests it's because `CONNECTORS_GH_TOKEN` is an org secret, not a repo secret. 