### PR TITLE
fix(revit): receive Rhino solids as solids, not meshes (ENG-8800)

### DIFF
--- a/Connectors/Revit/Speckle.Connectors.RevitShared/DependencyInjection/RevitConnectorModule.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/DependencyInjection/RevitConnectorModule.cs
@@ -89,16 +89,19 @@ public static class ServiceRegistration
     serviceCollection.AddScoped<ITransactionManager, TransactionManager>();
 
     // Speckle 4.0 artefact receive: download the parquet bundle + reconstruct the Base graph (DataObjects with
-    // displayValue meshes → DirectShapes). Revit can't import 3dm, so PreferSolids = false (meshes only).
+    // displayValue meshes → DirectShapes). PreferSolids = true: reconstruction only runs when receive-as-families is on
+    // (RevitHostObjectArtefactBuilder.Build delegates to the v1 builder), and Revit DOES import 3dm — the rebuilt
+    // RhinoObject.rawEncoding goes through IRawEncodedObjectConverter → DB.ShapeImporter → real solids [ENG-8800].
     serviceCollection.AddScoped<
       Speckle.Sdk.Pipelines.Receive.Artifacts.IArtifactDownloader,
       Speckle.Sdk.Pipelines.Receive.Artifacts.ArtifactDownloader
     >();
-    serviceCollection.AddSingleton(new Speckle.Objects.Utils.ArtifactReceiveOptions(PreferSolids: false));
+    serviceCollection.AddSingleton(new Speckle.Objects.Utils.ArtifactReceiveOptions(PreferSolids: true));
     serviceCollection.AddScoped<IArtifactReceiver, ArtifactReceiver>();
-    // Native artefact receive (DirectShape from SGEO meshes, Base-free). Registering this activates the direct-bake
+    // Native artefact receive (DirectShape from raw 3dm solids / SGEO meshes, Base-free). Registering this activates the direct-bake
     // branch in ReceiveOperation;
     serviceCollection.AddScoped<IArtifactHostObjectBuilder, RevitHostObjectArtefactBuilder>();
