### PR TITLE
fix(rhino): close six artefact round-trip gaps (ENG-9108, 9111, 9112, 9113, 9114, 9115)

### DIFF
--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/Operations/Receive/RhinoArtefactUserStrings.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/Operations/Receive/RhinoArtefactUserStrings.cs
@@ -1,0 +1,110 @@
+using System.Globalization;
+using Rhino.DocObjects;
+
+namespace Speckle.Connectors.Rhino.Operations.Receive;
+
+/// <summary>
+/// Writes an artefact object's eav properties onto Rhino object attributes as user strings, so Rhino user text,
+/// nested user dictionaries and foreign parameters (Revit/IFC) survive an artefact receive [ENG-9111].
+/// </summary>
+/// <remarks>
+/// The key shape is the legacy one (<c>SpeckleAttributeExtensions.GetAttributes</c>): nested dictionaries flatten to
+/// dot-delimited paths, so <c>{ "User Dictionary": { "phase": 2 } }</c> becomes <c>User Dictionary.phase</c>. Values
+/// are formatted with the invariant culture — a Rhino user string is plain text, and formatting a double under the
+/// operator's locale would make the same bundle bake differently on different machines (and not re-parse on re-send).
+/// </remarks>
+internal static class RhinoArtefactUserStrings
+{
+  private const string PROPERTY_PATH_DELIMITER = ".";
+
+  /// <summary>
+  /// Bundle plumbing rather than user data: the root scalars every object carries
+  /// (<c>RhinoArtifactRootObjectBuilder.RootScalars</c>) and the hatch styling the send side stashes for
+  /// <see cref="RhinoHatchStyler"/>. All of it is either already applied to the native object (name, units, hatch
+  /// pattern) or reconstructed on the next send, so writing it as user text would only add noise the user then
+  /// sees in the Rhino properties panel.
+  /// </summary>
+  private static readonly HashSet<string> s_suppressedKeys = new(StringComparer.Ordinal)
+  {
+    "speckle_type",
+    "name",
+    "units",
+    "type",
+    "internalDefinitionName",
+    "hatchPatternName",
+    "hatchRotation",
+    "hatchScale",
+  };
+
+  /// <summary>Legacy noise filter: the trailing segment of a nested key, e.g. <c>area.units</c>, <c>area.name</c>.</summary>
+  private static readonly string[] s_suppressedSuffixes =
+  {
+    PROPERTY_PATH_DELIMITER + "units",
+    PROPERTY_PATH_DELIMITER + "name",
+    PROPERTY_PATH_DELIMITER + "internalDefinitionName",
+  };
+
+  /// <summary>
+  /// Flattens <paramref name="properties"/> onto <paramref name="atts"/> as user strings. A null or empty dictionary
+  /// is a no-op, so an object with no eav row costs nothing.
+  /// </summary>
+  public static void Apply(ObjectAttributes atts, Dictionary<string, object?>? properties)
+  {
+    if (properties is null || properties.Count == 0)
+    {
+      return;
+    }
+    Flatten(atts, properties, "");
+  }
+
+  private static void Flatten(ObjectAttributes atts, Dictionary<string, object?> dict, string keyPrefix)
+  {
+    foreach (var kvp in dict)
+    {
+      if (kvp.Key.Length == 0 || (keyPrefix.Length == 0 && s_suppressedKeys.Contains(kvp.Key)))
+      {
+        continue;
+      }
+
+      string key = keyPrefix.Length == 0 ? kvp.Key : keyPrefix + PROPERTY_PATH_DELIMITER + kvp.Key;
+
+      // Nested groups (a Rhino user dictionary, or the area/volume records the send side writes) recurse into
+      // dot-delimited paths rather than stringifying the dictionary itself.
+      if (kvp.Value is Dictionary<string, object?> childDict)
+      {
+        Flatten(atts, childDict, key);
+        continue;
+      }
+
+      if (IsSuppressedPath(key))
+      {
+        continue;
+      }
+
+      atts.SetUserString(key, Stringify(kvp.Value));
+    }
+  }
+
+  private static bool IsSuppressedPath(string key)
+  {
+    foreach (var suffix in s_suppressedSuffixes)
+    {
+      if (key.EndsWith(suffix, StringComparison.Ordinal))
+      {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  // Culture-independent text for the value types an eav scalar can hold (string, long, double, bool) — see the
+  // <remarks> on why this is not ToString() under the ambient culture.
+  private static string Stringify(object? value) =>
+    value switch
+    {
+      null => "",
+      string s => s,
+      IFormattable f => f.ToString(null, CultureInfo.InvariantCulture),
+      _ => value.ToString() ?? "",
+    };
+}

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/Operations/Receive/RhinoArtefactViewBaker.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/Operations/Receive/RhinoArtefactViewBaker.cs
@@ -1,0 +1,169 @@
+using Microsoft.Extensions.Logging;
+using Rhino;
+using Rhino.DocObjects;
+using Speckle.Connectors.Common.Diagnostics;
+using Speckle.Sdk;
+using Speckle.Sdk.Common;
+using Speckle.Sdk.Pipelines.Receive.Artifacts;
+using RG = Rhino.Geometry;
+
+namespace Speckle.Connectors.Rhino.Operations.Receive;
+
+/// <summary>
+/// Recreates an artefact bundle's named camera viewpoints (<c>envelope.camera_views.parquet</c>) as Rhino named
+/// views [ENG-9112].
+/// </summary>
+/// <remarks>
+/// <para>Follows the v1 <c>RhinoViewBaker</c> mechanism — clone the active viewport, retarget its camera, push it
+/// onto the viewport, add the named view from it, then restore the viewport. Going through a real viewport is what
+/// guarantees a valid screen port and frustum aspect; a bare <c>new ViewInfo()</c> has neither.</para>
+/// <para>Unlike the v1 baker this preserves the source projection: an artefact camera view records
+/// <see cref="ArtefactCameraView.IsOrtho"/>, so a parallel view stays parallel instead of being forced to
+/// perspective. Lens length is applied through <c>Camera35mmLensLength</c> rather than the
+/// <c>ChangeToPerspectiveProjection</c> lens argument, which is documented to be ignored when the viewport is
+/// already perspective (as a cloned active viewport usually is).</para>
+/// </remarks>
+internal static class RhinoArtefactViewBaker
+{
+  public static void BakeViews(
+    RhinoDoc doc,
+    IReadOnlyList<ArtefactCameraView> views,
+    string docUnits,
+    ArtefactSessionLog session,
+    ILogger logger
+  )
+  {
+    if (views.Count == 0)
+    {
+      return;
+    }
+
+    var activeView = doc.Views.ActiveView;
+    if (activeView is null)
+    {
+      // headless / no open viewport (the importer legs): nothing to clone a valid frustum from.
+      logger.LogWarning("Skipped baking {Count} artefact named view(s): no active Rhino view", views.Count);
+      return;
+    }
+
+    var viewport = activeView.ActiveViewport;
+    using var original = new ViewportInfo(viewport);
+
+    foreach (var view in views)
+    {
+      if (view.Name is not { Length: > 0 } rawName || rawName.Trim().Length == 0)
+      {
+        continue; // an unnamed viewpoint cannot be a Rhino named view
+      }
+      var name = rawName.Trim();
+
+      try
+      {
+        RemoveNamedView(doc, name); // re-receive replaces rather than duplicating
+        if (Apply(viewport, view, docUnits))
+        {
+          doc.NamedViews.Add(name, activeView.ActiveViewportID);
+          session.Increment("namedViewsBaked");
+        }
+      }
+      catch (Exception ex) when (!ex.IsFatal())
+      {
+        logger.LogError(ex, "Failed to create artefact named view '{ViewName}'", name);
+      }
+    }
+
+    // put the user's viewport back exactly as it was — it was only ever a scratch surface
+    viewport.SetViewProjection(original, false);
+    activeView.Redraw();
+  }
+
+  // Retargets the viewport's camera onto one artefact view. Returns false when the recorded camera frame is
+  // degenerate, so the caller skips it instead of adding a broken named view.
+  private static bool Apply(global::Rhino.Display.RhinoViewport viewport, ArtefactCameraView view, string docUnits)
+  {
+    var forward = new RG.Vector3d(view.ForwardX, view.ForwardY, view.ForwardZ);
+    var up = new RG.Vector3d(view.UpX, view.UpY, view.UpZ);
+    if (!forward.Unitize() || !up.Unitize())
+    {
+      return false;
+    }
+
+    // Positions, target and the ortho/frustum extents are in the bundle's model units; direction vectors and the
+    // 35mm lens length are unitless, so they are NOT scaled.
+    double scale = view.Units is { Length: > 0 } u ? Units.GetConversionFactor(u, docUnits) : 1.0;
+
+    using var vp = new ViewportInfo(viewport);
+    vp.SetCameraLocation(new RG.Point3d(view.PosX * scale, view.PosY * scale, view.PosZ * scale));
+    vp.SetCameraDirection(forward);
+    vp.SetCameraUp(up);
+
+    if (view.TargetX is double tx && view.TargetY is double ty && view.TargetZ is double tz)
+    {
+      vp.TargetPoint = new RG.Point3d(tx * scale, ty * scale, tz * scale);
+    }
+
+    if (view.IsOrtho)
+    {
+      vp.ChangeToParallelProjection(true);
+      ApplyOrthoExtents(vp, view, scale);
+    }
+    else
+    {
+      // targetDistance = UnsetValue → keep the current frustum plane; the lens is set explicitly below.
+      vp.ChangeToPerspectiveProjection(RhinoMath.UnsetValue, true, 50.0);
+      if (view.LensMm is double lens && lens > 0)
+      {
+        vp.Camera35mmLensLength = lens;
+      }
+    }
+
+    if (!vp.IsValidCamera)
+    {
+      return false;
+    }
+
+    // updateTargetLocation: false — the target set above is the source's own, not one recomputed from the direction.
+    return viewport.SetViewProjection(vp, false);
+  }
+
+  // A parallel view's "zoom" is its frustum height, which the send side records as OrthoHeight. Rebuild a symmetric
+  // frustum of that height, widened by the recorded aspect (falling back to the viewport's own) so the view frames
+  // the same region it did in the source document.
+  private static void ApplyOrthoExtents(ViewportInfo vp, ArtefactCameraView view, double scale)
+  {
+    if (view.OrthoHeight is not double orthoHeight || orthoHeight <= 0)
+    {
+      return;
+    }
+
+    double height = orthoHeight * scale;
+    double aspect = view.Aspect is double a && a > 0 ? a : vp.FrustumAspect;
+    if (aspect <= 0)
+    {
+      aspect = 1.0;
+    }
+
+    double halfHeight = height / 2.0;
+    double halfWidth = halfHeight * aspect;
+    double near = view.Near is double n && n > 0 ? n * scale : vp.FrustumNear;
+    double far = view.Far is double f && f > 0 ? f * scale : vp.FrustumFar;
+    if (far <= near)
+    {
+      return; // recorded planes are unusable — keep whatever the parallel switch produced
+    }
+
+    vp.SetFrustum(-halfWidth, halfWidth, -halfHeight, halfHeight, near, far);
+  }
+
+  private static void RemoveNamedView(RhinoDoc doc, string name)
+  {
+    for (int i = doc.NamedViews.Count - 1; i >= 0; i--)
+    {
+      if (string.Equals(doc.NamedViews[i].Name, name, StringComparison.OrdinalIgnoreCase))
+      {
+        doc.NamedViews.Delete(i);
+        break;
+      }
+    }
+  }
+}

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/Operations/Receive/RhinoHostObjectArtefactBuilder.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/Operations/Receive/RhinoHostObjectArtefactBuilder.cs
@@ -229,6 +229,7 @@ public class RhinoHostObjectArtefactBuilder : IArtifactHostObjectBuilder
           bundle,
           rels,
           baseLayerIndex,
+          baseLayerName,
           layerCache,
           materialByObject,
           materialByGeometry,
@@ -501,6 +502,7 @@ public class RhinoHostObjectArtefactBuilder : IArtifactHostObjectBuilder
     ArtefactBundle bundle,
     ArtefactRelations rels,
     int baseLayerIndex,
+    string baseLayerName,
     Dictionary<string, int> layerCache,
     Dictionary<string, Guid> materialByObject,
     Dictionary<int, Guid> materialByGeometry,
@@ -514,7 +516,7 @@ public class RhinoHostObjectArtefactBuilder : IArtifactHostObjectBuilder
     var docUnits = _converterSettings.Current.SpeckleUnits;
 
     // definitions (incl. nested blocks): a DEFINITION node owns its geometry directly and may contain nested placements.
-    var defIndexByNode = BuildDefinitions(doc, bundle, rels, materialByGeometry, docUnits, session);
+    var defIndexByNode = BuildDefinitions(doc, bundle, rels, materialByGeometry, docUnits, baseLayerName, session);
 
     // placements: one instance per DISPLAY_INSTANCE edge (object → INSTANCE node); an object may place several.
     foreach (var edge in rels.DisplayInstanceEdges)
@@ -640,6 +642,7 @@ public class RhinoHostObjectArtefactBuilder : IArtifactHostObjectBuilder
     ArtefactRelations rels,
     Dictionary<int, Guid> materialByGeometry,
     string docUnits,
+    string baseLayerName,
     ArtefactSessionLog session
   )
   {
@@ -737,7 +740,12 @@ public class RhinoHostObjectArtefactBuilder : IArtifactHostObjectBuilder
         session.Increment("definitionsEmpty");
         return -1;
       }
-      var defName = RhinoUtils.CleanBlockDefinitionName($"{defNode.Name ?? "Definition"}-(def-{defNodeK})");
+      // The baseLayerName suffix scopes the generated name to this model card, so DeepClean can purge exactly the
+      // definitions the previous receive of THIS card created and leave other cards' and user-authored blocks alone
+      // [ENG-9115]. Same convention as the group names in BakeGroups.
+      var defName = RhinoUtils.CleanBlockDefinitionName(
+        $"{defNode.Name ?? "Definition"}-(def-{defNodeK}) ({baseLayerName})"
+      );
       int defIndex = doc.InstanceDefinitions.Add(defName, "", RG.Point3d.Origin, geometryList, attributeList);
       if (defIndex < 0)
       {
@@ -1046,6 +1054,22 @@ public class RhinoHostObjectArtefactBuilder : IArtifactHostObjectBuilder
         if (group is { Name: not null } && group.Name.Contains(baseLayerName))
         {
           doc.Groups.Delete(i);
+        }
+      }
+
+      // then this model's generated block definitions — they carry the same baseLayerName suffix (BuildDefinitions).
+      // Without this every receive added a fresh "…-(def-K)" set and the block table grew without bound [ENG-9115].
+      // Match on the CLEANED suffix: BuildDefinitions runs the whole name through CleanBlockDefinitionName, which
+      // rewrites / and \, so a project or model name containing either would not match the raw baseLayerName.
+      // deleteReferences: true because the placements are still in the doc at this point (their layers are purged
+      // just below); with false, Delete refuses while any reference is alive and the definition would survive.
+      var definitionSuffix = RhinoUtils.CleanBlockDefinitionName(baseLayerName);
+      for (int i = doc.InstanceDefinitions.Count - 1; i >= 0; i--)
+      {
+        var definition = doc.InstanceDefinitions[i];
+        if (definition is { IsDeleted: false, Name: not null } && definition.Name.Contains(definitionSuffix))
+        {
+          doc.InstanceDefinitions.Delete(i, true, true);
         }
       }
 

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/Operations/Receive/RhinoHostObjectArtefactBuilder.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/Operations/Receive/RhinoHostObjectArtefactBuilder.cs
@@ -232,6 +232,7 @@ public class RhinoHostObjectArtefactBuilder : IArtifactHostObjectBuilder
           layerCache,
           materialByObject,
           materialByGeometry,
+          colorByObject,
           bakedObjectIds,
           bakedGuidsByObjK,
           conversionResults,
@@ -503,6 +504,7 @@ public class RhinoHostObjectArtefactBuilder : IArtifactHostObjectBuilder
     Dictionary<string, int> layerCache,
     Dictionary<string, Guid> materialByObject,
     Dictionary<int, Guid> materialByGeometry,
+    Dictionary<string, int> colorByObject,
     HashSet<string> bakedObjectIds,
     Dictionary<int, List<Guid>> bakedGuidsByObjK,
     HashSet<ReceiveConversionResult> conversionResults,
@@ -563,6 +565,12 @@ public class RhinoHostObjectArtefactBuilder : IArtifactHostObjectBuilder
       {
         atts.RenderMaterial = RenderContent.FromId(doc, materialGuid) as RhinoRenderMaterial;
         atts.MaterialSource = ObjectMaterialSource.MaterialFromObject;
+      }
+      // the placement's own colour (object-sourced HAS_COLOR), so a per-instance override survives [ENG-9114]
+      if (colorByObject.TryGetValue(appId, out int instArgb))
+      {
+        atts.ObjectColor = Color.FromArgb(instArgb);
+        atts.ColorSource = ObjectColorSource.ColorFromObject;
       }
 
       var id = doc.Objects.AddInstanceObject(defIndex, transform, atts);
@@ -924,7 +932,7 @@ public class RhinoHostObjectArtefactBuilder : IArtifactHostObjectBuilder
   // CreateMaterials. Applied as ObjectColor + ColorSource.ColorFromObject on bake.
   private static Dictionary<string, int> CreateColors(ArtefactBundle bundle, Dictionary<int, int> objByGeom)
   {
-    var byObject = new Dictionary<string, int>();
+    var byObject = new Dictionary<string, int>(StringComparer.Ordinal);
     foreach (var kv in bundle.Relations.ColorByGeometry)
     {
       if (!bundle.Nodes.TryGetValue(kv.Value, out var n) || n.Kind != NodeKind.Color || n.Argb is not int argb)
@@ -932,6 +940,22 @@ public class RhinoHostObjectArtefactBuilder : IArtifactHostObjectBuilder
         continue;
       }
       if (objByGeom.TryGetValue(kv.Key, out int objK) && bundle.ObjectAppIds.TryGetValue(objK, out var appId))
+      {
+        byObject[appId] = argb;
+      }
+    }
+
+    // Object-sourced edges (ord=1): a block placement's own colour. A placement owns no geometry, so it never appears
+    // in objByGeom — resolve it straight through the object dictionary [ENG-8822, ENG-9114]. Same shape as the Autocad
+    // artefact builder's MapColors.
+    foreach (var kv in bundle.Relations.ColorByObject)
+    {
+      if (
+        bundle.Nodes.TryGetValue(kv.Value, out var n)
+        && n.Kind == NodeKind.Color
+        && n.Argb is int argb
+        && bundle.ObjectAppIds.TryGetValue(kv.Key, out var appId)
+      )
       {
         byObject[appId] = argb;
       }

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/Operations/Receive/RhinoHostObjectArtefactBuilder.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/Operations/Receive/RhinoHostObjectArtefactBuilder.cs
@@ -237,6 +237,21 @@ public class RhinoHostObjectArtefactBuilder : IArtifactHostObjectBuilder
       }
     }
 
+    // 6 - named camera viewpoints (envelope.camera_views) → Rhino named views, replacing same-named ones [ENG-9112].
+    if (bundle.CameraViews.Count > 0)
+    {
+      using (session.Phase("Views"))
+      {
+        RhinoArtefactViewBaker.BakeViews(
+          doc,
+          bundle.CameraViews,
+          _converterSettings.Current.SpeckleUnits,
+          session,
+          _logger
+        );
+      }
+    }
+
     doc.Views.Redraw();
     return new HostObjectBuilderResult(bakedObjectIds, conversionResults);
   }

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/Operations/Receive/RhinoHostObjectArtefactBuilder.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/Operations/Receive/RhinoHostObjectArtefactBuilder.cs
@@ -179,16 +179,16 @@ public class RhinoHostObjectArtefactBuilder : IArtifactHostObjectBuilder
           }
 
           var name = ObjectName(bundle, objK);
