### PR TITLE
feat(groups): via IN_GROUP (17) for Rhino + AutoCAD

### DIFF
--- a/Connectors/Autocad/Speckle.Connectors.AutocadShared/Operations/Receive/AutocadHostObjectArtefactBuilder.cs
+++ b/Connectors/Autocad/Speckle.Connectors.AutocadShared/Operations/Receive/AutocadHostObjectArtefactBuilder.cs
@@ -119,6 +119,8 @@ public class AutocadHostObjectArtefactBuilder : IArtifactHostObjectBuilder
     var bakedObjectIds = new HashSet<string>();
     var conversionResults = new HashSet<ReceiveConversionResult>();
     var layerCache = new HashSet<string>(StringComparer.Ordinal);
+    // objK → its baked entity ids, tracked only for grouped objects (IN_GROUP) so step 4 can rebuild native groups.
+    var bakedIdsByObjK = new Dictionary<int, List<ObjectId>>();
 
     using var docLock = doc.LockDocument();
 
@@ -242,6 +244,10 @@ public class AutocadHostObjectArtefactBuilder : IArtifactHostObjectBuilder
           }
 
           bakedObjectIds.UnionWith(ids.Select(i => i.ToString()));
+          if (rels.GroupsByObject.ContainsKey(objK))
+          {
+            bakedIdsByObjK[objK] = ids;
+          }
           conversionResults.Add(new(Status.SUCCESS, source, ids[0].ToString(), "Object", null, srcType));
           session.RecordObject(appId, srcType, Status.SUCCESS, null, sw.ElapsedMilliseconds);
         }
@@ -272,10 +278,22 @@ public class AutocadHostObjectArtefactBuilder : IArtifactHostObjectBuilder
           colorArgbByGeometry,
           colorArgbByObject,
           bakedObjectIds,
+          bakedIdsByObjK,
           conversionResults,
           session
         );
         itr.Commit();
+      }
+    }
+
+    // 4 - authored scene groups (IN_GROUP → CONTAINER(Group) nodes) → native AutoCAD groups.
+    if (rels.GroupsByObject.Count > 0)
+    {
+      using (session.Phase("Groups"))
+      using (var gtr = doc.TransactionManager.StartTransaction())
+      {
+        BakeGroups(bundle, rels, db, gtr, bakedIdsByObjK, baseLayerName, session);
+        gtr.Commit();
       }
     }
 
@@ -570,6 +588,7 @@ public class AutocadHostObjectArtefactBuilder : IArtifactHostObjectBuilder
     Dictionary<int, int> colorArgbByGeometry,
     Dictionary<string, int> colorArgbByObject,
     HashSet<string> bakedObjectIds,
+    Dictionary<int, List<ObjectId>> bakedIdsByObjK,
     HashSet<ReceiveConversionResult> conversionResults,
     ArtefactSessionLog session
   )
@@ -601,6 +620,7 @@ public class AutocadHostObjectArtefactBuilder : IArtifactHostObjectBuilder
       defIdByNode,
       modelSpace,
       bakedObjectIds,
+      bakedIdsByObjK,
       conversionResults,
       session
     );
@@ -748,6 +768,7 @@ public class AutocadHostObjectArtefactBuilder : IArtifactHostObjectBuilder
     Dictionary<int, ObjectId> defIdByNode,
     BlockTableRecord modelSpace,
     HashSet<string> bakedObjectIds,
+    Dictionary<int, List<ObjectId>> bakedIdsByObjK,
     HashSet<ReceiveConversionResult> conversionResults,
     ArtefactSessionLog session
   )
@@ -811,6 +832,14 @@ public class AutocadHostObjectArtefactBuilder : IArtifactHostObjectBuilder
         modelSpace.AppendEntity(blockRef);
         tr.AddNewlyCreatedDBObject(blockRef, true);
         bakedObjectIds.Add(blockRef.ObjectId.ToString());
