### PR TITLE
fix(artifacts): report the host-app slug as the bundle's produced_by

### DIFF
--- a/Connectors/Autocad/Speckle.Connectors.AutocadShared/Operations/Send/AutocadArtifactRootObjectBuilder.cs
+++ b/Connectors/Autocad/Speckle.Connectors.AutocadShared/Operations/Send/AutocadArtifactRootObjectBuilder.cs
@@ -65,6 +65,7 @@ public class AutocadArtifactRootObjectBuilder(
   AutocadColorUnpacker colorUnpacker,
   IThreadContext threadContext,
   IArtifactPipelineFactory artifactPipelineFactory,
+  ISpeckleApplication speckleApplication,
   ILogger<AutocadArtifactRootObjectBuilder> logger
 ) : IArtifactRootObjectBuilder<AutocadRootObject>
 {
@@ -297,7 +298,7 @@ public class AutocadArtifactRootObjectBuilder(
   )
   {
     ZstdNativeLoader.Ensure(logger); // net48: ensure the parquet Zstd native is loaded (no-op on net8+)
-    using var pipeline = new ObjectsArtifactPipeline(outputDir, versionId);
+    using var pipeline = new ObjectsArtifactPipeline(outputDir, versionId, producedBy: speckleApplication.Slug);
 
     // Pre-create DEFINITION nodes so they carry their proper name (the per-object pass only has the definitionId).
     foreach (var defProxy in model.Definitions)

--- a/Connectors/Autocad/Speckle.Connectors.Civil3dShared/Operations/Send/Civil3dArtifactRootObjectBuilder.cs
+++ b/Connectors/Autocad/Speckle.Connectors.Civil3dShared/Operations/Send/Civil3dArtifactRootObjectBuilder.cs
@@ -8,6 +8,7 @@ using Speckle.Converters.Autocad;
 using Speckle.Converters.Civil3dShared.ToSpeckle;
 using Speckle.Converters.Common;
 using Speckle.Objects.Utils;
+using Speckle.Sdk;
 using Speckle.Sdk.Pipelines.Send.Artifacts;
 
 namespace Speckle.Connectors.Civil3dShared.Operations.Send;
@@ -24,6 +25,7 @@ public class Civil3dArtifactRootObjectBuilder : AutocadArtifactRootObjectBuilder
     AutocadColorUnpacker colorUnpacker,
     IThreadContext threadContext,
     IArtifactPipelineFactory artifactPipelineFactory,
+    ISpeckleApplication speckleApplication,
     ILogger<AutocadArtifactRootObjectBuilder> logger,
     PropertySetDefinitionHandler propertySetDefinitionHandler
   )
@@ -35,6 +37,7 @@ public class Civil3dArtifactRootObjectBuilder : AutocadArtifactRootObjectBuilder
       colorUnpacker,
       threadContext,
       artifactPipelineFactory,
+      speckleApplication,
       logger
     )
   {

--- a/Connectors/CSi/Speckle.Connectors.CSiShared/Operations/Send/CsiArtifactRootObjectBuilder.cs
+++ b/Connectors/CSi/Speckle.Connectors.CSiShared/Operations/Send/CsiArtifactRootObjectBuilder.cs
@@ -52,6 +52,7 @@ public class CsiArtifactRootObjectBuilder(
   AnalysisResultsExtractor analysisResultsExtractor,
   IThreadContext threadContext,
   IArtifactPipelineFactory artifactPipelineFactory,
+  ISpeckleApplication speckleApplication,
   ILogger<CsiArtifactRootObjectBuilder> logger
 ) : IArtifactRootObjectBuilder<ICsiWrapper>
 {
@@ -412,7 +413,7 @@ public class CsiArtifactRootObjectBuilder(
   )
   {
     ZstdNativeLoader.Ensure(logger); // net48: ensure the parquet Zstd native is loaded (no-op on net8+)
-    using var pipeline = new ObjectsArtifactPipeline(outputDir, versionId);
+    using var pipeline = new ObjectsArtifactPipeline(outputDir, versionId, producedBy: speckleApplication.Slug);
     var collectionKByPath = new Dictionary<string, int>(StringComparer.Ordinal);
 
     int count = 0;

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/RevitArtifactRootObjectBuilder.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/RevitArtifactRootObjectBuilder.cs
@@ -57,6 +57,7 @@ public class RevitArtifactRootObjectBuilder(
   IArtifactPipelineFactory artifactPipelineFactory,
   IScalingServiceToSpeckle scalingService,
   IReferencePointConverter referencePointConverter,
+  ISpeckleApplication speckleApplication,
   ILogger<RevitArtifactRootObjectBuilder> logger
 ) : IArtifactRootObjectBuilder<DocumentToConvert>
 {
@@ -193,7 +194,7 @@ public class RevitArtifactRootObjectBuilder(
     }
 
     ZstdNativeLoader.Ensure(logger); // net48: ensure the parquet Zstd native is loaded (no-op on net8+)
-    using var pipeline = new ObjectsArtifactPipeline(outputDir, versionId);
+    using var pipeline = new ObjectsArtifactPipeline(outputDir, versionId, producedBy: speckleApplication.Slug);
 
     // element.UniqueId -> the object K(s) it was interned as. A linked element placed by N link instances
     // yields N interned objects (disambiguated by transform hash), so the value is a list. Used to resolve

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Operations/Send/GrasshopperArtifactRootObjectBuilder.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Operations/Send/GrasshopperArtifactRootObjectBuilder.cs
@@ -52,7 +52,8 @@ public class GrasshopperArtifactRootObjectBuilder(
   IInstanceObjectsManager<SpeckleGeometryWrapper, List<string>> instanceObjectsManager,
   IConverterSettingsStore<RhinoConversionSettings> converterSettings,
   IThreadContext threadContext,
-  IArtifactPipelineFactory artifactPipelineFactory
+  IArtifactPipelineFactory artifactPipelineFactory,
+  ISpeckleApplication speckleApplication
 ) : IArtifactRootObjectBuilder<SpeckleCollectionWrapperGoo>
 {
   public async Task<ArtifactBuildResult> BuildAndUpload(
@@ -111,7 +112,7 @@ public class GrasshopperArtifactRootObjectBuilder(
   )
   {
     ZstdNativeLoader.Ensure(); // net48: ensure the parquet Zstd native is loaded (no-op on net8+)
-    using var pipeline = new ObjectsArtifactPipeline(outputDir, versionId);
+    using var pipeline = new ObjectsArtifactPipeline(outputDir, versionId, producedBy: speckleApplication.Slug);
     var units = converterSettings.Current.SpeckleUnits;
 
     // Reused as-is from the v1 send path — they derive the color/material/instance proxies whose `.objects` arrays are

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/Operations/Send/RhinoArtifactRootObjectBuilder.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/Operations/Send/RhinoArtifactRootObjectBuilder.cs
@@ -75,6 +75,7 @@ public class RhinoArtifactRootObjectBuilder(
   PropertiesExtractor propertiesExtractor,
   IThreadContext threadContext,
   IArtifactPipelineFactory artifactPipelineFactory,
+  ISpeckleApplication speckleApplication,
   ILogger<RhinoArtifactRootObjectBuilder> logger
 ) : IArtifactRootObjectBuilder<RhinoObject>
 {
@@ -456,7 +457,7 @@ public class RhinoArtifactRootObjectBuilder(
   )
   {
     ZstdNativeLoader.Ensure(logger); // net48: ensure the parquet Zstd native is loaded (no-op on net8+)
-    using var pipeline = new ObjectsArtifactPipeline(outputDir, versionId);
+    using var pipeline = new ObjectsArtifactPipeline(outputDir, versionId, producedBy: speckleApplication.Slug);
 
     // Pre-create DEFINITION nodes so they carry their proper name (the per-object pass only has the definitionId).
     foreach (var defProxy in model.Definitions)

--- a/Connectors/TSD/Speckle.Connectors.TSDShared/Operations/Send/TsdArtifactRootObjectBuilder.cs
+++ b/Connectors/TSD/Speckle.Connectors.TSDShared/Operations/Send/TsdArtifactRootObjectBuilder.cs
@@ -33,6 +33,7 @@ internal sealed class TsdArtifactRootObjectBuilder : IArtifactRootObjectBuilder<
   private readonly TsdConversionSettings _conversionSettings;
   private readonly IThreadContext _threadContext;
   private readonly IArtifactPipelineFactory _artifactPipelineFactory;
+  private readonly ISpeckleApplication _speckleApplication;
   private readonly ILogger<TsdArtifactRootObjectBuilder> _logger;
 
   public TsdArtifactRootObjectBuilder(
@@ -42,6 +43,7 @@ internal sealed class TsdArtifactRootObjectBuilder : IArtifactRootObjectBuilder<
     TsdConversionSettings conversionSettings,
     IThreadContext threadContext,
     IArtifactPipelineFactory artifactPipelineFactory,
+    ISpeckleApplication speckleApplication,
     ILogger<TsdArtifactRootObjectBuilder> logger
   )
   {
@@ -51,6 +53,7 @@ internal sealed class TsdArtifactRootObjectBuilder : IArtifactRootObjectBuilder<
     _conversionSettings = conversionSettings;
     _threadContext = threadContext;
     _artifactPipelineFactory = artifactPipelineFactory;
+    _speckleApplication = speckleApplication;
     _logger = logger;
   }
 
@@ -313,7 +316,7 @@ internal sealed class TsdArtifactRootObjectBuilder : IArtifactRootObjectBuilder<
     CancellationToken cancellationToken
   )
   {
-    using var pipeline = new ObjectsArtifactPipeline(outputDir, versionId);
+    using var pipeline = new ObjectsArtifactPipeline(outputDir, versionId, producedBy: _speckleApplication.Slug);
     var collectionKByName = new Dictionary<string, int>(StringComparer.Ordinal);
 
     int count = 0;

--- a/Connectors/Tekla/Speckle.Connector.TeklaShared/Operations/Send/TeklaArtifactRootObjectBuilder.cs
+++ b/Connectors/Tekla/Speckle.Connector.TeklaShared/Operations/Send/TeklaArtifactRootObjectBuilder.cs
@@ -50,6 +50,7 @@ public class TeklaArtifactRootObjectBuilder(
   TeklaMaterialUnpacker materialUnpacker,
   IThreadContext threadContext,
   IArtifactPipelineFactory artifactPipelineFactory,
+  ISpeckleApplication speckleApplication,
   ILogger<TeklaArtifactRootObjectBuilder> logger
 ) : IArtifactRootObjectBuilder<TSM.ModelObject>
 {
@@ -167,7 +168,7 @@ public class TeklaArtifactRootObjectBuilder(
   )
   {
     ZstdNativeLoader.Ensure(logger); // net48: ensure the parquet Zstd native is loaded (no-op on net8+)
-    using var pipeline = new ObjectsArtifactPipeline(outputDir, versionId);
+    using var pipeline = new ObjectsArtifactPipeline(outputDir, versionId, producedBy: speckleApplication.Slug);
     var collectionKByName = new Dictionary<string, int>(StringComparer.Ordinal);
     var geometryKsByAppId = new Dictionary<string, List<int>>(StringComparer.Ordinal);
 


### PR DESCRIPTION
meta.produced_by carried the SDK writer class name instead of the producing host app. Every artifact root object builder now injects ISpeckleApplication and passes its Slug ('rhino', 'revit', 'autocad', 'civil3d', …) to ObjectsArtifactPipeline, which writes it to the envelope meta table. Needs the matching SDK change (EnvelopeWriter producedBy parameter) on big-truck.
