### PR TITLE
fix(civil3d/autocad): entity names on send, huge meshes on receive, model card highlight

### DIFF
--- a/Connectors/Autocad/Speckle.Connectors.AutocadShared/Operations/Receive/AutocadHostObjectArtefactBuilder.cs
+++ b/Connectors/Autocad/Speckle.Connectors.AutocadShared/Operations/Receive/AutocadHostObjectArtefactBuilder.cs
@@ -7,6 +7,7 @@ using Autodesk.AutoCAD.Geometry;
 using Autodesk.AutoCAD.GraphicsInterface;
 using Microsoft.Extensions.Logging;
 using Speckle.Connectors.Autocad.HostApp;
+using Speckle.Connectors.Autocad.HostApp.Extensions;
 using Speckle.Connectors.Common.Builders;
 using Speckle.Connectors.Common.Conversion;
 using Speckle.Connectors.Common.Diagnostics;
@@ -117,6 +118,10 @@ public class AutocadHostObjectArtefactBuilder : IArtifactHostObjectBuilder
     var docUnits = _converterSettings.Current.SpeckleUnits;
     var rels = bundle.Relations;
     var objByGeom = rels.ObjectByGeometry();
+    // Baked entities are identified by their AutoCAD HANDLE (decimal, as GetSpeckleApplicationId spells it) — the id
+    // space the receiver model card, the conversion report and DocumentExtensions.GetObjects all speak. Reporting
+    // ObjectId.ToString() (a parenthesised in-memory pointer) instead meant "Highlight" on a received card resolved
+    // nothing and errored with "No objects found to highlight" [ENG-8833].
     var bakedObjectIds = new HashSet<string>();
     var conversionResults = new HashSet<ReceiveConversionResult>();
     var layerCache = new HashSet<string>(StringComparer.Ordinal);
@@ -196,13 +201,15 @@ public class AutocadHostObjectArtefactBuilder : IArtifactHostObjectBuilder
           materialIdByObject.TryGetValue(appId, out ObjectId objMaterial);
           bool hasObjColor = colorArgbByObject.TryGetValue(appId, out int objArgb);
 
-          var ids = new List<ObjectId>();
+          // (ObjectId, handle) per baked entity: the ObjectId drives native grouping below, while the model card and
+          // the conversion report identify entities by their HANDLE — see the note on bakedObjectIds [ENG-8833].
+          var baked = new List<(ObjectId Id, string Handle)>();
           using (var tr = doc.TransactionManager.StartTransaction())
           {
             var modelSpace = (BlockTableRecord)tr.GetObject(db.CurrentSpaceId, OpenMode.ForWrite);
             var (primaryKs, fallbackKs) = GeometryIndices(objK, rels, bundle);
             BakeGeometry(primaryKs);
-            if (ids.Count == 0)
+            if (baked.Count == 0)
             {
               // the solid blob(s) produced nothing (SAT AcisIn failure) — bake the DISPLAY shadow instead [ENG-8820]
               BakeGeometry(fallbackKs);
@@ -230,14 +237,15 @@ public class AutocadHostObjectArtefactBuilder : IArtifactHostObjectBuilder
                   {
                     entity.Color = ToAcadColor(a);
                   }
-                  ids.Add(entity.ObjectId);
+                  // The handle is read while the entity is still open in this transaction (it is assigned on append).
+                  baked.Add((entity.ObjectId, entity.GetSpeckleApplicationId()));
                   PostBakeEntity(entity, props, tr); // Civil3D hook (property sets) — fires for fallback bakes too
                 }
               }
             }
           }
 
-          if (ids.Count == 0)
+          if (baked.Count == 0)
           {
             session.RecordObject(
               appId,
@@ -259,12 +267,12 @@ public class AutocadHostObjectArtefactBuilder : IArtifactHostObjectBuilder
             continue;
           }
 
-          bakedObjectIds.UnionWith(ids.Select(i => i.ToString()));
+          bakedObjectIds.UnionWith(baked.Select(b => b.Handle));
           if (rels.GroupsByObject.ContainsKey(objK))
           {
-            bakedIdsByObjK[objK] = ids;
+            bakedIdsByObjK[objK] = baked.Select(b => b.Id).ToList();
           }
-          conversionResults.Add(new(Status.SUCCESS, source, ids[0].ToString(), "Object", null, srcType));
+          conversionResults.Add(new(Status.SUCCESS, source, baked[0].Handle, "Object", null, srcType));
           session.RecordObject(appId, srcType, Status.SUCCESS, null, sw.ElapsedMilliseconds);
         }
         catch (Exception ex) when (!ex.IsFatal())
@@ -998,7 +1006,8 @@ public class AutocadHostObjectArtefactBuilder : IArtifactHostObjectBuilder
         }
         modelSpace.AppendEntity(blockRef);
         tr.AddNewlyCreatedDBObject(blockRef, true);
-        bakedObjectIds.Add(blockRef.ObjectId.ToString());
+        string blockRefHandle = blockRef.GetSpeckleApplicationId(); // handle, not ObjectId — see bakedObjectIds
+        bakedObjectIds.Add(blockRefHandle);
         if (rels.GroupsByObject.ContainsKey(objK))
         {
           if (!bakedIdsByObjK.TryGetValue(objK, out var grouped))
@@ -1007,9 +1016,7 @@ public class AutocadHostObjectArtefactBuilder : IArtifactHostObjectBuilder
           }
           grouped.Add(blockRef.ObjectId); // an object may place several instances; all of them join its group(s)
         }
