### PR TITLE
fix(revit): restore Shared Coordinates round-trip

### DIFF
--- a/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/RevitFamilyBaker.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/RevitFamilyBaker.cs
@@ -75,7 +75,7 @@ public sealed class RevitFamilyBaker : IDisposable
     IReadOnlyDictionary<string, TraversalContext> speckleObjectLookup,
     IReadOnlyCollection<RenderMaterialProxy> materialProxies,
     IProgress<CardProgress> onOperationProgressed,
-    Transform? referencePointTransform
+    DB.Transform? referencePointTransform
   )
   {
     var document = _converterSettings.Current.Document;
@@ -451,7 +451,7 @@ public sealed class RevitFamilyBaker : IDisposable
     Document doc,
     InstanceProxy instanceProxy,
     FamilySymbol symbol,
-    Transform? referencePointTransform
+    DB.Transform? referencePointTransform
   )
   {
     var isMirrored = _familyTransformUtils.GetMirrorState(instanceProxy.transform).X;
@@ -505,7 +505,7 @@ public sealed class RevitFamilyBaker : IDisposable
   private FamilyInstance? PlaceFamilyInstance(
     Document document,
     InstanceProxy instanceProxy,
-    Transform? referencePointTransform
+    DB.Transform? referencePointTransform
   )
   {
     var definitionId = instanceProxy.definitionId;

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/RevitFamilyBaker.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/RevitFamilyBaker.cs
@@ -63,11 +63,19 @@ public sealed class RevitFamilyBaker : IDisposable
     Directory.CreateDirectory(_tempDirectory);
   }
 
+  // referencePointTransform [ENG-9099]: the composed (receiver setting ∘ sender's recorded) reference-point
+  // transform, or null when neither is set. Applied ONLY to the outermost placement of a top-level InstanceProxy
+  // (via PlaceFamilyInstance below) — every instance's own placement transform is sent already expressed in
+  // world/shared-coordinate space (same as atomic geometry), so it needs this correction to land back in the
+  // receiving document's internal coordinates. Nested placements baked while AUTHORING a family template
+  // (PlaceNestedInstance, inside a temporary famDoc) stay purely local/relative to that family and must NOT get
+  // this correction — passing null there is deliberate, not an oversight.
   public (List<ReceiveConversionResult> results, List<string> createdElementIds) BakeInstances(
     ICollection<(Collection[] collectionPath, IInstanceComponent component)> instanceComponents,
     IReadOnlyDictionary<string, TraversalContext> speckleObjectLookup,
     IReadOnlyCollection<RenderMaterialProxy> materialProxies,
-    IProgress<CardProgress> onOperationProgressed
+    IProgress<CardProgress> onOperationProgressed,
+    Transform? referencePointTransform
   )
   {
     var document = _converterSettings.Current.Document;
@@ -119,7 +127,7 @@ public sealed class RevitFamilyBaker : IDisposable
             continue;
           }
 
-          var instance = PlaceFamilyInstance(document, instanceProxy);
+          var instance = PlaceFamilyInstance(document, instanceProxy, referencePointTransform);
 
           if (instance != null)
           {
@@ -398,7 +406,7 @@ public sealed class RevitFamilyBaker : IDisposable
       symbol.Activate();
     }
 
-    var instance = CreateAndPlaceFamilyInstance(famDoc, instanceProxy, symbol);
+    var instance = CreateAndPlaceFamilyInstance(famDoc, instanceProxy, symbol, referencePointTransform: null);
 
     if (instance != null && materialManager != null)
     {
@@ -439,7 +447,12 @@ public sealed class RevitFamilyBaker : IDisposable
     return family;
   }
 
-  private FamilyInstance? CreateAndPlaceFamilyInstance(Document doc, InstanceProxy instanceProxy, FamilySymbol symbol)
+  private FamilyInstance? CreateAndPlaceFamilyInstance(
+    Document doc,
+    InstanceProxy instanceProxy,
+    FamilySymbol symbol,
+    Transform? referencePointTransform
+  )
   {
     var isMirrored = _familyTransformUtils.GetMirrorState(instanceProxy.transform).X;
     var hasScaleOrSkew = _familyTransformUtils.HasScaleOrSkew(instanceProxy.transform);
@@ -450,6 +463,13 @@ public sealed class RevitFamilyBaker : IDisposable
         : instanceProxy.transform;
 
     var revitTransform = _transformConverter.Convert((cleanMatrix, instanceProxy.units));
+    if (referencePointTransform is not null)
+    {
+      // instanceProxy.transform is sent in world/shared-coordinate space (same frame as atomic geometry) — compose
+      // the reference-point transform onto this OUTERMOST placement to land back in the document's internal
+      // coordinates, mirroring RevitHostObjectArtefactBuilder.BuildInstanceTransform [ENG-9099].
+      revitTransform = referencePointTransform.Multiply(revitTransform);
+    }
 
     XYZ origin = revitTransform.Origin;
     XYZ basisX = revitTransform.BasisX.Normalize();
@@ -482,13 +502,17 @@ public sealed class RevitFamilyBaker : IDisposable
     return instance;
   }
 
-  private FamilyInstance? PlaceFamilyInstance(Document document, InstanceProxy instanceProxy)
+  private FamilyInstance? PlaceFamilyInstance(
+    Document document,
+    InstanceProxy instanceProxy,
+    Transform? referencePointTransform
+  )
   {
     var definitionId = instanceProxy.definitionId;
 
     if (_cache.SymbolsByDefinitionId.TryGetValue(definitionId, out var symbol))
     {
-      return CreateAndPlaceFamilyInstance(document, instanceProxy, symbol);
+      return CreateAndPlaceFamilyInstance(document, instanceProxy, symbol, referencePointTransform);
     }
 
     _logger.LogWarning("No family symbol found for definition {DefinitionId}", definitionId);

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Receive/RevitHostObjectArtefactBuilder.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Receive/RevitHostObjectArtefactBuilder.cs
@@ -42,8 +42,15 @@ namespace Speckle.Connectors.Revit.Operations.Receive;
 /// needs <c>IInstanceComponent</c>s and a <c>TraversalContext</c> lookup built from a <c>Base</c> graph, so it
 /// can't consume bundle data directly. When the setting is on, this builder instead reconstructs a <c>Base</c> graph
 /// (<see cref="IArtifactReceiver.Reconstruct"/>) and delegates the whole receive to the v1
-/// <see cref="RevitHostObjectBuilder"/>, which already honours it — slower than the direct bake, but the only way to
-/// get real families across all Revit versions.</para>
+/// <see cref="RevitHostObjectBuilder"/> — slower than the direct bake, but the only way to get real families across
+/// all Revit versions.</para>
+/// <para><b>Known limitation (tracked separately, "Revit: Make family receive artifact-native"):</b> the
+/// reconstruction bridge above resolves each object's placement via a last-wins <c>objectK → instanceNodeK</c> map,
+/// not the full edge list, so an object that places <i>several</i> instances (e.g. a Railing → many balusters) only
+/// keeps the last one — the rest are silently dropped from the reconstructed graph, not merely mis-transformed.
+/// Fixing this properly means reworking the bridge (and a matching last-wins lookup in
+/// <see cref="RevitHostObjectBuilder"/> itself) to synthesize a unique id per placement — out of scope here; the
+/// planned fix is to remove this bridge entirely in favour of bundle-native family baking.</para>
 /// </remarks>
 public sealed class RevitHostObjectArtefactBuilder : IArtifactHostObjectBuilder
 {

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Receive/RevitHostObjectArtefactBuilder.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Receive/RevitHostObjectArtefactBuilder.cs
@@ -139,11 +139,13 @@ public sealed class RevitHostObjectArtefactBuilder : IArtifactHostObjectBuilder
     var doc = _converterSettings.Current.Document;
     var rels = bundle.Relations;
 
-    // ENG-8808: undo/redo the sender's reference-point re-basing. The send pipeline baked its main-model
-    // reference-point transform into geometry and recorded it in the bundle; compose it with the receiver's own
-    // reference-point setting (Source = no local transform → apply the sender's as-is, restoring the source
-    // model's internal coordinates) and push it so ToInternalPoints/ConvertToInternalCoordinates re-bases every
-    // vertex. Mirrors v1 RevitHostObjectBuilder's composition. No recorded transform + no local setting = no-op.
+    // ENG-8808 / ENG-9099: undo/redo the sender's reference-point re-basing (translation + rotation, e.g. Shared
+    // Coordinates' true-north angle). The send pipeline baked its main-model reference-point transform into
+    // geometry and recorded it in the bundle; compose it with the receiver's own reference-point setting
+    // (Source = no local transform → apply the sender's as-is, restoring the source model's internal coordinates)
+    // and push it so ToInternalPoints/ConvertToInternalCoordinates re-bases every atomic vertex, and
+    // BuildInstanceTransform re-bases every instance placement. Mirrors v1 RevitHostObjectBuilder's composition.
+    // No recorded transform + no local setting = no-op.
     var sourceReferencePoint = ReadSourceReferencePointTransform(bundle);
     using var referencePointScope = _converterSettings.Push(s =>
       s with
@@ -290,7 +292,9 @@ public sealed class RevitHostObjectArtefactBuilder : IArtifactHostObjectBuilder
         foreach (var edge in displayEdges.OrderBy(e => e.Ord))
         {
           materialIdByGeometry.TryGetValue(edge.Dst, out var matId);
-          geometry.AddRange(DecodeGeometry(bundle, edge.Dst, matId ?? ElementId.InvalidElementId));
+          geometry.AddRange(
+            DecodeGeometry(bundle, edge.Dst, matId ?? ElementId.InvalidElementId, applyReferencePoint: true)
+          );
         }
         if (geometry.Count == 0)
         {
@@ -376,18 +380,24 @@ public sealed class RevitHostObjectArtefactBuilder : IArtifactHostObjectBuilder
 
       var geometry = new List<GeometryObject>();
 
-      // direct geometry members (DEFINES → geometry blobs).
+      // direct geometry members (DEFINES → geometry blobs). Definition/local-space vertices — no reference-point
+      // re-basing here; it's applied once, to the outer instance placement, in the top-level BakeInstances loop
+      // below [ENG-9099].
       if (rels.DefinesByDefinition.TryGetValue(defNodeK, out var geomKs))
       {
         foreach (var geomK in geomKs)
         {
           materialIdByGeometry.TryGetValue(geomK, out var matId);
-          geometry.AddRange(DecodeGeometry(bundle, geomK, matId ?? ElementId.InvalidElementId));
+          geometry.AddRange(
+            DecodeGeometry(bundle, geomK, matId ?? ElementId.InvalidElementId, applyReferencePoint: false)
+          );
         }
       }
 
       // nested block/family members (DEFINES_INSTANCE → INSTANCE node): build the child definition first
       // (depth-first) and add a geometry-instance reference to it with the nested placement's own transform.
+      // Still local/definition space (relative to the parent definition, not world space) — no reference-point
+      // correction here either; only the outermost placement crosses into world/document space.
       if (rels.DefinesInstanceByDefinition.TryGetValue(defNodeK, out var nestedInstNodeKs))
       {
         foreach (var instNodeK in nestedInstNodeKs)
@@ -404,7 +414,8 @@ public sealed class RevitHostObjectArtefactBuilder : IArtifactHostObjectBuilder
           }
           var nestedTransform = BuildInstanceTransform(
             nestedInst.Transform,
-            nestedInst.Units is { Length: > 0 } u ? u : docUnits
+            nestedInst.Units is { Length: > 0 } u ? u : docUnits,
+            applyReferencePoint: false
           );
           geometry.AddRange(DirectShape.CreateGeometryInstance(doc, childDefKey, nestedTransform));
           session.Increment("nestedInstancesPlaced");
@@ -474,7 +485,11 @@ public sealed class RevitHostObjectArtefactBuilder : IArtifactHostObjectBuilder
 
       try
       {
-        var transform = BuildInstanceTransform(instNode.Transform, instNode.Units is { Length: > 0 } u ? u : docUnits);
+        var transform = BuildInstanceTransform(
+          instNode.Transform,
+          instNode.Units is { Length: > 0 } u ? u : docUnits,
+          applyReferencePoint: true
+        );
         var geometry = DirectShape.CreateGeometryInstance(doc, defKey, transform);
 
         var ds = DirectShape.CreateElement(doc, ResolveCategory(doc, props, validCategories, categoryCache));
@@ -497,7 +512,18 @@ public sealed class RevitHostObjectArtefactBuilder : IArtifactHostObjectBuilder
   // ── geometry ──────────────────────────────────────────────────────────────────────────────────────────
   // Decodes one SGEO mesh geometry index → Revit GeometryObjects (TessellatedShapeBuilder), material baked per face.
   // Revit receives meshes only (no raw 3dm); non-SGEO / undecodable blobs yield nothing.
-  private List<GeometryObject> DecodeGeometry(ArtefactBundle bundle, int geomK, ElementId materialId)
+  //
+  // applyReferencePoint distinguishes WORLD-space vertices (atomic DISPLAY geometry — true, needs re-basing) from
+  // LOCAL/definition-space vertices (an instance/family's own shape — false). The sender never bakes the reference
+  // point into definition geometry (only into each instance's placement transform, see FormatReferencePointTransform
+  // on the send side), so re-applying it here to definition vertices would double up with the correction now applied
+  // to the instance placement in BuildInstanceTransform below [ENG-9099].
+  private List<GeometryObject> DecodeGeometry(
+    ArtefactBundle bundle,
+    int geomK,
+    ElementId materialId,
+    bool applyReferencePoint
+  )
   {
     if (
       !bundle.Geometries.TryGetValue(geomK, out var g)
@@ -507,12 +533,12 @@ public sealed class RevitHostObjectArtefactBuilder : IArtifactHostObjectBuilder
     {
       return new List<GeometryObject>();
     }
-    return BuildMesh(sm, materialId);
+    return BuildMesh(sm, materialId, applyReferencePoint);
   }
 
   // Flat SGEO mesh (verts/faces, Speckle count-prefixed) → Revit GeometryObjects. Mirrors MeshConverterToHost: scale
   // to internal units + apply the reference-point transform, fan/triangulate, salvage fallback.
-  private List<GeometryObject> BuildMesh(SgeoMesh sm, ElementId materialId)
+  private List<GeometryObject> BuildMesh(SgeoMesh sm, ElementId materialId, bool applyReferencePoint)
   {
     using var tsb = new TessellatedShapeBuilder();
     tsb.Fallback = TessellatedShapeBuilderFallback.Salvage;
@@ -520,7 +546,7 @@ public sealed class RevitHostObjectArtefactBuilder : IArtifactHostObjectBuilder
     tsb.GraphicsStyleId = ElementId.InvalidElementId;
     tsb.OpenConnectedFaceSet(false);
 
-    var verts = ToInternalPoints(sm.Vertices, sm.Units);
+    var verts = ToInternalPoints(sm.Vertices, sm.Units, applyReferencePoint);
     var f = sm.Faces;
     int p = 0;
     while (p < f.Length)
@@ -569,8 +595,9 @@ public sealed class RevitHostObjectArtefactBuilder : IArtifactHostObjectBuilder
     return tsb.GetBuildResult().GetGeometricalObjects().ToList();
   }
 
-  // SGEO flat verts (double[] xyz) → Revit internal-unit XYZ[], reference-point transform applied (no-op when unset).
-  private XYZ[] ToInternalPoints(double[] verts, string units)
+  // SGEO flat verts (double[] xyz) → Revit internal-unit XYZ[]. Reference-point transform applied only for
+  // world-space (atomic) vertices — see DecodeGeometry's applyReferencePoint doc.
+  private XYZ[] ToInternalPoints(double[] verts, string units, bool applyReferencePoint)
   {
     var fTypeId = ResolveForge(units);
     var points = new XYZ[verts.Length / 3];
@@ -579,7 +606,9 @@ public sealed class RevitHostObjectArtefactBuilder : IArtifactHostObjectBuilder
       var x = _scalingService.ScaleToNative(verts[i], fTypeId);
       var y = _scalingService.ScaleToNative(verts[i + 1], fTypeId);
       var z = _scalingService.ScaleToNative(verts[i + 2], fTypeId);
-      points[k++] = _referencePointConverter.ConvertToInternalCoordinates(new XYZ(x, y, z), true);
+      points[k++] = applyReferencePoint
+        ? _referencePointConverter.ConvertToInternalCoordinates(new XYZ(x, y, z), true)
+        : new XYZ(x, y, z);
     }
     return points;
   }
@@ -763,10 +792,12 @@ public sealed class RevitHostObjectArtefactBuilder : IArtifactHostObjectBuilder
     return resolved;
   }
 
-  // ENG-8947: rebuild the sender's reference-point transform from the bundle meta offset (translation kinds only).
-  // The offset is in the bundle's display units; scale to internal feet so it composes with the receive setting and
-  // applies through ConvertToInternalCoordinates. Null (internal origin / fallback / Shared Coordinates) → no source
-  // re-basing.
+  // ENG-8947 / ENG-9099: rebuild the sender's reference-point transform from the bundle meta offset. Two formats
+  // share the one field: a 3-value "x,y,z" CSV (projectBasePoint / surveyPoint — translation only, no rotation to
+  // lose) or a 16-value row-major CSV (sharedCoordinates — full rotation + translation, same layout ParseMatrix
+  // already uses for InstanceProxy transforms). Both are in the bundle's display units; scale to internal feet so
+  // the result composes with the receive setting and applies through ConvertToInternalCoordinates. Null (internal
+  // origin / fallback) → no source re-basing.
   private Transform? ReadSourceReferencePointTransform(ArtefactBundle bundle)
   {
     if (bundle.ReferencePointOffset is not { Length: > 0 } offsetCsv)
@@ -774,6 +805,30 @@ public sealed class RevitHostObjectArtefactBuilder : IArtifactHostObjectBuilder
       return null;
     }
     var parts = offsetCsv.Split(',');
+    var fTypeId = ResolveForge(bundle.Units);
+
+    if (parts.Length == 16)
+    {
+      var d = new double[16];
+      for (int i = 0; i < 16; i++)
+      {
+        if (!double.TryParse(parts[i], NumberStyles.Float, CultureInfo.InvariantCulture, out d[i]))
+        {
+          return null;
+        }
+      }
+      var full = Transform.Identity;
+      full.BasisX = new XYZ(d[0], d[4], d[8]);
+      full.BasisY = new XYZ(d[1], d[5], d[9]);
+      full.BasisZ = new XYZ(d[2], d[6], d[10]);
+      full.Origin = new XYZ(
+        _scalingService.ScaleToNative(d[3], fTypeId),
+        _scalingService.ScaleToNative(d[7], fTypeId),
+        _scalingService.ScaleToNative(d[11], fTypeId)
+      );
+      return full;
+    }
+
     if (parts.Length != 3)
     {
       return null;
@@ -786,7 +841,6 @@ public sealed class RevitHostObjectArtefactBuilder : IArtifactHostObjectBuilder
         return null;
       }
     }
-    var fTypeId = ResolveForge(bundle.Units);
     // Identity + Origin (not Transform.CreateTranslation) to match ReferencePointHelper.GetTransformFromRootObject and
     // keep the analyzer's disposable-ownership tracking happy — the result is pushed into converter settings.
     var t = Transform.Identity;
@@ -800,9 +854,16 @@ public sealed class RevitHostObjectArtefactBuilder : IArtifactHostObjectBuilder
 
   // ── transforms ────────────────────────────────────────────────────────────────────────────────────────
   // Instance transform CSV (row-major 16) → Revit Transform: basis columns carry rotation/scale (unscaled), only the
-  // translation column is converted to internal units. Note: when a reference point is set, instance placement is
-  // approximate (the definition geometry already carries it); the common no-reference-point case is exact.
-  private Transform BuildInstanceTransform(string? csv, string units)
+  // translation column is converted to internal units.
+  //
+  // applyReferencePoint [ENG-9099]: the sender bakes (reference point)⁻¹ into every instance's placement transform
+  // (definition geometry itself stays in local/family space, see DecodeGeometry). To land back in the receiver's
+  // internal coordinates, the CURRENT effective reference-point transform (receiver setting ∘ sender's recorded
+  // transform, pushed onto _converterSettings before this runs — see BakeAll) must be composed onto the OUTERMOST
+  // placement only: newTransform.OfPoint(p) = referencePoint.OfPoint(rawTransform.OfPoint(p)), i.e.
+  // referencePoint.Multiply(rawTransform). Nested placements inside a definition (BuildDefinition's
+  // DEFINES_INSTANCE loop) stay purely local/relative and must NOT get this correction — pass false there.
+  private Transform BuildInstanceTransform(string? csv, string units, bool applyReferencePoint)
   {
     var d = ParseMatrix(csv);
     double w = Math.Abs(d[15]) < 1e-12 ? 1.0 : d[15];
@@ -815,6 +876,11 @@ public sealed class RevitHostObjectArtefactBuilder : IArtifactHostObjectBuilder
       _scalingService.ScaleToNative(d[7] / w, units),
       _scalingService.ScaleToNative(d[11] / w, units)
     );
+
+    if (applyReferencePoint && _converterSettings.Current.ReferencePointTransform is { } referencePoint)
+    {
+      return referencePoint.Multiply(t);
+    }
     return t;
   }
 

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Receive/RevitHostObjectBuilder.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Receive/RevitHostObjectBuilder.cs
@@ -80,6 +80,14 @@ public sealed class RevitHostObjectBuilder(
       referencePointTransformFromRootObject = ReferencePointHelper.GetTransformFromRootObject(transformValue);
     }
 
+    // ENG-9099: computed once so BakeObjects (via the settings push below) and BakeInstancesAsFamilies (which runs
+    // OUTSIDE that push, after it's disposed — see step 5/"Bakes instances as families" below) apply the SAME
+    // effective reference-point transform to their respective outermost placements.
+    var effectiveReferencePointTransform = ReferencePointHelper.CalculateNewTransform(
+      converterSettings.Current.ReferencePointTransform,
+      referencePointTransformFromRootObject
+    );
+
     var baseGroupName = $"Project {projectName}: Model {modelName}"; // TODO: unify this across connectors!
 
     onOperationProgressed.Report(new("Converting", null));
@@ -127,10 +135,7 @@ public sealed class RevitHostObjectBuilder(
         converterSettings.Push(currentSettings =>
           currentSettings with
           {
-            ReferencePointTransform = ReferencePointHelper.CalculateNewTransform(
-              currentSettings.ReferencePointTransform,
-              referencePointTransformFromRootObject
-            ),
+            ReferencePointTransform = effectiveReferencePointTransform,
           }
         )
       )
@@ -176,7 +181,8 @@ public sealed class RevitHostObjectBuilder(
         conversionResults,
         speckleObjectLookup,
         materialProxies,
-        onOperationProgressed
+        onOperationProgressed,
+        effectiveReferencePointTransform
       );
     }
 
@@ -210,7 +216,8 @@ public sealed class RevitHostObjectBuilder(
     ) currentResults,
     Dictionary<string, TraversalContext> speckleObjectLookup,
     IReadOnlyCollection<RenderMaterialProxy> materialProxies,
-    IProgress<CardProgress> onOperationProgressed
+    IProgress<CardProgress> onOperationProgressed,
+    Autodesk.Revit.DB.Transform? referencePointTransform
   )
   {
     using var _ = activityFactory.Start("Creating families");
@@ -220,7 +227,8 @@ public sealed class RevitHostObjectBuilder(
       instanceComponents,
       speckleObjectLookup,
       materialProxies,
-      onOperationProgressed
+      onOperationProgressed,
+      referencePointTransform
     );
 
     // Merge results

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/RevitArtifactRootObjectBuilder.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/RevitArtifactRootObjectBuilder.cs
@@ -476,20 +476,22 @@ public class RevitArtifactRootObjectBuilder(
     }
   }
 
-  // ENG-8947: record the MAIN-model reference point in the bundle meta — the SINGLE source for both federation and
-  // Revit→Revit round-trip (the receiver rebuilds the translation from the offset). Only the host (non-linked)
-  // document's Transform is the pure reference-point transform — a linked doc's is (referencePoint ∘ linkPlacement⁻¹)
-  // and must NOT be persisted. Only the translation kinds are recorded: projectBasePoint / surveyPoint (offset in
-  // display units — the vector subtracted) + the requested-but-missing internalOriginFallback. Internal origin and
-  // Shared Coordinates record nothing: internal origin has nothing to record, and Shared Coordinates is a
-  // connector-only kind outside the shared spec vocabulary whose true-north rotation a translation offset can't
-  // represent (so it does not round-trip — a deliberate scope call, see ENG-8808 discussion).
+  // ENG-8947 / ENG-9099: record the MAIN-model reference point in the bundle meta — the SINGLE source for both
+  // federation and Revit→Revit round-trip (the receiver rebuilds the transform from this value). Only the host
+  // (non-linked) document's Transform is the pure reference-point transform — a linked doc's is
+  // (referencePoint ∘ linkPlacement⁻¹) and must NOT be persisted.
+  // projectBasePoint / surveyPoint are translation-only in Revit (no rotation to lose), so they keep the original
+  // 3-value "x,y,z" offset format for back-compat with older bundles/readers. sharedCoordinates carries a
+  // true-north ROTATION on top of the translation (Document.ActiveProjectLocation.GetTotalTransform()), which a
+  // 3-value offset can't represent — it is recorded as the full 16-value row-major transform instead (same
+  // convention already used for InstanceProxy transforms below, see Flatten). internalOriginFallback records the
+  // requested-but-missing base point (not silent); internal origin itself has nothing to record.
   private void EmitMainModelReferencePoint(ObjectsArtifactPipeline pipeline, DocumentToConvert documentContext)
   {
     if (
       documentContext.Doc.IsLinked
       || converterSettings.Current.ReferencePointKind
-        is not (ReferencePointType.ProjectBase or ReferencePointType.Survey)
+        is not (ReferencePointType.ProjectBase or ReferencePointType.Survey or ReferencePointType.SharedCoordinates)
     )
     {
       return;
@@ -497,11 +499,18 @@ public class RevitArtifactRootObjectBuilder(
 
     if (documentContext.Transform is { } transform)
     {
-      var kind =
-        converterSettings.Current.ReferencePointKind == ReferencePointType.ProjectBase
-          ? "projectBasePoint"
-          : "surveyPoint";
-      pipeline.SetReferencePoint(kind, FormatReferencePointOffset(transform));
+      switch (converterSettings.Current.ReferencePointKind)
+      {
+        case ReferencePointType.ProjectBase:
+          pipeline.SetReferencePoint("projectBasePoint", FormatReferencePointOffset(transform));
+          break;
+        case ReferencePointType.Survey:
+          pipeline.SetReferencePoint("surveyPoint", FormatReferencePointOffset(transform));
+          break;
+        default:
+          pipeline.SetReferencePoint("sharedCoordinates", FormatReferencePointTransform(transform));
+          break;
+      }
     }
     else
     {
@@ -519,6 +528,26 @@ public class RevitArtifactRootObjectBuilder(
       scalingService.ScaleLength(transform.Origin.Y),
       scalingService.ScaleLength(transform.Origin.Z)
     );
+
+  // ENG-9099 reference_point_offset (rotation-carrying kinds): the full rigid transform subtracted from
+  // world-space output, as 16 row-major doubles — same layout Flatten/BuildInstanceTransform already use for
+  // InstanceProxy transforms (basis columns unscaled/unit vectors, translation column in display units).
+  private string FormatReferencePointTransform(Transform transform)
+  {
+    var scaled = Transform.Identity;
+    scaled.BasisX = transform.BasisX;
+    scaled.BasisY = transform.BasisY;
+    scaled.BasisZ = transform.BasisZ;
+    scaled.Origin = new XYZ(
+      scalingService.ScaleLength(transform.Origin.X),
+      scalingService.ScaleLength(transform.Origin.Y),
+      scalingService.ScaleLength(transform.Origin.Z)
+    );
+    return string.Join(
+      ",",
+      Flatten(ReferencePointHelper.TransformToMatrix(scaled)).Select(v => v.ToString(CultureInfo.InvariantCulture))
+    );
+  }
 
   // Emits an object's displayValue as renderable geometry: meshes → DISPLAY, instance proxies → INSTANCE +
   // DISPLAY_INSTANCE, curves/points → DISPLAY (via the SGEO encoder, same as Rhino's artefact send).


### PR DESCRIPTION
## Description

Artifact send only ever recorded a translation offset for the reference point, and skipped Shared Coordinates entirely since it needed rotation too. Receive had no way to undo a rotation it was never told about. Also found and fixed instance/family placements ignoring the reference-point transform altogether (both direct-bake and "receive instances as families").

## User Value

Models sent using Shared Coordinates (translated + rotated) now round-trip correctly instead of landing shifted and facing the wrong way.

## Changes:

- Record the full reference-point transform (translation + rotation) for Shared Coordinates in bundle metadata; Project Base Point/Survey Point keep their existing translation-only format, unchanged
- Receive parses both the old 3-value and new 16-value format, so older bundles still work
- Fix instance/family placements not applying the reference-point transform at all, in both the direct-bake and "receive instances as families" paths
- Documented a known, separate limitation: "receive instances as families" still drops repeated placements of one object (e.g. a Railing's balusters) — tracked by the planned "Revit: Make family receive artifact-native" work, out of scope here

## Validation of changes:

Manually round-tripped Revit-to-Revit with a translated + rotated Shared Coordinates setup, checked Project Base Point/Survey Point/Internal Origin for regressions, and re-tested with "receive instances as families" on. No automated Revit integration tests exist in this repo yet to add to.

## Checklist:

- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] I have added appropriate tests.
- [x] I have updated or added relevant documentation.