### PR TITLE
feat(revit): recreate named camera views on receive (ENG-9100)

### DIFF
--- a/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/RevitViewBaker.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/RevitViewBaker.cs
@@ -5,11 +5,13 @@ using Speckle.Converters.Common.Objects;
 using Speckle.Converters.RevitShared.Settings;
 using Speckle.Objects.Other;
 using Speckle.Sdk;
+using Speckle.Sdk.Common.Exceptions;
 
 namespace Speckle.Connectors.Revit.HostApp;
 
 /// <summary>
-/// Utility class that creates View3D elements from Camera objects during receive.
+/// Creates View3D elements during receive: <see cref="BakeViews"/> for the legacy v1 <c>Camera</c> path, and
+/// <see cref="BakeArtefactView"/>/<see cref="PurgeArtefactViews"/> for the artefact bundle's <c>camera_views</c> rows.
 /// </summary>
 public class RevitViewBaker
 {
@@ -152,5 +154,83 @@ public class RevitViewBaker
     {
       farClipParam.Set(0);
     }
+  }
+
+  // ── artefact bundle camera_views (Speckle 4.0 direct-bake path) ─────────────────────────────────────────
+  // Delete-then-recreate on every receive (unlike BakeViews' name-matched update-in-place) since perspective and
+  // orthographic are different ViewTypes and can't be swapped in place.
+
+  /// <summary>Deletes every non-template View3D stamped with <paramref name="marker"/> (mirrors the DirectShape
+  /// pre-clean), so a re-receive doesn't accumulate duplicate views.</summary>
+  public void PurgeArtefactViews(string marker)
+  {
+    var document = _converterSettings.Current.Document;
+    var toDelete = new List<ElementId>();
+    using var collector = new FilteredElementCollector(document);
+    foreach (var element in collector.OfClass(typeof(View3D)))
+    {
+      if (
+        element is View3D { IsTemplate: false }
+        && element.get_Parameter(BuiltInParameter.ALL_MODEL_INSTANCE_COMMENTS)?.AsString() is string c
+        && string.Equals(c, marker, StringComparison.Ordinal)
+      )
+      {
+        toDelete.Add(element.Id);
+      }
+    }
+    if (toDelete.Count > 0)
+    {
+      document.Delete(toDelete);
+    }
+  }
+
+  /// <summary>Bakes one <c>camera_views</c> row as a fresh perspective or orthographic View3D, stamped with
+  /// <paramref name="marker"/>. <paramref name="eye"/>/<paramref name="forward"/>/<paramref name="up"/> must already
+  /// be in Revit internal units and coordinates. FOV/lens/crop are not restored — Revit's 3D-view API has no direct
+  /// setter for them.</summary>
+  /// <returns>The created view's UniqueId.</returns>
+  public string BakeArtefactView(string name, bool isOrtho, XYZ eye, XYZ forward, XYZ up, string marker)
+  {
+    var document = _converterSettings.Current.Document;
+    var viewName = RestoreViewName(name);
+    if (string.IsNullOrWhiteSpace(viewName))
+    {
+      throw new ConversionException($"Camera view name '{name}' has no valid characters for a Revit view name.");
+    }
+
+    using var collector = new FilteredElementCollector(document);
+    var viewFamilyType = collector
+      .OfClass(typeof(ViewFamilyType))
+      .Cast<ViewFamilyType>()
+      .FirstOrDefault(vft => vft.ViewFamily == ViewFamily.ThreeDimensional);
+
+    if (viewFamilyType == null)
+    {
+      throw new ConversionException("Could not find a 3D ViewFamilyType to create a camera view.");
+    }
+
+    // View3D is a document element, not disposable — low happiness level.
+#pragma warning disable CA2000
+    var view3D = isOrtho
+      ? View3D.CreateIsometric(document, viewFamilyType.Id)
+      : View3D.CreatePerspective(document, viewFamilyType.Id);
+#pragma warning restore CA2000
+
+    view3D.SetOrientation(new ViewOrientation3D(eye, up, forward));
+    view3D.Name = viewName;
+    view3D.DisplayStyle = DisplayStyle.Shading;
+    view3D.get_Parameter(BuiltInParameter.ALL_MODEL_INSTANCE_COMMENTS)?.Set(marker);
+
+    if (!isOrtho)
+    {
+      // Disable far clipping so depth is infinite (matches the legacy Camera-object bake above).
+      var farClipParam = view3D.get_Parameter(BuiltInParameter.VIEWER_BOUND_ACTIVE_FAR);
+      if (farClipParam != null && !farClipParam.IsReadOnly)
+      {
+        farClipParam.Set(0);
+      }
+    }
+
+    return view3D.UniqueId;
   }
 }

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Receive/RevitHostObjectArtefactBuilder.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Receive/RevitHostObjectArtefactBuilder.cs
@@ -67,6 +67,7 @@ public sealed class RevitHostObjectArtefactBuilder : IArtifactHostObjectBuilder
   private readonly IArtifactReceiver _artifactReceiver;
   private readonly IHostObjectBuilder _hostObjectBuilder;
   private readonly RevitGroupBaker _groupBaker;