+    serviceCollection.AddScoped<RevitArtefactSolidImporter>();
     serviceCollection.AddScoped<RevitFamilyBaker>();
     serviceCollection.AddScoped<FamilyGeometryBaker>();
     serviceCollection.AddScoped<RevitGroupBaker>();

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Receive/RevitArtefactSolidImporter.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Receive/RevitArtefactSolidImporter.cs
@@ -1,0 +1,194 @@
+using System.IO;
+using Autodesk.Revit.DB;
+using Microsoft.Extensions.Logging;
+using Speckle.Connectors.Common.Diagnostics;
+using Speckle.Converters.Common;
+using Speckle.Converters.Common.FileOps;
+using Speckle.Converters.RevitShared.Settings;
+using Speckle.Sdk;
+using Speckle.Sdk.Pipelines.Receive.Artifacts;
+// aliased, not imported: Speckle.Objects.Other.Transform would collide with DB.Transform
+using RawEncodingFormats = Speckle.Objects.Other.RawEncodingFormats;
+
+namespace Speckle.Connectors.Revit.Operations.Receive;
+
+/// <summary>
+/// Turns the raw 3dm <c>SOLID</c> blobs of a Speckle 4.0 artefact bundle into real Revit solids, and paints the
+/// elements baked from them (an imported solid carries no material of its own, unlike a tessellated mesh which bakes
+/// one into every <see cref="TessellatedFace"/>). Split out of <see cref="RevitHostObjectArtefactBuilder"/> so the
+/// Revit-API surface the raw import needs — <see cref="ShapeImporter"/>, <c>SubTransaction</c>,
+/// <see cref="SolidUtils"/>, painting — stays out of the builder's own coupling budget.
+/// </summary>
+/// <remarks>
+/// Drives the same machinery as the v1 <c>IRawEncodedObjectConverter</c> on the <c>Base</c>-graph receive path, and
+/// deliberately keeps its semantics [ENG-8800]: the import runs in a <c>SubTransaction</c> that is rolled back
+/// when it yields nothing, because a failed <see cref="ShapeImporter"/> leaves "ghost" state behind that breaks later
+/// painting and group creation.
+/// </remarks>
+public sealed class RevitArtefactSolidImporter
+{
+  private readonly IConverterSettingsStore<RevitConversionSettings> _converterSettings;
+  private readonly ILogger<RevitArtefactSolidImporter> _logger;
+
+  public RevitArtefactSolidImporter(
+    IConverterSettingsStore<RevitConversionSettings> converterSettings,
+    ILogger<RevitArtefactSolidImporter> logger
+  )
+  {
+    _converterSettings = converterSettings;
+    _logger = logger;
+  }
+
+  /// <summary>
+  /// Imports the given geometry indices as Revit solids. Anything that isn't <c>RHINO_3DM</c> is filtered out up front:
+  /// a foreign blob (e.g. AutoCAD's SAT) must never reach the importer. An empty result is the caller's signal to fall
+  /// back to the object's DISPLAY meshes — which happens when the importer rejects the blob outright or degrades it to
+  /// <see cref="Mesh"/>, since its meshes are worse than ours (they can't be painted and carry no per-face material).
+  /// </summary>
+  public List<GeometryObject> ImportSolids(
+    Document doc,
+    ArtefactBundle bundle,
+    IReadOnlyList<int> solidKs,
+    ArtefactSessionLog session
+  )
+  {
+    var result = new List<GeometryObject>();
+    foreach (var solidK in solidKs)
+    {
+      if (
+        !bundle.Geometries.TryGetValue(solidK, out var g)
+        || g.Type != RawEncodingFormats.RHINO_3DM
+        || g.Content.Length == 0
+      )
+      {
+        continue;
+      }
+      try
+      {
+        var imported = ImportShape(doc, g.Content);
+        if (imported.Count == 0)
+        {
+          session.Increment("solidImportEmpty");
+          continue;
+        }
+        if (imported.Any(o => o is Mesh))
+        {
+          session.Increment("solidImportDegradedToMesh");
+          continue;
+        }
+        // Solids come back in the source file's own coordinates — unlike mesh vertices (ToInternalPoints), nothing has
+        // re-based them, so apply the composed reference-point transform here [ENG-8808/ENG-8947]. A non-solid the
+        // transform can't be applied to counts as a failed import, so the caller uses the re-based display meshes.
+        if (_converterSettings.Current.ReferencePointTransform is Transform transform)
+        {
+          if (imported.Any(o => o is not Solid))
+          {
+            session.Increment("solidImportNotTransformable");
+            continue;
+          }
+          imported = imported.Select(o => (GeometryObject)SolidUtils.CreateTransformed((Solid)o, transform)).ToList();
+        }
+        result.AddRange(imported);
+        session.Increment("solidsImported");
+      }
+      catch (Exception ex) when (!ex.IsFatal())
+      {
+        session.Increment("solidImportFailed");
+        _logger.LogWarning(
+          ex,
+          "3dm solid import failed for geometry {GeomK} ({Bytes} bytes)",
+          solidK,
+          g.Content.Length
+        );
+      }
+    }
+    return result;
+  }
+
+  private static List<GeometryObject> ImportShape(Document doc, byte[] content)
+  {
+    var filePath = TempFileProvider.GetTempFile("RevitArtefact", RawEncodingFormats.RHINO_3DM);
+    File.WriteAllBytes(filePath, content);
+
+    IList<GeometryObject> imported;
+    using (var subTx = new SubTransaction(doc))
+    {
+      subTx.Start();
+      using var importer = new ShapeImporter();
+      imported = importer.Convert(doc, filePath);
+      if (imported.Count == 0)
+      {
+        subTx.RollBack(); // clean up the invalid state Revit created, otherwise we get "ghost" objects
+      }
+      else
+      {
+        subTx.Commit();
+      }
+    }
+    return imported.ToList();
+  }
+
+  /// <summary>
+  /// Paints every face of the elements baked from imported solids with their object's material — the same approach as
+  /// v1 <c>RevitHostObjectBuilder.PostBakePaint</c>, and like it this must run in its own transaction <b>after</b> the
+  /// bake committed, since an element's faces aren't queryable before then. Per element best-effort: painting is
+  /// cosmetic, so an element Revit won't paint (a placement whose solids live inside a <see cref="GeometryInstance"/>
+  /// being the likely case) keeps its geometry and is counted in the session log instead of failing the object.
+  /// </summary>
+  public void PaintSolids(
+    Document doc,
+    List<(ElementId Element, ElementId Material)> paintTargets,
+    ArtefactSessionLog session
+  )
+  {
+    foreach (var (elementId, materialId) in paintTargets)
+    {
+      try
+      {
+        if (doc.GetElement(elementId) is not Element element)
+        {
+          continue;
+        }
+        int painted = 0;
+        foreach (var geo in element.get_Geometry(new Options() { DetailLevel = ViewDetailLevel.Undefined }))
+        {
+          switch (geo)
+          {
+            case Solid solid:
+              painted += PaintFaces(doc, elementId, solid, materialId);
+              break;
+            // a placement's geometry is a GeometryInstance over the shared definition
+            case GeometryInstance instance:
+              foreach (var nested in instance.GetInstanceGeometry())
+              {
+                if (nested is Solid nestedSolid)
+                {
+                  painted += PaintFaces(doc, elementId, nestedSolid, materialId);
+                }
+              }
+              break;
+            default:
+              break;
+          }
+        }
+        session.Increment(painted > 0 ? "solidsPainted" : "solidsUnpainted");
+      }
+      catch (Exception ex) when (!ex.IsFatal())
+      {
+        session.Increment("solidPaintFailed");
+        _logger.LogDebug(ex, "Could not paint imported solid faces on element {ElementId}", elementId);
+      }
+    }
+  }
+
+  private static int PaintFaces(Document doc, ElementId elementId, Solid solid, ElementId materialId)
+  {
+    int painted = 0;
+    foreach (Face face in solid.Faces)
+    {
+      doc.Paint(elementId, face, materialId);
+      painted++;
+    }
+    return painted;
+  }
+}

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Receive/RevitHostObjectArtefactBuilder.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Receive/RevitHostObjectArtefactBuilder.cs
@@ -22,17 +22,19 @@ using Speckle.Sdk.Models;
 using Speckle.Sdk.Pipelines;
 using Speckle.Sdk.Pipelines.Progress;
 using Speckle.Sdk.Pipelines.Receive.Artifacts;
