### PR TITLE
fix(autocad): text survives send + receive (ENG-8827)

### DIFF
--- a/Converters/Autocad/Speckle.Converters.AutocadShared/Helpers/TextAlignmentMap.cs
+++ b/Converters/Autocad/Speckle.Converters.AutocadShared/Helpers/TextAlignmentMap.cs
@@ -1,0 +1,74 @@
+namespace Speckle.Converters.Autocad.Helpers;
+
+/// <summary>
+/// Maps an AutoCAD <see cref="ADB.AttachmentPoint"/> onto the 3x3 alignment grid Speckle's
+/// <see cref="SA.Text"/> exposes. Shared by the MText converter (where it comes from
+/// <c>MText.Attachment</c>) and the DBText converter (where it comes from <c>DBText.Justify</c>),
+/// so both spell the same anchor semantics.
+/// </summary>
+public static class TextAlignmentMap
+{
+  /// <summary>
+  /// Simplify horizontal text alignment to 3 options: Left, Center, Right.
+  /// </summary>
+  public static SA.AlignmentHorizontal GetHorizontalAlignment(ADB.AttachmentPoint attachmentPt) =>
+    attachmentPt switch
+    {
+      ADB.AttachmentPoint.TopLeft
+      or ADB.AttachmentPoint.MiddleLeft
+      or ADB.AttachmentPoint.BottomLeft
+      or ADB.AttachmentPoint.BaseLeft => SA.AlignmentHorizontal.Left,
+      ADB.AttachmentPoint.TopCenter
+      or ADB.AttachmentPoint.MiddleCenter
+      or ADB.AttachmentPoint.BottomCenter
+      or ADB.AttachmentPoint.BaseCenter
+      // Middle (the DBText "MC"-like justification) is centred on both axes.
+      or ADB.AttachmentPoint.BaseMid
+      or ADB.AttachmentPoint.MiddleMid
+      or ADB.AttachmentPoint.TopMid
+      or ADB.AttachmentPoint.BottomMid => SA.AlignmentHorizontal.Center,
+      ADB.AttachmentPoint.TopRight
+      or ADB.AttachmentPoint.MiddleRight
+      or ADB.AttachmentPoint.BottomRight
+      or ADB.AttachmentPoint.BaseRight => SA.AlignmentHorizontal.Right,
+      _ => SA.AlignmentHorizontal.Left,
+    };
+
+  /// <summary>
+  /// Simplify vertical text alignment to 3 options: Top, Center, Bottom.
+  /// </summary>
+  /// <remarks>
+  /// The <c>Base*</c> members are DBText baseline justifications — the baseline is the bottom of the
+  /// text box for Speckle's purposes, so they map to <see cref="SA.AlignmentVertical.Bottom"/>.
+  /// MText never reports them.
+  /// </remarks>
+  public static SA.AlignmentVertical GetVerticalAlignment(ADB.AttachmentPoint attachmentPt) =>
+    attachmentPt switch
+    {
+      ADB.AttachmentPoint.TopLeft
+      or ADB.AttachmentPoint.TopCenter
+      or ADB.AttachmentPoint.TopRight
+      or ADB.AttachmentPoint.TopMid
+      or ADB.AttachmentPoint.TopAlign
+      or ADB.AttachmentPoint.TopFit => SA.AlignmentVertical.Top,
+      ADB.AttachmentPoint.MiddleLeft
+      or ADB.AttachmentPoint.MiddleCenter
+      or ADB.AttachmentPoint.MiddleRight
+      or ADB.AttachmentPoint.MiddleAlign
+      or ADB.AttachmentPoint.MiddleFit
+      or ADB.AttachmentPoint.MiddleMid => SA.AlignmentVertical.Center,
+      ADB.AttachmentPoint.BottomLeft
+      or ADB.AttachmentPoint.BottomCenter
+      or ADB.AttachmentPoint.BottomRight
+      or ADB.AttachmentPoint.BottomAlign
+      or ADB.AttachmentPoint.BottomFit
+      or ADB.AttachmentPoint.BottomMid
+      or ADB.AttachmentPoint.BaseLeft
+      or ADB.AttachmentPoint.BaseCenter
+      or ADB.AttachmentPoint.BaseRight
+      or ADB.AttachmentPoint.BaseAlign
+      or ADB.AttachmentPoint.BaseFit
+      or ADB.AttachmentPoint.BaseMid => SA.AlignmentVertical.Bottom,
+      _ => SA.AlignmentVertical.Top,
+    };
+}

