### PR TITLE
feat(rhino): Rhino 9/net10 head, headless connector slice, Build/BuildAndUpload split (ENG-8980)

### DIFF
--- a/Connectors/Autocad/Speckle.Connectors.AutocadShared/Operations/Receive/AutocadHostObjectArtefactBuilder.cs
+++ b/Connectors/Autocad/Speckle.Connectors.AutocadShared/Operations/Receive/AutocadHostObjectArtefactBuilder.cs
@@ -327,10 +327,9 @@ public class AutocadHostObjectArtefactBuilder : IArtifactHostObjectBuilder
     ArtefactBundle bundle
   )
   {
-    var display =
-      rels.DisplayByObject(objK) is { } displayEdges
-        ? displayEdges.OrderBy(x => x.Ord).Select(e => e.Dst).ToList()
-        : new List<int>();
+    var display = rels.DisplayByObject(objK) is { } displayEdges
+      ? displayEdges.OrderBy(x => x.Ord).Select(e => e.Dst).ToList()
+      : new List<int>();
     if (rels.SolidByObject.TryGetValue(objK, out var solidKs) && solidKs.Count > 0)
     {
       var decodable = solidKs

--- a/Connectors/Autocad/Speckle.Connectors.AutocadShared/Operations/Send/AutocadArtifactRootObjectBuilder.cs
+++ b/Connectors/Autocad/Speckle.Connectors.AutocadShared/Operations/Send/AutocadArtifactRootObjectBuilder.cs
@@ -268,7 +268,14 @@ public class AutocadArtifactRootObjectBuilder(
     {
       var instanceProps =
         instanceProxy["properties"] as Dictionary<string, object?> ?? new Dictionary<string, object?>();
-      return new CollectedObject(applicationId, sourceType, entity.Layer, instanceProps, instanceProxy, entity.Color.IsByLayer);
+      return new CollectedObject(
+        applicationId,
+        sourceType,
+        entity.Layer,
+        instanceProps,
+        instanceProxy,
+        entity.Color.IsByLayer
+      );
     }
 
     Base converted = converter.Convert(entity);

--- a/Connectors/Autocad/Speckle.Connectors.Civil3dShared/HostApp/PropertySetBaker.cs
+++ b/Connectors/Autocad/Speckle.Connectors.Civil3dShared/HostApp/PropertySetBaker.cs
@@ -386,12 +386,11 @@ public class PropertySetBaker
       {
         string propertyName = propertyEntry.Key;
 
-        object? value =
-          propertyEntry.Value is Dictionary<string, object?> propertyDataDict
-            ? propertyDataDict.TryGetValue("value", out var nested)
-              ? nested
-              : null
-            : propertyEntry.Value;
+        object? value = propertyEntry.Value is Dictionary<string, object?> propertyDataDict
+          ? propertyDataDict.TryGetValue("value", out var nested)
+            ? nested
+            : null
+          : propertyEntry.Value;
 
         if (value == null)
         {

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Receive/RevitHostObjectArtefactBuilder.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Receive/RevitHostObjectArtefactBuilder.cs
@@ -117,7 +117,10 @@ public sealed class RevitHostObjectArtefactBuilder : IArtifactHostObjectBuilder
     using var referencePointScope = _converterSettings.Push(s =>
       s with
       {
-        ReferencePointTransform = ReferencePointHelper.CalculateNewTransform(s.ReferencePointTransform, sourceReferencePoint),
+        ReferencePointTransform = ReferencePointHelper.CalculateNewTransform(
+          s.ReferencePointTransform,
+          sourceReferencePoint
+        ),
       }
     );
 

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Receive/RevitHostObjectBuilder.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Receive/RevitHostObjectBuilder.cs
@@ -248,7 +248,6 @@ public sealed class RevitHostObjectBuilder(
     );
   }
 
-
   private (
     HostObjectBuilderResult builderResult,
     List<(DirectShape res, string applicationId)> postBakePaintTargets

--- a/Connectors/Rhino/Speckle.Connectors.RhinoHeadless/Speckle.Connectors.RhinoHeadless.csproj
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoHeadless/Speckle.Connectors.RhinoHeadless.csproj
@@ -1,0 +1,55 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <!-- Headless (DUI3-free) slice of Speckle.Connectors.RhinoShared for the containerized converter legs:
+       the artefact send path around RhinoArtifactRootObjectBuilder, cherry-picked by file link. The shared
+       project compiles wholesale and hard-requires DUI3 WebView/WPF/RhinoWindows, so it cannot be consumed
+       headless as-is; this project links exactly the builder's closure. Consumed by the speckle-converters
+       host via sibling-checkout project references (Local configuration). -->
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Configurations>Debug;Release;Local</Configurations>
+    <DefineConstants>$(DefineConstants);RHINO9;RHINO7_OR_GREATER;RHINO8_OR_GREATER;RHINO9_OR_GREATER</DefineConstants>
+    <RootNamespace>Speckle.Connectors.Rhino</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- The Windows heads get this implicitly via UseWindowsForms; the slice only uses Color
+         (System.Drawing.Primitives — cross-platform). -->
+    <Using Include="System.Drawing" />
+    <!-- The WPF heads drop System.IO from implicit usings, so the shared files carry explicit
+         System.IO usings; mirror that view here or IDE0005 flags them as redundant. -->
+    <Using Remove="System.IO" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- Same exact pin as the Rhino 9 head (see its csproj for the lockstep rule). -->
+    <PackageReference
+      Include="RhinoCommon"
+      IncludeAssets="compile; build"
+      PrivateAssets="all"
+      VersionOverride="9.0.26167.11545-wip"
+    />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\Converters\Rhino\Speckle.Converters.Rhino9\Speckle.Converters.Rhino9.csproj" />
+    <ProjectReference Include="..\..\..\Sdk\Speckle.Connectors.Common\Speckle.Connectors.Common.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="..\Speckle.Connectors.RhinoShared\Operations\Send\RhinoArtifactRootObjectBuilder.cs" Link="Operations\Send\RhinoArtifactRootObjectBuilder.cs" />
+    <Compile Include="..\Speckle.Connectors.RhinoShared\HostApp\RhinoInstanceUnpacker.cs" Link="HostApp\RhinoInstanceUnpacker.cs" />
+    <Compile Include="..\Speckle.Connectors.RhinoShared\HostApp\RhinoMaterialUnpacker.cs" Link="HostApp\RhinoMaterialUnpacker.cs" />
+    <Compile Include="..\Speckle.Connectors.RhinoShared\HostApp\RhinoColorUnpacker.cs" Link="HostApp\RhinoColorUnpacker.cs" />
+    <Compile Include="..\Speckle.Connectors.RhinoShared\HostApp\RhinoLayerHelper.cs" Link="HostApp\RhinoLayerHelper.cs" />
+    <Compile Include="..\Speckle.Connectors.RhinoShared\HostApp\Properties\PropertiesExtractor.cs" Link="HostApp\Properties\PropertiesExtractor.cs" />
+    <Compile Include="..\Speckle.Connectors.RhinoShared\Mapper\Revit\CategoryMapping.cs" Link="Mapper\Revit\CategoryMapping.cs" />
+    <Compile Include="..\Speckle.Connectors.RhinoShared\Mapper\Revit\LayerCategoryMapping.cs" Link="Mapper\Revit\LayerCategoryMapping.cs" />
+    <Compile Include="..\Speckle.Connectors.RhinoShared\Mapper\Revit\LayerOption.cs" Link="Mapper\Revit\LayerOption.cs" />
+    <Compile Include="..\Speckle.Connectors.RhinoShared\Mapper\Revit\RevitMappingConstants.cs" Link="Mapper\Revit\RevitMappingConstants.cs" />
+    <Compile Include="..\Speckle.Connectors.RhinoShared\Mapper\Revit\RevitMappingResolver.cs" Link="Mapper\Revit\RevitMappingResolver.cs" />
+    <Compile Include="..\Speckle.Connectors.RhinoShared\Extensions\AttributeExtensions.cs" Link="Extensions\AttributeExtensions.cs" />
+    <Compile Include="..\Speckle.Connectors.RhinoShared\Extensions\BoundingBox.cs" Link="Extensions\BoundingBox.cs" />
+    <Compile Include="..\Speckle.Connectors.RhinoShared\Extensions\RhinoUnitsExtension.cs" Link="Extensions\RhinoUnitsExtension.cs" />
+    <Compile Include="..\Speckle.Connectors.RhinoShared\Extensions\SpeckleApplicationIdExtensions.cs" Link="Extensions\SpeckleApplicationIdExtensions.cs" />
+  </ItemGroup>
+</Project>

--- a/Connectors/Rhino/Speckle.Connectors.RhinoHeadless/Speckle.Connectors.RhinoHeadless.csproj
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoHeadless/Speckle.Connectors.RhinoHeadless.csproj
@@ -1,9 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <!-- Headless (DUI3-free) slice of Speckle.Connectors.RhinoShared for the containerized converter legs:
-       the artefact send path around RhinoArtifactRootObjectBuilder, cherry-picked by file link. The shared
-       project compiles wholesale and hard-requires DUI3 WebView/WPF/RhinoWindows, so it cannot be consumed
-       headless as-is; this project links exactly the builder's closure. Consumed by the speckle-converters
-       host via sibling-checkout project references (Local configuration). -->
+  <!-- Headless (DUI3-free) slice of Speckle.Connectors.RhinoShared: the artefact send path around
+       RhinoArtifactRootObjectBuilder, linked file-by-file because the shared project hard-requires
+       DUI3 WebView/WPF/RhinoWindows and cannot be consumed headless wholesale. Consumed by the
+       speckle-converters host via sibling-checkout project references. -->
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <Configurations>Debug;Release;Local</Configurations>
@@ -12,8 +11,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- The Windows heads get this implicitly via UseWindowsForms; the slice only uses Color
-         (System.Drawing.Primitives — cross-platform). -->
+    <!-- The Windows heads get this implicit using via UseWindowsForms; here it resolves to the
+         cross-platform System.Drawing.Primitives types. -->
     <Using Include="System.Drawing" />
     <!-- The WPF heads drop System.IO from implicit usings, so the shared files carry explicit
          System.IO usings; mirror that view here or IDE0005 flags them as redundant. -->
@@ -36,20 +35,62 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Include="..\Speckle.Connectors.RhinoShared\Operations\Send\RhinoArtifactRootObjectBuilder.cs" Link="Operations\Send\RhinoArtifactRootObjectBuilder.cs" />
-    <Compile Include="..\Speckle.Connectors.RhinoShared\HostApp\RhinoInstanceUnpacker.cs" Link="HostApp\RhinoInstanceUnpacker.cs" />
-    <Compile Include="..\Speckle.Connectors.RhinoShared\HostApp\RhinoMaterialUnpacker.cs" Link="HostApp\RhinoMaterialUnpacker.cs" />
-    <Compile Include="..\Speckle.Connectors.RhinoShared\HostApp\RhinoColorUnpacker.cs" Link="HostApp\RhinoColorUnpacker.cs" />
-    <Compile Include="..\Speckle.Connectors.RhinoShared\HostApp\RhinoLayerHelper.cs" Link="HostApp\RhinoLayerHelper.cs" />
-    <Compile Include="..\Speckle.Connectors.RhinoShared\HostApp\Properties\PropertiesExtractor.cs" Link="HostApp\Properties\PropertiesExtractor.cs" />
-    <Compile Include="..\Speckle.Connectors.RhinoShared\Mapper\Revit\CategoryMapping.cs" Link="Mapper\Revit\CategoryMapping.cs" />
-    <Compile Include="..\Speckle.Connectors.RhinoShared\Mapper\Revit\LayerCategoryMapping.cs" Link="Mapper\Revit\LayerCategoryMapping.cs" />
-    <Compile Include="..\Speckle.Connectors.RhinoShared\Mapper\Revit\LayerOption.cs" Link="Mapper\Revit\LayerOption.cs" />
-    <Compile Include="..\Speckle.Connectors.RhinoShared\Mapper\Revit\RevitMappingConstants.cs" Link="Mapper\Revit\RevitMappingConstants.cs" />
-    <Compile Include="..\Speckle.Connectors.RhinoShared\Mapper\Revit\RevitMappingResolver.cs" Link="Mapper\Revit\RevitMappingResolver.cs" />
-    <Compile Include="..\Speckle.Connectors.RhinoShared\Extensions\AttributeExtensions.cs" Link="Extensions\AttributeExtensions.cs" />
+    <Compile
+      Include="..\Speckle.Connectors.RhinoShared\Operations\Send\RhinoArtifactRootObjectBuilder.cs"
+      Link="Operations\Send\RhinoArtifactRootObjectBuilder.cs"
+    />
+    <Compile
+      Include="..\Speckle.Connectors.RhinoShared\HostApp\RhinoInstanceUnpacker.cs"
+      Link="HostApp\RhinoInstanceUnpacker.cs"
+    />
+    <Compile
+      Include="..\Speckle.Connectors.RhinoShared\HostApp\RhinoMaterialUnpacker.cs"
+      Link="HostApp\RhinoMaterialUnpacker.cs"
+    />
+    <Compile
+      Include="..\Speckle.Connectors.RhinoShared\HostApp\RhinoColorUnpacker.cs"
+      Link="HostApp\RhinoColorUnpacker.cs"
+    />
+    <Compile
+      Include="..\Speckle.Connectors.RhinoShared\HostApp\RhinoLayerHelper.cs"
+      Link="HostApp\RhinoLayerHelper.cs"
+    />
+    <Compile
+      Include="..\Speckle.Connectors.RhinoShared\HostApp\Properties\PropertiesExtractor.cs"
+      Link="HostApp\Properties\PropertiesExtractor.cs"
+    />
+    <Compile
+      Include="..\Speckle.Connectors.RhinoShared\Mapper\Revit\CategoryMapping.cs"
+      Link="Mapper\Revit\CategoryMapping.cs"
+    />
+    <Compile
+      Include="..\Speckle.Connectors.RhinoShared\Mapper\Revit\LayerCategoryMapping.cs"
+      Link="Mapper\Revit\LayerCategoryMapping.cs"
+    />
+    <Compile
+      Include="..\Speckle.Connectors.RhinoShared\Mapper\Revit\LayerOption.cs"
+      Link="Mapper\Revit\LayerOption.cs"
+    />
+    <Compile
+      Include="..\Speckle.Connectors.RhinoShared\Mapper\Revit\RevitMappingConstants.cs"
+      Link="Mapper\Revit\RevitMappingConstants.cs"
+    />
+    <Compile
+      Include="..\Speckle.Connectors.RhinoShared\Mapper\Revit\RevitMappingResolver.cs"
+      Link="Mapper\Revit\RevitMappingResolver.cs"
+    />
+    <Compile
+      Include="..\Speckle.Connectors.RhinoShared\Extensions\AttributeExtensions.cs"
+      Link="Extensions\AttributeExtensions.cs"
+    />
     <Compile Include="..\Speckle.Connectors.RhinoShared\Extensions\BoundingBox.cs" Link="Extensions\BoundingBox.cs" />
-    <Compile Include="..\Speckle.Connectors.RhinoShared\Extensions\RhinoUnitsExtension.cs" Link="Extensions\RhinoUnitsExtension.cs" />
-    <Compile Include="..\Speckle.Connectors.RhinoShared\Extensions\SpeckleApplicationIdExtensions.cs" Link="Extensions\SpeckleApplicationIdExtensions.cs" />
+    <Compile
+      Include="..\Speckle.Connectors.RhinoShared\Extensions\RhinoUnitsExtension.cs"
+      Link="Extensions\RhinoUnitsExtension.cs"
+    />
+    <Compile
+      Include="..\Speckle.Connectors.RhinoShared\Extensions\SpeckleApplicationIdExtensions.cs"
+      Link="Extensions\SpeckleApplicationIdExtensions.cs"
+    />
   </ItemGroup>
 </Project>

--- a/Connectors/Rhino/Speckle.Connectors.RhinoHeadless/packages.lock.json
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoHeadless/packages.lock.json
@@ -1,0 +1,265 @@
+{
+  "version": 2,
+  "dependencies": {
+    "net10.0": {
+      "Microsoft.NETFramework.ReferenceAssemblies": {
+        "type": "Direct",
+        "requested": "[1.0.3, )",
+        "resolved": "1.0.3",
+        "contentHash": "vUc9Npcs14QsyOD01tnv/m8sQUnGTGOw1BCmKcv77LBJY7OxhJ+zJF7UD/sCL3lYNFuqmQEVlkfS4Quif6FyYg==",
+        "dependencies": {
+          "Microsoft.NETFramework.ReferenceAssemblies.net461": "1.0.3"
+        }
+      },
+      "PolySharp": {
+        "type": "Direct",
+        "requested": "[1.15.0, )",
+        "resolved": "1.15.0",
+        "contentHash": "FbU0El+EEjdpuIX4iDbeS7ki1uzpJPx8vbqOzEtqnl1GZeAGJfq+jCbxeJL2y0EPnUNk8dRnnqR2xnYXg9Tf+g=="
+      },
+      "RhinoCommon": {
+        "type": "Direct",
+        "requested": "[9.0.26167.11545-wip, )",
+        "resolved": "9.0.26167.11545-wip",
+        "contentHash": "ZGR2Zdv6P7avp6CAuMM1jK7suOZquHMSORbvIq4NthjVQwdYWJEPBVixFNJguPiEStGIoYzPgJe8RcVNhki5CA==",
+        "dependencies": {
+          "System.Drawing.Common": "8.0.0"
+        }
+      },
+      "Speckle.InterfaceGenerator": {
+        "type": "Direct",
+        "requested": "[0.9.6, )",
+        "resolved": "0.9.6",
+        "contentHash": "HKH7tYrYYlCK1ct483hgxERAdVdMtl7gUKW9ijWXxA1UsYR4Z+TrRHYmzZ9qmpu1NnTycSrp005NYM78GDKV1w=="
+      },
+      "GraphQL.Client": {
+        "type": "Transitive",
+        "resolved": "6.1.0",
+        "contentHash": "oKliAxtNuZDMxO9079mjSbwA0YwhjXBzVnVPuNZ3HI4OllO++CcOLT30l90mM/fxCAMaa8GU4ZYMwD9YjLkyiw==",
+        "dependencies": {
+          "GraphQL.Client.Abstractions": "6.1.0",
+          "GraphQL.Client.Abstractions.Websocket": "6.1.0",
+          "System.Reactive": "6.0.0"
+        }
+      },
+      "GraphQL.Client.Abstractions": {
+        "type": "Transitive",
+        "resolved": "6.1.0",
+        "contentHash": "Za31wjKLEeROZYJmp0Lmj/TLQ1Yw6x6QM0JHABcuyMC3OSopr34ufayrtdxtbL1a3129FTVFKOFC0hcooSQoJQ==",
+        "dependencies": {
+          "GraphQL.Primitives": "6.1.0"
+        }
+      },
+      "GraphQL.Client.Abstractions.Websocket": {
+        "type": "Transitive",
+        "resolved": "6.1.0",
+        "contentHash": "PjdG3q4MzPsa5NiBOBhuIRMRTo59der5bFmX2r1gSS3RIjytwpooxF2RffFCBh16sqbwuH1/dllDcNG+EJt1qA==",
+        "dependencies": {
+          "GraphQL.Client.Abstractions": "6.1.0"
+        }
+      },
+      "GraphQL.Primitives": {
+        "type": "Transitive",
+        "resolved": "6.1.0",
+        "contentHash": "L8yQ70Wd9p8hMJvnmpgyZfr2R6Q7S0/lPyEBI1tacJa5XzsoJSVtHdmfsMaHyufwk03hlUsBXgNerAs66kxHdA=="
+      },
+      "Microsoft.Data.Sqlite": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "I/azQ5WjwoLvSlTyDydkhARPSjYJN8jkXRjR5D92OeyTLbTrQ1K93rgf6XU+HYWHZA6lBI9SUOfl69OqEHb4ow==",
+        "dependencies": {
+          "Microsoft.Data.Sqlite.Core": "10.0.0",
+          "SQLitePCLRaw.bundle_e_sqlite3": "2.1.11",
+          "SQLitePCLRaw.core": "2.1.11"
+        }
+      },
+      "Microsoft.Data.Sqlite.Core": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "wPKG/Ym6tSMCo06UOZXzVfeFGzawnOZrTba/R3PfK+RhNuNELZ9I7nFns4WGTtv2kKlrlmmErgJ+kgTXHaNdHg==",
+        "dependencies": {
+          "SQLitePCLRaw.core": "2.1.11"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "f0RBabswJq+gRu5a+hWIobrLWiUYPKMhCD9WO3sYBAdSy3FFH14LMvLVFZc2kPSCimBLxSuitUhsd6tb0TAY6A==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "L3AdmZ1WOK4XXT5YFPEwyt0ep6l8lGIPs7F5OOBZc77Zqeo01Of7XXICy47628sdVl0v/owxYJTe86DTgFwKCA=="
+      },
+      "Microsoft.Extensions.Logging": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "BStFkd5CcnEtarlcgYDBcFzGYCuuNMzPs02wN3WBsOFoYIEmYoUdAiU+au6opzoqfTYJsMTW00AeqDdnXH2CvA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection": "10.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Options": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Logging.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "FU/IfjDfwaMuKr414SSQNTIti/69bHEMb+QKrskRb26oVqpx3lNFXMjs/RC9ZUuhBhcwDM2BwOgoMw+PZ+beqQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.ObjectPool": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "bpeCq0IYmVLACyEUMzFIOQX+zZUElG1t+nu1lSxthe7B+1oNYking7b91305+jNB6iwojp9fqTY9O+Nh7ULQxg=="
+      },
+      "Microsoft.Extensions.Options": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "8oCAgXOow5XDrY9HaXX1QmH3ORsyZO/ANVHBlhLyCeWTH5Sg4UuqZeOTWJi6484M+LqSx0RqQXDJtdYy2BNiLQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Primitives": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Primitives": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "inRnbpCS0nwO/RuoZIAqxQUuyjaknOOnCEZB55KSMMjRhl0RQDttSmLSGsUJN3RQ3ocf5NDLFd2mOQViHqMK5w=="
+      },
+      "Microsoft.NETFramework.ReferenceAssemblies.net461": {
+        "type": "Transitive",
+        "resolved": "1.0.3",
+        "contentHash": "AmOJZwCqnOCNp6PPcf9joyogScWLtwy0M1WkqfEQ0M9nYwyDD7EX9ZjscKS5iYnyvteX7kzSKFCKt9I9dXA6mA=="
+      },
+      "Microsoft.Win32.SystemEvents": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "9opKRyOKMCi2xJ7Bj7kxtZ1r9vbzosMvRrdEhVhDz8j8MoBGgB+WmC94yH839NPH+BclAjtQ/pyagvi/8gDLkw=="
+      },
+      "Speckle.Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "13.0.2",
+        "contentHash": "g1BejUZwax5PRfL6xHgLEK23sqHWOgOj9hE7RvfRRlN00AGt8GnPYt8HedSK7UB3HiRW8zCA9Pn0iiYxCK24BA=="
+      },
+      "SQLitePCLRaw.bundle_e_sqlite3": {
+        "type": "Transitive",
+        "resolved": "2.1.11",
+        "contentHash": "DC4nA7yWnf4UZdgJDF+9Mus4/cb0Y3Sfgi3gDnAoKNAIBwzkskNAbNbyu+u4atT0ruVlZNJfwZmwiEwE5oz9LQ==",
+        "dependencies": {
+          "SQLitePCLRaw.lib.e_sqlite3": "2.1.11",
+          "SQLitePCLRaw.provider.e_sqlite3": "2.1.11"
+        }
+      },
+      "SQLitePCLRaw.core": {
+        "type": "Transitive",
+        "resolved": "2.1.11",
+        "contentHash": "PK0GLFkfhZzLQeR3PJf71FmhtHox+U3vcY6ZtswoMjrefkB9k6ErNJEnwXqc5KgXDSjige2XXrezqS39gkpQKA=="
+      },
+      "SQLitePCLRaw.lib.e_sqlite3": {
+        "type": "Transitive",
+        "resolved": "2.1.11",
+        "contentHash": "Ev2ytaXiOlWZ4b3R67GZBsemTINslLD1DCJr2xiacpn4tbapu0Q4dHEzSvZSMnVWeE5nlObU3VZN2p81q3XOYQ=="
+      },
+      "SQLitePCLRaw.provider.e_sqlite3": {
+        "type": "Transitive",
+        "resolved": "2.1.11",
+        "contentHash": "Y/0ZkR+r0Cg3DQFuCl1RBnv/tmxpIZRU3HUvelPw6MVaKHwYYR8YNvgs0vuNuXCMvlyJ+Fh88U1D4tah1tt6qw==",
+        "dependencies": {
+          "SQLitePCLRaw.core": "2.1.11"
+        }
+      },
+      "System.Drawing.Common": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "JkbHJjtI/dWc5dfmEdJlbe3VwgZqCkZRtfuWFh5GOv0f+gGCfBtzMpIVkmdkj2AObO9y+oiOi81UGwH3aBYuqA==",
+        "dependencies": {
+          "Microsoft.Win32.SystemEvents": "8.0.0"
+        }
+      },
+      "System.Reactive": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "31kfaW4ZupZzPsI5PVe77VhnvFF55qgma7KZr/E0iFTs6fmdhhG8j0mgEx620iLTey1EynOkEfnyTjtNEpJzGw=="
+      },
+      "speckle.connectors.common": {
+        "type": "Project",
+        "dependencies": {
+          "Speckle.Connectors.Logging": "[1.0.0, )",
+          "Speckle.Converters.Common": "[1.0.0, )",
+          "Speckle.Objects": "[1.0.0, )"
+        }
+      },
+      "speckle.connectors.logging": {
+        "type": "Project"
+      },
+      "speckle.converters.common": {
+        "type": "Project",
+        "dependencies": {
+          "Speckle.Objects": "[1.0.0, )"
+        }
+      },
+      "speckle.converters.rhino9": {
+        "type": "Project",
+        "dependencies": {
+          "Rhino.Inside": "[9.0.26084.13070-beta, )",
+          "Speckle.Converters.Common": "[1.0.0, )"
+        }
+      },
+      "speckle.objects": {
+        "type": "Project",
+        "dependencies": {
+          "Speckle.Sdk": "[1.0.0, )"
+        }
+      },
+      "speckle.sdk": {
+        "type": "Project",
+        "dependencies": {
+          "GraphQL.Client": "[6.1.0, )",
+          "Microsoft.Data.Sqlite": "[10.0.0, )",
+          "Microsoft.Extensions.Logging": "[10.0.0, )",
+          "Microsoft.Extensions.ObjectPool": "[10.0.0, )",
+          "Speckle.DoubleNumerics": "[4.1.0, )",
+          "Speckle.Newtonsoft.Json": "[13.0.2, )",
+          "Speckle.Sdk.Dependencies": "[1.0.0, )",
+          "Speckle.Sdk.Parquet": "[1.0.0, )"
+        }
+      },
+      "speckle.sdk.dependencies": {
+        "type": "Project"
+      },
+      "speckle.sdk.parquet": {
+        "type": "Project"
+      },
+      "Grasshopper": {
+        "type": "CentralTransitive",
+        "requested": "[8.31.26126.13431, )",
+        "resolved": "9.0.25350.305-wip",
+        "contentHash": "xpHvialc/neqxzvgIAguSPpqT/db40a1kX3idmEPH1eOHI/vgt9nNtjfp3xjKgGwd5od4PY24SzqkwD7dh87Aw==",
+        "dependencies": {
+          "RhinoCommon": "[9.0.25350.305-wip]"
+        }
+      },
+      "Rhino.Inside": {
+        "type": "CentralTransitive",
+        "requested": "[8.0.7-beta, )",
+        "resolved": "9.0.26084.13070-beta",
+        "contentHash": "aCDeFv/AMA7qm4hXBGn8Dy8rdskP+u0kRuFpWU7ksmZH3rDeLmoyqJUweN70PW0wuG+2KtlgHU6sjMS/QcDQ/Q==",
+        "dependencies": {
+          "Grasshopper": "9.0.25350.305-wip",
+          "RhinoCommon": "9.0.25350.305-wip"
+        }
+      },
+      "Speckle.DoubleNumerics": {
+        "type": "CentralTransitive",
+        "requested": "[4.1.0, )",
+        "resolved": "4.1.0",
+        "contentHash": "20DtS+FsDRsOD9+AU3TwNFZ0qrKo5f6f7B5ZR9wStsIHHHC9k7DpjbCvuNtmnSjx54MD+TJC7wV2f5iyGVPj1A=="
+      }
+    }
+  }
+}

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/Operations/Send/RhinoArtifactRootObjectBuilder.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/Operations/Send/RhinoArtifactRootObjectBuilder.cs
@@ -132,9 +132,8 @@ public class RhinoArtifactRootObjectBuilder(
 
   /// <summary>
   /// Build-only entry point: converts <paramref name="objects"/> and writes the artefact bundle into
-  /// <paramref name="outputDir"/>, touching no auth, storage, or server API. Headless hosts (the containerized
-  /// converter legs) call this and hand the outdir to their own uploader; <see cref="BuildAndUpload"/> is this
-  /// plus the connector's in-process upload.
+  /// <paramref name="outputDir"/> — no auth, storage, or server API involved. For hosts that upload out of
+  /// process (the headless converter legs); <see cref="BuildAndUpload"/> is the in-process path.
   /// </summary>
   public async Task<ArtifactBundleResult> Build(
     IReadOnlyList<RhinoObject> objects,
@@ -150,8 +149,7 @@ public class RhinoArtifactRootObjectBuilder(
     return await BuildCore(objects, session, versionId, outputDir, onOperationProgressed, cancellationToken);
   }
 
-  // Collect + write under one session: phase 1 on the Rhino UI thread, phase 2 on a worker thread (the artefact
-  // pipeline's sync-over-async parquet IO deadlocks on a UI SynchronizationContext — see the class <remarks>).
+  // Collect must run on the Rhino UI thread and the bundle write on a worker — see the class <remarks>.
   private async Task<ArtifactBundleResult> BuildCore(
     IReadOnlyList<RhinoObject> objects,
     ArtefactSessionLog session,

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/Operations/Send/RhinoArtifactRootObjectBuilder.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/Operations/Send/RhinoArtifactRootObjectBuilder.cs
@@ -96,25 +96,18 @@ public class RhinoArtifactRootObjectBuilder(
     // Per-session diagnostics (per-object timing/failures, phase timings, bundle stats) → %TEMP%\Speckle\sessions\.
     using var session = ArtefactSessionLog.Start("Rhino", ArtefactDirection.Send, projectId, null, versionId, logger);
 
-    // Phase 1 — convert + unpack on the Rhino UI thread (RhinoCommon is main-thread-affine) → pure-Speckle snapshot.
-    CollectedModel collected;
-    using (session.Phase("Collect"))
-    {
-      collected = await threadContext.RunOnMainAsync(() =>
-        Task.FromResult(CollectOnMain(objects, session, onOperationProgressed, cancellationToken))
-      );
-    }
+    ArtifactBundleResult built = await BuildCore(
+      objects,
+      session,
+      versionId,
+      outputDir,
+      onOperationProgressed,
+      cancellationToken
+    );
 
-    // Phase 2 — build the parquet bundle + upload on a WORKER thread (no UI SynchronizationContext/TaskScheduler,
-    // so the pipeline's sync-over-async parquet IO doesn't deadlock — see the class <remarks>).
+    // Upload on a WORKER thread too — same reasoning as the write phase (see the class <remarks>).
     return await threadContext.RunOnWorkerAsync(async () =>
     {
-      BundleResult built;
-      using (session.Phase("Write"))
-      {
-        built = WriteBundle(collected, session, versionId, outputDir, onOperationProgressed, cancellationToken);
-      }
-
       using var pipeline = artifactPipelineFactory.CreateInstance(
         projectId,
         ingestionId,
@@ -133,7 +126,57 @@ public class RhinoArtifactRootObjectBuilder(
           .ConfigureAwait(false);
       }
 
-      return new ArtifactBuildResult(finalVersionId, built.RootId, built.Results);
+      return new ArtifactBuildResult(finalVersionId, built.RootId, built.ConversionResults);
+    });
+  }
+
+  /// <summary>
+  /// Build-only entry point: converts <paramref name="objects"/> and writes the artefact bundle into
+  /// <paramref name="outputDir"/>, touching no auth, storage, or server API. Headless hosts (the containerized
+  /// converter legs) call this and hand the outdir to their own uploader; <see cref="BuildAndUpload"/> is this
+  /// plus the connector's in-process upload.
+  /// </summary>
+  public async Task<ArtifactBundleResult> Build(
+    IReadOnlyList<RhinoObject> objects,
+    string? projectId,
+    string versionId,
+    string outputDir,
+    IProgress<CardProgress> onOperationProgressed,
+    CancellationToken cancellationToken
+  )
+  {
+    Directory.CreateDirectory(outputDir);
+    using var session = ArtefactSessionLog.Start("Rhino", ArtefactDirection.Send, projectId, null, versionId, logger);
+    return await BuildCore(objects, session, versionId, outputDir, onOperationProgressed, cancellationToken);
+  }
+
+  // Collect + write under one session: phase 1 on the Rhino UI thread, phase 2 on a worker thread (the artefact
+  // pipeline's sync-over-async parquet IO deadlocks on a UI SynchronizationContext — see the class <remarks>).
+  private async Task<ArtifactBundleResult> BuildCore(
+    IReadOnlyList<RhinoObject> objects,
+    ArtefactSessionLog session,
+    string versionId,
+    string outputDir,
+    IProgress<CardProgress> onOperationProgressed,
+    CancellationToken cancellationToken
+  )
+  {
+    CollectedModel collected;
+    using (session.Phase("Collect"))
+    {
+      collected = await threadContext.RunOnMainAsync(() =>
+        Task.FromResult(CollectOnMain(objects, session, onOperationProgressed, cancellationToken))
+      );
+    }
+
+    return await threadContext.RunOnWorkerAsync(() =>
+    {
+      using (session.Phase("Write"))
+      {
+        return Task.FromResult(
+          WriteBundle(collected, session, versionId, outputDir, onOperationProgressed, cancellationToken)
+        );
+      }
     });
   }
 
@@ -405,7 +448,7 @@ public class RhinoArtifactRootObjectBuilder(
 
   // ── Phase 2 (worker thread): pure-Speckle snapshot → parquet bundle ──────────────────────────────────
   [SuppressMessage("Maintainability", "CA1506:Avoid excessive class coupling")]
-  private BundleResult WriteBundle(
+  private ArtifactBundleResult WriteBundle(
     CollectedModel model,
     ArtefactSessionLog session,
     string versionId,
@@ -498,7 +541,7 @@ public class RhinoArtifactRootObjectBuilder(
     session.SetStat("groups", model.Groups.Count);
 
     logger.LogInformation("Built artefact bundle: {fileCount} files, {objectCount} objects", bundle.Count, objectCount);
-    return new BundleResult(bundle, rootId, objectCount, results);
+    return new ArtifactBundleResult(bundle, rootId, objectCount, results);
   }
 
   // Emits one object: eav labels + IN_COLLECTION, then a block placement (DISPLAY_INSTANCE → INSTANCE node) or
@@ -829,13 +872,6 @@ public class RhinoArtifactRootObjectBuilder(
     IReadOnlyList<InstanceDefinitionProxy> Definitions,
     IReadOnlyList<CollectedGroup> Groups,
     IReadOnlyList<CameraView> CameraViews,
-    IReadOnlyList<SendConversionResult> Results
-  );
-
-  private sealed record BundleResult(
-    IReadOnlyDictionary<string, string> Bundle,
-    string RootId,
-    int ObjectCount,
     IReadOnlyList<SendConversionResult> Results
   );
 }

--- a/Converters/Rhino/Speckle.Converters.Rhino9/Speckle.Converters.Rhino9.csproj
+++ b/Converters/Rhino/Speckle.Converters.Rhino9/Speckle.Converters.Rhino9.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <!-- Rhino 9 WIP head for the headless linux converter leg (rhino.inside, net10). Consumed by the
-       speckle-converters host via sibling-checkout project references (Local configuration).
+  <!-- Rhino 9 WIP head for the headless linux converter leg (rhino.inside, net10), consumed by the
+       speckle-converters host via sibling-checkout project references.
        EXACT version pins only: the RhinoCommon/Rhino.Inside pins move in lockstep with the converters
-       image's rhino3d deb pin (monthly WIP rebuild) — a float on either side silently skews the managed
-       API surface against the installed Rhino and fails at runtime. -->
+       image's rhino3d deb pin — a float on either side silently skews the managed API surface against
+       the installed Rhino and fails at runtime. -->
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <Configurations>Debug;Release;Local</Configurations>

--- a/Converters/Rhino/Speckle.Converters.Rhino9/Speckle.Converters.Rhino9.csproj
+++ b/Converters/Rhino/Speckle.Converters.Rhino9/Speckle.Converters.Rhino9.csproj
@@ -1,0 +1,37 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <!-- Rhino 9 WIP head for the headless linux converter leg (rhino.inside, net10). Consumed by the
+       speckle-converters host via sibling-checkout project references (Local configuration).
+       EXACT version pins only: the RhinoCommon/Rhino.Inside pins move in lockstep with the converters
+       image's rhino3d deb pin (monthly WIP rebuild) — a float on either side silently skews the managed
+       API surface against the installed Rhino and fails at runtime. -->
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Configurations>Debug;Release;Local</Configurations>
+    <DefineConstants>$(DefineConstants);RHINO9;RHINO7_OR_GREATER;RHINO8_OR_GREATER;RHINO9_OR_GREATER</DefineConstants>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference
+      Include="RhinoCommon"
+      IncludeAssets="compile; build"
+      PrivateAssets="all"
+      VersionOverride="9.0.26167.11545-wip"
+    />
+    <!-- Resolver for hosts that boot Rhino in-process; flows transitively so the host exe inherits the pin. -->
+    <PackageReference Include="Rhino.Inside" VersionOverride="9.0.26084.13070-beta" />
+    <!-- Not used by the converter: pinned only to keep restore consistent — Rhino.Inside's open-range
+         Grasshopper floor exact-pins an older RhinoCommon (NU1608). Same date-code as the RhinoCommon pin. -->
+    <PackageReference
+      Include="Grasshopper"
+      IncludeAssets="compile; build"
+      PrivateAssets="all"
+      VersionOverride="9.0.26167.11545-wip"
+    />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\Sdk\Speckle.Converters.Common\Speckle.Converters.Common.csproj" />
+  </ItemGroup>
+
+  <Import Project="..\Speckle.Converters.RhinoShared\Speckle.Converters.RhinoShared.projitems" Label="Shared" />
+</Project>

--- a/Converters/Rhino/Speckle.Converters.Rhino9/packages.lock.json
+++ b/Converters/Rhino/Speckle.Converters.Rhino9/packages.lock.json
@@ -1,0 +1,247 @@
+{
+  "version": 2,
+  "dependencies": {
+    "net10.0": {
+      "Grasshopper": {
+        "type": "Direct",
+        "requested": "[9.0.26167.11545-wip, )",
+        "resolved": "9.0.26167.11545-wip",
+        "contentHash": "ZYBijH+YZYD/rbUeRD5tjrebYA5fVVUj4quKg4EI1FMR3N+pMQ0KOH+9XPzRv7OvYznoDB68GeRf2tsdbOJrYA==",
+        "dependencies": {
+          "RhinoCommon": "[9.0.26167.11545-wip]"
+        }
+      },
+      "Microsoft.NETFramework.ReferenceAssemblies": {
+        "type": "Direct",
+        "requested": "[1.0.3, )",
+        "resolved": "1.0.3",
+        "contentHash": "vUc9Npcs14QsyOD01tnv/m8sQUnGTGOw1BCmKcv77LBJY7OxhJ+zJF7UD/sCL3lYNFuqmQEVlkfS4Quif6FyYg==",
+        "dependencies": {
+          "Microsoft.NETFramework.ReferenceAssemblies.net461": "1.0.3"
+        }
+      },
+      "PolySharp": {
+        "type": "Direct",
+        "requested": "[1.15.0, )",
+        "resolved": "1.15.0",
+        "contentHash": "FbU0El+EEjdpuIX4iDbeS7ki1uzpJPx8vbqOzEtqnl1GZeAGJfq+jCbxeJL2y0EPnUNk8dRnnqR2xnYXg9Tf+g=="
+      },
+      "Rhino.Inside": {
+        "type": "Direct",
+        "requested": "[9.0.26084.13070-beta, )",
+        "resolved": "9.0.26084.13070-beta",
+        "contentHash": "aCDeFv/AMA7qm4hXBGn8Dy8rdskP+u0kRuFpWU7ksmZH3rDeLmoyqJUweN70PW0wuG+2KtlgHU6sjMS/QcDQ/Q==",
+        "dependencies": {
+          "Grasshopper": "9.0.25350.305-wip",
+          "RhinoCommon": "9.0.25350.305-wip"
+        }
+      },
+      "RhinoCommon": {
+        "type": "Direct",
+        "requested": "[9.0.26167.11545-wip, )",
+        "resolved": "9.0.26167.11545-wip",
+        "contentHash": "ZGR2Zdv6P7avp6CAuMM1jK7suOZquHMSORbvIq4NthjVQwdYWJEPBVixFNJguPiEStGIoYzPgJe8RcVNhki5CA==",
+        "dependencies": {
+          "System.Drawing.Common": "8.0.0"
+        }
+      },
+      "Speckle.InterfaceGenerator": {
+        "type": "Direct",
+        "requested": "[0.9.6, )",
+        "resolved": "0.9.6",
+        "contentHash": "HKH7tYrYYlCK1ct483hgxERAdVdMtl7gUKW9ijWXxA1UsYR4Z+TrRHYmzZ9qmpu1NnTycSrp005NYM78GDKV1w=="
+      },
+      "GraphQL.Client": {
+        "type": "Transitive",
+        "resolved": "6.1.0",
+        "contentHash": "oKliAxtNuZDMxO9079mjSbwA0YwhjXBzVnVPuNZ3HI4OllO++CcOLT30l90mM/fxCAMaa8GU4ZYMwD9YjLkyiw==",
+        "dependencies": {
+          "GraphQL.Client.Abstractions": "6.1.0",
+          "GraphQL.Client.Abstractions.Websocket": "6.1.0",
+          "System.Reactive": "6.0.0"
+        }
+      },
+      "GraphQL.Client.Abstractions": {
+        "type": "Transitive",
+        "resolved": "6.1.0",
+        "contentHash": "Za31wjKLEeROZYJmp0Lmj/TLQ1Yw6x6QM0JHABcuyMC3OSopr34ufayrtdxtbL1a3129FTVFKOFC0hcooSQoJQ==",
+        "dependencies": {
+          "GraphQL.Primitives": "6.1.0"
+        }
+      },
+      "GraphQL.Client.Abstractions.Websocket": {
+        "type": "Transitive",
+        "resolved": "6.1.0",
+        "contentHash": "PjdG3q4MzPsa5NiBOBhuIRMRTo59der5bFmX2r1gSS3RIjytwpooxF2RffFCBh16sqbwuH1/dllDcNG+EJt1qA==",
+        "dependencies": {
+          "GraphQL.Client.Abstractions": "6.1.0"
+        }
+      },
+      "GraphQL.Primitives": {
+        "type": "Transitive",
+        "resolved": "6.1.0",
+        "contentHash": "L8yQ70Wd9p8hMJvnmpgyZfr2R6Q7S0/lPyEBI1tacJa5XzsoJSVtHdmfsMaHyufwk03hlUsBXgNerAs66kxHdA=="
+      },
+      "Microsoft.Data.Sqlite": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "I/azQ5WjwoLvSlTyDydkhARPSjYJN8jkXRjR5D92OeyTLbTrQ1K93rgf6XU+HYWHZA6lBI9SUOfl69OqEHb4ow==",
+        "dependencies": {
+          "Microsoft.Data.Sqlite.Core": "10.0.0",
+          "SQLitePCLRaw.bundle_e_sqlite3": "2.1.11",
+          "SQLitePCLRaw.core": "2.1.11"
+        }
+      },
+      "Microsoft.Data.Sqlite.Core": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "wPKG/Ym6tSMCo06UOZXzVfeFGzawnOZrTba/R3PfK+RhNuNELZ9I7nFns4WGTtv2kKlrlmmErgJ+kgTXHaNdHg==",
+        "dependencies": {
+          "SQLitePCLRaw.core": "2.1.11"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "f0RBabswJq+gRu5a+hWIobrLWiUYPKMhCD9WO3sYBAdSy3FFH14LMvLVFZc2kPSCimBLxSuitUhsd6tb0TAY6A==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "L3AdmZ1WOK4XXT5YFPEwyt0ep6l8lGIPs7F5OOBZc77Zqeo01Of7XXICy47628sdVl0v/owxYJTe86DTgFwKCA=="
+      },
+      "Microsoft.Extensions.Logging": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "BStFkd5CcnEtarlcgYDBcFzGYCuuNMzPs02wN3WBsOFoYIEmYoUdAiU+au6opzoqfTYJsMTW00AeqDdnXH2CvA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection": "10.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Options": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Logging.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "FU/IfjDfwaMuKr414SSQNTIti/69bHEMb+QKrskRb26oVqpx3lNFXMjs/RC9ZUuhBhcwDM2BwOgoMw+PZ+beqQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.ObjectPool": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "bpeCq0IYmVLACyEUMzFIOQX+zZUElG1t+nu1lSxthe7B+1oNYking7b91305+jNB6iwojp9fqTY9O+Nh7ULQxg=="
+      },
+      "Microsoft.Extensions.Options": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "8oCAgXOow5XDrY9HaXX1QmH3ORsyZO/ANVHBlhLyCeWTH5Sg4UuqZeOTWJi6484M+LqSx0RqQXDJtdYy2BNiLQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Primitives": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Primitives": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "inRnbpCS0nwO/RuoZIAqxQUuyjaknOOnCEZB55KSMMjRhl0RQDttSmLSGsUJN3RQ3ocf5NDLFd2mOQViHqMK5w=="
+      },
+      "Microsoft.NETFramework.ReferenceAssemblies.net461": {
+        "type": "Transitive",
+        "resolved": "1.0.3",
+        "contentHash": "AmOJZwCqnOCNp6PPcf9joyogScWLtwy0M1WkqfEQ0M9nYwyDD7EX9ZjscKS5iYnyvteX7kzSKFCKt9I9dXA6mA=="
+      },
+      "Microsoft.Win32.SystemEvents": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "9opKRyOKMCi2xJ7Bj7kxtZ1r9vbzosMvRrdEhVhDz8j8MoBGgB+WmC94yH839NPH+BclAjtQ/pyagvi/8gDLkw=="
+      },
+      "Speckle.Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "13.0.2",
+        "contentHash": "g1BejUZwax5PRfL6xHgLEK23sqHWOgOj9hE7RvfRRlN00AGt8GnPYt8HedSK7UB3HiRW8zCA9Pn0iiYxCK24BA=="
+      },
+      "SQLitePCLRaw.bundle_e_sqlite3": {
+        "type": "Transitive",
+        "resolved": "2.1.11",
+        "contentHash": "DC4nA7yWnf4UZdgJDF+9Mus4/cb0Y3Sfgi3gDnAoKNAIBwzkskNAbNbyu+u4atT0ruVlZNJfwZmwiEwE5oz9LQ==",
+        "dependencies": {
+          "SQLitePCLRaw.lib.e_sqlite3": "2.1.11",
+          "SQLitePCLRaw.provider.e_sqlite3": "2.1.11"
+        }
+      },
+      "SQLitePCLRaw.core": {
+        "type": "Transitive",
+        "resolved": "2.1.11",
+        "contentHash": "PK0GLFkfhZzLQeR3PJf71FmhtHox+U3vcY6ZtswoMjrefkB9k6ErNJEnwXqc5KgXDSjige2XXrezqS39gkpQKA=="
+      },
+      "SQLitePCLRaw.lib.e_sqlite3": {
+        "type": "Transitive",
+        "resolved": "2.1.11",
+        "contentHash": "Ev2ytaXiOlWZ4b3R67GZBsemTINslLD1DCJr2xiacpn4tbapu0Q4dHEzSvZSMnVWeE5nlObU3VZN2p81q3XOYQ=="
+      },
+      "SQLitePCLRaw.provider.e_sqlite3": {
+        "type": "Transitive",
+        "resolved": "2.1.11",
+        "contentHash": "Y/0ZkR+r0Cg3DQFuCl1RBnv/tmxpIZRU3HUvelPw6MVaKHwYYR8YNvgs0vuNuXCMvlyJ+Fh88U1D4tah1tt6qw==",
+        "dependencies": {
+          "SQLitePCLRaw.core": "2.1.11"
+        }
+      },
+      "System.Drawing.Common": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "JkbHJjtI/dWc5dfmEdJlbe3VwgZqCkZRtfuWFh5GOv0f+gGCfBtzMpIVkmdkj2AObO9y+oiOi81UGwH3aBYuqA==",
+        "dependencies": {
+          "Microsoft.Win32.SystemEvents": "8.0.0"
+        }
+      },
+      "System.Reactive": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "31kfaW4ZupZzPsI5PVe77VhnvFF55qgma7KZr/E0iFTs6fmdhhG8j0mgEx620iLTey1EynOkEfnyTjtNEpJzGw=="
+      },
+      "speckle.converters.common": {
+        "type": "Project",
+        "dependencies": {
+          "Speckle.Objects": "[1.0.0, )"
+        }
+      },
+      "speckle.objects": {
+        "type": "Project",
+        "dependencies": {
+          "Speckle.Sdk": "[1.0.0, )"
+        }
+      },
+      "speckle.sdk": {
+        "type": "Project",
+        "dependencies": {
+          "GraphQL.Client": "[6.1.0, )",
+          "Microsoft.Data.Sqlite": "[10.0.0, )",
+          "Microsoft.Extensions.Logging": "[10.0.0, )",
+          "Microsoft.Extensions.ObjectPool": "[10.0.0, )",
+          "Speckle.DoubleNumerics": "[4.1.0, )",
+          "Speckle.Newtonsoft.Json": "[13.0.2, )",
+          "Speckle.Sdk.Dependencies": "[1.0.0, )",
+          "Speckle.Sdk.Parquet": "[1.0.0, )"
+        }
+      },
+      "speckle.sdk.dependencies": {
+        "type": "Project"
+      },
+      "speckle.sdk.parquet": {
+        "type": "Project"
+      },
+      "Speckle.DoubleNumerics": {
+        "type": "CentralTransitive",
+        "requested": "[4.1.0, )",
+        "resolved": "4.1.0",
+        "contentHash": "20DtS+FsDRsOD9+AU3TwNFZ0qrKo5f6f7B5ZR9wStsIHHHC9k7DpjbCvuNtmnSjx54MD+TJC7wV2f5iyGVPj1A=="
+      }
+    }
+  }
+}