+// aliased, not imported: Speckle.Objects.Other.Transform would collide with DB.Transform used throughout this file
+using RawEncodingFormats = Speckle.Objects.Other.RawEncodingFormats;
 
 namespace Speckle.Connectors.Revit.Operations.Receive;
 
 /// <summary>
 /// Bakes a Speckle 4.0 artefact <see cref="ArtefactBundle"/> <b>directly</b> into the Revit document as native
 /// <see cref="DirectShape"/>s — talking only to the neutral dense-int graph + raw Revit API, skipping the v1
-/// <c>RootObjectUnpacker</c> / traversal / per-type converter dispatch. SGEO meshes are tessellated straight into
-/// DirectShape geometry (mirroring <c>MeshConverterToHost</c>), materials are created directly from MATERIAL nodes,
-/// and instances are placed per <c>DISPLAY_INSTANCE</c> edge via the <see cref="DirectShapeLibrary"/>. The
-/// receive-side twin of the send-side <c>RevitArtifactRootObjectBuilder</c> — except when
-/// <c>ReceiveInstancesAsFamilies</c> is on (see remarks).
+/// <c>RootObjectUnpacker</c> / traversal / per-type converter dispatch. A raw <c>SOLID</c> 3dm blob is imported as real
+/// Revit solids (<see cref="ShapeImporter"/>) and SGEO meshes are tessellated straight into DirectShape geometry
+/// (mirroring <c>MeshConverterToHost</c>), materials are created directly from MATERIAL nodes, and instances are placed
+/// per <c>DISPLAY_INSTANCE</c> edge via the <see cref="DirectShapeLibrary"/>. The receive-side twin of the send-side
+/// <c>RevitArtifactRootObjectBuilder</c> — except when <c>ReceiveInstancesAsFamilies</c> is on (see remarks).
 /// </summary>
 /// <remarks>
 /// <para><b>Grouping.</b> Revit has no layers; each baked element is stamped with its model marker in the Comments
