### PR TITLE
fix(civil3d): stop double-emitting civil base curves on 4.0 send (ENG-8835)

### DIFF
--- a/Connectors/Autocad/Speckle.Connectors.AutocadShared/Operations/Send/AutocadArtifactRootObjectBuilder.cs
+++ b/Connectors/Autocad/Speckle.Connectors.AutocadShared/Operations/Send/AutocadArtifactRootObjectBuilder.cs
@@ -426,15 +426,16 @@ public class AutocadArtifactRootObjectBuilder(
     // ── geometry object ───────────────────────────────────────────────────────────────────────────────
     // The DataObject carrier (AutocadObject / Civil3dObject) already split display meshes from the lossless raw
     // encoding (a Solid3d carries both; a plain mesh/curve/point is its own display). AutoCAD solids carry an
-    // ACIS-SAT rawEncoding; Civil3D objects carry their base curve(s) which are also renderable geometry.
+    // ACIS-SAT rawEncoding; Civil3D objects carry their base curve(s) as a display FALLBACK (see
+    // WithCivilBaseCurveFallback).
     List<Base> displayGeometry;
     RawEncoding? rawEncoding = null;
     if (co.Converted is DataObject dataObject)
     {
       displayGeometry = new List<Base>(dataObject.displayValue);
-      if (co.Converted is Civil3dObject civil && civil.baseCurves is { Count: > 0 } baseCurves)
+      if (co.Converted is Civil3dObject civil)
       {
-        displayGeometry.AddRange(baseCurves.Cast<Base>());
+        displayGeometry = WithCivilBaseCurveFallback(displayGeometry, civil);
       }
       rawEncoding = (co.Converted as AutocadObject)?.rawEncoding;
     }
@@ -532,6 +533,21 @@ public class AutocadArtifactRootObjectBuilder(
     return dropReason;
   }
 
+  // A Civil3dObject's baseCurves are a display FALLBACK, never extra geometry on top of displayValue.
+  // CivilEntityToSpeckleTopLevelConverter already fills displayValue FROM the base curves for every entity with no
+  // display of its own (alignments, parcels, parcel segments — via ProcessICurvesForDisplay), so appending them
+  // wholesale emitted each of those curves TWICE: the viewer hid it, but receive baked two coincident entities per
+  // curve, and every alignment/parcel arrived doubled [ENG-8835]. Emitting displayValue alone is also what the v1
+  // path bakes (DataObjectConverter reads displayValue only, never baseCurves), so this restores parity.
+  //
+  // The fallback still matters for the one case displayValue cannot cover: ProcessICurvesForDisplay only passes
+  // Line/Polyline/Arc (and recurses Polycurve), so a base curve of any other type — a circular or spline parcel
+  // boundary — leaves displayValue empty, and the raw base curve is then the object's only geometry.
+  private static List<Base> WithCivilBaseCurveFallback(List<Base> displayGeometry, Civil3dObject civil) =>
+    displayGeometry.Count == 0 && civil.baseCurves is { Count: > 0 } baseCurves
+      ? baseCurves.Cast<Base>().ToList()
+      : displayGeometry;
+
   // ByLayer member: pin its resolved layer colour onto its geometry so it doesn't inherit the instance's
   // colour override — the fallback stays reserved for ByBlock members [ENG-8825].
   private static void EmitMemberLayerColor(
@@ -577,11 +593,9 @@ public class AutocadArtifactRootObjectBuilder(
       string childType = child is Civil3dObject ct ? ct.type : child.speckle_type;
       pipeline.AddProperties(childAppId, props, RootScalars(child.speckle_type, childName, units, childType));
 
-      var display = child is Civil3dObject cc ? new List<Base>(cc.displayValue) : new List<Base> { child };
-      if (child is Civil3dObject cb && cb.baseCurves is { Count: > 0 } baseCurves)
-      {
-        display.AddRange(baseCurves.Cast<Base>());
-      }
+      var display = child is Civil3dObject cc
+        ? WithCivilBaseCurveFallback(new List<Base>(cc.displayValue), cc)
+        : new List<Base> { child };
       var gKs = new List<int>();
       int ord = 0;
       foreach (Base fragment in display)


### PR DESCRIPTION
Closes [ENG-8835](https://linear.app/speckle/issue/ENG-8835/civil-3d-receive-fails-for-nearly-all-civil-entity-classes-alignments) (pending the in-host acceptance run, see below).

### Context: the ticket's stated root cause is already fixed

ENG-8835 says Civil 3D receive drops every entity class that displays as linework or points — alignments, feature lines, parcels, catchments, CogoPoints — and identifies the cause as "exactly ENG-8819 / finding A1", expecting **no Civil-specific code change**. That was right: #1485 added the `SgeoDecoder.Decode` → `IRootToHostConverter` fallback to `DecodeAndAppend`, so those classes now bake. Traced end to end:

| Class | SGEO primitive | Receive path |
|---|---|---|
| Alignment | `Line` / `Arc` / `Polyline` | `LineToHostConverter` / `ArcToHostConverter` / `PolylineToHostConverter` |
| Feature line, survey figure | `Polyline` (+ `Polycurve` base curve) | `PolylineToHostConverter` → **`Polyline3d`**, so per-vertex elevations survive |
| Parcel, parcel segment | `Polycurve` segments | `PolycurveToHostConverter` (also fixed in #1485) |
| Catchment | `Polyline` (closed) | `PolylineToHostConverter` |
| CogoPoint | `Points` | `Decode` → one-point `Pointcloud` → `PointcloudToPoints` → `DBPoint` |

Worth recording a theory I chased and **disproved**, because the code reads alarmingly: `AddRootCommon<Civil3dRootToSpeckleConverter>(civil3dAssembly)` scans only the Civil3D assembly, and `Speckle.Converters.Civil3dShared` contains **zero** `IToHostTopLevelConverter` implementations — which would leave the ToHost converter manager empty and break *all* non-mesh Civil3D receive independently of ENG-8819. It's fine: `Speckle.Converters.Civil3d2026.csproj` imports both the Civil3dShared *and* AutocadShared `.projitems`, so it is one assembly and all 18 AutoCAD ToHost converters are registered.

### What this changes

Verifying the above surfaced a separate Civil3D-only defect, on the **send** side.

`773f708c` appended `Civil3dObject.baseCurves` to the display set, reasoning they are "often the only geometry for linear civil objects". They aren't — `CivilEntityToSpeckleTopLevelConverter:49-53` already fills `displayValue` **from** the base curves (via `ProcessICurvesForDisplay`) for every entity with no display of its own. For alignments the two lists hold the *same `ICurve` instances*, so every alignment/parcel curve was emitted **twice** and receive baked two coincident entities per curve. The viewer hid it (overlapping linework); a receiving document doesn't.

This demotes base curves to what they actually are — a fallback used only when `displayValue` is empty (`WithCivilBaseCurveFallback`, applied on both the top-level and the `EmitCivilChild` path). That also restores v1 parity: `DataObjectConverter` bakes `displayValue` and never reads `baseCurves`.

The fallback still covers the one case `displayValue` cannot: `ProcessICurvesForDisplay` only passes `Line`/`Polyline`/`Arc` (recursing `Polycurve`), so a circular or spline parcel boundary leaves `displayValue` empty and the raw base curve becomes the object's only geometry. SGEO encodes `Circle` and `Curve` and AutoCAD has ToHost converters for both, so that path round-trips.

⚠️ **Deliberate behaviour change:** a pipe no longer bakes its centreline alongside its solid mesh — again v1 behaviour. Easy to revert if we'd rather keep it.

### Scope calls (agreed with @dkekesi, recorded on the ticket)

Two of ENG-8835's acceptance criteria can't be met by an ENG-8819 fallout fix, and both are pre-existing (unchanged `dev..big-truck`) rather than 4.0 regressions:

- **Profiles send no geometry at all** → split out as [ENG-9042](https://linear.app/speckle/issue/ENG-9042/civil-3d-profiles-send-no-geometry-no-profile-case-in). Neither `BaseCurveExtractor` nor `DisplayValueExtractor` has a `CDB.Profile` case, so `displayValue` is empty and `baseCurves` is null — profiles are silently skipped as non-geometric, never reported as "did not convert". The ticket's claim that profile curves are "verified present in `geometries.parquet`" does not hold. Adding it is a feature plus a coordinate-space design question (profile geometry lives in station/elevation space, not plan).
- **US survey feet criterion dropped.** `Civil3dToSpeckleUnitConverter.cs:23` has the `SurveyFoot` mapping commented out, so `ConvertOrThrow` throws `UnitNotSupportedException` while building `Civil3dConversionSettings` and the whole receive card fails before any geometry is touched. Cause is upstream and deliberate — `Speckle.Sdk.Common.Units` keeps `us_ft` **private** ("now not supported by Speckle, kept privately for backwards compatibility"), so it can't be mapped without an SDK change.

### Testing

Compile-verified: `Speckle.Connectors.Civil3d2026` builds `-c Local` against the side-by-side SDK checkout, **0 warnings / 0 errors**. `csharpier check` clean (1178 files). No `packages.lock.json` churn.

**Runtime acceptance in Civil 3D is not yet done** — the remaining ENG-8835 criteria:

- [ ] Send the repro drawing (alignment + profiles, feature line, parcel, catchment, CogoPoints) from Civil 3D, receive into a fresh Civil 3D doc: all bake as native entities on the correct layers, zero "did not convert" errors
- [ ] CogoPoints bake as `DBPoint`s
- [ ] Regression: surfaces and pipe-network parts still receive as before
- [ ] **New, from this fix:** alignments and parcels bake exactly *one* entity per curve, not two coincident ones

🤖 Generated with [Claude Code](https://claude.com/claude-code)
