### PR TITLE
feat(grasshopper): allow Speckle Geometry in collections, deprecate Speckle Data Object

### DIFF
--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Collections/CreateCollection.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Collections/CreateCollection.cs
@@ -83,7 +83,7 @@ public class CreateCollection : VariableParameterComponentBase
     {
       AddRuntimeMessage(
         GH_RuntimeMessageLevel.Error,
-        "Collection contains no valid content. Ensure inputs are Speckle Data Objects or sub-collections."
+        "Collection contains no valid content. Ensure inputs are Speckle Geometry, Speckle Data Objects, or sub-collections."
       );
       return;
     }
@@ -144,16 +144,13 @@ public class CreateCollection : VariableParameterComponentBase
         dataObjectWrapper.Parent = childCollection;
         childCollection.Elements.Add(dataObjectWrapper);
       }
-      // reject bare geometry — collections may only contain Data Objects or sub-collections.
-      // SpeckleGeometry is easily wrapped: wire your geometry through a 'Speckle Data Object' component first.
-      else if (obj?.ToSpeckleGeometryWrapper() is not null)
+      // handle bare geometry directly (deep copy to avoid mutations)
+      else if (obj?.ToSpeckleGeometryWrapper() is SpeckleGeometryWrapper geometryWrapper)
       {
-        AddRuntimeMessage(
-          GH_RuntimeMessageLevel.Error,
-          "Speckle Geometry cannot be added directly to a Collection. "
-            + "Use a 'Speckle Data Object' component to wrap your geometry first, then pipe it into the Collection."
-        );
-        return null;
+        var geometryCopy = geometryWrapper.DeepCopy();
+        geometryCopy.Path = childPath;
+        geometryCopy.Parent = childCollection;
+        childCollection.Elements.Add(geometryCopy);
       }
       else
       {

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Objects/SpeckleDataObjectPassthrough.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Objects/SpeckleDataObjectPassthrough.cs
@@ -37,7 +37,13 @@ public class SpeckleDataObjectPassthrough()
 
   public override Guid ComponentGuid => GetType().GUID;
   protected override Bitmap Icon => Resources.speckle_objects_dataobject;
-  public override GH_Exposure Exposure => GH_Exposure.secondary;
+  public override GH_Exposure Exposure => GH_Exposure.hidden;
+
+  /// <remarks>
+  /// Marks this component as obsolete in the Grasshopper UI (hides it from the ribbon, adds the
+  /// "obsolete" overlay icon on canvas).
+  /// </remarks>
+  public override bool Obsolete => true;
 
   protected override int FixedInputCount => 4;
   protected override int FixedOutputCount => 5;
@@ -113,6 +119,11 @@ public class SpeckleDataObjectPassthrough()
 
   protected override void SolveInstance(IGH_DataAccess da)
   {
+    AddRuntimeMessage(
+      GH_RuntimeMessageLevel.Remark,
+      "The 'Speckle Data Object' component is deprecated. We recommend using the 'Speckle Geometry' component(s) instead."
+    );
+
     // process the object
     // deep copy so we don't mutate the object
     SpeckleDataObjectWrapperGoo inputObject = new();

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/HostApp/CollectionHelpers.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/HostApp/CollectionHelpers.cs
@@ -75,7 +75,7 @@ public static class CollectionHelpers
   public static bool HasAnyValidContent(ISpeckleCollectionObject? element) =>
     element switch
     {
-      SpeckleGeometryWrapper => true, // kept for legacy receive (before ENG-8234): old models may have bare geometry in collections
+      SpeckleGeometryWrapper => true,
       SpeckleDataObjectWrapper => true,
       SpeckleCollectionWrapper collection => collection.Elements.Any(HasAnyValidContent),
       _ => false,

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/Wrappers/SpeckleDataObjectWrapperParam.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/Wrappers/SpeckleDataObjectWrapperParam.cs
@@ -30,7 +30,22 @@ public class SpeckleDataObjectParam : GH_Param<SpeckleDataObjectWrapperGoo>, IGH
 
   public override Guid ComponentGuid => new("47B930F9-587B-4A88-8CEB-19986E60BA61");
   protected override Bitmap Icon => Resources.speckle_param_dataobject;
-  public override GH_Exposure Exposure => GH_Exposure.secondary;
+  public override GH_Exposure Exposure => GH_Exposure.hidden;
+
+  /// <remarks>
+  /// Marks this param as obsolete in the Grasshopper UI (hides it from the ribbon, adds the
+  /// "obsolete" overlay icon on canvas).
+  /// </remarks>
+  public override bool Obsolete => true;
+
+  public override void AddedToDocument(GH_Document document)
+  {
+    base.AddedToDocument(document);
+    AddRuntimeMessage(
+      GH_RuntimeMessageLevel.Remark,
+      "The 'Speckle Data Object' parameter is deprecated. We recommend using the 'Speckle Geometry' parameter/component(s) instead."
+    );
+  }
 
   bool IGH_BakeAwareObject.IsBakeCapable => !VolatileData.IsEmpty;
 


### PR DESCRIPTION
## Description

- `SpeckleDataObject` marked as obsolete and hidden from components panel
- `CreateCollection` reverted to allow `SpeckleGeometry` again

## Screenshots & Validation of changes:

### Collections accepts Speckle Geometry again

<img width="1250" height="614" alt="image" src="https://github.com/user-attachments/assets/c1a81aed-dfeb-4d69-b53e-ee1203896db4" />

### Speckle Data Object marked as obsolete

<img width="1250" height="614" alt="image" src="https://github.com/user-attachments/assets/eedb021d-c8ab-445d-9db5-5a829d2610ce" />


## Checklist:

- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] I have added appropriate tests.
- [x] I have updated or added relevant documentation.