### PR TITLE
fix(revit): decode non-mesh SGEO primitives on artefact receive

### DIFF
--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Receive/RevitHostObjectArtefactBuilder.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Receive/RevitHostObjectArtefactBuilder.cs
@@ -10,6 +10,7 @@ using Speckle.Connectors.Common.Operations;
 using Speckle.Connectors.Common.Threading;
 using Speckle.Connectors.Revit.HostApp;
 using Speckle.Converters.Common;
+using Speckle.Converters.Common.Objects;
 using Speckle.Converters.RevitShared;
 using Speckle.Converters.RevitShared.Helpers;
 using Speckle.Converters.RevitShared.Services;
@@ -29,10 +30,11 @@ namespace Speckle.Connectors.Revit.Operations.Receive;
 /// Bakes a Speckle 4.0 artefact <see cref="ArtefactBundle"/> <b>directly</b> into the Revit document as native
 /// <see cref="DirectShape"/>s — talking only to the neutral dense-int graph + raw Revit API, skipping the v1
 /// <c>RootObjectUnpacker</c> / traversal / per-type converter dispatch. SGEO meshes are tessellated straight into
-/// DirectShape geometry (mirroring <c>MeshConverterToHost</c>), materials are created directly from MATERIAL nodes,
-/// and instances are placed per <c>DISPLAY_INSTANCE</c> edge via the <see cref="DirectShapeLibrary"/>. The
-/// receive-side twin of the send-side <c>RevitArtifactRootObjectBuilder</c> — except when
-/// <c>ReceiveInstancesAsFamilies</c> is on (see remarks).
+/// DirectShape geometry (mirroring <c>MeshConverterToHost</c>); non-mesh SGEO primitives (points, curves, regions,
+/// …) decode to a Speckle geometry object and convert via the shared Revit ToHost geometry converter. Materials are
+/// created directly from MATERIAL nodes, and instances are placed per <c>DISPLAY_INSTANCE</c> edge via the
+/// <see cref="DirectShapeLibrary"/>. The receive-side twin of the send-side <c>RevitArtifactRootObjectBuilder</c> —
+/// except when <c>ReceiveInstancesAsFamilies</c> is on (see remarks).
 /// </summary>
 /// <remarks>
 /// <para><b>Grouping.</b> Revit has no layers; each baked element is stamped with its model marker in the Comments
@@ -58,6 +60,11 @@ public sealed class RevitHostObjectArtefactBuilder : IArtifactHostObjectBuilder
   private readonly IArtifactReceiver _artifactReceiver;
   private readonly IHostObjectBuilder _hostObjectBuilder;
   private readonly RevitGroupBaker _groupBaker;
+  private readonly ITypedConverter<Base, List<GeometryObject>> _geometryConverter;
+
+  // Set by DecodeGeometry when the non-mesh SGEO fallback fails; surfaced by callers as the ERROR reason for an
+  // empty geometry result instead of the generic "did not convert to any native geometry" message.
+  private string? _lastDecodeFailure;
 
   public RevitHostObjectArtefactBuilder(
     IConverterSettingsStore<RevitConversionSettings> converterSettings,
@@ -70,7 +77,8 @@ public sealed class RevitHostObjectArtefactBuilder : IArtifactHostObjectBuilder
     ILogger<RevitHostObjectArtefactBuilder> logger,
     IArtifactReceiver artifactReceiver,
     IHostObjectBuilder hostObjectBuilder,
-    RevitGroupBaker groupBaker
+    RevitGroupBaker groupBaker,
+    ITypedConverter<Base, List<GeometryObject>> geometryConverter
   )
   {
     _converterSettings = converterSettings;
@@ -84,6 +92,7 @@ public sealed class RevitHostObjectArtefactBuilder : IArtifactHostObjectBuilder
     _artifactReceiver = artifactReceiver;
     _hostObjectBuilder = hostObjectBuilder;
     _groupBaker = groupBaker;
+    _geometryConverter = geometryConverter;
   }
 
   public async Task<HostObjectBuilderResult> Build(
@@ -286,6 +295,7 @@ public sealed class RevitHostObjectArtefactBuilder : IArtifactHostObjectBuilder
       var sw = Stopwatch.StartNew();
       try
       {
+        _lastDecodeFailure = null;
         var geometry = new List<GeometryObject>();
         foreach (var edge in displayEdges.OrderBy(e => e.Ord))
         {
@@ -294,23 +304,9 @@ public sealed class RevitHostObjectArtefactBuilder : IArtifactHostObjectBuilder
         }
         if (geometry.Count == 0)
         {
-          session.RecordObject(
-            appId,
-            srcType,
-            Status.ERROR,
-            "did not convert to any native geometry",
-            sw.ElapsedMilliseconds
-          );
-          conversionResults.Add(
-            new(
-              Status.ERROR,
-              source,
-              null,
-              null,
-              new ConversionException("Object did not convert to any native geometry"),
-              srcType
-            )
-          );
+          var reason = _lastDecodeFailure ?? "object did not convert to any native geometry";
+          session.RecordObject(appId, srcType, Status.ERROR, reason, sw.ElapsedMilliseconds);
+          conversionResults.Add(new(Status.ERROR, source, null, null, new ConversionException(reason), srcType));
           continue;
         }
 
@@ -375,6 +371,7 @@ public sealed class RevitHostObjectArtefactBuilder : IArtifactHostObjectBuilder
       session.Increment("definitionsSeen");
 
       var geometry = new List<GeometryObject>();
+      _lastDecodeFailure = null;
 
       // direct geometry members (DEFINES → geometry blobs).
       if (rels.DefinesByDefinition.TryGetValue(defNodeK, out var geomKs))
@@ -385,6 +382,8 @@ public sealed class RevitHostObjectArtefactBuilder : IArtifactHostObjectBuilder
           geometry.AddRange(DecodeGeometry(bundle, geomK, matId ?? ElementId.InvalidElementId));
         }
       }