-        conversionResults.Add(
-          new(Status.SUCCESS, source, blockRef.ObjectId.ToString(), "Instance (Block)", null, srcType)
-        );
+        conversionResults.Add(new(Status.SUCCESS, source, blockRefHandle, "Instance (Block)", null, srcType));
         session.RecordObject(appId, srcType, Status.SUCCESS, null, sw.ElapsedMilliseconds);
       }
       catch (Exception ex) when (!ex.IsFatal())

--- a/Connectors/Autocad/Speckle.Connectors.AutocadShared/Operations/Receive/AutocadHostObjectArtefactBuilder.cs
+++ b/Connectors/Autocad/Speckle.Connectors.AutocadShared/Operations/Receive/AutocadHostObjectArtefactBuilder.cs
@@ -37,7 +37,8 @@ namespace Speckle.Connectors.Autocad.Operations.Receive;
 /// Civil3D), talking only to the neutral dense-int graph + raw AutoCAD API — no v1 <c>Base</c>/<c>DataObject</c>/
 /// <c>Collection</c>/proxy types and no traversal / <c>AutocadLayerBaker</c> / <c>AutocadMaterialBaker</c> machinery.
 /// Solids come from raw ACIS-SAT blobs (<see cref="Body.AcisIn(string)"/>), meshes from SGEO
-/// (<see cref="SgeoDecoder.TryDecodeMesh(ReadOnlySpan{byte}, out SgeoMesh)"/>) built straight into a <see cref="PolyFaceMesh"/>; every other SGEO
+/// (<see cref="SgeoDecoder.TryDecodeMesh(ReadOnlySpan{byte}, out SgeoMesh)"/>) built straight into a <see cref="PolyFaceMesh"/> (or a
+/// <see cref="SubDMesh"/> past its 16-bit vertex-index ceiling); every other SGEO
 /// primitive (curves, points, text, regions…) decodes to its Speckle geometry object and converts via the AutoCAD
 /// ToHost converter. Layers are the flat AutoCAD layer namespace projected from the scene view (with the source layer
 /// colour); materials from MATERIAL nodes (HAS_MATERIAL), by-object colours from COLOR nodes (HAS_COLOR). Instances
@@ -521,10 +522,16 @@ public class AutocadHostObjectArtefactBuilder : IArtifactHostObjectBuilder
     return entities;
   }
 
-  // SGEO neutral mesh → AutoCAD PolyFaceMesh (must be appended to a BTR before adding vertices/faces; vertex indices
-  // are 1-based; faces are Speckle count-prefixed). Mirrors the construction in MeshToHostConverter, Base-free.
-  private static PolyFaceMesh BuildMesh(SgeoMesh sm, BlockTableRecord target, Transaction tr)
+  // SGEO neutral mesh → native AutoCAD mesh. Mirrors the construction in MeshToHostConverter, Base-free: a
+  // PolyFaceMesh (must be appended to a BTR before adding vertices/faces; vertex indices are 1-based; faces are
+  // Speckle count-prefixed), or a SubDMesh once the mesh outgrows PolyFaceMesh's 16-bit vertex indices [ENG-8836].
+  private static AcadEntity BuildMesh(SgeoMesh sm, BlockTableRecord target, Transaction tr)
   {
+    if (sm.Vertices.Length / 3 > MAX_POLYFACE_MESH_VERTICES)
+    {
+      return BuildSubDMesh(sm, target, tr);
+    }
+
     var mesh = new PolyFaceMesh();
     mesh.SetDatabaseDefaults();
     target.AppendEntity(mesh);
@@ -584,6 +591,114 @@ public class AutocadHostObjectArtefactBuilder : IArtifactHostObjectBuilder
     }
 
     return mesh;