+  private readonly RevitViewBaker _viewBaker;
   private readonly ITypedConverter<Base, List<GeometryObject>> _geometryConverter;
 
   // Set by DecodeGeometry when the non-mesh SGEO fallback fails; surfaced by callers as the ERROR reason for an
@@ -85,6 +86,7 @@ public sealed class RevitHostObjectArtefactBuilder : IArtifactHostObjectBuilder
     IArtifactReceiver artifactReceiver,
     IHostObjectBuilder hostObjectBuilder,
     RevitGroupBaker groupBaker,
+    RevitViewBaker viewBaker,
     ITypedConverter<Base, List<GeometryObject>> geometryConverter
   )
   {
@@ -99,6 +101,7 @@ public sealed class RevitHostObjectArtefactBuilder : IArtifactHostObjectBuilder
     _artifactReceiver = artifactReceiver;
     _hostObjectBuilder = hostObjectBuilder;
     _groupBaker = groupBaker;
+    _viewBaker = viewBaker;
     _geometryConverter = geometryConverter;
   }
 
@@ -151,6 +154,7 @@ public sealed class RevitHostObjectArtefactBuilder : IArtifactHostObjectBuilder
     session.SetStat("geometryBlobs", bundle.Geometries.Count);
     session.SetStat("definitions", bundle.Nodes.Values.Count(n => n.Kind == NodeKind.Definition));
     session.SetStat("instanceNodes", bundle.Nodes.Values.Count(n => n.Kind == NodeKind.Instance));
+    session.SetStat("cameraViews", bundle.CameraViews.Count);
 
     var doc = _converterSettings.Current.Document;
     var rels = bundle.Relations;
@@ -248,6 +252,16 @@ public sealed class RevitHostObjectArtefactBuilder : IArtifactHostObjectBuilder
             session,
             cancellationToken
           );
+        }
+      }
+
+      // 4 — named camera viewpoints (envelope.camera_views.parquet) → View3D per row.
+      if (bundle.CameraViews.Count > 0)
+      {
+        onOperationProgressed.Report(new("Converting camera views", null));
+        using (session.Phase("Views"))
+        {
+          BakeCameraViews(bundle, marker, bakedObjectIds, conversionResults, session);
         }
       }
 