@@ -58,6 +60,7 @@ public sealed class RevitHostObjectArtefactBuilder : IArtifactHostObjectBuilder
   private readonly IArtifactReceiver _artifactReceiver;
   private readonly IHostObjectBuilder _hostObjectBuilder;
   private readonly RevitGroupBaker _groupBaker;
+  private readonly RevitArtefactSolidImporter _solidImporter;
 
   public RevitHostObjectArtefactBuilder(
     IConverterSettingsStore<RevitConversionSettings> converterSettings,
@@ -70,7 +73,8 @@ public sealed class RevitHostObjectArtefactBuilder : IArtifactHostObjectBuilder
     ILogger<RevitHostObjectArtefactBuilder> logger,
     IArtifactReceiver artifactReceiver,
     IHostObjectBuilder hostObjectBuilder,
-    RevitGroupBaker groupBaker
+    RevitGroupBaker groupBaker,
+    RevitArtefactSolidImporter solidImporter
   )
   {
     _converterSettings = converterSettings;
@@ -84,6 +88,7 @@ public sealed class RevitHostObjectArtefactBuilder : IArtifactHostObjectBuilder
     _artifactReceiver = artifactReceiver;
     _hostObjectBuilder = hostObjectBuilder;
     _groupBaker = groupBaker;
+    _solidImporter = solidImporter;
   }
 
   public async Task<HostObjectBuilderResult> Build(
@@ -157,6 +162,10 @@ public sealed class RevitHostObjectArtefactBuilder : IArtifactHostObjectBuilder
 
     var bakedObjectIds = new List<string>();
     var conversionResults = new HashSet<ReceiveConversionResult>();
+    // Solids imported from a raw 3dm carry no material of their own (a tessellated mesh bakes it into every
+    // TessellatedFace), so they are painted with the object's material — but only once the bake transaction has
+    // committed, since an element's faces aren't queryable before then. Same ordering as v1 RevitHostObjectBuilder.
+    var paintTargets = new List<(ElementId Element, ElementId Material)>();
 
     // 0 — clean a previous receive of this model (delete marked DirectShapes; reset the geometry-instance library).
     _transactionManager.StartTransaction(true, "Pre receive clean");
@@ -205,6 +214,7 @@ public sealed class RevitHostObjectArtefactBuilder : IArtifactHostObjectBuilder
           marker,
           bakedObjectIds,
           conversionResults,
+          paintTargets,
           session,
           onOperationProgressed,
           cancellationToken
@@ -227,6 +237,7 @@ public sealed class RevitHostObjectArtefactBuilder : IArtifactHostObjectBuilder
             marker,
             bakedObjectIds,
             conversionResults,
+            paintTargets,
             session,
             cancellationToken
           );
@@ -239,6 +250,26 @@ public sealed class RevitHostObjectArtefactBuilder : IArtifactHostObjectBuilder
     {
       _transactionManager.RollbackTransaction();
       throw;
+    }
+
+    // 4 — paint the imported solids (own transaction: their faces only exist now that the bake is committed).
+    if (paintTargets.Count > 0)
+    {
+      using (session.Phase("Painting"))
+      {
+        _transactionManager.StartTransaction(true, "Painting solids");
+        try
+        {
+          _solidImporter.PaintSolids(doc, paintTargets, session);
+          _transactionManager.CommitTransaction();
+        }
+        catch (Exception ex) when (!ex.IsFatal())
+        {
+          // painting is cosmetic — a failure must not cost the user the geometry they just received
+          _transactionManager.RollbackTransaction();
+          _logger.LogError(ex, "Artefact receive solid painting failed for '{Marker}'", marker);
+        }
+      }
     }
 
     return new HostObjectBuilderResult(bakedObjectIds, conversionResults);
@@ -256,6 +287,7 @@ public sealed class RevitHostObjectArtefactBuilder : IArtifactHostObjectBuilder
     string marker,
     List<string> bakedObjectIds,
     HashSet<ReceiveConversionResult> conversionResults,
+    List<(ElementId Element, ElementId Material)> paintTargets,
     ArtefactSessionLog session,
     IProgress<CardProgress> onOperationProgressed,
     CancellationToken cancellationToken
@@ -270,7 +302,9 @@ public sealed class RevitHostObjectArtefactBuilder : IArtifactHostObjectBuilder
       int objK = kv.Key;
       string appId = kv.Value;
 