--- a/Converters/Autocad/Speckle.Converters.AutocadShared/ServiceRegistration.cs
+++ b/Converters/Autocad/Speckle.Converters.AutocadShared/ServiceRegistration.cs
@@ -33,6 +33,7 @@ public static class ServiceRegistration
     serviceCollection.AddScoped<IPropertiesExtractor, PropertiesExtractor>();
     serviceCollection.AddScoped<ExtensionDictionaryExtractor>();
     serviceCollection.AddScoped<XDataExtractor>();
+    serviceCollection.AddScoped<TextPropertiesExtractor>();
     serviceCollection.AddScoped<EntityUnitConverter>();
   }
 }

--- a/Converters/Autocad/Speckle.Converters.AutocadShared/Speckle.Converters.AutocadShared.projitems
+++ b/Converters/Autocad/Speckle.Converters.AutocadShared/Speckle.Converters.AutocadShared.projitems
@@ -54,6 +54,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)GlobalUsings.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ToHost\Raw\PointToHostRawConverter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ToHost\Geometry\PointToHostConverter.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)ToHost\Geometry\TextToHostConverter.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Helpers\TextAlignmentMap.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)ToSpeckle\Properties\TextPropertiesExtractor.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ToSpeckle\DataObjectDisplayValueExtractor.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ToSpeckle\Geometry\ArcToSpeckleConverter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ToSpeckle\Geometry\AttributeDefinitionToSpeckleConverter.cs" />

--- a/Converters/Autocad/Speckle.Converters.AutocadShared/ToHost/Geometry/TextToHostConverter.cs
+++ b/Converters/Autocad/Speckle.Converters.AutocadShared/ToHost/Geometry/TextToHostConverter.cs
@@ -28,7 +28,7 @@ public class TextToHostConverter : IToHostTopLevelConverter, ITypedConverter<SA.
     double f = Units.GetConversionFactor(target.units, _settingsStore.Current.SpeckleUnits);
     var mtext = new ADB.MText
     {
-      Contents = target.value,
+      Contents = ToMTextContents(target.value),
       TextHeight = target.height * f,
       Attachment = GetAttachment(target.alignmentH, target.alignmentV),
     };
@@ -46,11 +46,31 @@ public class TextToHostConverter : IToHostTopLevelConverter, ITypedConverter<SA.
     }
     mtext.Location = _pointConverter.Convert(target.plane.origin);
 
-    if (target.maxWidth is double maxWidth)
+    // Only a positive wrap width is a wrap width: MText.Width == 0 IS AutoCAD's "no wrap", and versions before
+    // [ENG-8827] published that 0 verbatim, so treat a non-positive maxWidth as "unset" rather than a zero column.
+    if (target.maxWidth is double maxWidth && maxWidth > 0)
     {
       mtext.Width = maxWidth * f;
     }
     return mtext;
+  }
+
+  /// <summary>
+  /// Turns the plain text Speckle carries into MText contents. MText contents is a mini markup language:
+  /// <c>\</c>, <c>{</c> and <c>}</c> are control characters that must be escaped or AutoCAD swallows them as
+  /// formatting, and a paragraph break is <c>\P</c>, not a newline character.
+  /// </summary>
+  private static string ToMTextContents(string value)
+  {
+    if (string.IsNullOrEmpty(value))
+    {
+      return value;
+    }
+
+    // Escape the control characters FIRST (so the \P inserted below isn't escaped in turn), then fold
+    // CRLF/CR/LF down to the single paragraph-break code.
+    string result = value.Replace("\\", "\\\\").Replace("{", "\\{").Replace("}", "\\}");
+    return result.Replace("\r\n", "\\P").Replace("\r", "\\P").Replace("\n", "\\P");
   }
 
   private static ADB.AttachmentPoint GetAttachment(SA.AlignmentHorizontal h, SA.AlignmentVertical v) =>

