### PR TITLE
fix(civil3d): don't emit "(none)" as a property unit

### DIFF
--- a/Converters/Civil3d/Speckle.Converters.Civil3dShared/ToSpeckle/Properties/PartDataExtractor.cs
+++ b/Converters/Civil3d/Speckle.Converters.Civil3dShared/ToSpeckle/Properties/PartDataExtractor.cs
@@ -62,8 +62,12 @@ public class PartDataExtractor
         ["value"] = value,
         ["name"] = field.Name,
         ["context"] = fieldName,
-        ["units"] = field.Units,
       };
+      // eav `unit` contract is real-unit-or-absent — skip empty / "(none)" placeholder units.
+      if (field.Units is { Length: > 0 } fieldUnits && fieldUnits != "(none)")
+      {
+        fieldDictionary["units"] = fieldUnits;
+      }
 
       if (!result.ContainsKey(fieldName))
       {

--- a/Converters/Civil3d/Speckle.Converters.Civil3dShared/ToSpeckle/Properties/PropertySetExtractor.cs
+++ b/Converters/Civil3d/Speckle.Converters.Civil3dShared/ToSpeckle/Properties/PropertySetExtractor.cs
@@ -101,7 +101,17 @@ public class PropertySetExtractor
           ["internalDefinitionName"] = data.FieldBucketId,
         };
         PropertyHandler propHandler = new();
-        propHandler.TryAddToDictionary(propertyValueDict, "units", () => data.UnitType.GetTypeDisplayName(true)); // units not always applicable to def, will throw
+        // Units aren't always applicable to a def (the getter throws — swallowed by TryGetValue), and a unitless
+        // def reports Autodesk's literal display name "(none)" — UI text, not a unit. The eav `unit` column
+        // contract is real-unit-or-absent, so add `units` only when a genuine unit comes back.
+        if (
+          propHandler.TryGetValue(() => data.UnitType.GetTypeDisplayName(true), out string? unitDisplay)
+          && unitDisplay is { Length: > 0 }
+          && unitDisplay != "(none)"
+        )
+        {
+          propertyValueDict["units"] = unitDisplay;
+        }
 
         propertySetData[dataName] = propertyValueDict;
       }


### PR DESCRIPTION
Autodesk's `GetTypeDisplayName` returns the literal `"(none)"` for unitless property-set definitions (UI text, not a unit), and part-data `field.Units` can be empty. Both flowed verbatim into the eav `unit` column, whose contract is real-unit-or-absent (consumers feature-detect by presence). Units are now added only when a genuine unit comes back.

Spotted in the model inspector while validating #1467 (`properties.Property Sets.test.* | unit: (none)`).

?? Generated with [Claude Code](https://claude.com/claude-code)