+      // captured now — a recursive BuildDefinition call below resets _lastDecodeFailure for the child definition.
+      var directGeometryFailure = _lastDecodeFailure;
 
       // nested block/family members (DEFINES_INSTANCE → INSTANCE node): build the child definition first
       // (depth-first) and add a geometry-instance reference to it with the nested placement's own transform.
@@ -416,6 +415,14 @@ public sealed class RevitHostObjectArtefactBuilder : IArtifactHostObjectBuilder
       if (geometry.Count == 0)
       {
         session.Increment("definitionsEmpty");
+        if (directGeometryFailure is not null)
+        {
+          _logger.LogWarning(
+            "Definition {DefNodeK} built with no geometry: {Reason}",
+            defNodeK,
+            directGeometryFailure
+          );
+        }
         return null;
       }
 
@@ -495,19 +502,42 @@ public sealed class RevitHostObjectArtefactBuilder : IArtifactHostObjectBuilder
   }
 
   // ── geometry ──────────────────────────────────────────────────────────────────────────────────────────
-  // Decodes one SGEO mesh geometry index → Revit GeometryObjects (TessellatedShapeBuilder), material baked per face.
-  // Revit receives meshes only (no raw 3dm); non-SGEO / undecodable blobs yield nothing.
+  // Decodes one SGEO geometry index → Revit GeometryObjects. Meshes take the fast hand-rolled path
+  // (TessellatedShapeBuilder, material baked per face). Points, curves, regions and other non-mesh primitives decode
+  // to a Speckle geometry object and convert via the shared Revit ToHost geometry converter (mirrors
+  // Rhino/AutoCAD's SGEO fallback — see RhinoHostObjectArtefactBuilder.DecodeGeometryIndex). An unsupported
+  // primitive degrades to nothing (with a recorded reason, see _lastDecodeFailure) rather than aborting the receive.
   private List<GeometryObject> DecodeGeometry(ArtefactBundle bundle, int geomK, ElementId materialId)
   {
-    if (
-      !bundle.Geometries.TryGetValue(geomK, out var g)
-      || !g.IsSgeo
-      || !SgeoDecoder.TryDecodeMesh(g.Content, out var sm)
-    )
+    if (!bundle.Geometries.TryGetValue(geomK, out var g) || !g.IsSgeo)
     {
       return new List<GeometryObject>();
     }
-    return BuildMesh(sm, materialId);
+    if (SgeoDecoder.TryDecodeMesh(g.Content, out var sm))
+    {
+      return BuildMesh(sm, materialId);
+    }
+
+    Base? decoded = null;
+    try
+    {
+      decoded = SgeoDecoder.Decode(g.Content);
+      return _geometryConverter.Convert(decoded);
+    }
+    catch (Exception ex) when (!ex.IsFatal())
+    {
+      string stage = decoded is null ? "decode" : $"convert of {decoded.speckle_type}";
+      _lastDecodeFailure = $"geom {geomK} ({g.Type}) {stage} failed — {ex.GetType().Name}: {ex.Message}";
+      _logger.LogWarning(
+        ex,
+        "Skipped SGEO geometry {GeomK} ({Bytes} bytes) at {Stage}: {Error}",
+        geomK,
+        g.Content.Length,
+        stage,
+        ex.Message
+      );
+      return new List<GeometryObject>();
+    }
   }
 
   // Flat SGEO mesh (verts/faces, Speckle count-prefixed) → Revit GeometryObjects. Mirrors MeshConverterToHost: scale

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Receive/RevitHostObjectArtefactBuilder.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Receive/RevitHostObjectArtefactBuilder.cs
@@ -417,11 +417,7 @@ public sealed class RevitHostObjectArtefactBuilder : IArtifactHostObjectBuilder
         session.Increment("definitionsEmpty");
         if (directGeometryFailure is not null)
         {
-          _logger.LogWarning(
-            "Definition {DefNodeK} built with no geometry: {Reason}",
-            defNodeK,
-            directGeometryFailure
-          );
+          _logger.LogWarning("Definition {DefNodeK} built with no geometry: {Reason}", defNodeK, directGeometryFailure);
         }
         return null;
       }