--- a/Converters/Autocad/Speckle.Converters.AutocadShared/ToSpeckle/Properties/PropertiesExtractor.cs
+++ b/Converters/Autocad/Speckle.Converters.AutocadShared/ToSpeckle/Properties/PropertiesExtractor.cs
@@ -7,11 +7,17 @@ public class PropertiesExtractor : IPropertiesExtractor
 {
   private readonly ExtensionDictionaryExtractor _extensionDictionaryExtractor;
   private readonly XDataExtractor _xDataExtractor;
+  private readonly TextPropertiesExtractor _textPropertiesExtractor;
 
-  public PropertiesExtractor(ExtensionDictionaryExtractor extensionDictionaryExtractor, XDataExtractor xDataExtractor)
+  public PropertiesExtractor(
+    ExtensionDictionaryExtractor extensionDictionaryExtractor,
+    XDataExtractor xDataExtractor,
+    TextPropertiesExtractor textPropertiesExtractor
+  )
   {
     _extensionDictionaryExtractor = extensionDictionaryExtractor;
     _xDataExtractor = xDataExtractor;
+    _textPropertiesExtractor = textPropertiesExtractor;
   }
 
   public Dictionary<string, object?> GetProperties(ADB.Entity entity)
@@ -23,6 +29,7 @@ public class PropertiesExtractor : IPropertiesExtractor
       properties
     );
     AddDictionaryToPropertyDictionary(_xDataExtractor.GetXData(entity), "XData", properties);
+    AddDictionaryToPropertyDictionary(_textPropertiesExtractor.GetTextProperties(entity), "Text", properties);
 
     return properties;
   }