+        if (rels.GroupsByObject.ContainsKey(objK))
+        {
+          if (!bakedIdsByObjK.TryGetValue(objK, out var grouped))
+          {
+            bakedIdsByObjK[objK] = grouped = new List<ObjectId>();
+          }
+          grouped.Add(blockRef.ObjectId); // an object may place several instances; all of them join its group(s)
+        }
         conversionResults.Add(
           new(Status.SUCCESS, source, blockRef.ObjectId.ToString(), "Instance (Block)", null, srcType)
         );
@@ -820,6 +849,75 @@ public class AutocadHostObjectArtefactBuilder : IArtifactHostObjectBuilder
       {
         session.RecordObject(appId, srcType, Status.ERROR, ex.Message, sw.ElapsedMilliseconds);
         conversionResults.Add(new(Status.ERROR, source, null, null, ex, srcType));
+      }
+    }
+  }
+
+  // ── groups ────────────────────────────────────────────────────────────────────────────────────────────
+  // Authored scene groups: inverts GroupsByObject (object → its CONTAINER(Group) nodes) to group → member entity ids
+  // and creates one native Group per node in the document group dictionary (mirrors the v1 AutocadGroupBaker). The
+  // name carries the baseLayerName suffix so PreClean purges this model's groups on re-receive; the dictionary
+  // requires unique keys (unlike Rhino's group table), so a clashing name gets a -N suffix. A member that failed to
+  // bake (or is non-geometric) is skipped; the group keeps its other members. Smaller groups first, as in v1.
+  private void BakeGroups(
+    ArtefactBundle bundle,
+    ArtefactRelations rels,
+    Database db,
+    Transaction tr,
+    Dictionary<int, List<ObjectId>> bakedIdsByObjK,
+    string baseLayerName,
+    ArtefactSessionLog session
+  )
+  {
+    var membersByGroup = new Dictionary<int, List<ObjectId>>();
+    foreach (var kv in rels.GroupsByObject)
+    {
+      if (!bakedIdsByObjK.TryGetValue(kv.Key, out var ids))
+      {
+        continue;
+      }
+      foreach (int groupK in kv.Value)
+      {
+        if (!membersByGroup.TryGetValue(groupK, out var list))
+        {
+          membersByGroup[groupK] = list = new List<ObjectId>();
+        }
+        list.AddRange(ids);
+      }
+    }
+    if (membersByGroup.Count == 0)
+    {
+      return;
+    }
+
+    var groupDictionary = (DBDictionary)tr.GetObject(db.GroupDictionaryId, OpenMode.ForWrite);
+    foreach (var kv in membersByGroup.OrderBy(g => g.Value.Count))
+    {
+      try
+      {
+        bundle.Nodes.TryGetValue(kv.Key, out var node);
+        var rawName = node?.Name is { Length: > 0 } n ? n : "Group";
+        var baseName = $"{_autocadContext.RemoveInvalidChars(rawName)} ({baseLayerName})";
+        string name = baseName;
+        for (int i = 1; groupDictionary.Contains(name); i++)
+        {
+          name = $"{baseName}-{i}";
+        }
+
+        var memberIds = new ObjectIdCollection();
+        foreach (var id in kv.Value)
+        {
+          memberIds.Add(id);
+        }
+        var group = new Group(name, true); // NOTE: this constructor sets both description and name
+        group.Append(memberIds);
+        groupDictionary.SetAt(name, group);
+        tr.AddNewlyCreatedDBObject(group, true);
+        session.Increment("groupsBaked");
+      }
+      catch (Exception ex) when (!ex.IsFatal())
+      {
+        _logger.LogError(ex, "Failed to bake AutoCAD group node {GroupK}", kv.Key);
       }
     }
   }
