### PR TITLE
fix(rhino): keep hatches as hatches on artefact round-trip

### DIFF
--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/Operations/Receive/RhinoHostObjectArtefactBuilder.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/Operations/Receive/RhinoHostObjectArtefactBuilder.cs
@@ -356,6 +356,10 @@ public class RhinoHostObjectArtefactBuilder : IArtifactHostObjectBuilder
       atts.RenderMaterial = RenderContent.FromId(doc, materialGuid) as RhinoRenderMaterial;
       atts.MaterialSource = ObjectMaterialSource.MaterialFromObject;
     }
+    if (geom is RG.Hatch hatch)
+    {
+      return doc.Objects.AddHatch(hatch, atts);
+    }
     return doc.Objects.Add(geom, atts);
   }
 

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/Operations/Send/RhinoArtifactRootObjectBuilder.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/Operations/Send/RhinoArtifactRootObjectBuilder.cs
@@ -207,7 +207,9 @@ public class RhinoArtifactRootObjectBuilder(
     Base rawGeometry = converter.Convert(rhinoObject);
     var properties = propertiesExtractor.GetProperties(rhinoObject);
     propertiesExtractor.AddGeometryProperties(properties, rawGeometry, units);
-    return new CollectedObject(applicationId, name, sourceType, layerIndex, properties, rawGeometry);
+    RawEncoding? rawSolid =
+      rawGeometry is SOG.IRawEncodedObject ? null : RhinoHatchSolidEncoder.TryEncode(rhinoObject, converterSettings.Current.Document);
+    return new CollectedObject(applicationId, name, sourceType, layerIndex, properties, rawGeometry, rawSolid);
   }
 
   // Walks a layer + its ancestors (via ParentLayerId) into the snapshot, keyed by layer index. RhinoCommon-bound.
@@ -365,9 +367,10 @@ public class RhinoArtifactRootObjectBuilder(
 
     // Authoritative solid: the raw 3dm blob, kept verbatim for receive-as-solids. Skipped for definition members —
     // a member is never a standalone solid; it renders only through its definition's display meshes (DEFINES).
-    if (!isDefinitionMember && rawEncoding is not null && rawEncoding.format == RawEncodingFormats.RHINO_3DM)
+    RawEncoding? solid = rawEncoding ?? co.RawSolid;
+    if (!isDefinitionMember && solid is not null && solid.format == RawEncodingFormats.RHINO_3DM)
     {
-      byte[] solidBytes = Convert.FromBase64String(rawEncoding.contents);
+      byte[] solidBytes = Convert.FromBase64String(solid.contents);
       int solidK = pipeline.AddRawGeometry($"{co.ApplicationId}:solid", solidBytes, RawEncodingFormats.RHINO_3DM);
       pipeline.Solid(objK, solidK, 0);
     }
@@ -546,7 +549,8 @@ public class RhinoArtifactRootObjectBuilder(
     string SourceType,
     int LayerIndex,
     Dictionary<string, object?> Properties,
-    Base Converted // InstanceProxy for block instances, otherwise the converted geometry (Brep/Extrusion/SubD/Mesh/…)
+    Base Converted, // InstanceProxy for block instances, otherwise the converted geometry (Brep/Extrusion/SubD/Mesh/…)
+    RawEncoding? RawSolid = null
   );
 
   private sealed record CollectedModel(

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/Operations/Send/RhinoHatchSolidEncoder.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/Operations/Send/RhinoHatchSolidEncoder.cs
@@ -1,0 +1,25 @@
+using Rhino;
+using Rhino.DocObjects;
+using Rhino.FileIO;
+using Speckle.Objects.Other;
+using RG = Rhino.Geometry;
+
+namespace Speckle.Connectors.Rhino.Operations.Send;
+
+internal static class RhinoHatchSolidEncoder
+{
+  public static RawEncoding? TryEncode(RhinoObject rhinoObject, RhinoDoc doc)
+  {
+    if (rhinoObject.Geometry is not RG.Hatch hatch)
+    {
+      return null;
+    }
+    using var file = new File3dm();
+    file.Objects.AddHatch(hatch);
+    file.Settings.ModelUnitSystem = doc.ModelUnitSystem;
+    file.Settings.ModelAbsoluteTolerance = doc.ModelAbsoluteTolerance;
+    file.Settings.ModelAngleToleranceRadians = doc.ModelAngleToleranceRadians;
+    var bytes = file.ToByteArray(new File3dmWriteOptions() { SaveUserData = false, Version = 7 });
+    return new RawEncoding() { contents = System.Convert.ToBase64String(bytes), format = RawEncodingFormats.RHINO_3DM };
+  }
+}

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/Speckle.Connectors.RhinoShared.projitems
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/Speckle.Connectors.RhinoShared.projitems
@@ -41,6 +41,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Operations\Send\Filters\RhinoSelectionFilter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Operations\Send\Filters\RhinoLayersFilter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Operations\Send\RhinoArtifactRootObjectBuilder.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Operations\Send\RhinoHatchSolidEncoder.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Operations\Send\RhinoContinousTraversalBuilder.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Operations\Send\Settings\AddVisualizationProperties.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Operations\Send\Settings\ToSpeckleSettingsManager.cs" />


### PR DESCRIPTION
Rhino hatches were sent as display meshes only and came back as plain meshes. Now a hatch is also kept as a raw 3dm blob.