--- a/Converters/Autocad/Speckle.Converters.AutocadShared/ToSpeckle/Properties/TextPropertiesExtractor.cs
+++ b/Converters/Autocad/Speckle.Converters.AutocadShared/ToSpeckle/Properties/TextPropertiesExtractor.cs
@@ -1,0 +1,121 @@
+using Speckle.Converters.Autocad;
+using Speckle.Converters.Autocad.ToSpeckle.Raw;
+using Speckle.Converters.Common;
+
+namespace Speckle.Converters.AutocadShared.ToSpeckle;
+
+/// <summary>
+/// Extracts the annotation payload of text entities (DBText/MText and the attribute flavours that derive from
+/// DBText) as plain properties.
+/// </summary>
+/// <remarks>
+/// The text itself rides the SGEO Text geometry blob, which is what the viewer renders and what receive bakes.
+/// These properties are the DATA half of the same object: they make the content/height/position queryable in the
+/// object explorer and in automations, and they survive even when a consumer can't decode the geometry [ENG-8827].
+/// </remarks>
+public class TextPropertiesExtractor
+{
+  private readonly IConverterSettingsStore<AutocadConversionSettings> _settingsStore;
+
+  public TextPropertiesExtractor(IConverterSettingsStore<AutocadConversionSettings> settingsStore)
+  {
+    _settingsStore = settingsStore;
+  }
+
+  /// <summary>
+  /// Returns the text properties of <paramref name="entity"/>, or null when it is not a text entity.
+  /// </summary>
+  public Dictionary<string, object?>? GetTextProperties(ADB.Entity entity) =>
+    // MText first: it does NOT derive from DBText, but AttributeReference/AttributeDefinition do, so the
+    // DBText arm has to come last to stay the fallback for all single-line flavours.
+    entity switch
+    {
+      ADB.MText mText => FromMText(mText),
+      ADB.DBText dbText => FromDBText(dbText),
+      _ => null,
+    };
+
+  private Dictionary<string, object?> FromMText(ADB.MText target)
+  {
+    var properties = new Dictionary<string, object?>
+    {
+      ["value"] = MTextToSpeckleRawConverter.ConvertMTextToPlainText(target.Contents ?? string.Empty),
+      ["height"] = target.TextHeight,
+      ["rotation"] = target.Rotation,
+      ["attachment"] = target.Attachment.ToString(),
+      ["position"] = PositionDictionary(target.Location),
+    };
+
+    // The raw markup: kept so formatting (fonts, stacked fractions, colour codes) isn't lost to the plain-text
+    // flattening. Only worth carrying when it actually differs from the plain value.
+    string contents = target.Contents ?? string.Empty;
+    if (contents != properties["value"] as string)
+    {
+      properties["formattedValue"] = contents;
+    }
+    if (target.Width > 0)
+    {
+      properties["wrapWidth"] = target.Width;
+    }
+    AddStyleName(properties, target.TextStyleId);
+    return properties;
+  }
+
+  private Dictionary<string, object?> FromDBText(ADB.DBText target)
+  {
+    // Mirror the geometry converter's anchor choice: left-justified text is anchored by Position, everything
+    // else by AlignmentPoint.
+    bool isLeftJustified = target.Justify == ADB.AttachmentPoint.BaseLeft;
+    var properties = new Dictionary<string, object?>
+    {
+      ["value"] = target.TextString ?? string.Empty,
+      ["height"] = target.Height,
+      ["rotation"] = target.Rotation,
+      ["justification"] = target.Justify.ToString(),
+      ["widthFactor"] = target.WidthFactor,
+      ["oblique"] = target.Oblique,
+      ["position"] = PositionDictionary(isLeftJustified ? target.Position : target.AlignmentPoint),
+    };
+
+    // Block attributes carry their tag as the field name the value belongs to — without it a bag of attribute
+    // values is unattributable.
+    switch (target)
+    {
+      case ADB.AttributeReference attributeReference:
+        properties["tag"] = attributeReference.Tag;
+        break;
+      case ADB.AttributeDefinition attributeDefinition:
+        properties["tag"] = attributeDefinition.Tag;
+        break;
+      default:
+        break;
+    }
+
+    AddStyleName(properties, target.TextStyleId);
+    return properties;
+  }
+
+  private static Dictionary<string, object?> PositionDictionary(AG.Point3d point) =>
+    new()
+    {
+      ["x"] = point.X,
+      ["y"] = point.Y,
+      ["z"] = point.Z,
+    };
+
+  // The style NAME (not its id) is what a consumer can act on. Resolved in its own transaction: this extractor
+  // runs after the converter's transaction has been committed (see AutocadRootToSpeckleConverter).
+  private void AddStyleName(Dictionary<string, object?> properties, ADB.ObjectId textStyleId)
+  {
+    if (textStyleId == ADB.ObjectId.Null)
+    {
+      return;
+    }
+    using ADB.Transaction tr = _settingsStore.Current.Document.TransactionManager.StartTransaction();
+    if (tr.GetObject(textStyleId, ADB.OpenMode.ForRead) is ADB.TextStyleTableRecord record)
+    {
+      properties["style"] = record.Name;
+    }
+    tr.Commit();
+  }
+}

--- a/Converters/Autocad/Speckle.Converters.AutocadShared/ToSpeckle/Raw/DBTextToSpeckleRawConverter.cs
+++ b/Converters/Autocad/Speckle.Converters.AutocadShared/ToSpeckle/Raw/DBTextToSpeckleRawConverter.cs
@@ -43,17 +43,22 @@ public class DBTextToSpeckleRawConverter : ITypedConverter<ADB.DBText, Text>
       }
     }
 
-    // target.WidthFactor is ignored, because we don't support 1-dimensional text scaling
-    // AlignmentPoint can be ignored, as, if used for positioning, it will be already reflected in Rotation and Height
+    // target.WidthFactor is ignored, because we don't support 1-dimensional text scaling.
+    // Justification decides WHICH point anchors the text: left-justified (the AutoCAD default) text is anchored
+    // by Position, every other justification by AlignmentPoint — Position is then stale and publishing it put
+    // justified text in the wrong place [ENG-8827].
+    bool isLeftJustified = target.Justify == ADB.AttachmentPoint.BaseLeft;
+    AG.Point3d anchor = isLeftJustified ? target.Position : target.AlignmentPoint;
+
     return new()
     {
       value = target.TextString ?? string.Empty,
       height = target.Height,
       maxWidth = null, // always 1 line
-      plane = GetTextPlane(target),
+      plane = GetTextPlane(target, anchor),
       screenOriented = false,
-      alignmentH = AlignmentHorizontal.Left, // constant relevant to Position (.Justify & .Alignment Point can be ignored)
-      alignmentV = AlignmentVertical.Bottom, // constant relevant to Position (.Justify & .Alignment Point can be ignored)
+      alignmentH = TextAlignmentMap.GetHorizontalAlignment(target.Justify),
+      alignmentV = TextAlignmentMap.GetVerticalAlignment(target.Justify),
       units = _settingsStore.Current.SpeckleUnits,
     };
   }