@@ -515,6 +529,64 @@ public sealed class RevitHostObjectArtefactBuilder : IArtifactHostObjectBuilder
       {
         session.RecordObject(appId, srcType, Status.ERROR, ex.Message, sw.ElapsedMilliseconds);
         conversionResults.Add(new(Status.ERROR, source, null, null, ex, srcType));
+      }
+    }
+  }
+
+  // ── camera views ──────────────────────────────────────────────────────────────────────────────────────
+  // One View3D per envelope.camera_views.parquet row. A bad camera reports a per-row error (mirrors BakeAtomic)
+  // without affecting the rest of the receive.
+  private void BakeCameraViews(
+    ArtefactBundle bundle,
+    string marker,
+    List<string> bakedObjectIds,
+    HashSet<ReceiveConversionResult> conversionResults,
+    ArtefactSessionLog session
+  )
+  {
+    foreach (var cameraView in bundle.CameraViews)
+    {
+      var appId = $"camera-view-{cameraView.View.ToString(CultureInfo.InvariantCulture)}";
+      var source = Source(appId);
+      var sw = Stopwatch.StartNew();
+      try
+      {
+        var name = cameraView.Name?.Trim();
+        if (name is not { Length: > 0 })
+        {
+          throw new ConversionException("Camera view has no name");
+        }
+
+        var forward = new XYZ(cameraView.ForwardX, cameraView.ForwardY, cameraView.ForwardZ);
+        var up = new XYZ(cameraView.UpX, cameraView.UpY, cameraView.UpZ);
+        if (forward.IsZeroLength() || up.IsZeroLength())
+        {
+          throw new ConversionException("Camera view has a zero-length forward or up direction");
+        }
+
+        var units = cameraView.Units is { Length: > 0 } u ? u : bundle.Units;
+        var fTypeId = ResolveForge(units);
+        var eye = _referencePointConverter.ConvertToInternalCoordinates(
+          new XYZ(
+            _scalingService.ScaleToNative(cameraView.PosX, fTypeId),
+            _scalingService.ScaleToNative(cameraView.PosY, fTypeId),
+            _scalingService.ScaleToNative(cameraView.PosZ, fTypeId)
+          ),
+          true
+        );
+        forward = _referencePointConverter.ConvertToInternalCoordinates(forward, false).Normalize();
+        up = _referencePointConverter.ConvertToInternalCoordinates(up, false).Normalize();
+
+        var uniqueId = _viewBaker.BakeArtefactView(name, cameraView.IsOrtho, eye, forward, up, marker);
+
+        bakedObjectIds.Add(uniqueId);
+        conversionResults.Add(new(Status.SUCCESS, source, uniqueId, "View3D", null, "Camera View"));
+        session.RecordObject(appId, "Camera View", Status.SUCCESS, null, sw.ElapsedMilliseconds);
+      }
+      catch (Exception ex) when (!ex.IsFatal())
+      {
+        session.RecordObject(appId, "Camera View", Status.ERROR, ex.Message, sw.ElapsedMilliseconds);
+        conversionResults.Add(new(Status.ERROR, source, null, null, ex, "Camera View"));
       }
     }
   }
@@ -948,6 +1020,8 @@ public sealed class RevitHostObjectArtefactBuilder : IArtifactHostObjectBuilder
     // A previous receive of this model may have gone through the family-baking fallback (setting was on) and left a
     // pinned top-level Group of real families — not tracked by the Comments marker below, so purge it here too.
     _groupBaker.PurgeGroups(marker);