+          bundle.Properties.TryGetValue(objK, out var objProps);
           var ids = new List<Guid>();
           foreach (var geom in geometries)
           {
             if (geom is RG.Hatch hatch)
             {
               // restore pattern/rotation/scale carried as EAV onto the Hatch rebuilt from the SGEO Region
-              bundle.Properties.TryGetValue(objK, out var hatchProps);
-              RhinoHatchStyler.Apply(doc, hatch, hatchProps, _converterSettings.Current.SpeckleUnits);
+              RhinoHatchStyler.Apply(doc, hatch, objProps, _converterSettings.Current.SpeckleUnits);
             }
-            ids.Add(BakeObject(doc, geom, layerIndex, materialByObject, colorByObject, appId, name));
+            ids.Add(BakeObject(doc, geom, layerIndex, materialByObject, colorByObject, appId, name, objProps));
           }
           bakedObjectIds.UnionWith(ids.Select(g => g.ToString()));
           if (rels.GroupsByObject.ContainsKey(objK))
@@ -420,7 +420,8 @@ public class RhinoHostObjectArtefactBuilder : IArtifactHostObjectBuilder
     Dictionary<string, Guid> materialByObject,
     Dictionary<string, int> colorByObject,
     string appId,
-    string? name
+    string? name,
+    Dictionary<string, object?>? properties
   )
   {
     var atts = new ObjectAttributes { LayerIndex = layerIndex };
@@ -428,6 +429,8 @@ public class RhinoHostObjectArtefactBuilder : IArtifactHostObjectBuilder
     {
       atts.Name = name;
     }
+    // source properties (Rhino user text / user dictionaries, Revit + IFC parameters) → user strings [ENG-9111]
+    RhinoArtefactUserStrings.Apply(atts, properties);
     if (materialByObject.TryGetValue(appId, out Guid materialGuid))
     {
       atts.RenderMaterial = RenderContent.FromId(doc, materialGuid) as RhinoRenderMaterial;
@@ -505,6 +508,9 @@ public class RhinoHostObjectArtefactBuilder : IArtifactHostObjectBuilder
       {
         atts.Name = instName;
       }
+      // the placement's own properties → user strings, same as an atomic object [ENG-9111]
+      bundle.Properties.TryGetValue(objK, out var instProps);
+      RhinoArtefactUserStrings.Apply(atts, instProps);
       if (materialByObject.TryGetValue(appId, out Guid materialGuid))
       {
         atts.RenderMaterial = RenderContent.FromId(doc, materialGuid) as RhinoRenderMaterial;

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/Operations/Receive/RhinoHostObjectArtefactBuilder.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/Operations/Receive/RhinoHostObjectArtefactBuilder.cs
@@ -195,7 +195,19 @@ public class RhinoHostObjectArtefactBuilder : IArtifactHostObjectBuilder
           {
             bakedGuidsByObjK[objK] = ids;
           }
-          conversionResults.Add(new(Status.SUCCESS, source, ids[0].ToString(), "Speckle.Object"));
+
+          // One source object that decoded into several Rhino geometries (a Revit wall's display meshes, say) becomes
+          // one native group, so the element stays selectable and movable as a unit [ENG-9113]. The report entry then
+          // points at the GROUP id — the selection binding resolves a group id as well as an object id — while
+          // bakedObjectIds keeps only the members: a group id in there would make whole-model highlighting walk every
+          // object of every group (the same reason the v1 builder kept group ids out of it).
+          string reportId = ids[0].ToString();
+          if (ids.Count > 1 && GroupElement(doc, ids, name, ObjectType(bundle, objK), appId, baseLayerName) is Guid gid)
+          {
+            reportId = gid.ToString();
+            session.Increment("elementGroupsBaked");
+          }
+          conversionResults.Add(new(Status.SUCCESS, source, reportId, "Speckle.Object"));
           session.RecordObject(appId, "Speckle.Object", Status.SUCCESS, null, sw.ElapsedMilliseconds);
         }
         catch (Exception ex) when (!ex.IsFatal())
@@ -457,6 +469,27 @@ public class RhinoHostObjectArtefactBuilder : IArtifactHostObjectBuilder
       atts.ColorSource = ObjectColorSource.ColorFromObject; // by-object display colour (HAS_COLOR)
     }
     return doc.Objects.Add(geom, atts);
+  }
+
+  // Binds the several Rhino geometries decoded from ONE source object into a native group [ENG-9113]. The name carries
+  // the baseLayerName suffix — like BakeGroups and the v1 fallback grouping — so DeepClean purges it on re-receive.
+  // The source appId is in the name to keep it unique between two same-named elements. Returns null when Rhino
+  // refused the group, so the caller falls back to reporting the first member.
+  private static Guid? GroupElement(
+    RhinoDoc doc,
+    List<Guid> ids,
+    string? name,
+    string? type,
+    string appId,
+    string baseLayerName
+  )
+  {
+    var label =
+      name is { Length: > 0 } n ? n
+      : type is { Length: > 0 } t ? t
+      : "Element";
+    int index = doc.Groups.Add($"{label} - {appId} ({baseLayerName})", ids);
+    return index < 0 ? null : doc.Groups.FindIndex(index)?.Id;
   }
 
   // ── instances ─────────────────────────────────────────────────────────────────────────────────────────