+  }
+
+  /// <summary>
+  /// A <see cref="PolyFaceMesh"/> addresses its vertices through <see cref="FaceRecord"/>, whose 1-based vertex
+  /// indices are 16-bit — so it cannot hold more than <see cref="short.MaxValue"/> vertices. Beyond that the index
+  /// casts in <see cref="AppendFace"/> silently wrapped negative and the mesh baked as garbage [ENG-8836]; larger
+  /// meshes become a native MESH (<see cref="SubDMesh"/>) instead, whose face array is 32-bit.
+  /// </summary>
+  private const int MAX_POLYFACE_MESH_VERTICES = short.MaxValue;
+
+  // A mesh too large for a PolyFaceMesh [ENG-8836]. The MESH entity takes its whole topology in one call: a vertex
+  // array plus a count-prefixed, 0-based face array — the layout SGEO already carries — with 32-bit indices, and
+  // per-vertex colours on its EntityColor array. Smooth level 0 keeps the faceting exactly as sent.
+  private static SubDMesh BuildSubDMesh(SgeoMesh sm, BlockTableRecord target, Transaction tr)
+  {
+    var v = sm.Vertices;
+    int vertexCount = v.Length / 3;
+    var points = new Point3d[vertexCount];
+    for (int i = 0; i < vertexCount; i++)
+    {
+      points[i] = new Point3d(v[i * 3], v[i * 3 + 1], v[i * 3 + 2]);
+    }
+
+    using var vertices = new Point3dCollection(points);
+    var faceArray = new Int32Collection(SubDMeshFaces(sm.Faces, vertexCount));
+
+    var mesh = new SubDMesh();
+    mesh.SetDatabaseDefaults();
+    mesh.SetSubDMesh(vertices, faceArray, 0);
+
+    if (sm.Colors.Length == vertexCount)
+    {
+      try
+      {
+        var colors = new EntityColor[vertexCount];
+        for (int i = 0; i < vertexCount; i++)
+        {
+          var c = System.Drawing.Color.FromArgb(sm.Colors[i]);
+          colors[i] = new EntityColor(c.R, c.G, c.B);
+        }
+        mesh.VertexColorArray = colors;
+      }
+      catch (Exception e) when (!e.IsFatal())
+      {
+        // a bad vertex color must not abort the mesh (same rule as the polyface path)
+      }
+    }
+
+    target.AppendEntity(mesh);
+    tr.AddNewlyCreatedDBObject(mesh, true);
+    return mesh;
+  }
+
+  // SGEO faces are already the count-prefixed, 0-based layout SetSubDMesh expects, so this only normalizes it: the
+  // legacy 0/1 count encoding (triangle/quad), repeated corners, and faces that are truncated or point outside the
+  // vertex array. SetSubDMesh takes the topology in one call and rejects the WHOLE mesh on a single bad face, so a
+  // malformed face is dropped here instead of costing us the entire mesh. Mirrors MeshToHostConverter.
+  private static int[] SubDMeshFaces(int[] faces, int vertexCount)
+  {
+    var result = new List<int>(faces.Length);
+    var corners = new List<int>(4);
+    int p = 0;
+    while (p < faces.Length)
+    {
+      int n = faces[p];
+      if (n < 3)
+      {
+        n += 3; // legacy 0 -> triangle, 1 -> quad
+      }
+      if (p + n >= faces.Length)
+      {
+        break; // truncated face list
+      }
+
+      corners.Clear();
+      int lastCorner = -1;
+      for (int k = p + 1; k <= p + n; k++)
+      {
+        int index = faces[k];
+        if (index < 0 || index >= vertexCount)
+        {
+          corners.Clear(); // face points outside the vertex array — drop it whole
+          break;
+        }
+        // Collapse a repeated corner: a quad written [a, b, c, c] is really a triangle, and a face left with fewer
+        // than 3 distinct corners has no area to bake.
+        if (index != lastCorner)
+        {
+          corners.Add(index);
+          lastCorner = index;
+        }
+      }
+
+      if (corners.Count > 3 && corners[0] == lastCorner)
+      {
+        corners.RemoveAt(corners.Count - 1); // closed face: last corner repeats the first
+      }
+
+      if (corners.Count >= 3)
+      {
+        result.Add(corners.Count);
+        result.AddRange(corners);
+      }
+
+      p += n + 1;
+    }
+
+    return result.ToArray();
   }
 
   private static void AppendFace(PolyFaceMesh mesh, Transaction tr, int i1, int i2, int i3, int? i4, int vertexCount)

