### PR TITLE
fix(autocad): fall back to DISPLAY meshes when SOLID blobs can't decode (ENG-8820)

### DIFF
--- a/Connectors/Autocad/Speckle.Connectors.AutocadShared/Operations/Receive/AutocadHostObjectArtefactBuilder.cs
+++ b/Connectors/Autocad/Speckle.Connectors.AutocadShared/Operations/Receive/AutocadHostObjectArtefactBuilder.cs
@@ -196,29 +196,40 @@ public class AutocadHostObjectArtefactBuilder : IArtifactHostObjectBuilder
           using (var tr = doc.TransactionManager.StartTransaction())
           {
             var modelSpace = (BlockTableRecord)tr.GetObject(db.CurrentSpaceId, OpenMode.ForWrite);
-            foreach (var geomK in GeometryIndices(objK, rels))
+            var (primaryKs, fallbackKs) = GeometryIndices(objK, rels, bundle);
+            BakeGeometry(primaryKs);
+            if (ids.Count == 0)
             {
-              materialIdByGeometry.TryGetValue(geomK, out ObjectId geomMaterial);
-              ObjectId materialId = objMaterial != ObjectId.Null ? objMaterial : geomMaterial;
-              int? argb =
-                hasObjColor ? objArgb
-                : colorArgbByGeometry.TryGetValue(geomK, out int geomArgb) ? geomArgb
-                : null;
-              foreach (var entity in DecodeAndAppend(geomK, bundle, modelSpace, tr, ObjectUnits(bundle, objK)))
-              {
-                entity.Layer = layerName;
-                if (materialId != ObjectId.Null)
-                {
-                  entity.MaterialId = materialId;
-                }
-                if (argb is int a)
-                {
-                  entity.Color = ToAcadColor(a);
-                }
-                ids.Add(entity.ObjectId);
-              }
+              // the solid blob(s) produced nothing (SAT AcisIn failure) — bake the DISPLAY shadow instead [ENG-8820]
+              BakeGeometry(fallbackKs);
             }
             tr.Commit();
+
+            void BakeGeometry(IReadOnlyList<int> geomKs)
+            {
+              foreach (var geomK in geomKs)
+              {
+                materialIdByGeometry.TryGetValue(geomK, out ObjectId geomMaterial);
+                ObjectId materialId = objMaterial != ObjectId.Null ? objMaterial : geomMaterial;
+                int? argb =
+                  hasObjColor ? objArgb
+                  : colorArgbByGeometry.TryGetValue(geomK, out int geomArgb) ? geomArgb
+                  : null;
+                foreach (var entity in DecodeAndAppend(geomK, bundle, modelSpace, tr, ObjectUnits(bundle, objK)))
+                {
+                  entity.Layer = layerName;
+                  if (materialId != ObjectId.Null)
+                  {
+                    entity.MaterialId = materialId;
+                  }
+                  if (argb is int a)
+                  {
+                    entity.Color = ToAcadColor(a);
+                  }
+                  ids.Add(entity.ObjectId);
+                }
+              }
+            }
           }
 
           if (ids.Count == 0)
@@ -302,17 +313,31 @@ public class AutocadHostObjectArtefactBuilder : IArtifactHostObjectBuilder
 
   // ── geometry ──────────────────────────────────────────────────────────────────────────────────────────
   // Geometry indices to bake for an object: prefer the lossless SOLID (SAT) blobs, else its DISPLAY meshes.
-  private static IEnumerable<int> GeometryIndices(int objK, ArtefactRelations rels)
+  // The SOLID preference is a preference, NOT a commitment [ENG-8820]: a foreign solid blob (a Rhino 3dm this
+  // host can never read) is filtered out up front, and the caller retries the Fallback list when the Primary
+  // produced no entities (a SAT from a newer ACIS that Body.AcisIn rejects). The display meshes exist precisely
+  // so a host that can't read the raw format still gets renderable geometry.
+  private static (IReadOnlyList<int> Primary, IReadOnlyList<int> Fallback) GeometryIndices(
+    int objK,
+    ArtefactRelations rels,
+    ArtefactBundle bundle
+  )
   {
+    var display =
+      rels.DisplayByObject(objK) is { } displayEdges
+        ? displayEdges.OrderBy(x => x.Ord).Select(e => e.Dst).ToList()
+        : new List<int>();
     if (rels.SolidByObject.TryGetValue(objK, out var solidKs) && solidKs.Count > 0)
     {
-      return solidKs;
+      var decodable = solidKs
+        .Where(k => bundle.Geometries.TryGetValue(k, out var g) && g.Type == RawEncodingFormats.ACAD_SAT)
+        .ToList();
+      if (decodable.Count > 0)
+      {
+        return (decodable, display);
+      }
     }
-    if (rels.DisplayByObject(objK) is { } displayEdges)
-    {
-      return displayEdges.OrderBy(x => x.Ord).Select(e => e.Dst);
-    }
-    return Array.Empty<int>();
+    return (display, Array.Empty<int>());
   }
 
   // Decodes one geometry index and appends the resulting native entity(ies) to the target block-table record,