--- a/Converters/Revit/Speckle.Converters.RevitShared/ToHost/Raw/BaseToHostGeometryObjectConverter.cs
+++ b/Converters/Revit/Speckle.Converters.RevitShared/ToHost/Raw/BaseToHostGeometryObjectConverter.cs
@@ -25,6 +25,9 @@ public class BaseToHostGeometryObjectConverter(
         var xyz = pointConverter.Convert(point);
         result.Add(DB.Point.Create(xyz));
         break;
+      case SOG.Pointcloud pointcloud:
+        result.AddRange(ConvertPointcloud(pointcloud));
+        break;
       case ICurve curve:
         var curves = curveConverter.Convert(curve).Cast<DB.GeometryObject>();
         result.AddRange(curves);
@@ -61,5 +64,19 @@ public class BaseToHostGeometryObjectConverter(
     }
 
     return result;
+  }
+
+  // Revit has no way to build an in-memory point cloud (DB.PointCloudInstance is backed by an external point cloud
+  // engine/file, not constructible from raw points) — bake one DB.Point per point instead, reusing the point
+  // converter so units + the project base point are honoured (mirrors CurveConverterToHost's flat-array handling).
+  // Per-point colour is dropped: DB.Point carries no colour of its own.
+  private IEnumerable<DB.GeometryObject> ConvertPointcloud(SOG.Pointcloud pointcloud)
+  {
+    var pts = pointcloud.points;
+    for (int i = 0; i + 2 < pts.Count; i += 3)
+    {
+      var point = new SOG.Point(pts[i], pts[i + 1], pts[i + 2], pointcloud.units);
+      yield return DB.Point.Create(pointConverter.Convert(point));
+    }
   }
 }


### PR DESCRIPTION
## Description

Revit's artefact receive only knew how to decode SGEO meshes. Points, curves, and regions either failed with a generic error or got silently dropped when mixed with a mesh on the same object. Pointclouds hit a separate gap and threw a validation error.

Fixed both by wiring in converters that already exist — same approach Rhino and AutoCAD already use for this.

## User Value

Revit can now receive point and curve geometry (not just meshes) from Rhino, Grasshopper, AutoCAD and structural analysis apps, alongside mesh geometry in the same model.

## Changes:

- `RevitHostObjectArtefactBuilder.DecodeGeometry` now falls back to `SgeoDecoder.Decode` + the existing Base→GeometryObject converter when a geometry isn't a mesh (Point, Line, Polyline, Arc, Circle, Ellipse, Curve, Region).
- Failed conversions now report the actual reason instead of one generic "did not convert" message.
- `BaseToHostGeometryObjectConverter` now handles `Pointcloud` — bakes one Revit point per point, since Revit has no native in-memory point cloud type (same fallback AutoCAD uses).

## Validation of changes:

<img width="3840" height="2098" alt="Screenshot 2026-08-05 101102" src="https://github.com/user-attachments/assets/bd8da3cd-a4e2-4dbf-ba99-7e64d00b28f0" />

## Checklist:

- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] I have added appropriate tests.
- [x] I have updated or added relevant documentation.