--- a/Local.slnx
+++ b/Local.slnx
@@ -166,6 +166,10 @@
     <Project Path="Connectors\Rhino\Speckle.Connectors.RhinoImporter\Speckle.Connectors.RhinoImporter.csproj" />
     <Project Path="Converters\Rhino\Speckle.Converters.Rhino8\Speckle.Converters.Rhino8.csproj" />
   </Folder>
+  <Folder Name="/Connectors/Rhino/9/">
+    <Project Path="Connectors\Rhino\Speckle.Connectors.RhinoHeadless\Speckle.Connectors.RhinoHeadless.csproj" />
+    <Project Path="Converters\Rhino\Speckle.Converters.Rhino9\Speckle.Converters.Rhino9.csproj" />
+  </Folder>
   <Folder Name="/Connectors/Rhino/Shared/">
     <Project Path="Connectors\Rhino\Speckle.Connectors.GrasshopperShared\Speckle.Connectors.GrasshopperShared.shproj" />
     <Project Path="Connectors\Rhino\Speckle.Connectors.RhinoShared\Speckle.Connectors.RhinoShared.shproj" />

--- a/Sdk/Speckle.Connectors.Common/Builders/IArtifactRootObjectBuilder.cs
+++ b/Sdk/Speckle.Connectors.Common/Builders/IArtifactRootObjectBuilder.cs
@@ -37,10 +37,9 @@ public record ArtifactBuildResult(
   IReadOnlyList<SendConversionResult> ConversionResults
 );
 
