### PR TITLE
fix(revit): curve-only display geometry + non-unitized arc planes on artefact send (ENG-8801)

### DIFF
--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/RevitArtifactRootObjectBuilder.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/RevitArtifactRootObjectBuilder.cs
@@ -473,8 +473,13 @@ public class RevitArtifactRootObjectBuilder(
   }
 
   // Emits an object's displayValue as renderable geometry: meshes → DISPLAY, instance proxies → INSTANCE +
-  // DISPLAY_INSTANCE. Line/Arc/Curve display values (door/window swing arcs, symbolic 2D) are intentionally skipped —
-  // they aren't real model geometry and render as spurious arcs (matches ODA's mesh-only Revit extraction).
+  // DISPLAY_INSTANCE, curves/points → DISPLAY (via the SGEO encoder, same as Rhino's artefact send).
+  //
+  // Curves are role-filtered [ENG-8801]: on an element that ALSO has mesh/instance geometry, curve display values are
+  // symbolic 2D (door/window swing arcs) that render as spurious arcs (matches ODA's mesh-only extraction), so they
+  // stay suppressed. On an element whose ENTIRE display value is curves/points (model lines, grids, curve-based
+  // generic annotations) the curves ARE the geometry — dropping them made the element publish invisible, so we emit
+  // them.
   private void EmitDisplayValue(
     ObjectsArtifactPipeline pipeline,
     int objK,
@@ -482,6 +487,17 @@ public class RevitArtifactRootObjectBuilder(
     IReadOnlyList<Base> displayValue
   )
   {
+    // Does this element carry real 3D geometry (mesh/instance)? If so, any accompanying curves are symbolic 2D.
+    bool hasSolidGeometry = false;
+    foreach (var item in displayValue)
+    {
+      if (item is InstanceProxy or SOG.Mesh)
+      {
+        hasSolidGeometry = true;
+        break;
+      }
+    }
+
     int ord = 0;
     foreach (var item in displayValue)
     {
@@ -504,6 +520,28 @@ public class RevitArtifactRootObjectBuilder(
           break;
 
         default:
+          // Curves / polylines / points. Emit only on curve/point-only elements (see role-filter note above); on
+          // mesh/instance-bearing elements these are swing arcs and stay suppressed.
+          if (hasSolidGeometry)
+          {
+            break;
+          }
+          try
+          {
+            int curveK = pipeline.AddGeometry(item.applicationId ?? $"{appId}:g{ord}", item);
+            pipeline.Display(objK, curveK, ord++);
+          }
+          catch (Exception ex) when (!ex.IsFatal())
+          {
+            // A display fragment the SGEO encoder doesn't support is skipped without failing the whole object —
+            // its properties + topology still land (same tolerance as Rhino's artefact send).
+            logger.LogWarning(
+              ex,
+              "Skipped unsupported curve display geometry {Type} on {AppId}",
+              item.speckle_type,
+              appId
+            );
+          }
           break;
       }
     }

--- a/Converters/Revit/Speckle.Converters.RevitShared/ToSpeckle/Raw/Geometry/CurveOriginToPlaneConverter.cs
+++ b/Converters/Revit/Speckle.Converters.RevitShared/ToSpeckle/Raw/Geometry/CurveOriginToPlaneConverter.cs
@@ -49,12 +49,23 @@ public class CurveOriginToPlaneConverter
     }
 
     // beyond limits? then build Speckle plane directly
+    var xdir = _xyzToVectorConverter.Convert(target.xDir);
+    var ydir = _xyzToVectorConverter.Convert(target.yDir);
+    var normal = _xyzToVectorConverter.Convert(target.normal);
+
+    // Basis vectors are directions and MUST be unit length — VectorToSpeckleConverter scales by units (feet ->
+    // document units), leaving them non-unitized and mis-scaling any consumer that reads the plane's basis magnitude
+    // (e.g. arc.plane in the SGEO/viewer path). Same normalization as the in-limits PlaneToSpeckleConverter path.
+    xdir.Normalize();
+    ydir.Normalize();
+    normal.Normalize();
+
     return new SOG.Plane
     {
       origin = _xyzToPointConverter.Convert(target.origin),
-      xdir = _xyzToVectorConverter.Convert(target.xDir),
-      ydir = _xyzToVectorConverter.Convert(target.yDir),
-      normal = _xyzToVectorConverter.Convert(target.normal),
+      xdir = xdir,
+      ydir = ydir,
+      normal = normal,
       units = _converterSettings.Current.SpeckleUnits,
     };
   }

