### PR TITLE
fix(autocad): apply instance colours and ByBlock inheritance on receive (ENG-8822)

### DIFF
--- a/Connectors/Autocad/Speckle.Connectors.AutocadShared/Operations/Receive/AutocadHostObjectArtefactBuilder.cs
+++ b/Connectors/Autocad/Speckle.Connectors.AutocadShared/Operations/Receive/AutocadHostObjectArtefactBuilder.cs
@@ -743,10 +743,10 @@ public class AutocadHostObjectArtefactBuilder : IArtifactHostObjectBuilder
               {
                 entity.MaterialId = geomMaterial;
               }
-              if (hasGeomColor)
-              {
-                entity.Color = ToAcadColor(geomArgb);
-              }
+              // A member with an explicit colour edge keeps it (an explicit override, or the resolved layer colour
+              // a ByLayer member carries). A member with NO edge was ByBlock on send — bake it ByBlock so it
+              // inherits the placing BlockReference's colour instead of the block table record's default [ENG-8822].
+              entity.Color = hasGeomColor ? ToAcadColor(geomArgb) : AcadColor.FromColorIndex(ColorMethod.ByBlock, 0);
               memberCount++;
             }
           }
@@ -1172,6 +1172,21 @@ public class AutocadHostObjectArtefactBuilder : IArtifactHostObjectBuilder
       }
       byGeometry[kv.Key] = argb;
       if (objByGeom.TryGetValue(kv.Key, out int objK) && bundle.ObjectAppIds.TryGetValue(objK, out var appId))
+      {
+        byObject[appId] = argb;
+      }
+    }
+
+    // Object-sourced edges (ord=1): a block placement's own colour. It owns no geometry, so it never appears in
+    // objByGeom — resolve it straight through the object dictionary [ENG-8822].
+    foreach (var kv in rels.ColorByObject)
+    {
+      if (
+        bundle.Nodes.TryGetValue(kv.Value, out var n)
+        && n.Kind == NodeKind.Color
+        && n.Argb is int argb
+        && bundle.ObjectAppIds.TryGetValue(kv.Key, out var appId)
+      )
       {
         byObject[appId] = argb;
       }

--- a/Connectors/Autocad/Speckle.Connectors.AutocadShared/Operations/Send/AutocadArtifactRootObjectBuilder.cs
+++ b/Connectors/Autocad/Speckle.Connectors.AutocadShared/Operations/Send/AutocadArtifactRootObjectBuilder.cs
@@ -738,7 +738,9 @@ public class AutocadArtifactRootObjectBuilder(
         }
         else if (instanceKByObjectId.ContainsKey(objectId))
         {
-          pipeline.HasColor(pipeline.InternObject(objectId), colorK);
+          // srcIsObject: the object and geometry K-spaces overlap numerically, so the edge carries a namespace
+          // tag (ord=1) — without it receive can't tell this from a geometry-sourced colour [ENG-8822].
+          pipeline.HasColor(pipeline.InternObject(objectId), colorK, srcIsObject: true);
         }
       }
     }

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/Operations/Send/RhinoArtifactRootObjectBuilder.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/Operations/Send/RhinoArtifactRootObjectBuilder.cs
@@ -709,7 +709,9 @@ public class RhinoArtifactRootObjectBuilder(
         {
           // block instance: no geometry of its own — emit the colour OBJECT-sourced (spec HAS_COLOR src is
           // geometry|object; the viewer looks up both) so per-placement overrides survive [ENG-8825].
-          pipeline.HasColor(pipeline.InternObject(objectId), colorK);
+          // srcIsObject: the object and geometry K-spaces overlap numerically, so the edge carries a namespace
+          // tag (ord=1) — without it receive can't tell this from a geometry-sourced colour [ENG-8822].
+          pipeline.HasColor(pipeline.InternObject(objectId), colorK, srcIsObject: true);
         }
       }
     }


### PR DESCRIPTION
A block sent with a red instance colour came back **all white** on AutoCAD→AutoCAD receive: the placement lost its colour, and its ByBlock member had nothing to inherit.

- `MapColors` read every HAS_COLOR src as a **geometry** K, so the object-sourced instance edge (shipped in #1473) never resolved. It now also reads `ColorByObject` — the ord=1 namespace tag from the SDK — straight through the object dictionary, so the `BlockReference` gets its colour.
- A definition member with **no** colour edge was ByBlock on send (explicit and ByLayer members both carry edges now), so it is baked with `ColorMethod.ByBlock` instead of the block record default — members inherit the placing reference's colour, matching AutoCAD semantics.
- Both send builders tag their object-sourced edge with `srcIsObject`.

**Requires** speckle-sharp-sdk PR (ord namespace tag) to merge first.

### Testing
Send a block with a red instance colour containing a ByBlock line + a ByLayer rectangle → receive: the reference comes back red, the line inherits red, the rectangle keeps its layer colour.

Builds clean: AutoCAD 2024/2026, Civil3D 2024, Rhino 7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/specklesystems/codesmith/speckle-sharp-connectors/pr/1478"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787439360&installation_model_id=3962&pr_number=1478&repository=specklesystems%2Fspeckle-sharp-connectors&return_to=https%3A%2F%2Fgithub.com%2Fspecklesystems%2Fspeckle-sharp-connectors%2Fpull%2F1478&signature=060e1492b3e365bf87eca93313f5b3ab65a124c6d37a44e7eebd0084bad413c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->