@@ -1106,6 +1204,25 @@ public class AutocadHostObjectArtefactBuilder : IArtifactHostObjectBuilder
         {
           entity.UpgradeOpen();
           entity.Erase();
+        }
+      }
+
+      // purge this model's groups from the prior receive — they carry the baseLayerName suffix (BakeGroups).
+      // Collect first, then erase: erasing while enumerating the dictionary invalidates the enumerator.
+      var groupDictionary = (DBDictionary)tr.GetObject(db.GroupDictionaryId, OpenMode.ForRead);
+      var staleGroupIds = new List<ObjectId>();
+      foreach (DBDictionaryEntry entry in groupDictionary)
+      {
+        if (entry.Key.Contains(baseLayerName))
+        {
+          staleGroupIds.Add(entry.Value);
+        }
+      }
+      foreach (var groupId in staleGroupIds)
+      {
+        if (tr.GetObject(groupId, OpenMode.ForWrite) is Group staleGroup)
+        {
+          staleGroup.Erase();
         }
       }
 

--- a/Connectors/Autocad/Speckle.Connectors.AutocadShared/Operations/Send/AutocadArtifactRootObjectBuilder.cs
+++ b/Connectors/Autocad/Speckle.Connectors.AutocadShared/Operations/Send/AutocadArtifactRootObjectBuilder.cs
@@ -3,6 +3,7 @@ using System.Diagnostics.CodeAnalysis;
 using Autodesk.AutoCAD.DatabaseServices;
 using Microsoft.Extensions.Logging;
 using Speckle.Connectors.Autocad.HostApp;
+using Speckle.Connectors.Autocad.HostApp.Extensions;
 using Speckle.Connectors.Common.Builders;
 using Speckle.Connectors.Common.Conversion;
 using Speckle.Connectors.Common.Diagnostics;
@@ -55,7 +56,7 @@ namespace Speckle.Connectors.Autocad.Operations.Send;
 /// sync-over-async parquet IO that deadlocks on the UI thread).</para>
 /// <para>The single builder serves AutoCAD, Civil3D and Plant3D: the injected <see cref="IRootToSpeckleConverter"/>
 /// and unpackers resolve to each vertical's registrations, so per-vertical geometry/property extraction is correct
