### PR TITLE
fix(artifacts): emit object-sourced HAS_COLOR for block instances

### DIFF
--- a/Connectors/Autocad/Speckle.Connectors.AutocadShared/Operations/Send/AutocadArtifactRootObjectBuilder.cs
+++ b/Connectors/Autocad/Speckle.Connectors.AutocadShared/Operations/Send/AutocadArtifactRootObjectBuilder.cs
@@ -268,14 +268,14 @@ public class AutocadArtifactRootObjectBuilder(
     {
       var instanceProps =
         instanceProxy["properties"] as Dictionary<string, object?> ?? new Dictionary<string, object?>();
-      return new CollectedObject(applicationId, sourceType, entity.Layer, instanceProps, instanceProxy);
+      return new CollectedObject(applicationId, sourceType, entity.Layer, instanceProps, instanceProxy, entity.Color.IsByLayer);
     }
 
     Base converted = converter.Convert(entity);
     // AutoCAD wraps entities in AutocadObject, Civil3D in Civil3dObject — both are DataObjects carrying the
     // converted properties + display meshes.
     var properties = converted is DataObject dataObject ? dataObject.properties : new Dictionary<string, object?>();
-    return new CollectedObject(applicationId, sourceType, entity.Layer, properties, converted);
+    return new CollectedObject(applicationId, sourceType, entity.Layer, properties, converted, entity.Color.IsByLayer);
   }
 
   // ── Phase 2 (worker thread): pure-Speckle snapshot → parquet bundle ──────────────────────────────────