-      if (rels.DisplayByObject(objK) is not { Count: > 0 } displayEdges)
+      var displayEdges = rels.DisplayByObject(objK);
+      rels.SolidByObject.TryGetValue(objK, out var solidKs);
+      if (displayEdges is not { Count: > 0 } && solidKs is not { Count: > 0 })
       {
         // an instance placement (step 3) or a non-geometric element (room/level/area) → skip, don't error.
         if (!rels.DisplayInstanceByObject.ContainsKey(objK))
@@ -286,12 +320,18 @@ public sealed class RevitHostObjectArtefactBuilder : IArtifactHostObjectBuilder
       var sw = Stopwatch.StartNew();
       try
       {
-        var geometry = new List<GeometryObject>();
-        foreach (var edge in displayEdges.OrderBy(e => e.Ord))
-        {
-          materialIdByGeometry.TryGetValue(edge.Dst, out var matId);
-          geometry.AddRange(DecodeGeometry(bundle, edge.Dst, matId ?? ElementId.InvalidElementId));
-        }
+        var displayKs = displayEdges is { } edges
+          ? edges.OrderBy(e => e.Ord).Select(e => e.Dst).ToList()
+          : new List<int>();
+        var geometry = DecodeMemberGeometry(
+          doc,
+          bundle,
+          solidKs,
+          displayKs,
+          materialIdByGeometry,
+          session,
+          out bool fromSolid
+        );
         if (geometry.Count == 0)
         {
           session.RecordObject(
@@ -319,6 +359,15 @@ public sealed class RevitHostObjectArtefactBuilder : IArtifactHostObjectBuilder
         ds.SetShape(geometry);
         StampMarker(ds, marker);
 
+        if (fromSolid)
+        {
+          var materialId = ResolveMaterial(displayKs, solidKs, materialIdByGeometry);
+          if (materialId != ElementId.InvalidElementId)
+          {
+            paintTargets.Add((ds.Id, materialId));
+          }
+        }
+
         bakedObjectIds.Add(ds.UniqueId);
         conversionResults.Add(new(Status.SUCCESS, source, ds.UniqueId, "Direct Shape", null, srcType));
         session.RecordObject(appId, srcType, Status.SUCCESS, null, sw.ElapsedMilliseconds);
@@ -343,6 +392,7 @@ public sealed class RevitHostObjectArtefactBuilder : IArtifactHostObjectBuilder
     string marker,
     List<string> bakedObjectIds,
     HashSet<ReceiveConversionResult> conversionResults,
+    List<(ElementId Element, ElementId Material)> paintTargets,
     ArtefactSessionLog session,
     CancellationToken cancellationToken
   )
@@ -357,6 +407,9 @@ public sealed class RevitHostObjectArtefactBuilder : IArtifactHostObjectBuilder
     // (GeometryInstance derives from GeometryObject, so it slots into the parent's geometry list like any solid/mesh).
     var defKeyByNode = new Dictionary<int, string>();
     var defBuilding = new HashSet<int>();
+    // Definitions whose geometry came from imported 3dm solids, and the single material to paint onto each placement
+    // (solids carry none of their own). Ambiguous definitions — several materials across members — stay unpainted.
+    var defPaintMaterialByNode = new Dictionary<int, ElementId>();
 
     string? BuildDefinition(int defNodeK)
     {
@@ -374,17 +427,16 @@ public sealed class RevitHostObjectArtefactBuilder : IArtifactHostObjectBuilder
       }
       session.Increment("definitionsSeen");
 
-      var geometry = new List<GeometryObject>();
-
       // direct geometry members (DEFINES → geometry blobs).
-      if (rels.DefinesByDefinition.TryGetValue(defNodeK, out var geomKs))
-      {
-        foreach (var geomK in geomKs)
-        {
-          materialIdByGeometry.TryGetValue(geomK, out var matId);
-          geometry.AddRange(DecodeGeometry(bundle, geomK, matId ?? ElementId.InvalidElementId));
-        }
-      }
+      var geometry = DecodeDefinitionMembers(
+        doc,
+        bundle,
+        rels,
+        defNodeK,
+        materialIdByGeometry,
+        session,
+        out var solidPaintMaterial
+      );
 
       // nested block/family members (DEFINES_INSTANCE → INSTANCE node): build the child definition first
       // (depth-first) and add a geometry-instance reference to it with the nested placement's own transform.
@@ -422,6 +474,10 @@ public sealed class RevitHostObjectArtefactBuilder : IArtifactHostObjectBuilder
       var defKey = $"spk-def-{defNodeK.ToString(CultureInfo.InvariantCulture)}";
       library.AddDefinition(defKey, geometry);
       defKeyByNode[defNodeK] = defKey;
+      if (solidPaintMaterial is { } paint)
+      {
+        defPaintMaterialByNode[defNodeK] = paint;
+      }
       return defKey;
     }
 
@@ -482,6 +538,11 @@ public sealed class RevitHostObjectArtefactBuilder : IArtifactHostObjectBuilder
         ds.SetShape(geometry);
         StampMarker(ds, marker);
 
+        if (defPaintMaterialByNode.TryGetValue(defNodeK, out var paintMaterial))
+        {
+          paintTargets.Add((ds.Id, paintMaterial));
+        }
+
         bakedObjectIds.Add(ds.UniqueId);
         conversionResults.Add(new(Status.SUCCESS, source, ds.UniqueId, "Instance (Direct Shape)", null, srcType));
         session.RecordObject(appId, srcType, Status.SUCCESS, null, sw.ElapsedMilliseconds);
@@ -495,8 +556,153 @@ public sealed class RevitHostObjectArtefactBuilder : IArtifactHostObjectBuilder
   }
 
   // ── geometry ──────────────────────────────────────────────────────────────────────────────────────────
+  // A definition's direct geometry members (DEFINES → geometry blobs), grouped by member ordinal so a member's
+  // authoritative 3dm solid wins over its own display mesh(es) without shadowing a sibling member — mirrors
+  // RhinoHostObjectArtefactBuilder.GroupDefinesByMember. solidPaintMaterial is the single material shared by the members
+  // that came from imported solids (which carry none of their own); null when there is none, or when members disagree —
+  // one material can't stand in for several, and painting the wrong one is worse than leaving the definition unpainted.
+  private List<GeometryObject> DecodeDefinitionMembers(
+    Document doc,
+    ArtefactBundle bundle,
+    ArtefactRelations rels,
+    int defNodeK,
+    Dictionary<int, ElementId> materialIdByGeometry,
+    ArtefactSessionLog session,
+    out ElementId? solidPaintMaterial
+  )
+  {
+    solidPaintMaterial = null;
+    var geometry = new List<GeometryObject>();
+    if (!rels.DefinesByDefinition.TryGetValue(defNodeK, out var geomKs))
+    {
+      return geometry;
+    }
+
+    rels.DefinesOrdByDefinition.TryGetValue(defNodeK, out var ords);
+    var solidMaterials = new HashSet<ElementId>();
+    foreach (var (memberSolidKs, memberDisplayKs) in GroupDefinesByMember(geomKs, ords, bundle))
+    {
+      geometry.AddRange(
+        DecodeMemberGeometry(
+          doc,
+          bundle,
+          memberSolidKs,
+          memberDisplayKs,
+          materialIdByGeometry,
+          session,
+          out bool memberFromSolid
+        )
+      );
+      var memberMaterial = memberFromSolid
+        ? ResolveMaterial(memberDisplayKs, memberSolidKs, materialIdByGeometry)
+        : ElementId.InvalidElementId;
+      if (memberMaterial != ElementId.InvalidElementId)
+      {
+        solidMaterials.Add(memberMaterial);
+      }
+    }
+    if (solidMaterials.Count == 1)
+    {
+      solidPaintMaterial = solidMaterials.First();
+    }
+    return geometry;
+  }
+
+  // Geometry for one atomic object or one definition member: the lossless raw 3dm SOLID blob (→ real Revit solids) is
+  // PREFERRED over the DISPLAY meshes, but not committed to [ENG-8800, mirroring AutoCAD's ENG-8820] — the display
+  // meshes exist precisely as the shadow for when the import can't deliver (see RevitArtefactSolidImporter). Either
+  // list may be empty.
+  private List<GeometryObject> DecodeMemberGeometry(
+    Document doc,
+    ArtefactBundle bundle,
+    IReadOnlyList<int>? solidKs,
+    IReadOnlyList<int> displayKs,
+    Dictionary<int, ElementId> materialIdByGeometry,
+    ArtefactSessionLog session,
+    out bool fromSolid
+  )
+  {
+    if (solidKs is { Count: > 0 })
+    {
+      var solids = _solidImporter.ImportSolids(doc, bundle, solidKs, session);
+      if (solids.Count > 0)
+      {
+        fromSolid = true;
+        return solids;
+      }
+    }
+
+    fromSolid = false;
+    var geometry = new List<GeometryObject>();
+    foreach (var geomK in displayKs)
+    {
+      materialIdByGeometry.TryGetValue(geomK, out var matId);
+      geometry.AddRange(DecodeGeometry(bundle, geomK, matId ?? ElementId.InvalidElementId));
+    }
+    return geometry;
+  }
+
+  // Groups a definition's DEFINES geometry Ks by member ordinal (index-aligned with ords), splitting each member into
+  // its raw 3dm solid blob(s) and its display mesh(es) so the caller can prefer the former. Member order is preserved.
+  // When ords are absent (older bundle) every geometry is its own member — i.e. no grouping, the prior behaviour.
+  private static IEnumerable<(List<int> Solids, List<int> Display)> GroupDefinesByMember(
+    List<int> geomKs,
+    List<int>? ords,
+    ArtefactBundle bundle
+  )
+  {
+    var members = new List<List<int>>();
+    var indexByOrd = new Dictionary<int, int>();
+    for (int i = 0; i < geomKs.Count; i++)
+    {
+      int ord = ords is not null && i < ords.Count ? ords[i] : -(i + 1); // absent ords → unique key per geometry
+      if (!indexByOrd.TryGetValue(ord, out int idx))
+      {
+        idx = members.Count;
+        indexByOrd[ord] = idx;
+        members.Add(new List<int>());
+      }
+      members[idx].Add(geomKs[i]);
+    }
+    foreach (var geoms in members)
+    {
+      var solids = new List<int>();
+      var display = new List<int>();
+      foreach (var k in geoms)
+      {
+        if (bundle.Geometries.TryGetValue(k, out var g) && g.Type == RawEncodingFormats.RHINO_3DM)
+        {
+          solids.Add(k);
+        }
+        else
+        {
+          display.Add(k);
+        }
+      }
+      yield return (solids, display);
+    }
+  }
+
+  // The material to paint imported solids with: HAS_MATERIAL hangs off the display meshes for a standalone object and
+  // off every member geometry (solid included) for a definition member, so check the display keys first, then the solids.
+  private static ElementId ResolveMaterial(
+    IReadOnlyList<int> displayKs,
+    IReadOnlyList<int>? solidKs,
+    Dictionary<int, ElementId> materialIdByGeometry
+  )
+  {
+    foreach (var k in solidKs is null ? displayKs : displayKs.Concat(solidKs))
+    {
+      if (materialIdByGeometry.TryGetValue(k, out var id) && id != ElementId.InvalidElementId)
+      {
+        return id;
+      }
+    }
+    return ElementId.InvalidElementId;
+  }
+
   // Decodes one SGEO mesh geometry index → Revit GeometryObjects (TessellatedShapeBuilder), material baked per face.
-  // Revit receives meshes only (no raw 3dm); non-SGEO / undecodable blobs yield nothing.
+  // Raw (non-SGEO) blobs are handled by RevitArtefactSolidImporter; undecodable blobs yield nothing.
   private List<GeometryObject> DecodeGeometry(ArtefactBundle bundle, int geomK, ElementId materialId)
   {
     if (

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Speckle.Connectors.RevitShared.projitems
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Speckle.Connectors.RevitShared.projitems
@@ -53,6 +53,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Operations\Receive\ITransactionManager.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Operations\Receive\ReceiveInstancesAsFamiliesSetting.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Operations\Receive\ReceiveReferencePointSetting.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Operations\Receive\RevitArtefactSolidImporter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Operations\Receive\RevitHostObjectArtefactBuilder.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Operations\Receive\RevitHostObjectBuilder.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Operations\Receive\RevitPreBakeSetupService.cs" />


### PR DESCRIPTION
Closes [ENG-8800](https://linear.app/speckle/issue/ENG-8800/rhino-solids-received-in-revit-as-meshes-raw-3dm-solid-blob-dropped-on).

Receiving a Rhino model with solids into Revit baked tessellated mesh DirectShapes instead of the real solids `dev` produces: the lossless raw 3dm `SOLID` blob that the Rhino send side writes *alongside* the display meshes was dropped on the receive side. Send is fine (`RhinoArtifactRootObjectBuilder` emits both).

## Both Revit receive paths dropped it

Not for the reason the ticket assumed — the split isn't net48 vs net8 (`RevitHostObjectArtefactBuilder` is registered unconditionally for 2023–2027), it's which builder runs:

- **direct bake (default):** `DecodeGeometry` only read SGEO mesh blobs and never consulted `rels.SolidByObject`; `BakeAtomic` also skipped solid-only objects as non-geometric. Rhino/AutoCAD/Grasshopper all consult it — Revit was the outlier.
- **reconstruction (`ReceiveInstancesAsFamilies` on):** `ArtifactReceiveOptions(PreferSolids: false)` made `ObjectsArtifactReader` strip the `rawEncoding` before `IRawEncodedObjectConverter` could import it. The registration comment claiming "Revit can't import 3dm" was wrong — `dev` demonstrably imports it via `DB.ShapeImporter`.

## Approach

Prefer the solid, but don't commit to it — mirroring AutoCAD's ENG-8820 semantics. An import that returns nothing, degrades to `DB.Mesh`, or throws falls back to the display meshes, which exist precisely as that shadow. Non-`RHINO_3DM` blobs are filtered out up front so a foreign encoding (e.g. AutoCAD SAT) never reaches the importer.

- **new `RevitArtefactSolidImporter`** — `DB.ShapeImporter` in a `SubTransaction` with rollback-on-empty (a failed import leaves ghost state that breaks painting and grouping, same as the v1 converter), the composed reference-point transform applied via `SolidUtils.CreateTransformed` (mesh vertices get this through `ToInternalPoints`; raw imports otherwise wouldn't — ENG-8808/ENG-8947), and post-commit face painting since imported solids carry no material of their own.
- **`RevitHostObjectArtefactBuilder`** — solid preferred per atomic object and per definition member (grouped by `DefinesOrdByDefinition`, as in `RhinoHostObjectArtefactBuilder`), gate widened to `rels.SolidByObject`, paint targets collected during the bake then painted in their own transaction once it commits (an element's faces aren't queryable before then — same ordering as v1's `PostBakePaint`).
- **`RevitConnectorModule`** — `PreferSolids: true`, fixing the families-receive path, plus the corrected comment.

## Verification

Real Rhino→Revit 2026 receive on this build, from the artefact session log:

```
model: rhino/solids
--- counters ---   solidsImported: 23   solidImportDegradedToMesh: 3   nonGeometricSkipped: 4
```

23 blobs became real Revit solids (individually paintable faces, confirmed with the Paint tool); 3 degraded imports fell back to display meshes by design. Full `Local.slnx -c Local` build after a `deep-clean-local`: 0 errors, 0 warnings; csharpier clean.

New session-log counters report which path each object took: `solidsImported`, `solidImportEmpty`, `solidImportDegradedToMesh`, `solidImportNotTransformable`, `solidImportFailed`, `solidsPainted`, `solidsUnpainted`, `solidPaintFailed`.

## Not in this PR

- **Block/instance placements.** A solid inside a `DB.GeometryInstance` can't have its faces painted or individually selected, so block geometry still isn't face-paintable. Flattening for both receive paths exists on `david/eng-8800-instance-solid-flattening` but is unverified: the nested-blocks version I tested carries **no 3dm blobs at all** (`geometryBlobs == definitions`, zero solid counters), so whether the Rhino artefact send emits member solids for block definitions is still open.
- **Material on imported solids.** The verification run queued no paint targets (`solidsPainted`/`solidsUnpainted` absent), so no material resolved for those 23 solids — worth a look if the source objects do carry materials.
- **Polylines** error out on the artefact bake path ("did not convert to any native geometry") — `DecodeGeometry` handles SGEO meshes only. Pre-existing gap, separate ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)