### PR TITLE
Round-trip the Revit reference point through the artefact bundle (ENG-8808)

### DIFF
--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Bindings/RevitSendBinding.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Bindings/RevitSendBinding.cs
@@ -183,7 +183,8 @@ internal sealed class RevitSendBinding : RevitBaseBinding, ISendBinding
               _toSpeckleSettingsManager.GetLinkedModelsSetting(document, card),
               _toSpeckleSettingsManager.GetSendRebarsAsVolumetric(document, card),
               _toSpeckleSettingsManager.GetSendAreasAsMesh(document, card),
-              false
+              false,
+              referencePointKind: _toSpeckleSettingsManager.GetReferencePointKind(card)
             )
           );
       },

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Receive/RevitHostObjectArtefactBuilder.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Receive/RevitHostObjectArtefactBuilder.cs
@@ -10,6 +10,7 @@ using Speckle.Connectors.Common.Threading;
 using Speckle.Connectors.Revit.HostApp;
 using Speckle.Converters.Common;
 using Speckle.Converters.RevitShared;
+using Speckle.Converters.RevitShared.Helpers;
 using Speckle.Converters.RevitShared.Services;
 using Speckle.Converters.RevitShared.Settings;
 using Speckle.Objects.Utils;
@@ -106,6 +107,20 @@ public sealed class RevitHostObjectArtefactBuilder : IArtifactHostObjectBuilder
 
     var doc = _converterSettings.Current.Document;
     var rels = bundle.Relations;
+
+    // ENG-8808: undo/redo the sender's reference-point re-basing. The send pipeline baked its main-model
+    // reference-point transform into geometry and recorded it in the bundle; compose it with the receiver's own
+    // reference-point setting (Source = no local transform → apply the sender's as-is, restoring the source
+    // model's internal coordinates) and push it so ToInternalPoints/ConvertToInternalCoordinates re-bases every
+    // vertex. Mirrors v1 RevitHostObjectBuilder's composition. No recorded transform + no local setting = no-op.
+    var sourceReferencePoint = ReadSourceReferencePointTransform(bundle);
+    using var referencePointScope = _converterSettings.Push(s =>
+      s with
+      {
+        ReferencePointTransform = ReferencePointHelper.CalculateNewTransform(s.ReferencePointTransform, sourceReferencePoint),
+      }
+    );
+
     var bakedObjectIds = new List<string>();
     var conversionResults = new HashSet<ReceiveConversionResult>();
 
@@ -637,6 +652,41 @@ public sealed class RevitHostObjectArtefactBuilder : IArtifactHostObjectBuilder
 
     cache[key] = resolved;
     return resolved;