@@ -320,6 +320,11 @@ public class AutocadArtifactRootObjectBuilder(
     {
       cancellationToken.ThrowIfCancellationRequested();
       int collK = GetOrAddLayerCollection(pipeline, co.LayerName, model.LayerArgbByName, layerCollectionKByName);
+      // A ByLayer DEFINITION MEMBER sits outside the layer-container inheritance (it rides DEFINES, no
+      // IN_COLLECTION), so a consumer would fall back to the placing instance's colour — wrong in AutoCAD
+      // semantics, where ByLayer keeps the member's own layer colour. Resolve it at send time [ENG-8825].
+      int? memberLayerArgb =
+        co.ColorIsByLayer && model.LayerArgbByName.TryGetValue(co.LayerName, out int layerArgb) ? layerArgb : null;
       string? dropReason = EmitObject(
         pipeline,
         co,
@@ -327,7 +332,8 @@ public class AutocadArtifactRootObjectBuilder(
         model.Units,
         geometryKsByObjectId,
         instanceKByObjectId,
-        definitionMemberIds
+        definitionMemberIds,
+        memberLayerArgb
       );
       if (dropReason is not null && resultIndexByAppId.TryGetValue(co.ApplicationId, out int ri))
       {
@@ -377,7 +383,8 @@ public class AutocadArtifactRootObjectBuilder(
     string units,
     Dictionary<string, List<int>> geometryKsByObjectId,
     Dictionary<string, int> instanceKByObjectId,
-    HashSet<string> definitionMemberIds
+    HashSet<string> definitionMemberIds,
+    int? memberLayerArgb
   )
   {
     // A block-definition member renders ONLY through its definition (via a placed instance's transform), so it gets
@@ -488,6 +495,8 @@ public class AutocadArtifactRootObjectBuilder(
 
     geometryKsByObjectId[co.ApplicationId] = gKs;
 
+    EmitMemberLayerColor(pipeline, isDefinitionMember, memberLayerArgb, gKs);
+
     // Every display fragment was dropped and no solid landed → the bundle carries nothing renderable for this
     // object; report it instead of standing on the Collect-phase SUCCESS. An object that never had display
     // geometry (e.g. a Civil3D parent whose content rides its children) is NOT a drop.
@@ -514,6 +523,26 @@ public class AutocadArtifactRootObjectBuilder(
     }
 
     return dropReason;
+  }
+
+  // ByLayer member: pin its resolved layer colour onto its geometry so it doesn't inherit the instance's
+  // colour override — the fallback stays reserved for ByBlock members [ENG-8825].
+  private static void EmitMemberLayerColor(
+    ObjectsArtifactPipeline pipeline,
+    bool isDefinitionMember,
+    int? memberLayerArgb,
+    List<int> gKs
+  )
+  {
+    if (!isDefinitionMember || memberLayerArgb is not int mla || gKs.Count == 0)
+    {
+      return;
+    }
+    int layerColorK = pipeline.AddColor(mla);
+    foreach (var gK in gKs)
+    {
+      pipeline.HasColor(gK, layerColorK);
+    }
   }
 
   // One Civil3D child in the .elements tree. Emits a SUBELEMENT edge always; interns + emits the child's own
@@ -690,6 +719,13 @@ public class AutocadArtifactRootObjectBuilder(
     // namespaces — so per-placement colour overrides survive [ENG-8825].
     foreach (var colorProxy in model.Colors)
     {
+      // A "block"-sourced proxy is INHERITANCE, not an explicit colour: a ByBlock member must take its placing
+      // instance's colour — exactly the object-sourced edge below — and the unpacker itself notes ByBlock's
+      // ColorValue is garbage (near-black/white). Emitting it as an explicit edge pinned members to white.
+      if (colorProxy["source"] is "block")
+      {
+        continue;
+      }
       int colorK = pipeline.AddColor(colorProxy.value);
       foreach (var objectId in colorProxy.objects)
       {
@@ -797,7 +833,8 @@ public class AutocadArtifactRootObjectBuilder(
     string SourceType,
     string LayerName,
     Dictionary<string, object?> Properties,
-    Base Converted // InstanceProxy for block instances, otherwise the AutocadObject carrier (display meshes + SAT)
+    Base Converted, // InstanceProxy for block instances, otherwise the AutocadObject carrier (display meshes + SAT)
+    bool ColorIsByLayer = false // captured on the UI thread; drives member layer-colour resolution [ENG-8825]
   );
 
   private sealed record CollectedGroup(string Id, string? Name, List<string> MemberIds);

--- a/Connectors/Autocad/Speckle.Connectors.AutocadShared/Operations/Send/AutocadArtifactRootObjectBuilder.cs
+++ b/Connectors/Autocad/Speckle.Connectors.AutocadShared/Operations/Send/AutocadArtifactRootObjectBuilder.cs
@@ -624,7 +624,10 @@ public class AutocadArtifactRootObjectBuilder(
       }
     }
 
-    // 3) object colors → HAS_COLOR (geometry → color node). Color proxies list OBJECT ids.
+    // 3) object colors → HAS_COLOR (geometry → color node). Color proxies list OBJECT ids. A block INSTANCE has
+    // no geometry of its own (it enters instanceKByObjectId, not geometryKsByObjectId), so its colour edge is
+    // emitted OBJECT-sourced instead — spec HAS_COLOR src is geometry|object, and the viewer looks up both
+    // namespaces — so per-placement colour overrides survive [ENG-8825].
     foreach (var colorProxy in model.Colors)
     {
       int colorK = pipeline.AddColor(colorProxy.value);
@@ -636,6 +639,10 @@ public class AutocadArtifactRootObjectBuilder(
           {
             pipeline.HasColor(gK, colorK);
           }
+        }
+        else if (instanceKByObjectId.ContainsKey(objectId))
+        {
+          pipeline.HasColor(pipeline.InternObject(objectId), colorK);
         }
       }
     }

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/Operations/Send/RhinoArtifactRootObjectBuilder.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/Operations/Send/RhinoArtifactRootObjectBuilder.cs
@@ -670,6 +670,12 @@ public class RhinoArtifactRootObjectBuilder(
             pipeline.HasColor(gK, colorK);
           }
         }
+        else if (instanceKByObjectId.ContainsKey(objectId))
+        {
+          // block instance: no geometry of its own — emit the colour OBJECT-sourced (spec HAS_COLOR src is
+          // geometry|object; the viewer looks up both) so per-placement overrides survive [ENG-8825].
+          pipeline.HasColor(pipeline.InternObject(objectId), colorK);
+        }
       }
     }
   }


### PR DESCRIPTION
A colour set on a block instance (the BlockReference/InstanceObject itself, not its members) was silently dropped: EmitValueNodes resolved colour proxies through geometryKsByObjectId only, and instances never enter that map (they register in instanceKByObjectId). Emit the edge OBJECT-sourced instead — spec HAS_COLOR src is geometry|object and the viewer looks up both namespaces — so per-placement colour overrides survive. Fixed in both the AutoCAD and Rhino artifact builders (same gap in each).

Instance render MATERIALS remain open: HAS_MATERIAL src is geometry-only in the spec and the viewer reads it as such — extending it needs a spec + viewer change (follow-up).