### PR TITLE
docs: structural-results.parquet -> structural_results.parquet

### DIFF
--- a/Connectors/CSi/Speckle.Connectors.CSiShared/Operations/Send/CsiArtifactRootObjectBuilder.cs
+++ b/Connectors/CSi/Speckle.Connectors.CSiShared/Operations/Send/CsiArtifactRootObjectBuilder.cs
@@ -166,7 +166,7 @@ public class CsiArtifactRootObjectBuilder(
   }
 
   // Runs the (gated) analysis-results extraction on the host thread and flattens the extractor's nested dicts into
-  // structural-results rows. Covers the object/model-level result types that map cleanly to the results schema:
+  // structural_results rows. Covers the object/model-level result types that map cleanly to the results schema:
   // frame forces, joint reactions, base reactions, modal periods. Pier/spandrel/story results (string position
   // dimensions, dual identity) are not emitted yet — a schema/mapping decision is pending. A results failure (model
   // unlocked / analysis not run) is logged and skipped so the geometry+properties send still succeeds.
@@ -373,7 +373,7 @@ public class CsiArtifactRootObjectBuilder(
     }
   }
 
-  // The result types whose axes map cleanly onto the structural-results schema (all-numeric leaves, single identity).
+  // The result types whose axes map cleanly onto the structural_results schema (all-numeric leaves, single identity).
   private static readonly ResultDescriptor[] s_resultDescriptors =
   {
     new("frameForces", "frameForce", "Elm", new[] { "Elm", "LoadCase", "Wrap:ElmSta", "Wrap:StepNum" }),
@@ -465,7 +465,7 @@ public class CsiArtifactRootObjectBuilder(
       onOperationProgressed.Report(new("Building", (double)++count / model.Objects.Count));
     }
 
-    // Analysis results → {v}.eav.structural-results.parquet (object-level rows join back via object_index).
+    // Analysis results → {v}.eav.structural_results.parquet (object-level rows join back via object_index).
     foreach (var r in model.ResultRows)
     {
       pipeline.AddStructuralResult(

--- a/docs/connector-topology.md
+++ b/docs/connector-topology.md
@@ -73,7 +73,7 @@ opening-K for room adjacency, 0 unscoped. The façade `ConnectsTo(s,t,scope)` ov
 - ⛔ **AutoCAD groups** — `AutocadGroupUnpacker` exists; same grouping blocker as Rhino.
 
 ### CSi / ETABS / SAP2000 — `CsiArtifactRootObjectBuilder`
-- ✅ IN_COLLECTION (by-type / Level→Category tree), DISPLAY, structural-results (separate purpose file).
+- ✅ IN_COLLECTION (by-type / Level→Category tree), DISPLAY, structural_results (separate purpose file).
 - ✅ **CONNECTS_TO** — frame → I-/J-end joint objects (`Geometry["I-End Joint"|"J-End Joint"]` via
   `nameToAppId`). The slab↔beam↔column graph through shared joints.
 - 🔶 **ON_LEVEL** — story from `GetLabelAndLevel` (currently only a collection segment) → LEVEL node + edge.

--- a/docs/structural-results-parquet.md
+++ b/docs/structural-results-parquet.md
@@ -1,4 +1,4 @@
-# `eav.structural-results.parquet` — structural analysis/design results
+# `eav.structural_results.parquet` — structural analysis/design results
 
 > **Producer-side** doc for the Speckle 4.0 structural analysis-results artefact (CSi/ETABS extraction status +
 > mapping). The **canonical format spec** now lives in the bundle-spec repo:
@@ -17,7 +17,7 @@ and `envelope.*.parquet` (topology graph). This adds one more **purpose file** f
 results**:
 
 ```
-{versionId}.eav.structural-results.parquet
+{versionId}.eav.structural_results.parquet
 ```
 
 - **Per-domain, not per-connector.** ETABS/CSi, SAP2000, and **TSD** (Tekla Structural Designer, coming soon) all
@@ -100,7 +100,7 @@ case not finished) is **logged and skipped** so the geometry + properties still 
 
 ## Consumer notes (querying)
 
-- Join object-level results to geometry/properties: `structural-results.object_index = eav.objects.object_index`.
+- Join object-level results to geometry/properties: `structural_results.object_index = eav.objects.object_index`.
 - Model-level rows have `object_index IS NULL`; group by `location` (story) / `step` (mode).
 - `result_type` / `load_case` / `component` are dictionary-encoded → cheap to filter/group.
 - Numeric result = `value`; design verdicts = `value_text` (TSD).


### PR DESCRIPTION
Comment/doc references only — the emitting code lives in the SDK (StructuralResultsWriter). File name now matches the bundle_files logical table name; kebab-case breaks DuckDB view-name lookups.