-/// without subclassing. Deferred this pass: AutoCAD groups, Civil3D property-set definitions.</para>
+/// without subclassing. Deferred this pass: Civil3D property-set definitions.</para>
 /// </remarks>
 public class AutocadArtifactRootObjectBuilder(
   IRootToSpeckleConverter converter,
@@ -176,6 +177,9 @@ public class AutocadArtifactRootObjectBuilder(
     var colors = colorUnpacker.UnpackColors(atomicObjects, new List<LayerTableRecord>());
     var layerArgbByName = CollectLayerColors(atomicObjects);
 
+    // Authored scene groups → plain snapshot records (Base-free — no GroupProxy). Membership lists OBJECT ids.
+    var groups = CollectGroups(atomicObjects);
+
     return new CollectedModel(
       units,
       collectedObjects,
@@ -183,8 +187,43 @@ public class AutocadArtifactRootObjectBuilder(
       colors,
       layerArgbByName,
       instanceDefinitionProxies,
+      groups,
       results
     );
+  }
+
+  // AutoCAD groups → plain snapshot records. Membership rides persistent reactors on each entity (a Group is a
+  // reactor on its members); AutoCAD groups don't nest, so each membership is one flat IN_GROUP edge.
+  // AutoCAD-API-bound (transaction) → phase 1 only.
+  private List<CollectedGroup> CollectGroups(List<AutocadRootObject> atomicObjects)
+  {
+    var groups = new Dictionary<string, CollectedGroup>(StringComparer.Ordinal);
+    using var transaction = converterSettings.Current.Document.Database.TransactionManager.StartTransaction();
+    foreach (var (dbObject, applicationId) in atomicObjects)
+    {
+      try
+      {
+        foreach (ObjectId reactorId in dbObject.GetPersistentReactorIds())
+        {
+          if (transaction.GetObject(reactorId, OpenMode.ForRead) is not Group group)
+          {
+            continue;
+          }
+          string groupAppId = group.GetSpeckleApplicationId();
+          if (!groups.TryGetValue(groupAppId, out CollectedGroup? collected))
+          {
+            collected = new CollectedGroup(groupAppId, group.Name, new List<string>());
+            groups[groupAppId] = collected;
+          }
+          collected.MemberIds.Add(applicationId);
+        }
+      }
+      catch (Exception ex) when (!ex.IsFatal())
+      {
+        logger.LogWarning(ex, "Failed to unpack groups for {AppId}", applicationId);
+      }
+    }
+    return groups.Values.ToList();
   }
 
   // Captures the colour of every layer used by the selection (AutoCAD API is document-bound → phase 1 only), so
@@ -278,6 +317,7 @@ public class AutocadArtifactRootObjectBuilder(
     }
 
     EmitValueNodes(pipeline, model, geometryKsByObjectId, instanceKByObjectId);
+    EmitGroups(pipeline, model.Groups, definitionMemberIds);
     EmitCivilNetworkTopology(pipeline, model.Objects);
 
     // Default scene view: the (flat) AutoCAD layer namespace via IN_COLLECTION.
@@ -298,6 +338,7 @@ public class AutocadArtifactRootObjectBuilder(
     session.SetStat("definitions", model.Definitions.Count);
     session.SetStat("materials", model.Materials.Count);
     session.SetStat("layers", layerCollectionKByName.Count);
+    session.SetStat("groups", model.Groups.Count);
 
     logger.LogInformation("Built artefact bundle: {fileCount} files, {objectCount} objects", bundle.Count, objectCount);
     return new BundleResult(bundle, rootId, objectCount, model.Results);
@@ -603,6 +644,32 @@ public class AutocadArtifactRootObjectBuilder(
     }
   }
 
+  // Authored scene groups → CONTAINER("Group") nodes + IN_GROUP membership. A SEPARATE axis from IN_COLLECTION:
+  // an object keeps its layer AND its group(s); memberships overlap, so an object may carry several IN_GROUP
+  // edges. Definition members get no scene edges (same suppression as IN_COLLECTION), so a group emptied by
+  // that is skipped entirely.
+  private static void EmitGroups(
+    ObjectsArtifactPipeline pipeline,
+    IReadOnlyList<CollectedGroup> groups,
+    HashSet<string> definitionMemberIds
+  )
+  {
+    foreach (CollectedGroup group in groups)
+    {
+      var memberIds = group.MemberIds.Where(id => !definitionMemberIds.Contains(id)).ToList();
+      if (memberIds.Count == 0)
+      {
+        continue;
+      }
+      int groupK = pipeline.AddContainer(group.Id, group.Name, null, "Group");
+      int ord = 0;
+      foreach (string memberId in memberIds)
+      {
+        pipeline.InGroup(pipeline.InternObject(memberId), groupK, ord++);
+      }
+    }
+  }
+
   // Resolves (and interns once) the flat COLLECTION node for a layer name (with the layer's colour as its argb).
   // AutoCAD has no nested layers.
   private static int GetOrAddLayerCollection(
@@ -667,6 +734,8 @@ public class AutocadArtifactRootObjectBuilder(
     Base Converted // InstanceProxy for block instances, otherwise the AutocadObject carrier (display meshes + SAT)
   );
 
+  private sealed record CollectedGroup(string Id, string? Name, List<string> MemberIds);
+
   private sealed record CollectedModel(
     string Units,
     IReadOnlyList<CollectedObject> Objects,
@@ -674,6 +743,7 @@ public class AutocadArtifactRootObjectBuilder(
     IReadOnlyList<ColorProxy> Colors,
     IReadOnlyDictionary<string, int> LayerArgbByName,
     IReadOnlyList<InstanceDefinitionProxy> Definitions,
+    IReadOnlyList<CollectedGroup> Groups,
     IReadOnlyList<SendConversionResult> Results
   );
 

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/Operations/Receive/RhinoHostObjectArtefactBuilder.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/Operations/Receive/RhinoHostObjectArtefactBuilder.cs
@@ -118,6 +118,8 @@ public class RhinoHostObjectArtefactBuilder : IArtifactHostObjectBuilder
     var objByGeom = rels.ObjectByGeometry();
     var bakedObjectIds = new HashSet<string>();
     var conversionResults = new HashSet<ReceiveConversionResult>();
+    // objK → its baked Rhino guids, tracked only for grouped objects (IN_GROUP) so step 5 can rebuild native groups.
+    var bakedGuidsByObjK = new Dictionary<int, List<Guid>>();
 
     using var noDraw = new DisableRedrawScope(doc.Views);
 
@@ -189,6 +191,10 @@ public class RhinoHostObjectArtefactBuilder : IArtifactHostObjectBuilder
             ids.Add(BakeObject(doc, geom, layerIndex, materialByObject, colorByObject, appId, name));
           }
           bakedObjectIds.UnionWith(ids.Select(g => g.ToString()));
+          if (rels.GroupsByObject.ContainsKey(objK))
+          {
+            bakedGuidsByObjK[objK] = ids;
+          }
           conversionResults.Add(new(Status.SUCCESS, source, ids[0].ToString(), "Speckle.Object"));
           session.RecordObject(appId, "Speckle.Object", Status.SUCCESS, null, sw.ElapsedMilliseconds);
         }
@@ -215,9 +221,19 @@ public class RhinoHostObjectArtefactBuilder : IArtifactHostObjectBuilder
           materialByObject,
           materialByGeometry,
           bakedObjectIds,
+          bakedGuidsByObjK,
           conversionResults,
           session
         );
+      }
+    }
+
+    // 5 - authored scene groups (IN_GROUP → CONTAINER(Group) nodes) → native Rhino groups.
+    if (rels.GroupsByObject.Count > 0)
+    {
+      using (session.Phase("Groups"))
+      {
+        BakeGroups(doc, bundle, rels, bakedGuidsByObjK, baseLayerName, session);
       }
     }
 
