### PR TITLE
fix(rhino): resolve instance definitions without the doc-level instance C-API (ENG-9047)

### DIFF
--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/HostApp/RhinoInstanceUnpacker.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/HostApp/RhinoInstanceUnpacker.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Extensions.Logging;
 using Rhino;
 using Rhino.DocObjects;
+using Rhino.FileIO;
 using Rhino.Geometry;
 using Speckle.Connectors.Common.Instances;
 using Speckle.Connectors.Rhino.Extensions;
@@ -15,6 +16,17 @@ public class RhinoInstanceUnpacker : IInstanceUnpacker<RhinoObject>
   private readonly IInstanceObjectsManager<RhinoObject, List<string>> _instanceObjectsManager;
   private readonly RhinoLayerHelper _rhinoLayerHelper;
   private readonly ILogger<RhinoInstanceUnpacker> _logger;
+
+  // ENG-9047: the Linux Rhino WIP native (librhcommon_c.so) ships none of the doc-level
+  // instance C-API (CRhinoInstanceObject_*, CRhinoInstanceDefinition*, and the definition
+  // table), so InstanceObject.InstanceDefinition throws EntryPointNotFoundException there.
+  // Once observed, definitions are resolved from the doc's source 3dm via the opennurbs
+  // surface (ON_InstanceRef/ON_InstanceDefinition/ONX_Model), which that native does
+  // implement.
+  private static bool s_docInstanceApiMissing;
+  private Dictionary<Guid, InstanceDefinitionInfo>? _fileDefinitions;
+
+  private sealed record InstanceDefinitionInfo(string Name, string Description, IReadOnlyList<RhinoObject> Objects);
 
   public RhinoInstanceUnpacker(
     IInstanceObjectsManager<RhinoObject, List<string>> instanceObjectsManager,
@@ -45,14 +57,19 @@ public class RhinoInstanceUnpacker : IInstanceUnpacker<RhinoObject>
     try
     {
       var instanceId = instance.Id.ToString();
-      var instanceDefinitionId = instance.InstanceDefinition.Id.ToString();
+      // Read the definition id and transform off the ON_InstanceRef geometry rather than
+      // InstanceObject.InstanceDefinition/.InstanceXform: same underlying data, but the
+      // geometry route also exists on the Linux WIP native (ENG-9047).
+      var instanceGeometry = (InstanceReferenceGeometry)instance.Geometry;
+      var definitionGuid = instanceGeometry.ParentIdefId;
+      var instanceDefinitionId = definitionGuid.ToString();
       var currentDoc = RhinoDoc.ActiveDoc; // POC: too much right now to interface around
 
       InstanceProxy instanceProxy = new()
       {
         applicationId = instanceId,
-        definitionId = instance.InstanceDefinition.Id.ToString(),
-        transform = XFormToMatrix(instance.InstanceXform),
+        definitionId = instanceDefinitionId,
+        transform = XFormToMatrix(instanceGeometry.Xform),
         maxDepth = depth,
         units = currentDoc.ModelUnitSystem.ToSpeckleString(),
       };
@@ -100,22 +117,23 @@ public class RhinoInstanceUnpacker : IInstanceUnpacker<RhinoObject>
         return;
       }
 
+      var definitionInfo = GetDefinition(instance, definitionGuid);
+
       var definition = new InstanceDefinitionProxy
       {
         applicationId = instanceDefinitionId,
         objects = new List<string>(),
         maxDepth = depth,
-        name = instance.InstanceDefinition.Name,
-        ["description"] = instance.InstanceDefinition.Description,
+        name = definitionInfo.Name,
+        ["description"] = definitionInfo.Description,
       };
 
-      _instanceObjectsManager.AddDefinitionProxy(instance.InstanceDefinition.Id.ToString(), definition);
+      _instanceObjectsManager.AddDefinitionProxy(instanceDefinitionId, definition);
 
       // NOTE: InstanceDefinition.GetObjects() returns all constituent objects of a block, but those constituent
       // objects can be on layers, that are not visible. The publish should respect that.
       // See request: [CNX-2254](https://linear.app/speckle/issue/CNX-2254/rhino-publish-blocks-with-hidden-objects)
-      var allDefinitionObjects = instance.InstanceDefinition.GetObjects();
-      var visibleDefinitionObjects = _rhinoLayerHelper.FilterByLayerVisibility(allDefinitionObjects);
+      var visibleDefinitionObjects = _rhinoLayerHelper.FilterByLayerVisibility(definitionInfo.Objects);
       foreach (var obj in visibleDefinitionObjects)
       {
         definition.objects.Add(obj.Id.ToString());
@@ -131,6 +149,61 @@ public class RhinoInstanceUnpacker : IInstanceUnpacker<RhinoObject>
     {
       _logger.LogError(ex, "Failed unpacking Rhino instance");
     }
+  }
+
+  private InstanceDefinitionInfo GetDefinition(InstanceObject instance, Guid definitionId)
+  {
+    if (!s_docInstanceApiMissing)
+    {
+      try
+      {
+        var definition = instance.InstanceDefinition;
+        return new InstanceDefinitionInfo(definition.Name, definition.Description, definition.GetObjects());
+      }
+      catch (EntryPointNotFoundException)
+      {
+        s_docInstanceApiMissing = true;
+      }
+    }
+
+    _fileDefinitions ??= ReadDefinitionsFromSourceFile(instance.Document);
+    if (!_fileDefinitions.TryGetValue(definitionId, out var info))
+    {
+      throw new SpeckleException($"Instance definition {definitionId} not found in the doc's source 3dm");
+    }
+    return info;
+  }
+
+  private static Dictionary<Guid, InstanceDefinitionInfo> ReadDefinitionsFromSourceFile(RhinoDoc doc)
+  {
+    if (string.IsNullOrEmpty(doc.Path))
+    {
+      throw new SpeckleException(
+        "Cannot resolve instance definitions: the doc-level instance API is unavailable on this platform and the doc has no source 3dm to read them from"
+      );
+    }
+
+    // Known limit (ENG-9047): a linked (non-embedded) definition's file table entry carries
+    // the link path, not member ids, so it resolves to an empty definition here — where the
+    // doc-level GetObjects() would return the loaded linked geometry.
+    using var file = File3dm.Read(doc.Path, File3dm.TableTypeFilter.InstanceDefinition, File3dm.ObjectTypeFilter.None);
+    var definitions = new Dictionary<Guid, InstanceDefinitionInfo>();
+    foreach (InstanceDefinitionGeometry definition in file.AllInstanceDefinitions)
+    {
+      var objects = new List<RhinoObject>();
+      foreach (Guid objectId in definition.GetObjectIds())
+      {
+        // 3dm object ids survive the headless open, so the file's member list resolves
+        // against the live doc; a miss (e.g. an id the doc dropped on open) is skipped the
+        // same way the doc-level GetObjects() would simply not return it.
+        if (doc.Objects.FindId(objectId) is RhinoObject obj)
+        {
+          objects.Add(obj);
+        }
+      }
+      definitions[definition.Id] = new InstanceDefinitionInfo(definition.Name, definition.Description, objects);
+    }
+    return definitions;
   }
 
   private Matrix4x4 XFormToMatrix(Transform t) =>


### PR DESCRIPTION
## Problem

On the headless Linux rhino leg (speckle-converters, rhino.inside against the Rhino 9 WIP deb), every block instance fails to unpack: `InstanceObject.InstanceDefinition` throws `EntryPointNotFoundException` because the Linux native (`librhcommon_c.so`) ships **none** of the doc-level instance C-API — `CRhinoInstanceObject_*`, `CRhinoInstanceDefinition_*`, `CRhinoInstanceDefinitionTable_*` are all absent (verified on debs 9.0.26167 and 9.0.26211; the bundled RhinoCommon.dll binds them anyway). An all-blocks model fails wholesale.

[ENG-9047](https://linear.app/speckle/issue/ENG-9047)

## Fix

`RhinoInstanceUnpacker` now:

- reads the instance transform + definition id off the `ON_InstanceRef` geometry (`InstanceReferenceGeometry.ParentIdefId`/`.Xform` — same underlying data, and the opennurbs C-API **is** implemented on Linux);
- keeps `instance.InstanceDefinition` as the primary path for definition name/description/members, and on the first `EntryPointNotFoundException` flips a process-wide flag and resolves definitions from the doc's source 3dm instead (`File3dm.Read` filtered to the instance-definition table, member ids mapped back through `doc.Objects.FindId`).

Windows/Mac natives implement the doc-level API, so the fallback is unreachable there; the doc-level path is byte-identical to before. All APIs used exist down to RhinoCommon 7.13 (the Rhino7 head's pin), so every head compiles.

## Known limits / notes

- Linked (non-embedded) definitions resolve empty under the fallback (the file table entry carries the link path, not member ids) — noted in-code; irrelevant to the converter leg's corpus, unreachable elsewhere.
- `RhinoMapperBinding` still calls `InstanceObject.InstanceDefinition` in 4 places — interactive DUI binding code, not on the headless path, left untouched.

## Verification

Empirically verified in the converter image (probe + full tripwire tier): `blocks-nested.3dm` (nested defs, 5 instances) converts 8/8 objects and schema-validates; `attributes-eav.3dm` objectsFailed dropped 1 → 0; all 7 positive fixtures pass.

speckle-converters pins this commit as its vendor gitlink on the ENG-9047 branch — please prefer merge over squash/rebase, or the gitlink needs a re-pin to the landed SHA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)