--- a/Connectors/Autocad/Speckle.Connectors.AutocadShared/Operations/Send/AutocadArtifactRootObjectBuilder.cs
+++ b/Connectors/Autocad/Speckle.Connectors.AutocadShared/Operations/Send/AutocadArtifactRootObjectBuilder.cs
@@ -400,7 +400,7 @@ public class AutocadArtifactRootObjectBuilder(
     pipeline.AddProperties(
       co.ApplicationId,
       co.Properties,
-      RootScalars(co.Converted.speckle_type, co.SourceType, units, co.SourceType)
+      RootScalars(co.Converted.speckle_type, ObjectName(co), units, co.SourceType)
     );
 
     // ── block instance: object → INSTANCE node (transform + definition) via DISPLAY_INSTANCE ──────────
@@ -792,6 +792,13 @@ public class AutocadArtifactRootObjectBuilder(
     cache[layerName] = collK;
     return collK;
   }
+
+  // The object's authored name lives on the DataObject carrier the converter produced — a Civil3D entity name
+  // ("Alignment - (1)", "Corridor - (1)"), a Plant3D tag, a Civil3D subassembly name. Labelling every object with its
+  // .NET type name instead lost all of them [ENG-8831]. AutoCAD's own carrier sets name = type name anyway, so plain
+  // AutoCAD entities are unchanged; an InstanceProxy (block placement) carries no name and keeps the type.
+  private static string ObjectName(CollectedObject co) =>
+    co.Converted is DataObject { name.Length: > 0 } dataObject ? dataObject.name : co.SourceType;
 
   private static KeyValuePair<string, object?>[] RootScalars(
     string speckleType,

--- a/Converters/Autocad/Speckle.Converters.AutocadShared/ToHost/Geometry/BrepToHostConverter.cs
+++ b/Converters/Autocad/Speckle.Converters.AutocadShared/ToHost/Geometry/BrepToHostConverter.cs
@@ -5,7 +5,7 @@ using Speckle.Sdk.Models;
 namespace Speckle.Converters.Autocad.Geometry;
 
 /// <summary>
-/// Converts a Brep to a List(PolyFaceMesh,Mesh)> as fallback conversion
+/// Converts a Brep to a List(Entity,Mesh)> as fallback conversion
 /// </summary>
 /// <remarks>
 /// The return type is (Entity,Base) instead of the specific type (PolyfaceMesh, Mesh) so this result can be picked up by a generic list case in the SpeckleToHost connector object baking. This is essentially one-to-many fallback conversion.
@@ -13,9 +13,9 @@ namespace Speckle.Converters.Autocad.Geometry;
 [NameAndRankValue(typeof(SOG.Brep), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
 public class BrepToHostConverter : IToHostTopLevelConverter, ITypedConverter<SOG.Brep, List<(ADB.Entity a, Base b)>>
 {
-  private readonly ITypedConverter<SOG.Mesh, ADB.PolyFaceMesh> _meshConverter;
+  private readonly ITypedConverter<SOG.Mesh, ADB.Entity> _meshConverter;
 
-  public BrepToHostConverter(ITypedConverter<SOG.Mesh, ADB.PolyFaceMesh> meshConverter)
+  public BrepToHostConverter(ITypedConverter<SOG.Mesh, ADB.Entity> meshConverter)
   {
     _meshConverter = meshConverter;
   }
@@ -27,13 +27,13 @@ public class BrepToHostConverter : IToHostTopLevelConverter, ITypedConverter<SOG
   /// </remarks>
   public List<(ADB.Entity a, Base b)> Convert(SOG.Brep target)
   {
-    var result = new List<ADB.PolyFaceMesh>();
+    var result = new List<ADB.Entity>();
     foreach (SOG.Mesh mesh in target.displayValue)
     {
-      ADB.PolyFaceMesh convertedMesh = _meshConverter.Convert(mesh);
+      ADB.Entity convertedMesh = _meshConverter.Convert(mesh);
       result.Add(convertedMesh);
     }
 
-    return result.Zip(target.displayValue, (a, b) => ((ADB.Entity)a, (Base)b)).ToList();
+    return result.Zip(target.displayValue, (a, b) => (a, (Base)b)).ToList();
   }
 }

--- a/Converters/Autocad/Speckle.Converters.AutocadShared/ToHost/Geometry/BrepXToHostConverter.cs
+++ b/Converters/Autocad/Speckle.Converters.AutocadShared/ToHost/Geometry/BrepXToHostConverter.cs
@@ -5,7 +5,7 @@ using Speckle.Sdk.Models;
 namespace Speckle.Converters.Autocad.Geometry;
 
 /// <summary>
-/// Converts a BrepX to a List(PolyFaceMesh,Mesh)> as fallback conversion
+/// Converts a BrepX to a List(Entity,Mesh)> as fallback conversion
 /// </summary>
 /// <remarks>
 /// The return type is (Entity,Base) instead of the specific type (PolyfaceMesh, Mesh) so this result can be picked up by a generic list case in the SpeckleToHost connector object baking. This is essentially one-to-many fallback conversion.
@@ -13,9 +13,9 @@ namespace Speckle.Converters.Autocad.Geometry;
 [NameAndRankValue(typeof(SOG.BrepX), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
 public class BrepXToHostConverter : IToHostTopLevelConverter, ITypedConverter<SOG.BrepX, List<(ADB.Entity a, Base b)>>
 {
-  private readonly ITypedConverter<SOG.Mesh, ADB.PolyFaceMesh> _meshConverter;
+  private readonly ITypedConverter<SOG.Mesh, ADB.Entity> _meshConverter;
 
-  public BrepXToHostConverter(ITypedConverter<SOG.Mesh, ADB.PolyFaceMesh> meshConverter)
+  public BrepXToHostConverter(ITypedConverter<SOG.Mesh, ADB.Entity> meshConverter)
   {
     _meshConverter = meshConverter;
   }
@@ -27,13 +27,13 @@ public class BrepXToHostConverter : IToHostTopLevelConverter, ITypedConverter<SO
   /// </remarks>
   public List<(ADB.Entity a, Base b)> Convert(SOG.BrepX target)
   {
-    var result = new List<ADB.PolyFaceMesh>();
+    var result = new List<ADB.Entity>();
     foreach (SOG.Mesh mesh in target.displayValue)
     {
-      ADB.PolyFaceMesh convertedMesh = _meshConverter.Convert(mesh);
+      ADB.Entity convertedMesh = _meshConverter.Convert(mesh);
       result.Add(convertedMesh);
     }
 
-    return result.Zip(target.displayValue, (a, b) => ((ADB.Entity)a, (Base)b)).ToList();
+    return result.Zip(target.displayValue, (a, b) => (a, (Base)b)).ToList();
   }
 }

--- a/Converters/Autocad/Speckle.Converters.AutocadShared/ToHost/Geometry/DataObjectConverter.cs
+++ b/Converters/Autocad/Speckle.Converters.AutocadShared/ToHost/Geometry/DataObjectConverter.cs
@@ -16,7 +16,7 @@ public class DataObjectConverter : IToHostTopLevelConverter, ITypedConverter<Dat
   private readonly ITypedConverter<ICurve, List<(ADB.Entity, Base)>> _curveConverter;
   private readonly ITypedConverter<SOG.BrepX, List<(ADB.Entity a, Base b)>> _brepXConverter;
   private readonly ITypedConverter<SOG.ExtrusionX, List<(ADB.Entity a, Base b)>> _extrusionXConverter;
-  private readonly ITypedConverter<SOG.Mesh, ADB.PolyFaceMesh> _meshConverter;
+  private readonly ITypedConverter<SOG.Mesh, ADB.Entity> _meshConverter;
   private readonly ITypedConverter<SOG.Point, ADB.DBPoint> _pointConverter;
   private readonly ITypedConverter<SOG.SubDX, List<(ADB.Entity a, Base b)>> _subDXConverter;
   private readonly ITypedConverter<SOG.Region, ADB.Entity> _regionConverter;
@@ -27,7 +27,7 @@ public class DataObjectConverter : IToHostTopLevelConverter, ITypedConverter<Dat
     ITypedConverter<ICurve, List<(ADB.Entity, Base)>> curveConverter,
     ITypedConverter<SOG.BrepX, List<(ADB.Entity a, Base b)>> brepXConverter,
     ITypedConverter<SOG.ExtrusionX, List<(ADB.Entity a, Base b)>> extrusionXConverter,
-    ITypedConverter<SOG.Mesh, ADB.PolyFaceMesh> meshConverter,
+    ITypedConverter<SOG.Mesh, ADB.Entity> meshConverter,
     ITypedConverter<SOG.Point, ADB.DBPoint> pointConverter,
     ITypedConverter<SOG.SubDX, List<(ADB.Entity a, Base b)>> subDXConverter,
     ITypedConverter<SOG.Region, ADB.Entity> regionConverter,

--- a/Converters/Autocad/Speckle.Converters.AutocadShared/ToHost/Geometry/ExtrusionXToHostConverter.cs
+++ b/Converters/Autocad/Speckle.Converters.AutocadShared/ToHost/Geometry/ExtrusionXToHostConverter.cs
@@ -5,7 +5,7 @@ using Speckle.Sdk.Models;
 namespace Speckle.Converters.Autocad.Geometry;
 
 /// <summary>
-/// Converts a ExtrusionX to a List(PolyFaceMesh,Mesh)> as fallback conversion
+/// Converts a ExtrusionX to a List(Entity,Mesh)> as fallback conversion
 /// </summary>
 /// <remarks>
 /// The return type is (Entity,Base) instead of the specific type (PolyfaceMesh, Mesh) so this result can be picked up by a generic list case in the SpeckleToHost connector object baking. This is essentially one-to-many fallback conversion.
@@ -15,9 +15,9 @@ public class ExtrusionXToHostConverter
   : IToHostTopLevelConverter,
     ITypedConverter<SOG.ExtrusionX, List<(ADB.Entity a, Base b)>>
 {
-  private readonly ITypedConverter<SOG.Mesh, ADB.PolyFaceMesh> _meshConverter;
+  private readonly ITypedConverter<SOG.Mesh, ADB.Entity> _meshConverter;
 
-  public ExtrusionXToHostConverter(ITypedConverter<SOG.Mesh, ADB.PolyFaceMesh> meshConverter)
+  public ExtrusionXToHostConverter(ITypedConverter<SOG.Mesh, ADB.Entity> meshConverter)
   {
     _meshConverter = meshConverter;
   }
@@ -29,13 +29,13 @@ public class ExtrusionXToHostConverter
   /// </remarks>
   public List<(ADB.Entity a, Base b)> Convert(SOG.ExtrusionX target)
   {
-    var result = new List<ADB.PolyFaceMesh>();
+    var result = new List<ADB.Entity>();
     foreach (SOG.Mesh mesh in target.displayValue)
     {
-      ADB.PolyFaceMesh convertedMesh = _meshConverter.Convert(mesh);
+      ADB.Entity convertedMesh = _meshConverter.Convert(mesh);
       result.Add(convertedMesh);
     }
 
-    return result.Zip(target.displayValue, (a, b) => ((ADB.Entity)a, (Base)b)).ToList();
+    return result.Zip(target.displayValue, (a, b) => (a, (Base)b)).ToList();
   }
 }

--- a/Converters/Autocad/Speckle.Converters.AutocadShared/ToHost/Geometry/MeshToHostConverter.cs
+++ b/Converters/Autocad/Speckle.Converters.AutocadShared/ToHost/Geometry/MeshToHostConverter.cs
@@ -7,8 +7,16 @@ using Speckle.Sdk.Models;
 namespace Speckle.Converters.Autocad.Geometry;
 
 [NameAndRankValue(typeof(SOG.Mesh), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
-public class MeshToHostConverter : IToHostTopLevelConverter, ITypedConverter<SOG.Mesh, ADB.PolyFaceMesh>
+public class MeshToHostConverter : IToHostTopLevelConverter, ITypedConverter<SOG.Mesh, ADB.Entity>
 {
+  /// <summary>
+  /// A <see cref="ADB.PolyFaceMesh"/> addresses its vertices through <see cref="ADB.FaceRecord"/>, whose 1-based
+  /// vertex indices are 16-bit — so it cannot hold more than <see cref="short.MaxValue"/> vertices. Beyond that the
+  /// index casts silently wrapped negative and the mesh came in as garbage [ENG-8836]. Larger meshes are built as a
+  /// native MESH (<see cref="ADB.SubDMesh"/>) instead, whose face array is 32-bit.
+  /// </summary>
+  private const int MAX_POLYFACE_MESH_VERTICES = short.MaxValue;
+
   private readonly ITypedConverter<SOG.Point, AG.Point3d> _pointConverter;
   private readonly IConverterSettingsStore<AutocadConversionSettings> _settingsStore;
 
@@ -26,33 +34,42 @@ public class MeshToHostConverter : IToHostTopLevelConverter, ITypedConverter<SOG
   /// <remarks>
   /// Mesh conversion requires transaction since it's vertices needed to be added into database in advance..
   /// </remarks>
-  public ADB.PolyFaceMesh Convert(SOG.Mesh target)
+  public ADB.Entity Convert(SOG.Mesh target)
   {
     target.TriangulateMesh(true);
 
     // get vertex points
-    using AG.Point3dCollection vertices = new();
     List<AG.Point3d> points = target.GetPoints().Select(o => _pointConverter.Convert(o)).ToList();
-    foreach (var point in points)
-    {
-      vertices.Add(point);
-    }
-
-    ADB.PolyFaceMesh mesh = new();
 
     //TODO using?
     ADB.Transaction tr = _settingsStore.Current.Document.TransactionManager.TopTransaction;
 
+    // both mesh types are appended to the blocktable record here - the polyface mesh *requires* it before its
+    // vertices and faces can be added, and appending the subd mesh too keeps the entity db-resident either way.
+    var btr = (ADB.BlockTableRecord)
+      tr.GetObject(_settingsStore.Current.Document.Database.CurrentSpaceId, ADB.OpenMode.ForWrite);
+
+    return points.Count > MAX_POLYFACE_MESH_VERTICES
+      ? ConvertToSubDMesh(target, points, btr, tr)
+      : ConvertToPolyFaceMesh(target, points, btr, tr);
+  }
+
+  private static ADB.PolyFaceMesh ConvertToPolyFaceMesh(
+    SOG.Mesh target,
+    List<AG.Point3d> points,
+    ADB.BlockTableRecord btr,
+    ADB.Transaction tr
+  )
+  {
+    ADB.PolyFaceMesh mesh = new();
     mesh.SetDatabaseDefaults();
 
     // append mesh to blocktable record - necessary before adding vertices and faces
-    var btr = (ADB.BlockTableRecord)
-      tr.GetObject(_settingsStore.Current.Document.Database.CurrentSpaceId, ADB.OpenMode.ForWrite);
     btr.AppendEntity(mesh);
     tr.AddNewlyCreatedDBObject(mesh, true);
 
     // add polyfacemesh vertices
-    for (int i = 0; i < vertices.Count; i++)
+    for (int i = 0; i < points.Count; i++)
     {
       var vertex = new ADB.PolyFaceMeshVertex(points[i]);
       if (i < target.colors.Count)
@@ -112,5 +129,105 @@ public class MeshToHostConverter : IToHostTopLevelConverter, ITypedConverter<SOG
     }
 
     return mesh;
+  }
+
+  // A mesh too large for a PolyFaceMesh [ENG-8836]. The MESH entity takes its whole topology in one call: a vertex
+  // array plus a count-prefixed, 0-based face array — the layout Speckle already uses — with 32-bit indices, and
+  // carries per-vertex colours on its EntityColor array. Smooth level 0 keeps the faceting exactly as authored.
+  private static ADB.SubDMesh ConvertToSubDMesh(
+    SOG.Mesh target,
+    List<AG.Point3d> points,
+    ADB.BlockTableRecord btr,
+    ADB.Transaction tr
+  )
+  {
+    using AG.Point3dCollection vertices = new(points.ToArray());
+    AG.Int32Collection faceArray = new(GetSubDMeshFaces(target.faces, points.Count));
+
+    ADB.SubDMesh mesh = new();
+    mesh.SetDatabaseDefaults();
+    mesh.SetSubDMesh(vertices, faceArray, 0);
+
+    if (target.colors.Count == points.Count)
+    {
+      try
+      {
+        mesh.VertexColorArray = target
+          .colors.Select(argb =>
+          {
+            var color = System.Drawing.Color.FromArgb(argb);
+            return new Autodesk.AutoCAD.Colors.EntityColor(color.R, color.G, color.B);
+          })
+          .ToArray();
+      }
+      catch (System.Exception e) when (!e.IsFatal())
+      {
+        // Couldn't set vertex colors, but this should not prevent conversion (mirrors the polyface mesh path).
+      }
+    }
+
+    btr.AppendEntity(mesh);
+    tr.AddNewlyCreatedDBObject(mesh, true);
+
+    return mesh;
+  }
+
+  // Speckle's face list is already the count-prefixed, 0-based layout SetSubDMesh expects, so this only normalizes it:
+  // the legacy 0/1 count encoding (triangle/quad), repeated corners, and faces that are truncated or point outside the
+  // vertex array. SetSubDMesh takes the topology in one call and rejects the WHOLE mesh on a single bad face, so a
+  // malformed face is dropped here instead of costing us the entire surface.
+  private static int[] GetSubDMeshFaces(List<int> faces, int vertexCount)
+  {
+    List<int> result = new(faces.Count);
+    List<int> corners = new(4);
+    int i = 0;
+    while (i < faces.Count)
+    {
+      int vertexPerFace = faces[i];
+      if (vertexPerFace < 3)
+      {
+        vertexPerFace += 3; // legacy encoding: 0 -> triangle, 1 -> quad
+      }
+
+      if (i + vertexPerFace >= faces.Count)
+      {
+        break; // truncated face list
+      }
+
+      corners.Clear();
+      int lastCorner = -1;
+      for (int j = i + 1; j <= i + vertexPerFace; j++)
+      {
+        int index = faces[j];
+        if (index < 0 || index >= vertexCount)
+        {
+          corners.Clear(); // face points outside the vertex array - drop it whole
+          break;
+        }
+
+        // Collapse a repeated corner: a quad written [a, b, c, c] is really a triangle, and a face left with fewer
+        // than 3 distinct corners has no area to bake.
+        if (index != lastCorner)
+        {
+          corners.Add(index);
+          lastCorner = index;
+        }
+      }
+
+      if (corners.Count > 3 && corners[0] == lastCorner)
+      {
+        corners.RemoveAt(corners.Count - 1); // closed face: last corner repeats the first
+      }
+
+      if (corners.Count >= 3)
+      {
+        result.Add(corners.Count);
+        result.AddRange(corners);
+      }
+
+      i += vertexPerFace + 1;
+    }
+
+    return result.ToArray();
   }
 }

--- a/Converters/Autocad/Speckle.Converters.AutocadShared/ToHost/Geometry/SolidXToHostConverter.cs
+++ b/Converters/Autocad/Speckle.Converters.AutocadShared/ToHost/Geometry/SolidXToHostConverter.cs
@@ -14,13 +14,13 @@ namespace Speckle.Converters.Autocad.Geometry;
 [NameAndRankValue(typeof(SOG.SolidX), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
 public class SolidXToHostConverter : IToHostTopLevelConverter, ITypedConverter<SOG.SolidX, List<(ADB.Entity a, Base b)>>
 {
-  private readonly ITypedConverter<SOG.Mesh, ADB.PolyFaceMesh> _meshConverter;
+  private readonly ITypedConverter<SOG.Mesh, ADB.Entity> _meshConverter;
   private readonly ITypedConverter<RawEncoding, List<ADB.Entity>> _rawEncodingConverter;
   private readonly EntityUnitConverter _entityUnitConverter;
   private readonly ISdkActivityFactory _activityFactory;
 
   public SolidXToHostConverter(
-    ITypedConverter<SOG.Mesh, ADB.PolyFaceMesh> meshConverter,
+    ITypedConverter<SOG.Mesh, ADB.Entity> meshConverter,
     ITypedConverter<RawEncoding, List<ADB.Entity>> rawEncodingConverter,
     EntityUnitConverter entityUnitConverter,
     ISdkActivityFactory activityFactory
@@ -59,14 +59,14 @@ public class SolidXToHostConverter : IToHostTopLevelConverter, ITypedConverter<S
       }
     }
 
-    // Fallback: Convert displayValue meshes to PolyFaceMesh
-    var result = new List<ADB.PolyFaceMesh>();
+    // Fallback: Convert displayValue meshes to native meshes
+    var result = new List<ADB.Entity>();
     foreach (SOG.Mesh mesh in target.displayValue)
     {
-      ADB.PolyFaceMesh convertedMesh = _meshConverter.Convert(mesh);
+      ADB.Entity convertedMesh = _meshConverter.Convert(mesh);
       result.Add(convertedMesh);
     }
 
-    return result.Zip(target.displayValue, (a, b) => ((ADB.Entity)a, (Base)b)).ToList();
+    return result.Zip(target.displayValue, (a, b) => (a, (Base)b)).ToList();
   }
 }

--- a/Converters/Autocad/Speckle.Converters.AutocadShared/ToHost/Geometry/SubDXToHostConverter.cs
+++ b/Converters/Autocad/Speckle.Converters.AutocadShared/ToHost/Geometry/SubDXToHostConverter.cs
@@ -5,7 +5,7 @@ using Speckle.Sdk.Models;
 namespace Speckle.Converters.Autocad.Geometry;
 
 /// <summary>
-/// Converts a SubDX to a List(PolyFaceMesh,Mesh)> as fallback conversion
+/// Converts a SubDX to a List(Entity,Mesh)> as fallback conversion
 /// </summary>
 /// <remarks>
 /// The return type is (Entity,Base) instead of the specific type (PolyfaceMesh, Mesh) so this result can be picked up by a generic list case in the SpeckleToHost connector object baking. This is essentially one-to-many fallback conversion.
@@ -13,9 +13,9 @@ namespace Speckle.Converters.Autocad.Geometry;
 [NameAndRankValue(typeof(SOG.SubDX), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
 public class SubDXToHostConverter : IToHostTopLevelConverter, ITypedConverter<SOG.SubDX, List<(ADB.Entity a, Base b)>>
 {
-  private readonly ITypedConverter<SOG.Mesh, ADB.PolyFaceMesh> _meshConverter;
+  private readonly ITypedConverter<SOG.Mesh, ADB.Entity> _meshConverter;
 
-  public SubDXToHostConverter(ITypedConverter<SOG.Mesh, ADB.PolyFaceMesh> meshConverter)
+  public SubDXToHostConverter(ITypedConverter<SOG.Mesh, ADB.Entity> meshConverter)
   {
     _meshConverter = meshConverter;
   }
@@ -27,13 +27,13 @@ public class SubDXToHostConverter : IToHostTopLevelConverter, ITypedConverter<SO
   /// </remarks>
   public List<(ADB.Entity a, Base b)> Convert(SOG.SubDX target)
   {
-    var result = new List<ADB.PolyFaceMesh>();
+    var result = new List<ADB.Entity>();
     foreach (SOG.Mesh mesh in target.displayValue)
     {
-      ADB.PolyFaceMesh convertedMesh = _meshConverter.Convert(mesh);
+      ADB.Entity convertedMesh = _meshConverter.Convert(mesh);
       result.Add(convertedMesh);
     }
 
-    return result.Zip(target.displayValue, (a, b) => ((ADB.Entity)a, (Base)b)).ToList();
+    return result.Zip(target.displayValue, (a, b) => (a, (Base)b)).ToList();
   }
 }


### PR DESCRIPTION
Three independent Civil3D/AutoCAD bugs, one commit each.

### 1. Entity names lost on send — everything shows as its type name ([ENG-8831](https://linear.app/speckle/issue/ENG-8831))

`AutocadArtifactRootObjectBuilder.EmitObject` wrote the object's `name` scalar from `co.SourceType`, i.e. the host entity's .NET type name — so every object arrived named `Alignment`, `Corridor`, `Pipe`… The name the converter had already extracted was sitting unused on the `DataObject` carrier (the Civil3D child path in `EmitCivilChild` was already reading it from there).

Now taken from the carrier, falling back to the type when empty:
- **Civil3D** — the entity name (`"Alignment - (1)"`) from `CivilEntityToSpeckleTopLevelConverter`
- **Plant3D** — the tag value from `Plant3dEntityToSpeckleConverter` (same bug, also fixed by this)
- **AutoCAD** — unchanged, its carrier sets `name = type name` anyway
- **Block placements** (`InstanceProxy`, no carrier) — keep the type, as before

### 2. Meshes over 32767 vertices corrupted on receive ([ENG-8836](https://linear.app/speckle/issue/ENG-8836))

A `PolyFaceMesh` addresses its vertices through `FaceRecord`, whose 1-based vertex indices are **16-bit**. Both bake paths cast straight to `short`, so on any mesh past 32767 vertices (a Civil3D TIN surface gets there fast) every face beyond the ceiling wrapped negative and the mesh baked as garbage triangles. The send side is 32-bit clean — nothing was lost in the bundle, only the bake ceiling was wrong.

Past that vertex count both paths now build a native **MESH** (`SubDMesh`): `SetSubDMesh` takes the whole topology in one call — a vertex array plus the same count-prefixed, 0-based face array Speckle/SGEO already carry — with 32-bit indices, and per-vertex colours ride its `EntityColor` array. Smooth level 0 keeps the faceting exactly as authored. Meshes within the limit keep the existing `PolyFaceMesh` path untouched.

- `MeshToHostConverter` (v1 receive + every fallback that meshes its `displayValue`) now declares `ADB.Entity` instead of `ADB.PolyFaceMesh`; its six consumers follow. Both branches still append to the current space, so callers see no change in database residency.
- `AutocadHostObjectArtefactBuilder.BuildMesh` (the 4.0 artefact bake) mirrors it from the neutral `SgeoMesh`.
- `SetSubDMesh` rejects the *whole* mesh on a single bad face, so both face-array builders normalize first: legacy 0/1 face counts, repeated corners (`[a,b,c,c]` is really a triangle), and truncated / out-of-range faces are dropped rather than costing the entire surface.

### 3. Highlight on a received model card selects nothing ([ENG-8833](https://linear.app/speckle/issue/ENG-8833))

The artefact bake reported baked entities as `ObjectId.ToString()` — a parenthesised in-memory pointer, e.g. `"(2130508640)"`. Everything downstream speaks **handles**: the receiver card stores these ids and `AutocadBasicConnectorBinding.HighlightModel` feeds them to `DocumentExtensions.GetObjects`, which `long.TryParse`s each into a `Handle`. The parentheses fail the parse, so every id was dropped and Highlight reported *"No objects found to highlight"* (AutoCAD and Civil3D both).

Now reports the entity handle (`GetSpeckleApplicationId`, decimal `Handle.Value`) as the v1 builder always did, for atomic geometry and block placements alike, captured while the entity is still open in its bake transaction. The conversion report's `ResultId` moves to the same id space, so clicking a reported object selects it too. Native grouping keeps using `ObjectId`s.

### Testing

Compile-verified across all 12 AutoCAD-family connector projects (Autocad/Civil3d 2023–2027 + Plant3d 2026/2027, net48 and net8) — no runtime testing, over to you:
1. **Names** — send Civil3D alignments/corridors/pipe networks, check the object names in the web app (and a Plant3D send, if handy).
2. **Big meshes** — receive a model with a TIN surface over 32767 vertices; expect a clean MESH entity. Also receive a *small* mesh to confirm the PolyFaceMesh path is untouched.
3. **Highlight** — receive anything (incl. blocks), hit Highlight on the card: objects should select and the view should zoom to them. Also click an object in the conversion report.

> **Heads-up, unrelated:** `big-truck` currently doesn't compile against `speckle-sharp-sdk@big-truck` HEAD — SDK #516 (material PBR channels) added a `name` parameter to `ObjectsArtifactPipeline.AddMaterial`, and all five connectors here still call the 5-arg form. I left that alone (it needs one repo-wide sync commit, not an AutoCAD-only patch); to build locally, insert `null` after the app-id argument in `AutocadArtifactRootObjectBuilder.cs:697`, or build against an SDK at `ceb47b7`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)