+    // Same marker convention, but View3D isn't a DirectShape, so it's not covered by the collector loop below either.
+    _viewBaker.PurgeArtefactViews(marker);
     var toDelete = new List<ElementId>();
     using (var collector = new FilteredElementCollector(doc))
     {

--- a/docs/camera-views-parquet.md
+++ b/docs/camera-views-parquet.md
@@ -4,11 +4,12 @@
 > implemented, the **canonical format spec** lives in the bundle-spec repo:
 > `speckle-bundle-spec/spec/bundle-spec.sql` (`camera_views` table). Keep this doc in sync with that one.
 >
-> Status: **IMPLEMENTED (send + viewer consume), 2026-07.** Decisions: forward is primary (target optional),
-> `fov` is vertical degrees, Revit **linked-model views are included**, server Saved Views are **out of scope**.
-> Branches: bundle-spec `camera-views-purpose-file`, SDK + connectors + sketchup `camera-views-artifact`,
-> server-internal `oguzhan/camera-views-viewer`. Producers live: Rhino, Revit (host + linked), SketchUp.
-> Native receive-side baking (recreating host named views from `bundle.CameraViews`) is the open follow-up.
+> Status: **IMPLEMENTED (send + viewer consume + Revit native receive), 2026-08.** Decisions: forward is primary
+> (target optional), `fov` is vertical degrees, Revit **linked-model views are included**, server Saved Views are
+> **out of scope**. Branches: bundle-spec `camera-views-purpose-file`, SDK + connectors + sketchup
+> `camera-views-artifact`, server-internal `oguzhan/camera-views-viewer`. Producers live: Rhino, Revit (host +
+> linked), SketchUp. Revit native receive-side baking is done (position/direction/up/projection; no FOV/lens/crop —
+> Revit's `View3D` has no setter for those). Rhino receive-side baking remains an open follow-up.
 
 ## What it is (and isn't)
 
@@ -117,9 +118,12 @@ Upload is filename-glob driven and count-agnostic — **no upload/manifest chang
   `setOrthoCameraOn()`/`setPerspectiveCameraOn()` call driven by `is_ortho`.
 - **frontend-3 / non-tree consumers** (Power BI visual, dashboards): read the typed `getCameraViews()` helper
   directly, like `scene_views` pivots do.
-- **SDK receive:** `ArtefactBundle.cs` gets a `CameraView` record + optional `TryReadTableAsync` read;
-  connector bakers (`RhinoViewBaker`, `RevitViewBaker`) can then restore lens/projection instead of
-  hardcoding 50 mm perspective.
+- **SDK receive:** `ArtefactBundle.CameraViews` is read by `RevitHostObjectArtefactBuilder`, which scales +
+  reference-point-converts each row's eye/forward/up and hands them to `RevitViewBaker.BakeArtefactView` to create
+  a perspective or orthographic `View3D`. Re-receive purges the model's previously-baked views first
+  (`RevitViewBaker.PurgeArtefactViews`, same Comments-marker convention as the DirectShape bake). Not restored:
+  `fov`/`lens_mm`/`ortho_height`/`aspect`/`near`/`far`/`target` — `View3D` has no setter for FOV/lens, only a crop
+  box, which needs a target distance the bundle doesn't carry. Rhino receive-side baking remains an open follow-up.
 
 ## Resolved decisions (2026-07)
 


### PR DESCRIPTION
## Description

Revit's artefact receive path (`RevitHostObjectArtefactBuilder`) never read `bundle.CameraViews`, so named camera views sent by Revit, Rhino, or SketchUp were silently dropped on Revit receive. Adds camera view baking to that path.

## User Value

Named camera views survive a Revit receive instead of disappearing.

## Changes:

- `RevitHostObjectArtefactBuilder`: reads `bundle.CameraViews`, converts eye/forward/up through the existing unit-scaling + reference-point pipeline, bakes each row. A degenerate/unnamed camera reports a per-row conversion error without blocking the rest of the receive.
- `RevitViewBaker`: added `BakeArtefactView` (perspective or orthographic `View3D`) and `PurgeArtefactViews` (marker-based cleanup, same Comments convention as the DirectShape bake, so re-receive updates views instead of duplicating them).

## Screenshots & Validation of changes:

### Before

<img width="3600" height="2260" alt="image" src="https://github.com/user-attachments/assets/a851017c-0c7b-4f34-b81b-510de44c090e" />

### After

<img width="1920" height="1049" alt="image" src="https://github.com/user-attachments/assets/f09f531e-3dfc-40cd-9186-47e783d25360" />


## Checklist:
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] I have added appropriate tests.
- [x] I have updated or added relevant documentation.