### PR TITLE
fix(autocad): bake SGEO linework faithfully on 4.0 receive (ENG-8819)

### DIFF
--- a/Connectors/Autocad/Speckle.Connectors.AutocadShared/Operations/Receive/AutocadHostObjectArtefactBuilder.cs
+++ b/Connectors/Autocad/Speckle.Connectors.AutocadShared/Operations/Receive/AutocadHostObjectArtefactBuilder.cs
@@ -60,6 +60,11 @@ public class AutocadHostObjectArtefactBuilder : IArtifactHostObjectBuilder
   private readonly ISdkActivityFactory _activityFactory;
   private readonly ILogger<AutocadHostObjectArtefactBuilder> _logger;
 
+  // Why the last geometry blob produced no entities (missing blob / decode / convert), so an object that bakes nothing
+  // reports the actual cause instead of the opaque "did not convert to any native geometry" [ENG-8819]. Set by
+  // DecodeAndAppend, consumed + reset per object by the caller — the bake is single-threaded on the main thread.
+  private string? _lastDecodeFailure;
+
   public AutocadHostObjectArtefactBuilder(
     IConverterSettingsStore<AutocadConversionSettings> converterSettings,
     IRootToHostConverter converter,
@@ -182,6 +187,7 @@ public class AutocadHostObjectArtefactBuilder : IArtifactHostObjectBuilder
         var source = Source(appId);
         var srcType = SrcType(props);
         var sw = Stopwatch.StartNew();
+        _lastDecodeFailure = null;
         try
         {
           // The layer is created in its own committed transaction so a later per-object abort can't roll it back
@@ -238,23 +244,11 @@ public class AutocadHostObjectArtefactBuilder : IArtifactHostObjectBuilder
 
           if (ids.Count == 0)
           {
-            session.RecordObject(
-              appId,
-              srcType,
-              Status.ERROR,
-              "did not convert to any native geometry",
-              sw.ElapsedMilliseconds
-            );
-            conversionResults.Add(
-              new(
-                Status.ERROR,
-                source,
-                null,
-                null,
-                new ConversionException("Object did not convert to any native geometry"),
-                srcType
-              )
-            );
+            // Carry the decode/convert failure through to the report card — a dropped curve/point must say why
+            // [ENG-8819], not just that nothing landed.
+            var reason = _lastDecodeFailure ?? "did not convert to any native geometry";
+            session.RecordObject(appId, srcType, Status.ERROR, reason, sw.ElapsedMilliseconds);
+            conversionResults.Add(new(Status.ERROR, source, null, null, new ConversionException(reason), srcType));
             continue;
           }
 
@@ -356,6 +350,7 @@ public class AutocadHostObjectArtefactBuilder : IArtifactHostObjectBuilder
     var result = new List<AcadEntity>();
     if (!bundle.Geometries.TryGetValue(geomK, out var g))
     {
+      _lastDecodeFailure = $"geom {geomK}: no blob for this geometry index in the bundle";
       return result;
     }
 
@@ -370,6 +365,7 @@ public class AutocadHostObjectArtefactBuilder : IArtifactHostObjectBuilder
       }
       catch (Exception ex) when (!ex.IsFatal())
       {
+        _lastDecodeFailure = $"geom {geomK} (SAT) decode failed — {ex.GetType().Name}: {ex.Message}";
         _logger.LogWarning(ex, "SAT decode failed for geometry {GeomK} ({Bytes} bytes)", geomK, g.Content.Length);
         return result;
       }
@@ -431,16 +427,25 @@ public class AutocadHostObjectArtefactBuilder : IArtifactHostObjectBuilder
     try
     {
       decoded = SgeoDecoder.Decode(content);
-      return decoded switch
+      var converted = decoded switch
       {
         Speckle.Objects.Geometry.Pointcloud cloud => PointcloudToPoints(cloud),
         Speckle.Objects.Geometry.Spiral spiral => ConvertViaToHost(spiral.displayValue),
         _ => ConvertViaToHost(decoded),
       };
+      if (converted.Count == 0)
+      {
+        // decode + convert both ran without throwing but produced nothing (e.g. a converter returned an unhandled
+        // result shape) — record it so it isn't a silent drop.
+        _lastDecodeFailure = $"geom {geomK} ({decoded.speckle_type}): converter returned no native geometry";
+        _logger.LogWarning("Skipped SGEO geometry {GeomK}: {Reason}", geomK, _lastDecodeFailure);
+      }
+      return converted;
     }
     catch (Exception ex) when (!ex.IsFatal())
     {
       string stage = decoded is null ? "decode" : $"convert of {decoded.speckle_type}";
+      _lastDecodeFailure = $"geom {geomK} (SGEO) {stage} failed — {ex.GetType().Name}: {ex.Message}";
       _logger.LogWarning(
         ex,
         "Skipped SGEO geometry {GeomK} ({Bytes} bytes) at {Stage}: {Error}",
@@ -788,6 +793,13 @@ public class AutocadHostObjectArtefactBuilder : IArtifactHostObjectBuilder
 
       if (memberCount == 0)
       {
+        // A definition whose members all failed to decode leaves every placement of it unbaked — say why [ENG-8819].
+        _logger.LogWarning(
+          "Block definition {DefNodeK} ('{Name}') baked no members: {Reason}",
+          defNodeK,
+          defNode.Name,
+          _lastDecodeFailure ?? "no member geometry decoded"
+        );
         session.Increment("definitionsEmpty");
         btr.Erase();
         return ObjectId.Null;

--- a/Connectors/Autocad/Speckle.Connectors.AutocadShared/Operations/Send/AutocadArtifactRootObjectBuilder.cs
+++ b/Connectors/Autocad/Speckle.Connectors.AutocadShared/Operations/Send/AutocadArtifactRootObjectBuilder.cs
@@ -703,6 +703,7 @@ public class AutocadArtifactRootObjectBuilder(
       var value = materialProxy.value;
       int matK = pipeline.AddMaterial(
         materialProxy.applicationId.NotNull(),
+        value.name,
         value.diffuse,
         value.opacity,
         value.metalness,

--- a/Converters/Autocad/Speckle.Converters.AutocadShared/ToHost/Geometry/PolycurveToHostConverter.cs
+++ b/Converters/Autocad/Speckle.Converters.AutocadShared/ToHost/Geometry/PolycurveToHostConverter.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using Autodesk.AutoCAD.DatabaseServices;
 using Speckle.Converters.Common;
 using Speckle.Converters.Common.Objects;
@@ -8,24 +9,28 @@ namespace Speckle.Converters.AutocadShared.ToHost.Geometry;
 /// <summary>
 /// A polycurve has segments as list and it can contain different kind of ICurve objects like Arc, Line, Polyline, Curve etc..
 /// If polycurve segments are planar and only of type <see cref="SOG.Line"/> and <see cref="SOG.Arc"/>, it can be represented as Polyline in Autocad.
+/// A non-planar chain of straight segments becomes a single <see cref="ADB.Polyline3d"/>.
 /// Otherwise we convert it as spline (list of ADB.Entity) that switch cases according to each segment type.
 /// </summary>
 [NameAndRankValue(typeof(SOG.Polycurve), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
 public class PolycurveToHostConverter : IToHostTopLevelConverter, ITypedConverter<SOG.Polycurve, List<(Entity, Base)>>
 {
   private readonly ITypedConverter<SOG.Polycurve, ADB.Polyline> _polylineConverter;
+  private readonly ITypedConverter<SOG.Polyline, ADB.Polyline3d> _polyline3dConverter;
   private readonly ITypedConverter<SOG.Line, ADB.Line> _lineConverter;
   private readonly ITypedConverter<SOG.Arc, ADB.Arc> _arcConverter;
   private readonly ITypedConverter<SOG.Curve, ADB.Curve> _curveConverter;
 
   public PolycurveToHostConverter(
     ITypedConverter<SOG.Polycurve, ADB.Polyline> polylineConverter,
+    ITypedConverter<SOG.Polyline, ADB.Polyline3d> polyline3dConverter,
     ITypedConverter<SOG.Line, ADB.Line> lineConverter,
     ITypedConverter<SOG.Arc, ADB.Arc> arcConverter,
     ITypedConverter<SOG.Curve, ADB.Curve> curveConverter
   )
   {
     _polylineConverter = polylineConverter;
+    _polyline3dConverter = polyline3dConverter;
     _lineConverter = lineConverter;
     _arcConverter = arcConverter;
     _curveConverter = curveConverter;
@@ -38,15 +43,86 @@ public class PolycurveToHostConverter : IToHostTopLevelConverter, ITypedConverte
     bool convertAsSpline = target.segments.Any(s => s is not SOG.Line and not SOG.Arc);
     bool isPlanar = IsPolycurvePlanar(target);
 
-    if (convertAsSpline || !isPlanar)
-    {
-      return ConvertAsCurveSegments(target);
-    }
-    else
+    if (!convertAsSpline && isPlanar)
     {
       return new() { (_polylineConverter.Convert(target), target) };
     }
+
+    // A non-planar chain of straight segments IS a 3d polyline — bake it as one Polyline3d instead of exploding it into
+    // loose lines [ENG-8819]. The 4.0 artefact path has nothing else to go on: SGEO encodes an AutocadPolycurve as a
+    // plain Polycurve, so the subtype (and with it AutocadPolycurveToHostConverter) is gone by the time we receive.
+    if (!convertAsSpline && TryChainStraightSegments(target, out SOG.Polyline? chain))
+    {
+      return new() { (_polyline3dConverter.Convert(chain), target) };
+    }
+
+    return ConvertAsCurveSegments(target);
   }
+
+  /// <summary>
+  /// Flattens a polycurve whose segments are all <see cref="SOG.Line"/>s into the equivalent <see cref="SOG.Polyline"/>,
+  /// provided the segments actually chain end-to-start. Returns false for anything else (a gap would be silently bridged
+  /// by a polyline, so those keep the per-segment path).
+  /// </summary>
+  private static bool TryChainStraightSegments(SOG.Polycurve target, [NotNullWhen(true)] out SOG.Polyline? chain)
+  {
+    chain = null;
+    if (target.segments.Count < 2 || target.segments.Any(s => s is not SOG.Line))
+    {
+      return false;
+    }
+
+    var lines = target.segments.Cast<SOG.Line>().ToList();
+    // The chain's coordinates come from the segments, so they must all be in one unit for a single Polyline to describe
+    // them (SGEO writes a unit per nested segment blob, so don't assume).
+    string units = lines[0].units;
+    var value = new List<double>((lines.Count + 1) * 3);
+    for (int i = 0; i < lines.Count; i++)
+    {
+      if (!string.Equals(lines[i].units, units, StringComparison.Ordinal))
+      {
+        return false;
+      }
+      if (i > 0 && !IsCoincident(lines[i - 1].end, lines[i].start))
+      {
+        return false;
+      }
+      value.Add(lines[i].start.x);
+      value.Add(lines[i].start.y);
+      value.Add(lines[i].start.z);
+    }
+
+    var last = lines[^1].end;
+    if (target.closed)
+    {
+      // a closed Polyline omits the repeated last point; bail if the chain doesn't actually come back to the start
+      if (!IsCoincident(last, lines[0].start))
+      {
+        return false;
+      }
+    }
+    else
+    {
+      value.Add(last.x);
+      value.Add(last.y);
+      value.Add(last.z);
+    }
+
+    chain = new SOG.Polyline
+    {
+      value = value,
+      units = units,
+      closed = target.closed,
+      domain = target.domain,
+    };
+    return true;
+  }
+
+  // Segment endpoints come off a lossless SGEO/serialization round-trip, so this only absorbs float noise.
+  private static bool IsCoincident(SOG.Point a, SOG.Point b) =>
+    Math.Abs(a.x - b.x) < TOLERANCE && Math.Abs(a.y - b.y) < TOLERANCE && Math.Abs(a.z - b.z) < TOLERANCE;
+
+  private const double TOLERANCE = 1e-6;
 
   private bool IsPolycurvePlanar(SOG.Polycurve polycurve)
   {
@@ -99,29 +175,35 @@ public class PolycurveToHostConverter : IToHostTopLevelConverter, ITypedConverte
   {
     // POC: We can improve this once we have IIndex of raw converters and we can get rid of case converters?
     // POC: Should we join entities?
-    var list = new List<ADB.Entity>();
+    var converted = new List<(Entity, Base)>();
 
     foreach (var segment in target.segments)
     {
       switch (segment)
       {
         case SOG.Arc arc:
-          list.Add(_arcConverter.Convert(arc));
+          converted.Add((_arcConverter.Convert(arc), arc));
           break;
         case SOG.Line line:
-          list.Add(_lineConverter.Convert(line));
+          converted.Add((_lineConverter.Convert(line), line));
           break;
         case SOG.Polyline polyline:
-          list.Add(_polylineConverter.Convert(polyline));
+          // Polyline3d, NOT the lwpolyline converter: a segment reached here because the polycurve is non-planar, and
+          // the implicit Polyline→Polycurve conversion the lwpolyline converter would take flattens it to one plane.
+          converted.Add((_polyline3dConverter.Convert(polyline), polyline));
           break;
         case SOG.Curve curve:
-          list.Add(_curveConverter.Convert(curve));
+          converted.Add((_curveConverter.Convert(curve), curve));
+          break;
+        case SOG.Spiral spiral:
+          // no native Autocad spiral — bake the display polyline rather than dropping the segment [ENG-8819]
+          converted.Add((_polyline3dConverter.Convert(spiral.displayValue), spiral));
           break;
         default:
           break;
       }
     }
 
-    return list.Zip(target.segments, (a, b) => ((ADB.Entity)a, (Base)b)).ToList();
+    return converted;
   }
 }

--- a/Converters/Autocad/Speckle.Converters.AutocadShared/ToHost/Raw/PolycurveToHostPolylineRawConverter.cs
+++ b/Converters/Autocad/Speckle.Converters.AutocadShared/ToHost/Raw/PolycurveToHostPolylineRawConverter.cs
@@ -24,10 +24,26 @@ public class PolycurveToHostPolylineRawConverter : ITypedConverter<SOG.Polycurve
   public ADB.Polyline Convert(SOG.Polycurve target)
   {
     ADB.Polyline polyline = new() { Closed = target.closed };
-    AG.Plane plane = new(
-      AG.Point3d.Origin,
-      AG.Vector3d.ZAxis.TransformBy(_settingsStore.Current.Document.Editor.CurrentUserCoordinateSystem)
-    );
+    AG.Vector3d normal = AG
+      .Vector3d.ZAxis.TransformBy(_settingsStore.Current.Document.Editor.CurrentUserCoordinateSystem)
+      .GetNormal();
+    AG.Plane plane = new(AG.Point3d.Origin, normal);
+
+    // An ADB.Polyline is planar: its vertices are 2D in the plane defined by Normal + Elevation. Convert2d projects the
+    // scaled vertices onto the plane THROUGH THE ORIGIN, so without an explicit Elevation every planar polycurve bakes
+    // at Z=0 — a lwpolyline sent from a drawing at elevation came back flattened [ENG-8819]. The 4.0 artefact path
+    // always lands here (SGEO carries no AutocadPolycurve subtype, so the elevation-aware
+    // AutocadPolycurveToHostPolylineRawConverter is unreachable), so recover it from the first vertex: the caller only
+    // routes PLANAR polycurves here, so every vertex shares this offset along the normal.
+    double? elevation = null;
+
+    // Scales the point, records the plane offset from the first vertex, and projects it into the polyline's plane.
+    AG.Point2d ToPlane(SOG.Point point)
+    {
+      AG.Point3d scaled = _pointConverter.Convert(point);
+      elevation ??= scaled.GetAsVector().DotProduct(normal); // plane passes through the origin → offset is the dot
+      return scaled.Convert2d(plane);
+    }
 
     int count = 0;
     foreach (Objects.ICurve segment in target.segments)
@@ -35,10 +51,10 @@ public class PolycurveToHostPolylineRawConverter : ITypedConverter<SOG.Polycurve
       switch (segment)
       {
         case SOG.Line o:
-          polyline.AddVertexAt(count, _pointConverter.Convert(o.start).Convert2d(plane), 0, 0, 0);
+          polyline.AddVertexAt(count, ToPlane(o.start), 0, 0, 0);
           if (!target.closed && count == target.segments.Count - 1)
           {
-            polyline.AddVertexAt(count + 1, _pointConverter.Convert(o.end).Convert2d(plane), 0, 0, 0);
+            polyline.AddVertexAt(count + 1, ToPlane(o.end), 0, 0, 0);
           }
 
           count++;
@@ -52,19 +68,18 @@ public class PolycurveToHostPolylineRawConverter : ITypedConverter<SOG.Polycurve
           }
 
           var bulge = Math.Tan(measure / 4) * BulgeDirection(arc.startPoint, arc.midPoint, arc.endPoint);
-          polyline.AddVertexAt(count, _pointConverter.Convert(arc.startPoint).Convert2d(plane), bulge, 0, 0);
+          polyline.AddVertexAt(count, ToPlane(arc.startPoint), bulge, 0, 0);
           if (!target.closed && count == target.segments.Count - 1)
           {
-            polyline.AddVertexAt(count + 1, _pointConverter.Convert(arc.endPoint).Convert2d(plane), 0, 0, 0);
+            polyline.AddVertexAt(count + 1, ToPlane(arc.endPoint), 0, 0, 0);
           }
 
           count++;
           break;
         case SOG.Spiral o:
-          List<AG.Point3d> vertices = o.displayValue.GetPoints().Select(_pointConverter.Convert).ToList();
-          foreach (AG.Point3d vertex in vertices)
+          foreach (SOG.Point vertex in o.displayValue.GetPoints())
           {
-            polyline.AddVertexAt(count, vertex.Convert2d(plane), 0, 0, 0);
+            polyline.AddVertexAt(count, ToPlane(vertex), 0, 0, 0);
             count++;
           }
 
@@ -72,6 +87,13 @@ public class PolycurveToHostPolylineRawConverter : ITypedConverter<SOG.Polycurve
         default:
           break;
       }
+    }
+
+    // Normal before Elevation: the elevation is measured along the normal.
+    if (elevation is double e)
+    {
+      polyline.Normal = normal;
+      polyline.Elevation = e;
     }
 
     return polyline;


### PR DESCRIPTION
Closes the residual gaps in [ENG-8819](https://linear.app/speckle/issue/ENG-8819/autocad-40-receive-drops-all-2d-linework-sgeo-curvespoints-are-not).

### Context: the ticket's stated root cause is already fixed

ENG-8819 says `DecodeAndAppend` only calls `SgeoDecoder.TryDecodeMesh`, so every non-mesh SGEO primitive yields zero entities. That was true when it was filed, but 4f8e9d1d ("full SGEO receive coverage", 10 Jul) already added the reference implementation the ticket asks for — `ConvertSgeoFallback` → `SgeoDecoder.Decode` → `IRootToHostConverter`, plus the Pointcloud/Spiral manual paths and a `TextToHostConverter`.

So this PR is the result of auditing that path against the ticket's acceptance matrix instead. Things that already hold, for the record:

- **Units** — every AutoCAD ToHost converter for these primitives scales itself (point raw converter, circle radius, ellipse major axis, arc/curve via their points, MText height/width), so the builder deliberately skipping `ScaleEntity` on the non-mesh branch is correct.
- **The single-Point caveat** — `SgeoDecoder.Decode` returns a lone `Point` as a one-point `Pointcloud`; `PointcloudToPoints` handles it, with per-point colours.
- **Curves inside block definitions** — `BakeMember` runs the same `DecodeAndAppend` into the `BlockTableRecord`, and converters that self-append to current space (Hatch, Polyline3d) get re-parented via `AssumeOwnershipOf`.

### What this changes

**1. Report *why* linework dropped** (`AutocadHostObjectArtefactBuilder`)

Any decode or convert failure was swallowed into a log warning, so the report card only ever said *"Object did not convert to any native geometry"* — the exact opacity the ticket complains about. Tracks the last failure (missing blob / decode / convert, naming the primitive type) and surfaces it, mirroring `RhinoHostObjectArtefactBuilder`'s `_lastDecodeFailure`. A block definition that bakes no members now logs its reason too, since that silently unbakes every placement of it.

**2. Planar polycurves keep their elevation** (`PolycurveToHostPolylineRawConverter`)

The converter projects vertices onto the plane *through the origin* and never set `Elevation`, so every lwpolyline arrived flattened to Z=0. This only bites the 4.0 path: SGEO encodes an `AutocadPolycurve` as a plain `Polycurve`, so the elevation-aware `AutocadPolycurveToHostPolylineRawConverter` is unreachable and this generic converter is the only one in play. Recovers the offset from the first vertex, which is sound because the caller only routes *planar* polycurves here.

**3. 3d polylines stay one entity** (`PolycurveToHostConverter`)

- A non-planar chain of straight segments exploded into N loose `ADB.Line`s, so a 3d polyline never round-tripped as an entity. Now bakes as a single `Polyline3d` (bails to the per-segment path if the segments don't actually chain end-to-start, or mix units, so a gap is never silently bridged).
- `Polyline` segments went through the lwpolyline converter, which flattens them via the implicit `Polyline`→`Polycurve` operator; they now go to `Polyline3d`.
- `Spiral` segments hit `default: break` and vanished; they now bake via their display polyline.
- Replaced the positional `Zip` at the end — any skipped segment used to mis-pair every later entity with the wrong source `Base`.

**4. `AddMaterial` signature sync** (separate commit)

speckle-sharp-sdk's big-truck (4e043bdc, "material pbr channels") added a `name` parameter, so the AutoCAD send builder no longer compiled against the side-by-side SDK checkout. Passes `RenderMaterial.name`, which the receive side already reads — the AutoCAD material dictionary entry is named from the MATERIAL node, so received materials now carry their source name instead of `"Material"`.

⚠️ Only AutoCAD/Civil3D/Plant3D are fixed (one shared send builder), because that's what was needed to build this. **Rhino, Grasshopper, Revit, Tekla and the Rhino importer still call the 5-arg form and won't build in `Local` until synced** — one line each, worth its own PR.

### Testing

Compile-verified: `Speckle.Connectors.Autocad2025`, `Autocad2026`, `Civil3d2025`, `Civil3d2026` all build with 0 warnings / 0 errors (`-c Local`, against the side-by-side SDK checkout — `big-truck` can't build in Debug/Release because `Speckle.Objects` 2026.6.0 predates the artefact types). `csharpier check` clean.

**Runtime behaviour is not yet verified in AutoCAD** — the acceptance run is still to do:

- [ ] DWG with line, LW polyline (with bulges), 2d + 3d polyline, circle, arc, ellipse, spline, point → receive into a fresh doc: every entity bakes natively, correct layer, correct units, correct elevation
- [ ] The same geometry inside a block definition
- [ ] Rhino→AutoCAD / Grasshopper→AutoCAD linework (needs an already-published model, or the `AddMaterial` sync above to build those senders locally)
- [ ] Regression matrix G1–G9

Known remaining hole, worth a sub-issue rather than scope creep here: SGEO encodes `Box` but AutoCAD has no `Box` ToHost converter, so a Box from Rhino/GH still drops — though it now reports a clear reason instead of vanishing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