--- a/Converters/Revit/Speckle.Converters.RevitShared/ToSpeckle/Raw/Geometry/PlaneToSpeckleConverter.cs
+++ b/Converters/Revit/Speckle.Converters.RevitShared/ToSpeckle/Raw/Geometry/PlaneToSpeckleConverter.cs
@@ -28,6 +28,14 @@ public class PlaneToSpeckleConverter : ITypedConverter<DB.Plane, SOG.Plane>
     var xdir = _xyzToVectorConverter.Convert(target.XVec);
     var ydir = _xyzToVectorConverter.Convert(target.YVec);
 
+    // A plane's basis vectors are pure directions and MUST be unit length. VectorToSpeckleConverter applies length
+    // scaling (Revit feet -> document units, e.g. x304.8), which leaves them non-unitized — a plane that is not "true".
+    // Downstream consumers that read the plane's basis magnitude (e.g. arc.plane in the SGEO/viewer path) then
+    // mis-scale the geometry, so the arc renders at the wrong size. Normalize to restore unit basis vectors.
+    normal.Normalize();
+    xdir.Normalize();
+    ydir.Normalize();
+
     return new SOG.Plane
     {
       origin = origin,


### PR DESCRIPTION
## What & why

Two Revit send-side fixes for curve/arc geometry on the artefact (Speckle 4.0) send path.

### 1. Curve-only elements publish invisible (ENG-8801)

Model lines, grids and curve-based generic annotations published as property-only objects with **zero renderable geometry** — invisible in the viewer. `RevitArtifactRootObjectBuilder.EmitDisplayValue` only emitted meshes and instance proxies; its `default` arm silently dropped every curve/polyline/point display value.

That drop was deliberate, to suppress door/window swing arcs (symbolic 2D that renders as spurious arcs). But it also killed elements whose **entire** display value is curves.

**Fix:** emit curves/points through the SGEO pipeline (`AddGeometry` + `DISPLAY`, the same path Rhino's artefact send uses), **role-filtered** — only on elements with no mesh/instance geometry. On mesh/instance-bearing elements the accompanying curves are still treated as swing arcs and stay suppressed. SGEO-unsupported fragments are skipped per-object rather than failing the send.

> Native Revit→Rhino/AutoCAD round-trip of these curves additionally depends on the receive-side decoder work in ENG-8781.

### 2. Arc planes mis-scaled (non-unitized basis vectors)

Arcs (and circles/ellipses/bounding boxes) migrated to `next` came through at the wrong size. Root cause: the Revit connector emitted **non-unitized** `arc.plane` basis vectors.

`VectorToSpeckleConverter` applies length scaling (Revit feet → document units, e.g. ×304.8) to every `XYZ`. That's correct for positional/length quantities but wrong for a plane's basis vectors, which are pure directions and must be unit length. The scaled basis left the plane "untrue"; consumers that read the plane's basis magnitude (`arc.plane` in the SGEO/viewer-3 path) then mis-scaled the geometry. Viewer 2 and the DuckDB path normalize/ignore the magnitude and hid the bug; the SGEO reader does not.

**Fix:** normalize `xdir`/`ydir`/`normal` when building the Speckle plane, in both `PlaneToSpeckleConverter` (in-limits path, used by all curve converters) and the beyond-design-limits branch of `CurveOriginToPlaneConverter`. All Revit `SOG.Plane` producers (Arc/Circle/Ellipse/BoundingBox) route through these, so every plane now ships unit basis vectors.

## Testing

- Local build (`-c Local` against `speckle-sharp-sdk/big-truck` + `speckle-bundle-spec/unretire-in-group`): clean, 0 warnings / 0 errors (warnings-as-errors + all analyzers on).
- CSharpier: passes.

> Send-side fix — already-published versions need re-sending to look correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
