### PR TITLE
fix(autocad): emit ACIS SAT for block-definition members so solids ro…

### DIFF
--- a/Connectors/Autocad/Speckle.Connectors.AutocadShared/Operations/Send/AutocadArtifactRootObjectBuilder.cs
+++ b/Connectors/Autocad/Speckle.Connectors.AutocadShared/Operations/Send/AutocadArtifactRootObjectBuilder.cs
@@ -404,17 +404,31 @@ public class AutocadArtifactRootObjectBuilder(
       displayGeometry = new List<Base> { co.Converted };
     }
 
-    // Authoritative solid: the raw ACIS-SAT blob, kept verbatim for receive-as-solids. Skipped for definition members —
-    // a member is never a standalone solid; it renders only through its definition's display meshes (DEFINES).
-    if (!isDefinitionMember && rawEncoding is not null && rawEncoding.format == RawEncodingFormats.ACAD_SAT)
+    // Authoritative solid: the raw ACIS-SAT blob, kept verbatim for receive-as-solids. A standalone object links it
+    // via the SOLID rel; a definition member instead lets it ride DEFINES (added to gKs below) so the block
+    // reconstructs the native Solid3d, not just its display mesh [ENG-8855] — but a member still gets NO standalone
+    // SOLID edge (it renders only through a placed instance's transform). Mirrors the Rhino builder.
+    int? memberSolidK = null;
+    if (rawEncoding is not null && rawEncoding.format == RawEncodingFormats.ACAD_SAT)
     {
       byte[] solidBytes = Convert.FromBase64String(rawEncoding.contents);
       int solidK = pipeline.AddRawGeometry($"{co.ApplicationId}:solid", solidBytes, RawEncodingFormats.ACAD_SAT);
-      pipeline.Solid(objK, solidK, 0);
+      if (isDefinitionMember)
+      {
+        memberSolidK = solidK;
+      }
+      else
+      {
+        pipeline.Solid(objK, solidK, 0);
+      }
     }
 
     // Renderable display meshes (and self-display primitives the SGEO encoder supports: points/curves).
     var gKs = new List<int>();
+    if (memberSolidK is int msk)
+    {
+      gKs.Add(msk); // member's solid rides DEFINES alongside its display meshes; receive prefers the SAT per member
+    }
     int ord = 0;
     foreach (Base fragment in displayGeometry)
     {


### PR DESCRIPTION
A Solid3d inside a block degraded to PolyFaceMesh on receive: EmitObject skipped the raw SAT encoding entirely for definition members, so the definition only ever carried display meshes. Port the Rhino builder's memberSolidK pattern: the member's SAT blob is written to geometries.parquet and added to the member's geometry Ks so it rides DEFINES alongside its display meshes (still no standalone SOLID/DISPLAY edges for members — they render only through a placed instance's transform).

No receive change needed: EmitValueNodes already shares one member ordinal across a member's geometry, and GroupDefinesByMember in the receive builder already prefers ACAD_SAT over the mesh shadow — the preference was just never exercised. Standalone solids unaffected.