@@ -951,6 +984,15 @@ public class RhinoHostObjectArtefactBuilder : IArtifactHostObjectBuilder
     && s.Length > 0
       ? s
       : bundle.Units;
+
+  // The object's source type ("type" scalar, e.g. the Rhino ObjectType or the Revit category), or null when absent.
+  private static string? ObjectType(ArtefactBundle bundle, int objK) =>
+    bundle.Properties.TryGetValue(objK, out var props)
+    && props.TryGetValue("type", out var v)
+    && v is string s
+    && s.Length > 0
+      ? s
+      : null;
 
   // The send side stores "name" as (Attributes.Name || sourceType) alongside the "type" scalar (== sourceType), so an
   // unnamed object has name == type. Returns the real name only when it's present and differs from type; null otherwise

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/Operations/Send/RhinoArtifactRootObjectBuilder.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/Operations/Send/RhinoArtifactRootObjectBuilder.cs
@@ -198,6 +198,12 @@ public class RhinoArtifactRootObjectBuilder(
     var collectedObjects = new List<CollectedObject>(atomicObjects.Count);
     var results = new List<SendConversionResult>(atomicObjects.Count);
 
+    // An object whose material source is MaterialFromLayer gets NO object-level material proxy (the unpacker skips it);
+    // the material rides the proxy its LAYER stage builds, which lists the layer id — and a layer id resolves to no
+    // geometry in phase 2, so the inherited material was dropped entirely. Record object → the id of the layer whose
+    // material it inherits so phase 2 can land HAS_MATERIAL on the object's own display geometry [ENG-9108].
+    var layerMaterialInheritors = new Dictionary<string, string>(StringComparer.Ordinal);
+
     int count = 0;
     foreach (RhinoObject rhinoObject in atomicObjects)
     {
@@ -209,6 +215,15 @@ public class RhinoArtifactRootObjectBuilder(
       {
         int layerIndex = rhinoObject.Attributes.LayerIndex;
         CollectLayerChain(doc, layerIndex, layers, usedLayers);
+
+        if (
+          rhinoObject.Attributes.MaterialSource == ObjectMaterialSource.MaterialFromLayer
+          && layerIndex >= 0
+          && LayerHasRenderMaterial(doc.Layers[layerIndex])
+        )
+        {
+          layerMaterialInheritors[applicationId] = doc.Layers[layerIndex].Id.ToString();
+        }
 
         CollectedObject collected = CollectObject(
           rhinoObject,
@@ -259,9 +274,16 @@ public class RhinoArtifactRootObjectBuilder(
       instanceDefinitionProxies,
       groups,
       cameraViews,
+      layerMaterialInheritors,
       results
     );
   }
+
+  // True when the layer itself carries a render material. Mirrors the condition the material unpacker's layer stage
+  // uses to build a proxy for that layer, so every object recorded against it in <c>layerMaterialInheritors</c> is
+  // guaranteed to resolve to a MATERIAL node in phase 2. RhinoCommon-bound → phase 1 only [ENG-9108].
+  private static bool LayerHasRenderMaterial(RhinoLayer layer) =>
+    layer.RenderMaterial is not null || layer.RenderMaterialIndex != -1;
 
   // Rhino groups → plain snapshot records. An object's GetGroupList carries ALL its groups (nesting in Rhino is
   // implicit via overlapping membership — there is no group parent chain), so each entry becomes one IN_GROUP edge.
@@ -711,6 +733,18 @@ public class RhinoArtifactRootObjectBuilder(
 
     // 2) render materials → HAS_MATERIAL (geometry → material node). Rhino material proxies list OBJECT ids,
     // so resolve each object to its display-mesh geometry K(s).
+    // Layer-sourced proxies list a LAYER id instead, which owns no geometry — invert the object → layer map so those
+    // land on the display geometry of every object inheriting that layer's material (MaterialFromLayer) [ENG-9108].
+    var inheritorsByLayerId = new Dictionary<string, List<string>>(StringComparer.Ordinal);
+    foreach (var kv in model.LayerMaterialInheritors)
+    {
+      if (!inheritorsByLayerId.TryGetValue(kv.Value, out var inheritors))
+      {
+        inheritorsByLayerId[kv.Value] = inheritors = new List<string>();
+      }
+      inheritors.Add(kv.Key);
+    }
+
     foreach (var materialProxy in model.Materials)
     {
       var value = materialProxy.value;
@@ -731,6 +765,21 @@ public class RhinoArtifactRootObjectBuilder(
           foreach (var gK in gKs)
           {
             pipeline.HasMaterial(gK, matK);
+          }
+        }
+        else if (inheritorsByLayerId.TryGetValue(objectId, out var inheritors))
+        {
+          // layer-sourced: the layer has no geometry of its own, so the inherited material lands on each object that
+          // draws with it. An inheritor with no geometry (a block instance) is skipped — nothing to attach to.
+          foreach (var inheritorId in inheritors)
+          {
+            if (geometryKsByObjectId.TryGetValue(inheritorId, out var inheritorGKs))
+            {
+              foreach (var gK in inheritorGKs)
+              {
+                pipeline.HasMaterial(gK, matK);
+              }
+            }
           }
         }
       }
@@ -874,6 +923,8 @@ public class RhinoArtifactRootObjectBuilder(
     IReadOnlyList<InstanceDefinitionProxy> Definitions,
     IReadOnlyList<CollectedGroup> Groups,
     IReadOnlyList<CameraView> CameraViews,
+    // object id → the id of the layer whose render material it inherits (MaterialFromLayer only) [ENG-9108]
+    IReadOnlyDictionary<string, string> LayerMaterialInheritors,
     IReadOnlyList<SendConversionResult> Results
   );
 }

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/Speckle.Connectors.RhinoShared.projitems
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/Speckle.Connectors.RhinoShared.projitems
@@ -65,6 +65,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)HostApp\SpeckleRhinoPanelHost.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Operations\Receive\DisableRedrawScope.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Operations\Receive\RhinoArtefactUserStrings.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Operations\Receive\RhinoArtefactViewBaker.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Operations\Receive\RhinoHatchStyler.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Operations\Receive\RhinoHostObjectBuilder.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Operations\Receive\RhinoHostObjectArtefactBuilder.cs" />

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/Speckle.Connectors.RhinoShared.projitems
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/Speckle.Connectors.RhinoShared.projitems
@@ -64,6 +64,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)HostApp\RhinoMaterialUnpacker.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HostApp\SpeckleRhinoPanelHost.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Operations\Receive\DisableRedrawScope.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Operations\Receive\RhinoArtefactUserStrings.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Operations\Receive\RhinoHatchStyler.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Operations\Receive\RhinoHostObjectBuilder.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Operations\Receive\RhinoHostObjectArtefactBuilder.cs" />


### PR DESCRIPTION
Six of the nine Rhino artefact tickets in the Speckle 7.0 backlog, one commit each. Three are skipped and explained at the bottom.

All of these are round-trip gaps in the 4.0 rewrite rather than new features — data that either never made it into the bundle or was in the bundle and never read back out.

## Fixed

| Ticket | What was wrong |
|---|---|
| **ENG-9108** (High) | An object with `MaterialFromLayer` published with no material at all. The unpacker's object stage skips those by design and its layer stage builds a proxy listing the **layer** id — but phase 2 resolved proxy members only through `geometryKsByObjectId`, which is keyed by object id, so the MATERIAL node landed with zero `HAS_MATERIAL` edges. Phase 1 now records object → inherited-layer id (only when that layer really carries a material, mirroring the condition the unpacker uses, so every recorded object resolves); phase 2 inverts that and expands a layer-sourced proxy onto its inheritors' display geometry. |
| **ENG-9111** (High) | `ArtefactBundle.Properties` was never applied to object attributes, so Rhino user text / user dictionaries didn't survive a round trip and Revit + IFC parameters never reached received objects. The data was in the bundle the whole time. New `RhinoArtefactUserStrings` flattens it to the legacy dot-delimited user-string shape, for atomic objects and instance placements. |
| **ENG-9112** | Named views were being written to `envelope.camera_views.parquet` and surfaced as `ArtefactBundle.CameraViews`, but the bake never read the list. New `RhinoArtefactViewBaker` as step 6. |
| **ENG-9113** | One source object decoding to several geometries baked as loose objects, so a Revit wall arrived as a pile of meshes. Now bound into a native group. |
| **ENG-9114** | A colour set directly on a block instance is emitted object-sourced (`ord=1`, ENG-8825/8822) and parsed into `ColorByObject`, but `CreateColors` read only `ColorByGeometry` — so placements were never in the map. |
| **ENG-9115** | `DeepClean` purged this model's groups and layers but not its instance definitions, so every receive left another orphaned `…-(def-K)` set in the block table. |

### Notes on the less obvious bits

**ENG-9112** deliberately keeps the v1 `RhinoViewBaker` mechanism (clone the active viewport, retarget, push, add, restore) — going through a real viewport is what supplies a valid screen port and frustum aspect, which a bare `new ViewInfo()` does not have. Two things it does differently:

- **Projection type is preserved.** v1 unconditionally called `ChangeToPerspectiveProjection`, so parallel views came back perspective. `IsOrtho` is recorded, so a parallel view now switches to parallel and rebuilds a symmetric frustum from the recorded `OrthoHeight` + aspect.
- **Lens goes through `Camera35mmLensLength`.** The `lensLength` argument of `ChangeToPerspectiveProjection` is documented to be ignored when the viewport is already perspective, which a cloned active viewport normally is — so v1's value never took effect there. (v1 also passed `1.0` into it, having the argument order the other way round in its comment.)

**ENG-9113** matches the v1 contract exactly: the report entry points at the **group** id, because `RhinoBasicConnectorBinding.GetObjectsFromIds` resolves an id through both `Objects.FindId` and `Groups.FindId`, so highlighting from the report selects the whole element. `bakedObjectIds` keeps only the member guids — a group id there would make whole-model highlighting walk every object of every group, which is why v1 kept them out too.

**ENG-9115** deletes with `deleteReferences: true`: the previous receive's placements are still live at that point (their layers are purged immediately after), and with `false` Rhino refuses to delete while any reference exists, leaving exactly the orphans this removes. Definition names are matched on the **cleaned** suffix, since `CleanBlockDefinitionName` rewrites `/` and `\` and a project or model name containing either would otherwise not match.

**ENG-9111** also lists `RhinoArtefactUserStrings.cs` in the `RhinoShared` `.projitems` — that shared project enumerates `<Compile>` entries explicitly, so an unlisted file compiles into nothing. Same trap as ENG-8827 on the Autocad side.

## Scope limits, called out

- **ENG-9111 does not cover block-definition members.** A member gets no `DISPLAY` edge by design (it renders only through its definition) and `ObjectByGeometry()` is built from `DISPLAY` alone, so on receive there's no route from a definition's geometry back to the member object holding the eav row. The ticket's acceptance criteria don't require it. If ENG-9110 introduces a member↔geometry association, member properties come along nearly for free.
- **ENG-9108** skips a block instance inheriting from its layer: it owns no geometry, and instance-sourced `HAS_MATERIAL` needs the namespace tag `HAS_COLOR` got in ENG-8822 — that's ENG-9109.

## Skipped, and why

- **ENG-9107** (text publish) — the ticket's root cause is stale. `Speckle.Objects`/`Speckle.Sdk` resolve as a **`ProjectReference`** to the sibling `speckle-sharp-sdk` checkout under the `Local` configuration, and that checkout (also on `big-truck`) already has `Text`/`Region` in both `SgeoEncoder` and `SgeoDecoder`. There's also no package to bump — the pinned 2026.6.0 is the newest on nuget.org, and it predates the artefact pipeline entirely. Rhino's four text converters all exist and register, and the Rhino converter `.projitems` uses a `**\*.cs` wildcard, so nothing is silently unlisted. Needs a publish from a real Rhino document to see whether text still errors.
- **ENG-9109** (instance materials) — the spec allows `geometry|instance`, but `ObjectsArtifactPipeline.HasMaterial(geometryK, materialK)` has no namespace-tag parameter and the reader files every `HAS_MATERIAL` into `MaterialByGeometry`. Needs SDK work plus a convention decision (tag the INSTANCE node K per the spec text, or the object K as the colour path does).
- **ENG-9110** (member layers) — `ON_LAYER` exists only as prose in `docs/`. It's not in `speckle-bundle-spec/spec/bundle-spec.sql`, so it's in none of the generated bindings and not in the SDK's `RelKind`. Also needs a representation decision, since members are deliberately stripped of `IN_COLLECTION` to keep them out of the scene explorer (ENG-8782).

## Testing

Rhino7, Rhino8 and Grasshopper8 all build clean (`-c Local`, 0 errors / 0 warnings), CSharpier-formatted. **Not yet exercised in Rhino** — no runtime verification of any of the six. Suggested order, cheapest to falsify first:

1. **ENG-9108** — render material on a layer, object on it with material source *by layer*; check viewer + Rhino receive.
2. **ENG-9111** — user text + user dictionary round trip; plus a Revit/IFC receive for parameters.
3. **ENG-9115 + ENG-9113** — receive a block-heavy model with multi-mesh elements **twice**: one generated definition set left, elements selecting as units from the report.
4. **ENG-9112** — one perspective and one parallel named view. The parallel case is what v1 got wrong and the ortho frustum rebuild is the least-exercised code here.
5. **ENG-9114** — one instance red, siblings default; also AutoCAD→Rhino.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