@@ -75,10 +80,10 @@ public class DBTextToSpeckleRawConverter : ITypedConverter<ADB.DBText, Text>
   }
 
   // For DBText, the following properties are stored in:
-  // - Position: WCS
+  // - Position / AlignmentPoint: WCS
   // - Normal: WCS
   // - Rotation: OCS -> WCS https://help.autodesk.com/view/OARX/2020/ENU/?guid=OARX-ManagedRefGuide-Autodesk_AutoCAD_DatabaseServices_DBText_Rotation
-  private SOG.Plane GetTextPlane(ADB.DBText target)
+  private SOG.Plane GetTextPlane(ADB.DBText target, AG.Point3d origin)
   {
     // Rotation prop is in OCS: calculate the x and y axis based in WCS
     AG.Matrix3d transform = TransformHelper.GetTransformFromOCSToWCS(target.Normal).Inverse();
@@ -87,7 +92,7 @@ public class DBTextToSpeckleRawConverter : ITypedConverter<ADB.DBText, Text>
 
     return new()
     {
-      origin = _pointConverter.Convert(target.Position),
+      origin = _pointConverter.Convert(origin),
       normal = _vectorConverter.Convert(target.Normal),
       xdir = _vectorConverter.Convert(xDir),
       ydir = _vectorConverter.Convert(yDir),

--- a/Converters/Autocad/Speckle.Converters.AutocadShared/ToSpeckle/Raw/MTextToSpeckleRawConverter.cs
+++ b/Converters/Autocad/Speckle.Converters.AutocadShared/ToSpeckle/Raw/MTextToSpeckleRawConverter.cs
@@ -1,4 +1,5 @@
 using System.Text.RegularExpressions;
+using Speckle.Converters.Autocad.Helpers;
 using Speckle.Converters.Common;
 using Speckle.Converters.Common.Objects;
 
@@ -31,11 +32,13 @@ public class MTextToSpeckleRawConverter : ITypedConverter<ADB.MText, SA.Text>
     {
       value = ConvertMTextToPlainText(target.Contents ?? string.Empty),
       height = target.TextHeight,
-      maxWidth = target.Width,
+      // AutoCAD spells "no wrap" as Width == 0, but Speckle spells it as maxWidth == null: publishing the 0
+      // verbatim made consumers wrap the text to a zero-width column, which renders as nothing [ENG-8827].
+      maxWidth = target.Width > 0 ? target.Width : null,
       plane = GetTextPlane(target),
       screenOriented = false,
-      alignmentH = GetHorizontalAlignment(target.Attachment),
-      alignmentV = GetVerticalAlignment(target.Attachment),
+      alignmentH = TextAlignmentMap.GetHorizontalAlignment(target.Attachment),
+      alignmentV = TextAlignmentMap.GetVerticalAlignment(target.Attachment),
       units = _settingsStore.Current.SpeckleUnits,
     };
 
@@ -49,7 +52,7 @@ public class MTextToSpeckleRawConverter : ITypedConverter<ADB.MText, SA.Text>
   /// Turns raw MText contents into plain text with real newlines, so the viewer can render it
   /// on multiple lines. Covers common formatting; exotic cases may still need cleanup.
   /// </summary>
-  private static string ConvertMTextToPlainText(string contents)
+  public static string ConvertMTextToPlainText(string contents)
   {
     if (string.IsNullOrEmpty(contents))
     {
@@ -86,58 +89,6 @@ public class MTextToSpeckleRawConverter : ITypedConverter<ADB.MText, SA.Text>
       xdir = new(xDir.X, xDir.Y, xDir.Z, _settingsStore.Current.SpeckleUnits),
       ydir = new(yDir.X, yDir.Y, yDir.Z, _settingsStore.Current.SpeckleUnits),
       units = _settingsStore.Current.SpeckleUnits,
-    };
-  }
-
-  /// <summary>
-  /// Simplify horizontal text alignment to 3 options: Left, Center, Right
-  /// </summary>
-  private SA.AlignmentHorizontal GetHorizontalAlignment(ADB.AttachmentPoint attachmentPt)
-  {
-    return attachmentPt switch
-    {
-      ADB.AttachmentPoint.TopLeft
-      or ADB.AttachmentPoint.MiddleLeft
-      or ADB.AttachmentPoint.BottomLeft
-      or ADB.AttachmentPoint.BaseLeft => SA.AlignmentHorizontal.Left,
-      ADB.AttachmentPoint.TopCenter
-      or ADB.AttachmentPoint.MiddleCenter
-      or ADB.AttachmentPoint.BottomCenter
-      or ADB.AttachmentPoint.BaseCenter => SA.AlignmentHorizontal.Center,
-      ADB.AttachmentPoint.TopRight
-      or ADB.AttachmentPoint.MiddleRight
-      or ADB.AttachmentPoint.BottomRight
-      or ADB.AttachmentPoint.BaseRight => SA.AlignmentHorizontal.Right,
-      _ => SA.AlignmentHorizontal.Left,
-    };
-  }
-
-  /// <summary>
-  /// Simplify vertical text alignment to 3 options: Top, Middle, Bottom
-  /// </summary>
-  private SA.AlignmentVertical GetVerticalAlignment(ADB.AttachmentPoint attachmentPt)
-  {
-    return attachmentPt switch
-    {
-      ADB.AttachmentPoint.TopLeft
-      or ADB.AttachmentPoint.TopCenter
-      or ADB.AttachmentPoint.TopRight
-      or ADB.AttachmentPoint.TopMid
-      or ADB.AttachmentPoint.TopAlign
-      or ADB.AttachmentPoint.TopFit => SA.AlignmentVertical.Top,
-      ADB.AttachmentPoint.MiddleLeft
-      or ADB.AttachmentPoint.MiddleCenter
-      or ADB.AttachmentPoint.MiddleRight
-      or ADB.AttachmentPoint.MiddleAlign
-      or ADB.AttachmentPoint.MiddleFit
-      or ADB.AttachmentPoint.MiddleMid => SA.AlignmentVertical.Center,
-      ADB.AttachmentPoint.BottomLeft
-      or ADB.AttachmentPoint.BottomCenter
-      or ADB.AttachmentPoint.BottomRight
-      or ADB.AttachmentPoint.BottomAlign
-      or ADB.AttachmentPoint.BottomFit
-      or ADB.AttachmentPoint.BottomMid => SA.AlignmentVertical.Bottom,
-      _ => SA.AlignmentVertical.Top,
     };
   }
 }

--- a/Converters/Civil3d/Speckle.Converters.Civil3dShared/ServiceRegistration.cs
+++ b/Converters/Civil3d/Speckle.Converters.Civil3dShared/ServiceRegistration.cs
@@ -47,6 +47,7 @@ public static class ServiceRegistration
     serviceCollection.AddScoped<PropertySetDefinitionHandler>();
     serviceCollection.AddScoped<ClassPropertiesExtractor>();
     serviceCollection.AddScoped<ExtensionDictionaryExtractor>();
+    serviceCollection.AddScoped<Speckle.Converters.AutocadShared.ToSpeckle.TextPropertiesExtractor>(); // plain acad text in a civil drawing
     serviceCollection.AddScoped<CorridorHandler>();
     serviceCollection.AddScoped<CorridorDisplayValueExtractor>();
     serviceCollection.AddScoped<EntityUnitConverter>();

--- a/Converters/Civil3d/Speckle.Converters.Civil3dShared/ToSpeckle/Properties/PropertiesExtractor.cs
+++ b/Converters/Civil3d/Speckle.Converters.Civil3dShared/ToSpeckle/Properties/PropertiesExtractor.cs
@@ -9,18 +9,21 @@ public class PropertiesExtractor : Speckle.Converters.AutocadShared.ToSpeckle.IP
   private readonly PartDataExtractor _partDataExtractor;
   private readonly PropertySetExtractor _propertySetExtractor;
   private readonly ExtensionDictionaryExtractor _extensionDictionaryExtractor;
+  private readonly Speckle.Converters.AutocadShared.ToSpeckle.TextPropertiesExtractor _textPropertiesExtractor;
 
   public PropertiesExtractor(
     ClassPropertiesExtractor classPropertiesExtractor,
     PartDataExtractor partDataExtractor,
     PropertySetExtractor propertySetExtractor,
-    ExtensionDictionaryExtractor extensionDictionaryExtractor
+    ExtensionDictionaryExtractor extensionDictionaryExtractor,
+    Speckle.Converters.AutocadShared.ToSpeckle.TextPropertiesExtractor textPropertiesExtractor
   )
   {
     _classPropertiesExtractor = classPropertiesExtractor;
     _partDataExtractor = partDataExtractor;
     _propertySetExtractor = propertySetExtractor;
     _extensionDictionaryExtractor = extensionDictionaryExtractor;
+    _textPropertiesExtractor = textPropertiesExtractor;
   }
 
   public Dictionary<string, object?> GetProperties(ADB.Entity entity)
@@ -36,6 +39,9 @@ public class PropertiesExtractor : Speckle.Converters.AutocadShared.ToSpeckle.IP
       "Extension Dictionary",
       properties
     );
