### PR TITLE
fix(civil3d): round-trip property sets on 4.0 artefact versions

### DIFF
--- a/Connectors/Autocad/Speckle.Connectors.AutocadShared/Operations/Receive/AutocadHostObjectArtefactBuilder.cs
+++ b/Connectors/Autocad/Speckle.Connectors.AutocadShared/Operations/Receive/AutocadHostObjectArtefactBuilder.cs
@@ -126,6 +126,7 @@ public class AutocadHostObjectArtefactBuilder : IArtifactHostObjectBuilder
 
     // 0 - clean previous receive of this model (entities on this model's layers + its block definitions).
     PreClean(db, baseLayerName);
+    PreCleanAdditional(baseLayerName);
 
     // Transaction discipline: each phase/object gets its OWN short-lived transaction, started on the DOCUMENT
     // TransactionManager, committed immediately. BOTH halves are load-bearing — three other variants were tried
@@ -152,6 +153,8 @@ public class AutocadHostObjectArtefactBuilder : IArtifactHostObjectBuilder
     // 1b - by-object display colours (HAS_COLOR → COLOR nodes). Applied as explicit entity colour on bake; objects
     // with no edge keep AutoCAD's ByLayer default and inherit the restored layer colour (see ResolveLayer).
     var (colorArgbByGeometry, colorArgbByObject) = MapColors(bundle, rels, objByGeom);
+
+    ParseAndBakeAdditionalDefinitions(bundle, baseLayerName);
 
     // 2 - atomic geometry (objects with a direct DISPLAY/SOLID). Instances + non-geometric elements handled below.
     int count = 0;
@@ -216,6 +219,7 @@ public class AutocadHostObjectArtefactBuilder : IArtifactHostObjectBuilder
                   entity.Color = ToAcadColor(a);
                 }
                 ids.Add(entity.ObjectId);
+                PostBakeEntity(entity, props, tr);
               }
             }
             tr.Commit();
@@ -1251,6 +1255,12 @@ public class AutocadHostObjectArtefactBuilder : IArtifactHostObjectBuilder
       _logger.LogError(ex, "Artefact receive pre-clean failed for '{BaseLayer}'", baseLayerName);
     }
   }
+
+  protected virtual void PreCleanAdditional(string baseLayerName) { }
+
+  protected virtual void ParseAndBakeAdditionalDefinitions(ArtefactBundle bundle, string baseLayerName) { }
+
+  protected virtual void PostBakeEntity(AcadEntity entity, Dictionary<string, object?>? properties, Transaction tr) { }
 
   private static string SrcType(Dictionary<string, object?>? props) =>
     props is not null && props.TryGetValue("speckle_type", out var v) && v is string s && s.Length > 0

--- a/Connectors/Autocad/Speckle.Connectors.AutocadShared/Operations/Send/AutocadArtifactRootObjectBuilder.cs
+++ b/Connectors/Autocad/Speckle.Connectors.AutocadShared/Operations/Send/AutocadArtifactRootObjectBuilder.cs
@@ -318,6 +318,7 @@ public class AutocadArtifactRootObjectBuilder(
     EmitValueNodes(pipeline, model, geometryKsByObjectId, instanceKByObjectId);
     EmitGroups(pipeline, model.Groups, definitionMemberIds);
     EmitCivilNetworkTopology(pipeline, model.Objects);
+    EmitAdditionalNodes(pipeline);
 
     // Default scene view: the (flat) AutoCAD layer namespace via IN_COLLECTION.
     pipeline.AddSceneView(new SceneView(0, "Default", true, new[] { SceneViewKey.Rel(RelKind.InCollection) }));
@@ -640,6 +641,8 @@ public class AutocadArtifactRootObjectBuilder(
       }
     }
   }
+
+  protected virtual void EmitAdditionalNodes(ObjectsArtifactPipeline pipeline) { }
 
   // Authored scene groups → CONTAINER("Group") nodes + IN_GROUP membership. A SEPARATE axis from IN_COLLECTION:
   // an object keeps its layer AND its group(s); memberships overlap, so an object may carry several IN_GROUP

