### PR TITLE
fix(send): report the ingestion id for artifact sends so the DUI wait…

### DIFF
--- a/Sdk/Speckle.Connectors.Common/Operations/SendOperation.cs
+++ b/Sdk/Speckle.Connectors.Common/Operations/SendOperation.cs
@@ -261,8 +261,9 @@ public sealed class SendOperation<T>(
         buildResult.ConversionResults
       );
 
-      // The artefact pipeline's `complete` call already created the version; no separate Ingestion.Complete.
-      return (result, buildResult.VersionId, null);
+      // The pipeline's `complete` only signals "upload done" — the server creates the version after datgen.
+      // Returning the ingestion id makes the DUI subscribe and show "version created" only when it truly exists.
+      return (result, buildResult.VersionId, ingestion.id);
     }
     catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
     {


### PR DESCRIPTION
…s for the real version (ENG-9043)

SendViaArtifacts returned a null ingestion id, so the DUI treated the pre-allocated versionId as a created version and showed the View CTA while the server was still running datgen — pointing at a version that did not exist yet.

The pipeline's `complete` only signals "upload done"; the server creates the version after datgen. Returning ingestion.id routes the result through the DUI's existing ingestion subscription (same as SendViaIngestion already does), keeping the card in "Remote processing..." until the server reports success with the real versionId.

Below was the before behavior
<img width="3182" height="1862" alt="Screenshot 2026-08-03 133811" src="https://github.com/user-attachments/assets/edbc4643-b77c-4972-8c39-ee9816a00411" />