+    // A Civil drawing still holds plain AutoCAD annotation (street labels, notes) — keep its content queryable
+    // alongside the SGEO Text geometry [ENG-8827].
+    AddDictionaryToPropertyDictionary(_textPropertiesExtractor.GetTextProperties(entity), "Text", properties);
 
     return Speckle.Converters.AutocadShared.ToSpeckle.PropertyValueSanitizer.Sanitize(properties);
   }

--- a/Converters/Plant3d/Speckle.Converters.Plant3dShared/ServiceRegistration.cs
+++ b/Converters/Plant3d/Speckle.Converters.Plant3dShared/ServiceRegistration.cs
@@ -37,6 +37,7 @@ public static class ServiceRegistration
     serviceCollection.AddScoped<Speckle.Converters.Plant3dShared.ToSpeckle.PropertiesExtractor>(); // for plant3d
     serviceCollection.AddScoped<Speckle.Converters.AutocadShared.ToSpeckle.IPropertiesExtractor, PropertiesExtractor>();
     serviceCollection.AddScoped<ExtensionDictionaryExtractor>();
+    serviceCollection.AddScoped<Speckle.Converters.AutocadShared.ToSpeckle.TextPropertiesExtractor>(); // plain acad text in a plant drawing
     serviceCollection.AddScoped<Plant3dDataExtractor>();
     serviceCollection.AddScoped<EntityUnitConverter>();
   }