--- a/Connectors/Autocad/Speckle.Connectors.Civil3dShared/DependencyInjection/Civil3dConnectorModule.cs
+++ b/Connectors/Autocad/Speckle.Connectors.Civil3dShared/DependencyInjection/Civil3dConnectorModule.cs
@@ -22,6 +22,7 @@ public static class Civil3dConnectorModule
     // add send
     serviceCollection.LoadSend();
     serviceCollection.AddScoped<IRootObjectBuilder<AutocadRootObject>, Civil3dRootObjectBuilder>();
+    serviceCollection.AddScoped<IArtifactRootObjectBuilder<AutocadRootObject>, Civil3dArtifactRootObjectBuilder>();
     serviceCollection.AddScoped<
       IRootContinuousTraversalBuilder<AutocadRootObject>,
       Civil3dContinuousTraversalBuilder
@@ -31,6 +32,7 @@ public static class Civil3dConnectorModule
     // add receive
     serviceCollection.LoadReceive();
     serviceCollection.AddScoped<IHostObjectBuilder, Civil3dHostObjectBuilder>();
+    serviceCollection.AddScoped<IArtifactHostObjectBuilder, Civil3dHostObjectArtefactBuilder>();
     serviceCollection.AddSingleton<IBinding, Civil3dReceiveBinding>();
 
     // parameter updater

--- a/Connectors/Autocad/Speckle.Connectors.Civil3dShared/HostApp/PropertySetBaker.cs
+++ b/Connectors/Autocad/Speckle.Connectors.Civil3dShared/HostApp/PropertySetBaker.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using Microsoft.Extensions.Logging;
 using Speckle.Connectors.Common.Operations;
 using Speckle.Converters.Civil3dShared;