@@ -437,6 +453,7 @@ public class RhinoHostObjectArtefactBuilder : IArtifactHostObjectBuilder
     Dictionary<string, Guid> materialByObject,
     Dictionary<int, Guid> materialByGeometry,
     HashSet<string> bakedObjectIds,
+    Dictionary<int, List<Guid>> bakedGuidsByObjK,
     HashSet<ReceiveConversionResult> conversionResults,
     ArtefactSessionLog session
   )
@@ -510,6 +527,14 @@ public class RhinoHostObjectArtefactBuilder : IArtifactHostObjectBuilder
         continue;
       }
       bakedObjectIds.Add(id.ToString());
+      if (rels.GroupsByObject.ContainsKey(objK))
+      {
+        if (!bakedGuidsByObjK.TryGetValue(objK, out var grouped))
+        {
+          bakedGuidsByObjK[objK] = grouped = new List<Guid>();
+        }
+        grouped.Add(id); // an object may place several instances; all of them join its group(s)
+      }
       conversionResults.Add(new(Status.SUCCESS, source, id.ToString(), "Instance (Block)"));
       session.RecordObject(appId, "Instance (Block)", Status.SUCCESS, null, sw.ElapsedMilliseconds);
     }
@@ -670,6 +695,47 @@ public class RhinoHostObjectArtefactBuilder : IArtifactHostObjectBuilder
     }
 
     return defIndexByNode;