--- a/Converters/Plant3d/Speckle.Converters.Plant3dShared/ToSpeckle/Properties/PropertiesExtractor.cs
+++ b/Converters/Plant3d/Speckle.Converters.Plant3dShared/ToSpeckle/Properties/PropertiesExtractor.cs
@@ -8,14 +8,17 @@ namespace Speckle.Converters.Plant3dShared.ToSpeckle;
 public class PropertiesExtractor : Speckle.Converters.AutocadShared.ToSpeckle.IPropertiesExtractor
 {
   private readonly ExtensionDictionaryExtractor _extensionDictionaryExtractor;
+  private readonly Speckle.Converters.AutocadShared.ToSpeckle.TextPropertiesExtractor _textPropertiesExtractor;
   private readonly string _drawingName;
 
   public PropertiesExtractor(
     ExtensionDictionaryExtractor extensionDictionaryExtractor,
+    Speckle.Converters.AutocadShared.ToSpeckle.TextPropertiesExtractor textPropertiesExtractor,
     IConverterSettingsStore<Plant3dConversionSettings> settingsStore
   )
   {
     _extensionDictionaryExtractor = extensionDictionaryExtractor;
+    _textPropertiesExtractor = textPropertiesExtractor;
     _drawingName = Path.GetFileName(settingsStore.Current.Document.Name);
   }
 
@@ -33,6 +36,9 @@ public class PropertiesExtractor : Speckle.Converters.AutocadShared.ToSpeckle.IP
       "Extension Dictionary",
       properties
     );