+  }
+
+  // ENG-8947: rebuild the sender's reference-point transform from the bundle meta offset (translation kinds only).
+  // The offset is in the bundle's display units; scale to internal feet so it composes with the receive setting and
+  // applies through ConvertToInternalCoordinates. Null (internal origin / fallback / Shared Coordinates) → no source
+  // re-basing.
+  private Transform? ReadSourceReferencePointTransform(ArtefactBundle bundle)
+  {
+    if (bundle.ReferencePointOffset is not { Length: > 0 } offsetCsv)
+    {
+      return null;
+    }
+    var parts = offsetCsv.Split(',');
+    if (parts.Length != 3)
+    {
+      return null;
+    }
+    var o = new double[3];
+    for (int i = 0; i < 3; i++)
+    {
+      if (!double.TryParse(parts[i], NumberStyles.Float, CultureInfo.InvariantCulture, out o[i]))
+      {
+        return null;
+      }
+    }
+    var fTypeId = ResolveForge(bundle.Units);
+    // Identity + Origin (not Transform.CreateTranslation) to match ReferencePointHelper.GetTransformFromRootObject and
+    // keep the analyzer's disposable-ownership tracking happy — the result is pushed into converter settings.
+    var t = Transform.Identity;
+    t.Origin = new XYZ(
+      _scalingService.ScaleToNative(o[0], fTypeId),
+      _scalingService.ScaleToNative(o[1], fTypeId),
+      _scalingService.ScaleToNative(o[2], fTypeId)
+    );
+    return t;
   }
 
   // ── transforms ────────────────────────────────────────────────────────────────────────────────────────

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Receive/RevitHostObjectBuilder.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Receive/RevitHostObjectBuilder.cs
@@ -127,7 +127,7 @@ public sealed class RevitHostObjectBuilder(
         converterSettings.Push(currentSettings =>
           currentSettings with
           {
-            ReferencePointTransform = CalculateNewTransform(
+            ReferencePointTransform = ReferencePointHelper.CalculateNewTransform(
               currentSettings.ReferencePointTransform,
               referencePointTransformFromRootObject
             ),
@@ -248,23 +248,6 @@ public sealed class RevitHostObjectBuilder(
     );
   }
 
-  private Autodesk.Revit.DB.Transform? CalculateNewTransform(
-    Autodesk.Revit.DB.Transform? receiveTransform,
-    Autodesk.Revit.DB.Transform? rootTransform
-  )
-  {
-    if (receiveTransform == null)
-    {
-      return rootTransform;
-    }
-
-    if (rootTransform == null)
-    {
-      return receiveTransform;
-    }
-
-    return rootTransform.Multiply(receiveTransform);
-  }
 
   private (
     HostObjectBuilderResult builderResult,

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/RevitArtifactRootObjectBuilder.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/RevitArtifactRootObjectBuilder.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using System.IO;
 using Autodesk.Revit.DB;
 using Microsoft.Extensions.Logging;
@@ -224,6 +225,8 @@ public class RevitArtifactRootObjectBuilder(
 
       int modelK = pipeline.AddContainer(modelKey, modelName, null, "Model");
       modelContainerKeys.Add(modelKey);
+
+      EmitMainModelReferencePoint(pipeline, documentContext);
 
       using (
         converterSettings.Push(s =>
@@ -471,6 +474,50 @@ public class RevitArtifactRootObjectBuilder(
       }
     }
   }
+
+  // ENG-8947: record the MAIN-model reference point in the bundle meta — the SINGLE source for both federation and
+  // Revit→Revit round-trip (the receiver rebuilds the translation from the offset). Only the host (non-linked)
+  // document's Transform is the pure reference-point transform — a linked doc's is (referencePoint ∘ linkPlacement⁻¹)
+  // and must NOT be persisted. Only the translation kinds are recorded: projectBasePoint / surveyPoint (offset in
+  // display units — the vector subtracted) + the requested-but-missing internalOriginFallback. Internal origin and
+  // Shared Coordinates record nothing: internal origin has nothing to record, and Shared Coordinates is a
+  // connector-only kind outside the shared spec vocabulary whose true-north rotation a translation offset can't
+  // represent (so it does not round-trip — a deliberate scope call, see ENG-8808 discussion).
+  private void EmitMainModelReferencePoint(ObjectsArtifactPipeline pipeline, DocumentToConvert documentContext)
+  {
+    if (
+      documentContext.Doc.IsLinked
+      || converterSettings.Current.ReferencePointKind
+        is not (ReferencePointType.ProjectBase or ReferencePointType.Survey)
+    )
+    {
+      return;
+    }
+
+    if (documentContext.Transform is { } transform)
+    {
+      var kind =
+        converterSettings.Current.ReferencePointKind == ReferencePointType.ProjectBase
+          ? "projectBasePoint"
+          : "surveyPoint";
+      pipeline.SetReferencePoint(kind, FormatReferencePointOffset(transform));
+    }
+    else
+    {
+      // requested a base point the model doesn't have → converted at internal origin, recorded (not silent).
+      pipeline.SetReferencePoint("internalOriginFallback", null);
+    }
+  }
+
+  // ENG-8947 reference_point_offset: the translation subtracted from world-space output, in display units.
+  private string FormatReferencePointOffset(Transform transform) =>
+    string.Format(
+      CultureInfo.InvariantCulture,
+      "{0},{1},{2}",
+      scalingService.ScaleLength(transform.Origin.X),
+      scalingService.ScaleLength(transform.Origin.Y),
+      scalingService.ScaleLength(transform.Origin.Z)
+    );
 
   // Emits an object's displayValue as renderable geometry: meshes → DISPLAY, instance proxies → INSTANCE +
   // DISPLAY_INSTANCE, curves/points → DISPLAY (via the SGEO encoder, same as Rhino's artefact send).

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/Settings/ToSpeckleSettingsManager.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/Settings/ToSpeckleSettingsManager.cs
@@ -78,6 +78,26 @@ public class ToSpeckleSettingsManager(
     return null;
   }
 
+  /// <summary>
+  /// The REQUESTED reference-point kind (independent of whether the model actually has that base point). Mirrors
+  /// the setting resolution in <see cref="GetReferencePointSetting"/>; used by the 4.0 send pipeline to record
+  /// reference_point_kind in the bundle meta (ENG-8947). Absent/invalid setting → InternalOrigin.
+  /// </summary>
+  public ReferencePointType GetReferencePointKind(ModelCard modelCard)
+  {
+    var referencePointString =
+      modelCard.Settings?.FirstOrDefault(s => s.Id == SendReferencePointSetting.SETTING_ID)?.Value as string;
+    if (
+      referencePointString is not null
+      && SendReferencePointSetting.ReferencePointMap.TryGetValue(referencePointString, out ReferencePointType kind)
+    )
+    {
+      return kind;
+    }
+
+    return SendReferencePointSetting.DEFAULT_VALUE;
+  }
+
   public bool GetSendParameterNullOrEmptyStringsSetting(Document document, SenderModelCard modelCard) =>
     GetBooleanSettingWithCache(
       document,

--- a/Converters/Revit/Speckle.Converters.RevitShared/Helpers/ReferencePointHelper.cs
+++ b/Converters/Revit/Speckle.Converters.RevitShared/Helpers/ReferencePointHelper.cs
@@ -10,35 +10,62 @@ namespace Speckle.Converters.RevitShared.Helpers;
 public static class ReferencePointHelper
 {
   /// <summary>
+  /// Flattens a Revit <see cref="Transform"/> to the 16-element matrix Speckle stores (basis vectors in the first
+  /// three "columns", translation in the last), used by <see cref="CreateTransformDataForRootObject"/> — the same
+  /// element order <see cref="GetTransformFromRootObject"/> reads back.
+  /// </summary>
+  private static double[] TransformToArray(Transform transform) =>
+    new[]
+    {
+      transform.BasisX.X,
+      transform.BasisX.Y,
+      transform.BasisX.Z,
+      0,
+      transform.BasisY.X,
+      transform.BasisY.Y,
+      transform.BasisY.Z,
+      0,
+      transform.BasisZ.X,
+      transform.BasisZ.Y,
+      transform.BasisZ.Z,
+      0,
+      transform.Origin.X,
+      transform.Origin.Y,
+      transform.Origin.Z,
+      1,
+    };
+
+  /// <summary>
   /// Changes Revit Transform to a double array.
   /// Uses a 16-element column-major matrix representation. See https://speckle.guide/dev/objects.html
   /// </summary>
   public static Dictionary<string, object> CreateTransformDataForRootObject(Transform transform) =>
     new()
     {
-      {
-        "transform", // TODO: it would also be nice to include the key-value pair for reference point type as a string
-        new[]
-        {
-          transform.BasisX.X,
-          transform.BasisX.Y,
-          transform.BasisX.Z,
-          0,
-          transform.BasisY.X,
-          transform.BasisY.Y,
-          transform.BasisY.Z,
-          0,
-          transform.BasisZ.X,
-          transform.BasisZ.Y,
-          transform.BasisZ.Z,
-          0,
-          transform.Origin.X,
-          transform.Origin.Y,
-          transform.Origin.Z,
-          1,
-        }
-      },
+      // TODO: it would also be nice to include the key-value pair for reference point type as a string
+      { "transform", TransformToArray(transform) },
     };
+
+  /// <summary>
+  /// Combines the receiver's local reference-point setting with the transform the sender baked into the geometry,
+  /// so the received model lands where the receive setting asks. Mirrors the v1 receive-side composition: with no
+  /// local setting (receive = Source) the sender's transform is applied as-is (restoring the source's internal
+  /// coordinates); with no sender transform the local setting stands alone; otherwise they compose.
+  /// </summary>
+  public static Transform? CalculateNewTransform(Transform? receiveTransform, Transform? rootTransform)
+  {
+    if (receiveTransform == null)
+    {
+      return rootTransform;
+    }
+
+    if (rootTransform == null)
+    {
+      return receiveTransform;
+    }
+
+    return rootTransform.Multiply(receiveTransform);
+  }
 
   public static Matrix4x4 TransformToMatrix(Transform transform) =>
     new()

--- a/Converters/Revit/Speckle.Converters.RevitShared/Settings/RevitConversionSettings.cs
+++ b/Converters/Revit/Speckle.Converters.RevitShared/Settings/RevitConversionSettings.cs
@@ -10,5 +10,9 @@ public record RevitConversionSettings(
   bool SendRebarsAsVolumetric,
   bool SendAreasAsMesh,
   bool ReceiveInstancesAsFamilies,
-  double Tolerance = 0.0164042 // 5mm in ft
+  double Tolerance = 0.0164042, // 5mm in ft
+  // The requested reference-point kind alongside its resolved ReferencePointTransform. Carried so the 4.0 send
+  // pipeline can record it in the bundle meta (ENG-8947); ReferencePointTransform alone can't distinguish
+  // projectBasePoint from surveyPoint. Send-only; defaults to InternalOrigin (receive leaves it untouched).
+  ReferencePointType ReferencePointKind = ReferencePointType.InternalOrigin
 );

--- a/Converters/Revit/Speckle.Converters.RevitShared/Settings/RevitConversionSettingsFactory.cs
+++ b/Converters/Revit/Speckle.Converters.RevitShared/Settings/RevitConversionSettingsFactory.cs
@@ -19,7 +19,8 @@ public class RevitConversionSettingsFactory(
     bool sendRebarsAsVolumetric,
     bool sendAreasAsMesh,
     bool receiveInstancesAsFamilies,
-    double tolerance = 0.0164042 // 5mm in ft
+    double tolerance = 0.0164042, // 5mm in ft
+    ReferencePointType referencePointKind = ReferencePointType.InternalOrigin
   )
   {
     var document = revitContext.UIApplication.NotNull().ActiveUIDocument.Document;
@@ -33,7 +34,8 @@ public class RevitConversionSettingsFactory(
       sendRebarsAsVolumetric,
       sendAreasAsMesh,
       receiveInstancesAsFamilies,
-      tolerance
+      tolerance,
+      referencePointKind
     );
   }
 }


### PR DESCRIPTION
## What

Fixes **ENG-8808**. The Speckle 4.0 artefact send path dropped the reference-point transform the v1 pipeline stored on the root object, so Revit→Revit reference-point round-tripping (send Project Base / Survey → receive Source) was lost for every model sent through the artefact path — geometry landed offset by the base-point vector.

This records the applied reference point in the bundle `meta` (**ENG-8947**) and reverses it on receive.

## Changes

**Send** — `RevitArtifactRootObjectBuilder`
- Writes `reference_point_kind` + `reference_point_offset` (display units, the vector subtracted) for the **main (non-linked)** model: `projectBasePoint` / `surveyPoint`, or `internalOriginFallback` when the requested base point is missing.
- Only the host document's transform is persisted — a linked doc's is `(referencePoint ∘ linkPlacement⁻¹)` and must not be.
- The requested `ReferencePointType` is threaded to the send pipeline via `RevitConversionSettings` (the resolved transform alone can't distinguish `projectBasePoint` from `surveyPoint`).

**Receive**
- **net8** (`RevitHostObjectArtefactBuilder`): rebuilds the translation from the meta offset (scaled to internal feet), composes it with the local receive setting via the shared `ReferencePointHelper.CalculateNewTransform`, and applies through `ConvertToInternalCoordinates`.
- **net48**: works through the SDK reconstruction lift — `RevitHostObjectBuilder` is unchanged (its private `CalculateNewTransform` just moved to the shared helper).

## Shared Coordinates — deliberately NOT round-tripped

The Revit connector has a 4th reference-point kind, **Shared Coordinates** (`ActiveProjectLocation.GetTotalTransform()`), which:
- is **outside** ENG-8947's vocabulary (`internalOrigin | projectBasePoint | surveyPoint | internalOriginFallback`), and
- can carry **true-north rotation**, which a translation-only `reference_point_offset` structurally cannot represent, and
- has **no counterpart in the converters/native pipeline** (`rvextract` only reads the survey-point *position*; it would reject a `sharedCoordinates` value).

So Shared Coordinates records **no meta** and does **not** round-trip — a deliberate scope call (Option B): rather than invent a `sharedCoordinates` value nobody in the shared bundle-spec consumes, or mislabel it as `surveyPoint`, we leave it out. Internal Origin / Project Base / Survey are pure translations and map to ENG-8947 exactly. If Shared-coords georeferencing/federation later becomes a requirement, `sharedCoordinates` (with rotation handling) should be added to the bundle-spec **and** both pipelines together.

## Requires

The `meta` provision in the SDK: specklesystems/speckle-sharp-sdk#511

## Test

Revit 2025/2026: model with a Project Base Point offset from the internal origin → send with **Reference Point = Project Base** (also **Survey**) → receive into a second model (**Reference Point = Source**) → geometry should land on the source's internal coordinates (matching `dev`). Verify **Internal Origin** is unchanged and **linked models** still place correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