-/// <summary>Result of the build-only phase (bundle written to a local output directory, nothing uploaded):
-/// the bundle's parquet files keyed by file name, the synthetic root id, the count of successfully
-/// converted objects, and the per-object conversion results. Consumed by <c>BuildAndUpload</c>'s upload
-/// phase — and directly by headless hosts whose upload happens out of process (the converter legs).</summary>
+/// <summary>Result of the build-only phase: the bundle sits in a local output directory, nothing has been
+/// uploaded. Carries what an uploader needs, whether in-process (<c>BuildAndUpload</c>) or out of process
+/// (the headless converter legs).</summary>
 public record ArtifactBundleResult(
   IReadOnlyDictionary<string, string> Bundle,
   string RootId,

--- a/Sdk/Speckle.Connectors.Common/Builders/IArtifactRootObjectBuilder.cs
+++ b/Sdk/Speckle.Connectors.Common/Builders/IArtifactRootObjectBuilder.cs
@@ -36,3 +36,14 @@ public record ArtifactBuildResult(
   string RootId,
   IReadOnlyList<SendConversionResult> ConversionResults
 );
+
+/// <summary>Result of the build-only phase (bundle written to a local output directory, nothing uploaded):
+/// the bundle's parquet files keyed by file name, the synthetic root id, the count of successfully
+/// converted objects, and the per-object conversion results. Consumed by <c>BuildAndUpload</c>'s upload
+/// phase — and directly by headless hosts whose upload happens out of process (the converter legs).</summary>
+public record ArtifactBundleResult(
+  IReadOnlyDictionary<string, string> Bundle,
+  string RootId,
+  int ObjectCount,
+  IReadOnlyList<SendConversionResult> ConversionResults
+);

--- a/Speckle.Connectors.slnx
+++ b/Speckle.Connectors.slnx
@@ -167,6 +167,10 @@
     <Project Path="Connectors\Rhino\Speckle.Connectors.RhinoImporter\Speckle.Connectors.RhinoImporter.csproj" />
     <Project Path="Converters\Rhino\Speckle.Converters.Rhino8\Speckle.Converters.Rhino8.csproj" />
   </Folder>
+  <Folder Name="/Connectors/Rhino/9/">
+    <Project Path="Connectors\Rhino\Speckle.Connectors.RhinoHeadless\Speckle.Connectors.RhinoHeadless.csproj" />
+    <Project Path="Converters\Rhino\Speckle.Converters.Rhino9\Speckle.Converters.Rhino9.csproj" />
+  </Folder>
   <Folder Name="/Connectors/Rhino/Shared/">
     <Project Path="Connectors\Rhino\Speckle.Connectors.GrasshopperShared\Speckle.Connectors.GrasshopperShared.shproj" />
     <Project Path="Connectors\Rhino\Speckle.Connectors.RhinoShared\Speckle.Connectors.RhinoShared.shproj" />

--- a/Speckle.Rhino.slnx
+++ b/Speckle.Rhino.slnx
@@ -36,6 +36,10 @@
     <Project Path="Connectors\Rhino\Speckle.Connectors.RhinoImporter\Speckle.Connectors.RhinoImporter.csproj" />
     <Project Path="Converters\Rhino\Speckle.Converters.Rhino8\Speckle.Converters.Rhino8.csproj" />
   </Folder>
+  <Folder Name="/Connectors/Rhino/9/">
+    <Project Path="Connectors\Rhino\Speckle.Connectors.RhinoHeadless\Speckle.Connectors.RhinoHeadless.csproj" />
+    <Project Path="Converters\Rhino\Speckle.Converters.Rhino9\Speckle.Converters.Rhino9.csproj" />
+  </Folder>
   <Folder Name="/Connectors/Rhino/Shared/">
     <Project Path="Connectors\Rhino\Speckle.Connectors.GrasshopperShared\Speckle.Connectors.GrasshopperShared.shproj" />
     <Project Path="Connectors\Rhino\Speckle.Connectors.RhinoShared\Speckle.Connectors.RhinoShared.shproj" />


### PR DESCRIPTION
Linear: [ENG-8980](https://linear.app/speckle/issue/ENG-8980/big-truck-upstream-rhino-9net10-head-headless-connector-slice-build) — leg 1 of the Rhino leg productionization spec (`atlas/specs/2026-07-rhino-leg-productionization.md`).

The three upstream pieces the containerized Rhino converter leg consumes, landed as the compile-proven shapes from the wayfinder research:

## `Converters/Rhino/Speckle.Converters.Rhino9`
net10 head importing the shared Rhino converter projitems **unmodified** (the shared source has zero `#if RHINO*`). Exact pins in the head csproj — no floating ranges; they move in lockstep with the converters image's rhino3d deb pin:
- `RhinoCommon 9.0.26167.11545-wip`
- `Rhino.Inside 9.0.26084.13070-beta` (flows transitively so the host exe inherits the pin)
- `Grasshopper 9.0.26167.11545-wip` — not used by the converter; required because Rhino.Inside's open-range Grasshopper floor exact-pins an older RhinoCommon, which trips NU1608-as-error

## `Connectors/Rhino/Speckle.Connectors.RhinoHeadless`
The DUI3-free slice around `RhinoArtifactRootObjectBuilder` — 15 files linked from `RhinoShared` (builder + unpackers + `PropertiesExtractor` + Mapper/Revit + Extensions) with the `Speckle.Connectors.Common` closure. Two csproj shims, no source changes:
- `<Using Include="System.Drawing" />` (Windows heads get it via `UseWindowsForms`; only `Color` is used — cross-platform)
- `<Using Remove="System.IO" />` (the WPF heads drop `System.IO` from implicit usings, so the shared files carry explicit `using System.IO;` — a plain net10 project must mirror that view or IDE0005-as-error flags them)

## `Build` / `BuildAndUpload` split
`RhinoArtifactRootObjectBuilder` gains a public `Build(objects, projectId?, versionId, outputDir, progress, ct)` → new `ArtifactBundleResult` (bundle files, synthetic root id, object count, conversion results): collect + write-bundle-to-outdir, touching **no auth, storage, or server API**. `BuildAndUpload` calls the same core then uploads — `IArtifactRootObjectBuilder<T>` is unchanged and the other six implementers are untouched, so connector consumers behave exactly as before. This lets the converter host stop at the outdir; dispatch stays the single uploader.

Both new projects are added to `Speckle.Connectors.slnx` / `Local.slnx` / `Speckle.Rhino.slnx` under `/Connectors/Rhino/9/`.

## Verification
- Head + slice build on linux-x64 / net10, `-c Local` against the sibling sdk checkout: **0 warnings, 0 errors**
- Existing consumers of the shared builder still compile: `Speckle.Connectors.RhinoImporter` (net8.0-windows) and `Speckle.Connectors.Rhino8` (net48)
- All 137 tests pass (`Connectors.Common.Tests`, `Converters.Common.Tests`, `DUI.Tests`, `-c Local`)
- Note for reviewers: `-c Local` currently needs the sibling sdk at `ceb47b7` — sdk `4e043bd` (material PBR channels #516) changed `ObjectsArtifactPipeline.AddMaterial` and breaks the connectors build until connectors adapt. Release CI is red on big-truck independently of this PR (published `Speckle.Objects` lacks the big-truck pipeline APIs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)