+    // Plain AutoCAD annotation in a Plant drawing — keep its content queryable alongside the SGEO Text
+    // geometry [ENG-8827].
+    AddDictionaryToPropertyDictionary(_textPropertiesExtractor.GetTextProperties(entity), "Text", properties);
 
     return properties;
   }


### PR DESCRIPTION
Closes [ENG-8827](https://linear.app/speckle/issue/ENG-8827/autocad-send-text-dbtextmtext-publishes-geometry-less).

## The ticket's premise was stale

`SgeoEncoder` gained a **Text primitive** (code 12) in SDK specklesystems/speckle-sharp-connectors#503 on 9 July, and the viewer got its decode the same day — so DBText/MText *do* publish geometry now. Verified against a real bundle in `%TEMP%\Speckle\artifacts`: `geometries.parquet` carries `text` rows with correct values, planes and `DISPLAY` rels. Three separate defects sat downstream of that, which is why text still vanished end to end.

## 1\. Receive dropped every text object

```
geom 112 (SGEO) convert of Objects.Annotation.Text failed — ConversionException:
No direct conversion found for type Speckle.Objects.Annotation.Text
```

`ToHost/Geometry/TextToHostConverter.cs` existed on disk but was **never listed in** `Speckle.Converters.AutocadShared.projitems`. Shared projects don't glob, so it compiled into no assembly, registered nowhere, and failed only at runtime. Listing it is the entire receive fix.

## 2\. MText published `maxWidth = 0`

AutoCAD spells "no wrap" as `Width == 0`; Speckle spells it `null`. Civil3D corridor labels went out as `flags=1024, maxWidth=0.0`. The viewer's `TextBatch` does `maxWidth !== null ? maxWidth : Infinity`, handing troika a zero-width column — and because the batch resolves on a shared sync counter, one degenerate entry can take the whole text batch down with it, hiding the otherwise well-formed DBText too.

Now publishes `null`, and receive treats a non-positive `maxWidth` as unset so **already-published** versions still bake correctly.

## 3\. Justified DBText anchored on the wrong point

It used `Position` — stale for anything but left-justified text — with hard-coded `Left`/`Bottom`. Now anchors on `AlignmentPoint` when justified, and maps `Justify` through a new `TextAlignmentMap` shared with the MText converter (which previously carried a private copy of the same mapping).

## The ticket's EAV half

New `TextPropertiesExtractor` puts value / height / position / rotation / style under a `Text` group — plus justification, width factor and oblique for DBText; attachment, wrap width and the raw markup for MText; `tag` for block attributes. Wired into the AutoCAD, **Civil3D and Plant3D** extractors, since a Civil drawing's annotation goes through Civil3D's own `PropertiesExtractor`. Text content is now queryable, not only encoded in the geometry blob.

Also on receive: plain text is escaped into MText contents (`\`, `{`, `}` are MText control characters) and newlines become `\P`, so multi-line text bakes as paragraphs instead of literal markup.

## Testing

* `Speckle.Connectors.Autocad2025`, `Speckle.Connectors.Civil3d2026` and `Speckle.Connectors.Plant3d2026` build `-c Local` with 0 warnings / 0 errors; `dotnet csharpier check ./` clean; no lock-file churn.
* Verified `TextToHostConverter`, `TextPropertiesExtractor` and `TextAlignmentMap` are present in the deployed converter assemblies.
* Host-app verification (send → viewer, receive into a blank DWG) is being done locally against these builds.

## Follow-up in another repo

`TextBatch.ts:359` should treat `maxWidth <= 0` as no-wrap, not just `null`. Without that, every model already published with `maxWidth = 0` stays broken in the viewer even after this fix. Left out of scope here.

🤖 Generated with [Claude Code](<https://claude.com/claude-code>)