+  }
+
+  // ── groups ────────────────────────────────────────────────────────────────────────────────────────────
+  // Authored scene groups: inverts GroupsByObject (object → its CONTAINER(Group) nodes) to group → member guids and
+  // adds one native Rhino group per node. An overlapping/nested source group works out of the box — Rhino models
+  // nesting the same way (an object simply belongs to several groups). The name carries the baseLayerName suffix
+  // (like the v1 RhinoGroupBaker) so DeepClean purges this model's groups on re-receive. A member that failed to
+  // bake (or is non-geometric) is skipped; the group keeps its other members. Smaller groups first, as in v1.
+  private static void BakeGroups(
+    RhinoDoc doc,
+    ArtefactBundle bundle,
+    ArtefactRelations rels,
+    Dictionary<int, List<Guid>> bakedGuidsByObjK,
+    string baseLayerName,
+    ArtefactSessionLog session
+  )
+  {
+    var membersByGroup = new Dictionary<int, List<Guid>>();
+    foreach (var kv in rels.GroupsByObject)
+    {
+      if (!bakedGuidsByObjK.TryGetValue(kv.Key, out var guids))
+      {
+        continue;
+      }
+      foreach (int groupK in kv.Value)
+      {
+        if (!membersByGroup.TryGetValue(groupK, out var list))
+        {
+          membersByGroup[groupK] = list = new List<Guid>();
+        }
+        list.AddRange(guids);
+      }
+    }
+
+    foreach (var kv in membersByGroup.OrderBy(g => g.Value.Count))
+    {
+      bundle.Nodes.TryGetValue(kv.Key, out var node);
+      var name = node?.Name is { Length: > 0 } n ? n : "Group";
+      doc.Groups.Add($"{name} ({baseLayerName})", kv.Value);
+      session.Increment("groupsBaked");
+    }
   }
 
   // ── layers ────────────────────────────────────────────────────────────────────────────────────────────