@@ -333,7 +358,19 @@ public class AutocadHostObjectArtefactBuilder : IArtifactHostObjectBuilder
 
     if (g.Type == RawEncodingFormats.ACAD_SAT)
     {
-      foreach (var entity in DecodeSat(g.Content))
+      // A throwing AcisIn (SAT from a newer ACIS version) must degrade to "no entities", not error the whole
+      // object — the caller falls back to the DISPLAY meshes when the solid produced nothing [ENG-8820].
+      List<AcadEntity> satEntities;
+      try
+      {
+        satEntities = DecodeSat(g.Content);
+      }
+      catch (Exception ex) when (!ex.IsFatal())
+      {
+        _logger.LogWarning(ex, "SAT decode failed for geometry {GeomK} ({Bytes} bytes)", geomK, g.Content.Length);
+        return result;
+      }
+      foreach (var entity in satEntities)
       {
         target.AppendEntity(entity);
         tr.AddNewlyCreatedDBObject(entity, true);
@@ -679,7 +716,18 @@ public class AutocadHostObjectArtefactBuilder : IArtifactHostObjectBuilder
       if (rels.DefinesByDefinition.TryGetValue(defNodeK, out var geomKs))
       {
         rels.DefinesOrdByDefinition.TryGetValue(defNodeK, out var ords);
-        foreach (var memberGeomKs in GroupDefinesByMember(geomKs, ords, bundle))
+        foreach (var (preferredKs, fallbackKs) in GroupDefinesByMember(geomKs, ords, bundle))
+        {
+          int before = memberCount;
+          BakeMember(preferredKs);
+          if (memberCount == before)
+          {
+            // the member's solid blob produced nothing — bake its DISPLAY shadow instead [ENG-8820]
+            BakeMember(fallbackKs);
+          }
+        }
+
+        void BakeMember(List<int> memberGeomKs)
         {
           foreach (var geomK in memberGeomKs)
           {
@@ -923,9 +971,15 @@ public class AutocadHostObjectArtefactBuilder : IArtifactHostObjectBuilder
   }
 
   // Groups a definition's DEFINES geometry Ks by member ordinal (index-aligned with ords), then within each member
-  // prefers the authoritative SAT solid over its display mesh(es); a member with no solid yields all its geometry.
-  // Member order is preserved. When ords are absent (older bundle) each geometry is its own member — i.e. no grouping.
-  private static IEnumerable<List<int>> GroupDefinesByMember(List<int> geomKs, List<int>? ords, ArtefactBundle bundle)
+  // PREFERS the authoritative SAT solid over its display mesh(es) — but doesn't commit [ENG-8820]: the caller
+  // bakes Preferred and retries Fallback (the member's remaining display geometry) when it produced no entities
+  // (foreign/undecodable solid blob). A member with no decodable solid yields all its geometry up front. Member
+  // order is preserved. When ords are absent (older bundle) each geometry is its own member — i.e. no grouping.
+  private static IEnumerable<(List<int> Preferred, List<int> Fallback)> GroupDefinesByMember(
+    List<int> geomKs,
+    List<int>? ords,
+    ArtefactBundle bundle
+  )
   {
     var members = new List<List<int>>();
     var indexByOrd = new Dictionary<int, int>();
@@ -945,7 +999,15 @@ public class AutocadHostObjectArtefactBuilder : IArtifactHostObjectBuilder
       var solids = geoms
         .Where(k => bundle.Geometries.TryGetValue(k, out var g) && g.Type == RawEncodingFormats.ACAD_SAT)
         .ToList();
-      yield return solids.Count > 0 ? solids : geoms;
+      if (solids.Count > 0)
+      {
+        var solidSet = new HashSet<int>(solids);
+        yield return (solids, geoms.Where(k => !solidSet.Contains(k)).ToList());
+      }
+      else
+      {
+        yield return (geoms, new List<int>());
+      }
     }
   }
 


### PR DESCRIPTION
Fixes [ENG-8820](https://linear.app/speckle/issue/ENG-8820/rhinoautocad-receive-solids-fail-entirely-no-display-mesh-fallback-for).

## Problem

Receiving a Rhino model into AutoCAD lost every Brep/Extrusion/SubD — not even the display meshes baked. `GeometryIndices` committed to the `SOLID` rel unconditionally, but Rhino's solid blobs are `3dm`, which `DecodeAndAppend` can't read → zero entities → whole object recorded as ERROR. Same hole for a SAT that `Body.AcisIn` rejects (newer ACIS version), including inside block definitions.

## Fix — SOLID preference is a preference, not a commitment

- `GeometryIndices` filters foreign (non-SAT) solid blobs up front and returns `(primary, fallback)`, keeping the DISPLAY list alive — a Rhino Brep goes straight to its meshes.
- The atomic bake loop retries the fallback when the primary produced zero entities.
- A throwing `AcisIn` degrades to no-entities (logged warning) instead of erroring the object, so the fallback gets its turn.
- Block definitions get the same per-member retry: `GroupDefinesByMember` yields `(preferred solids, display shadow)` and `BuildDefinitions` bakes the shadow when the member's solid produced nothing.

Mirrors the fallback `RhinoHostObjectArtefactBuilder.DecodeObjectGeometry` already had.

## Testing

- Live round-trip: the ticket's Rhino repro model now receives into AutoCAD as display meshes with SUCCESS results (previously all-ERROR, empty document).
- Builds clean: AutoCAD 2024 (net48), AutoCAD 2026 (net8), Civil3D 2024 — 0 warnings / 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)