@@ -18,6 +19,9 @@ namespace Speckle.Connectors.Civil3dShared.HostApp;
 public class PropertySetBaker
 {
   private const string PROP_SET_DEF_DICT_NAME = "AecPropertySetDefs";
+
+  public const string DEFINITIONS_CARRIER_APP_ID = "speckle:civil3d:property-set-definitions";
+
   private readonly IConverterSettingsStore<Civil3dConversionSettings> _settingsStore;
   private readonly ILogger<PropertySetBaker> _logger;
   private readonly PropertyHandler _propertyHandler;
@@ -88,12 +92,18 @@ public class PropertySetBaker
   /// </summary>
   public void ParseAndBakePropertySetDefinitions(Base rootObject, string namePrefix)
   {
-    _propertySetDefinitionMap.Clear();
-
     if (rootObject[ProxyKeys.PROPERTYSET_DEFINITIONS] is not Dictionary<string, object?> definitions)
     {
+      _propertySetDefinitionMap.Clear();
       return;
     }
+
+    ParseAndBakePropertySetDefinitions(definitions, namePrefix);
+  }
+
+  public void ParseAndBakePropertySetDefinitions(Dictionary<string, object?> definitions, string namePrefix)
+  {
+    _propertySetDefinitionMap.Clear();
 
     if (definitions.Count == 0)
     {
@@ -140,9 +150,18 @@ public class PropertySetBaker
   /// </summary>
   public bool TryBakePropertySets(ADB.Entity entity, Base sourceObject, ADB.Transaction tr)
   {
+    if (sourceObject["properties"] is not Dictionary<string, object?> properties)
+    {
+      return false;
+    }
+
+    return TryBakePropertySets(entity, properties, tr);
+  }
+
+  public bool TryBakePropertySets(ADB.Entity entity, Dictionary<string, object?> properties, ADB.Transaction tr)
+  {
     if (
-      sourceObject["properties"] is not Dictionary<string, object?> properties
-      || !properties.TryGetValue("Property Sets", out var propertySetsObj)
+      !properties.TryGetValue("Property Sets", out var propertySetsObj)
       || propertySetsObj is not Dictionary<string, object?> propertySets
       || propertySets.Count == 0
     )
@@ -279,8 +298,8 @@ public class PropertySetBaker
           // Cast numeric types to avoid bad numeric value errors
           var convertedValue = dataType switch
           {
-            AAEC.PropertyData.DataType.Integer => (int)(long)defaultValue,
-            AAEC.PropertyData.DataType.AutoIncrement => (int)(long)defaultValue,
+            AAEC.PropertyData.DataType.Integer => Convert.ToInt32(defaultValue, CultureInfo.InvariantCulture),
+            AAEC.PropertyData.DataType.AutoIncrement => Convert.ToInt32(defaultValue, CultureInfo.InvariantCulture),
             _ => defaultValue,
           };
 
@@ -366,14 +385,15 @@ public class PropertySetBaker
       foreach (var propertyEntry in setData)
       {
         string propertyName = propertyEntry.Key;
-        object? propertyDataObj = propertyEntry.Value;
 
-        if (propertyDataObj is not Dictionary<string, object?> propertyDataDict)
-        {
-          continue;
-        }
+        object? value =
+          propertyEntry.Value is Dictionary<string, object?> propertyDataDict
+            ? propertyDataDict.TryGetValue("value", out var nested)
+              ? nested
+              : null
+            : propertyEntry.Value;
 
-        if (!propertyDataDict.TryGetValue("value", out var value) || value == null)
+        if (value == null)
         {
           continue;
         }

--- a/Connectors/Autocad/Speckle.Connectors.Civil3dShared/HostApp/PropertySetBaker.cs
+++ b/Connectors/Autocad/Speckle.Connectors.Civil3dShared/HostApp/PropertySetBaker.cs
@@ -375,11 +375,11 @@ public class PropertySetBaker
       var propertySet = (AAECPDB.PropertySet)tr.GetObject(propertySetId, ADB.OpenMode.ForWrite);
       var setDefinition = (AAECPDB.PropertySetDefinition)tr.GetObject(propertySetDefId, ADB.OpenMode.ForRead);
 
-      // Build a map of property names to definition IDs
-      Dictionary<string, int> propertyNameToId = new();
+      // Build a map of property names to definition IDs + data types (for value coercion below)
+      Dictionary<string, (int Id, AAEC.PropertyData.DataType Type)> propertyNameToDef = new();
       foreach (AAECPDB.PropertyDefinition propDef in setDefinition.Definitions)
       {
-        propertyNameToId[propDef.Name] = propDef.Id;
+        propertyNameToDef[propDef.Name] = (propDef.Id, propDef.DataType);
       }
 
       foreach (var propertyEntry in setData)
@@ -398,15 +398,42 @@ public class PropertySetBaker
           continue;
         }
 
-        if (!propertyNameToId.TryGetValue(propertyName, out int propertyId))
+        if (!propertyNameToDef.TryGetValue(propertyName, out var propDefInfo))
         {
+          continue;
+        }
+
+        // The eav path round-trips every number as double, and SetAt's failure is swallowed by the handler —
+        // without coercion an Integer-typed property silently stays unset (empty in the palette). Mirror the
+        // default-value cast in CreatePropertySetDefinition, driven by the definition's data type.
+        object coercedValue;
+        try
+        {
+          coercedValue = propDefInfo.Type switch
+          {
+            AAEC.PropertyData.DataType.Integer => Convert.ToInt32(value, CultureInfo.InvariantCulture),
+            AAEC.PropertyData.DataType.AutoIncrement => Convert.ToInt32(value, CultureInfo.InvariantCulture),
+            AAEC.PropertyData.DataType.Real => Convert.ToDouble(value, CultureInfo.InvariantCulture),
+            AAEC.PropertyData.DataType.Text => value.ToString() ?? "",
+            AAEC.PropertyData.DataType.TrueFalse => Convert.ToBoolean(value, CultureInfo.InvariantCulture),
+            _ => value,
+          };
+        }
+        catch (Exception ex) when (!ex.IsFatal())
+        {
+          _logger.LogWarning(
+            ex,
+            "Could not coerce received value for property {PropertyName} to {DataType}",
+            propertyName,
+            propDefInfo.Type
+          );
           continue;
         }
 
         _propertyHandler.TryGetValue(
           () =>
           {
-            propertySet.SetAt(propertyId, value);
+            propertySet.SetAt(propDefInfo.Id, coercedValue);
             return true;
           },
           out _

--- a/Connectors/Autocad/Speckle.Connectors.Civil3dShared/Operations/Receive/Civil3dHostObjectArtefactBuilder.cs
+++ b/Connectors/Autocad/Speckle.Connectors.Civil3dShared/Operations/Receive/Civil3dHostObjectArtefactBuilder.cs
@@ -1,0 +1,78 @@
+using Autodesk.AutoCAD.DatabaseServices;
+using Microsoft.Extensions.Logging;
+using Speckle.Connectors.Autocad.HostApp;
+using Speckle.Connectors.Autocad.Operations.Receive;
+using Speckle.Connectors.Civil3dShared.HostApp;
+using Speckle.Connectors.Common.Operations;
+using Speckle.Connectors.Common.Threading;
+using Speckle.Converters.Autocad;
+using Speckle.Converters.Common;
+using Speckle.Sdk.Logging;
+using Speckle.Sdk.Pipelines.Receive.Artifacts;
+
+namespace Speckle.Connectors.Civil3dShared.Operations.Receive;
+
+public class Civil3dHostObjectArtefactBuilder : AutocadHostObjectArtefactBuilder
+{
+  private readonly PropertySetBaker _propertySetBaker;
+
+  public Civil3dHostObjectArtefactBuilder(
+    IConverterSettingsStore<AutocadConversionSettings> converterSettings,
+    IRootToHostConverter converter,
+    IThreadContext threadContext,
+    AutocadContext autocadContext,
+    ISdkActivityFactory activityFactory,
+    ILogger<AutocadHostObjectArtefactBuilder> logger,
+    PropertySetBaker propertySetBaker
+  )
+    : base(converterSettings, converter, threadContext, autocadContext, activityFactory, logger)
+  {
+    _propertySetBaker = propertySetBaker;
+  }
+
+  protected override void PreCleanAdditional(string baseLayerName) =>
+    _propertySetBaker.PurgePropertySets(baseLayerName);
+
+  protected override void ParseAndBakeAdditionalDefinitions(ArtefactBundle bundle, string baseLayerName)
+  {
+    if (FindDefinitions(bundle) is { } definitions)
+    {
+      _propertySetBaker.ParseAndBakePropertySetDefinitions(definitions, baseLayerName);
+    }
+  }
+
+  protected override void PostBakeEntity(Entity entity, Dictionary<string, object?>? properties, Transaction tr)
+  {
+    if (
+      properties is not null
+      && properties.TryGetValue("properties", out var tree)
+      && tree is Dictionary<string, object?> propertyTree
+    )
+    {
+      _propertySetBaker.TryBakePropertySets(entity, propertyTree, tr);
+    }
+  }
+
+  private static Dictionary<string, object?>? FindDefinitions(ArtefactBundle bundle)
+  {
+    foreach (var kv in bundle.ObjectAppIds)
+    {
+      if (kv.Value != PropertySetBaker.DEFINITIONS_CARRIER_APP_ID)
+      {
+        continue;
+      }
+      if (
+        bundle.Properties.TryGetValue(kv.Key, out var props)
+        && props.TryGetValue("properties", out var treeObj)
+        && treeObj is Dictionary<string, object?> tree
+        && tree.TryGetValue(ProxyKeys.PROPERTYSET_DEFINITIONS, out var defsObj)
+        && defsObj is Dictionary<string, object?> definitions
+      )
+      {
+        return definitions;
+      }
+      return null;
+    }
+    return null;
+  }
+}

--- a/Connectors/Autocad/Speckle.Connectors.Civil3dShared/Operations/Send/Civil3dArtifactRootObjectBuilder.cs
+++ b/Connectors/Autocad/Speckle.Connectors.Civil3dShared/Operations/Send/Civil3dArtifactRootObjectBuilder.cs
@@ -1,0 +1,61 @@
+using Microsoft.Extensions.Logging;
+using Speckle.Connectors.Autocad.HostApp;
+using Speckle.Connectors.Autocad.Operations.Send;
+using Speckle.Connectors.Civil3dShared.HostApp;
+using Speckle.Connectors.Common.Operations;
+using Speckle.Connectors.Common.Threading;
+using Speckle.Converters.Autocad;
+using Speckle.Converters.Civil3dShared.ToSpeckle;
+using Speckle.Converters.Common;
+using Speckle.Objects.Utils;
+using Speckle.Sdk.Pipelines.Send.Artifacts;
+
+namespace Speckle.Connectors.Civil3dShared.Operations.Send;
+
+public class Civil3dArtifactRootObjectBuilder : AutocadArtifactRootObjectBuilder
+{
+  private readonly PropertySetDefinitionHandler _propertySetDefinitionHandler;
+
+  public Civil3dArtifactRootObjectBuilder(
+    IRootToSpeckleConverter converter,
+    IConverterSettingsStore<AutocadConversionSettings> converterSettings,
+    AutocadInstanceUnpacker instanceUnpacker,
+    AutocadMaterialUnpacker materialUnpacker,
+    AutocadColorUnpacker colorUnpacker,
+    IThreadContext threadContext,
+    IArtifactPipelineFactory artifactPipelineFactory,
+    ILogger<AutocadArtifactRootObjectBuilder> logger,
+    PropertySetDefinitionHandler propertySetDefinitionHandler
+  )
+    : base(
+      converter,
+      converterSettings,
+      instanceUnpacker,
+      materialUnpacker,
+      colorUnpacker,
+      threadContext,
+      artifactPipelineFactory,
+      logger
+    )
+  {
+    _propertySetDefinitionHandler = propertySetDefinitionHandler;
+  }
+
+  protected override void EmitAdditionalNodes(ObjectsArtifactPipeline pipeline)
+  {
+    if (_propertySetDefinitionHandler.Definitions.Count == 0)
+    {
+      return;
+    }
+
+    var definitions = new Dictionary<string, object?>();
+    foreach (var kvp in _propertySetDefinitionHandler.Definitions)
+    {
+      definitions[kvp.Key] = kvp.Value;
+    }
+
+    var properties = new Dictionary<string, object?> { [ProxyKeys.PROPERTYSET_DEFINITIONS] = definitions };
+    pipeline.InternObject(PropertySetBaker.DEFINITIONS_CARRIER_APP_ID);
+    pipeline.AddProperties(PropertySetBaker.DEFINITIONS_CARRIER_APP_ID, properties);
+  }
+}

--- a/Connectors/Autocad/Speckle.Connectors.Civil3dShared/Speckle.Connectors.Civil3dShared.projitems
+++ b/Connectors/Autocad/Speckle.Connectors.Civil3dShared/Speckle.Connectors.Civil3dShared.projitems
@@ -15,7 +15,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)HostApp\Civil3dParameterCreator.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HostApp\PropertySetBaker.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HostApp\PropertyUpdater.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Operations\Receive\Civil3dHostObjectArtefactBuilder.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Operations\Receive\Civil3dHostObjectBuilder.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Operations\Send\Civil3dArtifactRootObjectBuilder.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Operations\Send\Civil3dContinuousTraversalBuilder.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Operations\Send\Civil3dRootObjectBuilder.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bindings\Civil3dSendBinding.cs" />


### PR DESCRIPTION
Property sets stopped round-tripping on Civil3D 4.0 (artefact) versions. Two breaks, both fixed:

- **Send:** the shared artefact builder never emitted the property-set *definitions* (only per-object values reached EAV). Added a `Civil3dArtifactRootObjectBuilder` that writes the definitions the converter accumulates.
- **Receive:** 4.0 versions bake through the shared AutoCAD builder, so no Civil-specific baking ran. Added a `Civil3dHostObjectArtefactBuilder` that purges → recreates definitions → attaches sets.