@@ -867,6 +933,16 @@ public class RhinoHostObjectArtefactBuilder : IArtifactHostObjectBuilder
   {
     try
     {
+      // purge this model's groups from the prior receive first — they carry the baseLayerName suffix (BakeGroups)
+      for (int i = doc.Groups.Count - 1; i >= 0; i--)
+      {
+        var group = doc.Groups.FindIndex(i);
+        if (group is { Name: not null } && group.Name.Contains(baseLayerName))
+        {
+          doc.Groups.Delete(i);
+        }
+      }
+
       int rootLayerIndex = doc.Layers.Find(Guid.Empty, baseLayerName, RhinoMath.UnsetIntIndex);
       if (rootLayerIndex != RhinoMath.UnsetIntIndex)
       {

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/Operations/Send/RhinoArtifactRootObjectBuilder.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/Operations/Send/RhinoArtifactRootObjectBuilder.cs
@@ -195,6 +195,9 @@ public class RhinoArtifactRootObjectBuilder(
       throw new SpeckleException("Failed to convert all objects.");
     }
 
+    // Authored scene groups → plain snapshot records (Base-free — no GroupProxy). Membership lists OBJECT ids.
+    var groups = CollectGroups(doc, atomicObjects);
+
     // Render materials are keyed by material name; proxies list OBJECT ids (resolved to geometry K(s) in phase 2).
     var materials = materialUnpacker.UnpackRenderMaterials(atomicObjects, usedLayers);
 
@@ -212,9 +215,49 @@ public class RhinoArtifactRootObjectBuilder(
       materials,
       colors,
       instanceDefinitionProxies,
+      groups,
       cameraViews,
       results
     );
+  }
+
+  // Rhino groups → plain snapshot records. An object's GetGroupList carries ALL its groups (nesting in Rhino is
+  // implicit via overlapping membership — there is no group parent chain), so each entry becomes one IN_GROUP edge.
+  // RhinoCommon-bound (GroupTable) → phase 1 only.
+  private List<CollectedGroup> CollectGroups(global::Rhino.RhinoDoc doc, IReadOnlyList<RhinoObject> atomicObjects)
+  {
+    var groups = new Dictionary<string, CollectedGroup>(StringComparer.Ordinal);
+    foreach (RhinoObject rhinoObject in atomicObjects)
+    {
+      try
+      {
+        int[]? groupList = rhinoObject.GetGroupList();
+        if (groupList is null)
+        {
+          continue;
+        }
+        foreach (int groupIndex in groupList)
+        {
+          Group? group = doc.Groups.FindIndex(groupIndex);
+          if (group is null)
+          {
+            continue;
+          }
+          string groupId = group.Id.ToString();
+          if (!groups.TryGetValue(groupId, out CollectedGroup? collected))
+          {
+            collected = new CollectedGroup(groupId, group.Name, new List<string>());
+            groups[groupId] = collected;
+          }
+          collected.MemberIds.Add(rhinoObject.Id.ToString());
+        }
+      }
+      catch (Exception ex) when (!ex.IsFatal())
+      {
+        logger.LogWarning(ex, "Failed to unpack groups for {AppId}", rhinoObject.Id);
+      }
+    }
+    return groups.Values.ToList();
   }
 
   // Rhino named views → envelope camera_views. RhinoCommon-bound (NamedViewTable) → phase 1 only. Positions/target
@@ -401,6 +444,7 @@ public class RhinoArtifactRootObjectBuilder(
     }
 
     EmitValueNodes(pipeline, model, geometryKsByObjectId, instanceKByObjectId);
+    EmitGroups(pipeline, model.Groups, definitionMemberIds);
 
     // Default scene view: the Rhino layer tree (IN_COLLECTION). The COLLECTION nodes' parent chain carries the
     // nesting, so a single projection key rebuilds the full explorer hierarchy.
@@ -429,6 +473,7 @@ public class RhinoArtifactRootObjectBuilder(
     session.SetStat("definitions", model.Definitions.Count);
     session.SetStat("materials", model.Materials.Count);
     session.SetStat("layers", model.Layers.Count);
+    session.SetStat("groups", model.Groups.Count);
 
     logger.LogInformation("Built artefact bundle: {fileCount} files, {objectCount} objects", bundle.Count, objectCount);
     return new BundleResult(bundle, rootId, objectCount, model.Results);
@@ -629,6 +674,32 @@ public class RhinoArtifactRootObjectBuilder(
     }
   }
 
+  // Authored scene groups → CONTAINER("Group") nodes + IN_GROUP membership. A SEPARATE axis from IN_COLLECTION:
+  // an object keeps its layer AND its group(s); memberships overlap, so an object may carry several IN_GROUP
+  // edges. Definition members get no scene edges (same suppression as IN_COLLECTION), so a group emptied by
+  // that is skipped entirely.
+  private static void EmitGroups(
+    ObjectsArtifactPipeline pipeline,
+    IReadOnlyList<CollectedGroup> groups,
+    HashSet<string> definitionMemberIds
+  )
+  {
+    foreach (CollectedGroup group in groups)
+    {
+      var memberIds = group.MemberIds.Where(id => !definitionMemberIds.Contains(id)).ToList();
+      if (memberIds.Count == 0)
+      {
+        continue;
+      }
+      int groupK = pipeline.AddContainer(group.Id, group.Name, null, "Group");
+      int ord = 0;
+      foreach (string memberId in memberIds)
+      {
+        pipeline.InGroup(pipeline.InternObject(memberId), groupK, ord++);
+      }
+    }
+  }
+
   // Resolves (and interns once) the COLLECTION node for a layer index, building the ancestor chain from the
   // collected layer tree so the nesting is reproduced as nested COLLECTION nodes. Cached by layer index.
   private static int GetOrAddLayerCollection(
@@ -694,6 +765,8 @@ public class RhinoArtifactRootObjectBuilder(
   // ── pure-Speckle snapshot passed from the UI thread (phase 1) to the worker thread (phase 2) ──────────
   private sealed record CollectedLayer(string Id, string Name, int? ParentIndex, int Argb);
 
+  private sealed record CollectedGroup(string Id, string? Name, List<string> MemberIds);
+
   private sealed record CollectedObject(
     string ApplicationId,
     string Name,
@@ -711,6 +784,7 @@ public class RhinoArtifactRootObjectBuilder(
     IReadOnlyList<RenderMaterialProxy> Materials,
     IReadOnlyList<ColorProxy> Colors,
     IReadOnlyList<InstanceDefinitionProxy> Definitions,
+    IReadOnlyList<CollectedGroup> Groups,
     IReadOnlyList<CameraView> CameraViews,
     IReadOnlyList<SendConversionResult> Results
   );

--- a/docs/speckle_4_0_connectors_plan.md
+++ b/docs/speckle_4_0_connectors_plan.md
@@ -52,8 +52,11 @@ is externalized in `speckle-bundle-spec` (schema_version 5; COLLECTION folded in
 | Navisworks | — | — | **EXCLUDED** (handled natively by ODA) |
 
 **Deferred by request** (v1 concepts with no artefact-node equivalent — leave for a later, scoped design):
-CSi sections, Civil3D property-sets, AutoCAD groups, analysis-results blobs. Emit geometry + standard topology
-(layers/levels/materials/instances) only this pass.
+CSi sections, Civil3D property-sets, analysis-results blobs. Emit geometry + standard topology
+(layers/levels/materials/instances) only this pass. (Rhino/AutoCAD groups landed since: `IN_GROUP` (17) was
+un-retired in the spec — authored groups now emit `CONTAINER("Group")` nodes + `IN_GROUP` membership edges on
+send; receive rebuilds them natively — Rhino group table / AutoCAD group dictionary, with a baseLayerName-suffixed
+name purged on re-receive.)
 
 ## Cross-cutting requirement — per-session diagnostics logging
 
@@ -121,7 +124,9 @@ the v1 split). Mirror Rhino's two-phase collect-on-UI → write+upload-on-worker
   meshes/curves (Line/Polyline/Arc/Circle/Ellipse/Point/Mesh) → `AddGeometry` + `Display`; blocks →
   `AddDefinition`/`AddInstance`/`DisplayInstance`. Properties via `AddProperties`. Render materials →
   `AddMaterial`+`HasMaterial`; colors → `AddColor`+`HasColor`. Default scene view `[IN_COLLECTION]` (single layer tier).
-- **Deferred:** AutoCAD groups, Civil3D property-set defs.
+- Authored **groups** (via persistent reactors) → `AddContainer(…, "Group")` + `InGroup` membership edges —
+  a separate axis from `IN_COLLECTION` (an object keeps its layer AND its group(s)).
+- **Deferred:** Civil3D property-set defs.
 
 **Receive — `AutocadHostObjectArtefactBuilder : IArtifactHostObjectBuilder`** (new; Civil3D variant; **Plant3D
 send-only**). Mirror the Rhino receiver, baking into AutoCAD **layers** (`GetOrCreateLayer` from `SceneViewResolver`


### PR DESCRIPTION
Send: both artifact builders collect group membership Base-free (no GroupProxy) — Rhino from each object's GetGroupList (overlap = implicit nesting), AutoCAD from persistent reactors — and emit one CONTAINER(subtype "Group") node + IN_GROUP membership edges per group. A separate axis from IN_COLLECTION: an object keeps its layer AND its group(s). Definition members stay suppressed (no scene edges), and a group emptied by that is skipped.

Receive: a new Groups phase inverts GroupsByObject to group -> baked member ids (block placements included) and rebuilds native groups — Rhino group table / AutoCAD group dictionary (own committed doc-TM transaction; unique keys get a -N suffix). Names carry the baseLayerName suffix like the v1 bakers, and pre-clean now purges them, so re-receive is idempotent (fixes the old AutocadGroupBaker TODO).

Pairs with SDK big-truck (pipeline.InGroup / ArtefactRelations. GroupsByObject) + bundle-spec main (rel 17 un-retired, live). Tested live in Rhino and AutoCAD both directions.