### PR TITLE
fix(rhino): block members keep their layers on artefact round trip (ENG-9110)

### DIFF
--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/Operations/Receive/RhinoHostObjectArtefactBuilder.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/Operations/Receive/RhinoHostObjectArtefactBuilder.cs
@@ -8,6 +8,7 @@ using Rhino.Render;
 using Speckle.Connectors.Common.Builders;
 using Speckle.Connectors.Common.Conversion;
 using Speckle.Connectors.Common.Diagnostics;
+using Speckle.Connectors.Common.Instances;
 using Speckle.Connectors.Common.Threading;
 using Speckle.Connectors.Rhino.Extensions;
 using Speckle.Connectors.Rhino.HostApp;
@@ -116,6 +117,11 @@ public class RhinoHostObjectArtefactBuilder : IArtifactHostObjectBuilder
     var doc = _converterSettings.Current.Document;
     var rels = bundle.Relations;
     var objByGeom = rels.ObjectByGeometry();
+    // ObjectByGeometry only covers DISPLAY edges, so it can't reach a block-definition member (a member has no
+    // render edge by design). The member stamps invert that missing direction — geometry / INSTANCE K → the member's
+    // object row — which is what BuildDefinitions needs to recover each member's layer [ENG-9110].
+    var memberIndex = DefinitionMemberStamps.Read(bundle.Properties);
+    session.SetStat("memberStamps", memberIndex.ObjectByGeometry.Count + memberIndex.ObjectByInstance.Count);
     var bakedObjectIds = new HashSet<string>();
     var conversionResults = new HashSet<ReceiveConversionResult>();
     // objK → its baked Rhino guids, tracked only for grouped objects (IN_GROUP) so step 5 can rebuild native groups.
@@ -237,6 +243,7 @@ public class RhinoHostObjectArtefactBuilder : IArtifactHostObjectBuilder
           bakedObjectIds,
           bakedGuidsByObjK,
           conversionResults,
+          memberIndex,
           session
         );
       }
@@ -510,13 +517,25 @@ public class RhinoHostObjectArtefactBuilder : IArtifactHostObjectBuilder
     HashSet<string> bakedObjectIds,
     Dictionary<int, List<Guid>> bakedGuidsByObjK,
     HashSet<ReceiveConversionResult> conversionResults,
+    DefinitionMemberIndex memberIndex,
     ArtefactSessionLog session
   )
   {
     var docUnits = _converterSettings.Current.SpeckleUnits;
 
     // definitions (incl. nested blocks): a DEFINITION node owns its geometry directly and may contain nested placements.
-    var defIndexByNode = BuildDefinitions(doc, bundle, rels, materialByGeometry, docUnits, baseLayerName, session);
+    var defIndexByNode = BuildDefinitions(
+      doc,
+      bundle,
+      rels,
+      materialByGeometry,
+      docUnits,
+      baseLayerName,
+      baseLayerIndex,
+      layerCache,
+      memberIndex,
+      session
+    );
 
     // placements: one instance per DISPLAY_INSTANCE edge (object → INSTANCE node); an object may place several.
     foreach (var edge in rels.DisplayInstanceEdges)
@@ -635,7 +654,8 @@ public class RhinoHostObjectArtefactBuilder : IArtifactHostObjectBuilder
   // its geometry directly (DEFINES → geometry blobs) and may also contain nested block placements (DEFINES_INSTANCE →
   // INSTANCE node). Nested definitions are built depth-first (memoized in defIndexByNode) so a parent can reference the
   // child definition's Rhino Guid via an InstanceReferenceGeometry member carrying the nested placement's own transform.
-  // The geometry's material (HAS_MATERIAL → geometry) is baked onto the members so placed instances aren't all grey.
+  // The geometry's material (HAS_MATERIAL → geometry) is baked onto the members so placed instances aren't all grey,
+  // and each member's own LAYER is recovered through its stamp → object row → IN_COLLECTION [ENG-9110].
   private Dictionary<int, int> BuildDefinitions(
     RhinoDoc doc,
     ArtefactBundle bundle,
@@ -643,6 +663,9 @@ public class RhinoHostObjectArtefactBuilder : IArtifactHostObjectBuilder
     Dictionary<int, Guid> materialByGeometry,
     string docUnits,
     string baseLayerName,
+    int baseLayerIndex,
+    Dictionary<string, int> layerCache,
+    DefinitionMemberIndex memberIndex,
     ArtefactSessionLog session
   )
   {
@@ -683,13 +706,24 @@ public class RhinoHostObjectArtefactBuilder : IArtifactHostObjectBuilder
             // block sent from a metre model lands 1000x too small / mispositioned in a millimetre doc.
             var decoded = DecodeGeometryIndex(geomK, bundle, bundle.Units);
             materialByGeometry.TryGetValue(geomK, out Guid mg);
+            // The member's source layer, via its stamp → member object row → the ordinary IN_COLLECTION projection.
+            // Unstamped (pre-ENG-9110 bundle, or a member whose geometry didn't encode) → the base layer, exactly
+            // what members got before.
+            int memberLayerIndex = ResolveMemberLayer(
+              doc,
+              bundle,
+              memberIndex.ObjectByGeometry,
+              geomK,
+              baseLayerIndex,
+              layerCache
+            );
             foreach (var geom in decoded)
             {
               geometryList.Add(geom);
               // ObjectAttributes is IDisposable but InstanceDefinitions.Add takes ownership — disposing here would
               // corrupt the definition; the doc owns them for the document lifetime.
 #pragma warning disable CA2000
-              var a = new ObjectAttributes();
+              var a = new ObjectAttributes { LayerIndex = memberLayerIndex };
 #pragma warning restore CA2000
               if (mg != Guid.Empty)
               {
@@ -724,8 +758,19 @@ public class RhinoHostObjectArtefactBuilder : IArtifactHostObjectBuilder
             nestedInst.Units is { Length: > 0 } u ? u : docUnits,
             docUnits
           );
+          // a nested-block member owns no geometry K, so its layer is stamped onto its INSTANCE node K instead
 #pragma warning disable CA2000
-          var nestedAtts = new ObjectAttributes();
+          var nestedAtts = new ObjectAttributes
+          {
+            LayerIndex = ResolveMemberLayer(
+              doc,
+              bundle,
+              memberIndex.ObjectByInstance,
+              instNodeK,
+              baseLayerIndex,
+              layerCache
+            ),
+          };
 #pragma warning restore CA2000
           geometryList.Add(new RG.InstanceReferenceGeometry(childDefId, nestedTransform));
           attributeList.Add(nestedAtts);
@@ -829,6 +874,23 @@ public class RhinoHostObjectArtefactBuilder : IArtifactHostObjectBuilder
     var segments = SceneViewResolver.SegmentsWithColor(bundle, objK); // (name, argb) so layers get their source colour
     return segments.Count == 0 ? baseLayerIndex : GetOrCreateLayer(doc, segments, baseLayerIndex, layerCache);
   }
+
+  // A block-definition member's layer. The member has its own object row carrying the ordinary object-sourced
+  // IN_COLLECTION, but nothing reaches that row from the definition side — a member has no DISPLAY edge, so
+  // ObjectByGeometry() can't invert it. The DefinitionMemberStamps eav join supplies the missing direction:
+  // geometry K (or nested INSTANCE node K) → member object K → the SAME ResolveLayer every top-level object uses,
+  // so a layer shared by a member and a scene object is created once (shared layerCache). Unstamped → base layer.
+  private static int ResolveMemberLayer(
+    RhinoDoc doc,
+    ArtefactBundle bundle,
+    IReadOnlyDictionary<int, int> memberObjectByK,
+    int k,
+    int baseLayerIndex,
+    Dictionary<string, int> layerCache
+  ) =>
+    memberObjectByK.TryGetValue(k, out int memberObjK)
+      ? ResolveLayer(doc, bundle, memberObjK, baseLayerIndex, layerCache)
+      : baseLayerIndex;
 
   // Creates (or reuses) the nested layer chain for the given segments under the base layer; returns the leaf index.
   private static int GetOrCreateLayer(

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/Operations/Send/RhinoArtifactRootObjectBuilder.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/Operations/Send/RhinoArtifactRootObjectBuilder.cs
@@ -6,6 +6,7 @@ using Rhino.DocObjects;
 using Speckle.Connectors.Common.Builders;
 using Speckle.Connectors.Common.Conversion;
 using Speckle.Connectors.Common.Diagnostics;
+using Speckle.Connectors.Common.Instances;
 using Speckle.Connectors.Common.Operations;
 using Speckle.Connectors.Common.Threading;
 using Speckle.Connectors.Rhino.HostApp;
@@ -50,7 +51,9 @@ namespace Speckle.Connectors.Rhino.Operations.Send;
 ///   display meshes which link via the <c>DISPLAY</c> rel (for the viewer).</item>
 ///   <item><b>Layers are the default scene view.</b> The Rhino layer tree becomes <c>COLLECTION</c> nodes
 ///   (nested via <c>ParentLayerId</c>) with an <c>IN_COLLECTION</c> rel per object, and the default scene view
-///   projects on <c>IN_COLLECTION</c> — so the viewer explorer reproduces the layer hierarchy.</item>
+///   projects on <c>IN_COLLECTION</c> — so the viewer explorer reproduces the layer hierarchy. Block-definition
+///   members carry the same edge (that is how their layer survives, ENG-9110) and are kept out of the tree by
+///   having no render edge at all, plus a <see cref="DefinitionMemberStamps"/> join back from their geometry.</item>
 /// </list>
 /// <para><b>Threading.</b> Two phases. Phase 1 (<see cref="CollectOnMain"/>) runs on the Rhino UI thread —
 /// RhinoCommon (convert, unpack, layer/attribute reads) is main-thread-affine — and produces a pure-Speckle
@@ -580,15 +583,15 @@ public class RhinoArtifactRootObjectBuilder(
   )
   {
     // A block-definition member renders ONLY through its definition (via a placed instance's transform), so it gets
-    // NO standalone top-level render edge (DISPLAY / DISPLAY_INSTANCE) and NO scene-tree membership (IN_COLLECTION).
-    // Its geometry/instance K is still registered below so DEFINES / DEFINES_INSTANCE resolve.
+    // NO standalone top-level render edge (DISPLAY / DISPLAY_INSTANCE) — that is what drew it untransformed at the
+    // model origin [ENG-8782]. It DOES keep the ordinary object-sourced IN_COLLECTION below, which is how its layer
+    // travels; a DefinitionMemberStamps stamp joins its geometry/instance K back to this object row so receive can
+    // find it again [ENG-9110]. Render-less objects are skipped by every consumer that walks objects, so carrying
+    // the membership costs nothing in the scene tree.
     bool isDefinitionMember = definitionMemberIds.Contains(co.ApplicationId);
 
     int objK = pipeline.InternObject(co.ApplicationId);
-    if (!isDefinitionMember)
-    {
-      pipeline.InCollection(objK, collK, 0);
-    }
+    pipeline.InCollection(objK, collK, 0);
     pipeline.AddProperties(
       co.ApplicationId,
       co.Properties,
@@ -601,9 +604,19 @@ public class RhinoArtifactRootObjectBuilder(
       int defK = pipeline.AddDefinition(instanceProxy.definitionId, null);
       int instK = pipeline.AddInstance(co.ApplicationId, defK, Flatten(instanceProxy.transform), instanceProxy.units);
       instanceKByObjectId[co.ApplicationId] = instK;
-      if (!isDefinitionMember)
+      if (isDefinitionMember)
       {
-        pipeline.DisplayInstance(objK, instK, 0); // a nested-block member places only via DEFINES_INSTANCE
+        // A nested-block member places only via DEFINES_INSTANCE, so its INSTANCE node K is the only handle its
+        // definition has on it — stamp it so receive can join back to this object row for the member's layer.
+        pipeline.AddProperties(
+          co.ApplicationId,
+          DefinitionMemberStamps.NoProperties,
+          DefinitionMemberStamps.InstanceStamp(instK)
+        );
+      }
+      else
+      {
+        pipeline.DisplayInstance(objK, instK, 0);
       }
       return null;
     }
@@ -689,6 +702,19 @@ public class RhinoArtifactRootObjectBuilder(
     }
 
     geometryKsByObjectId[co.ApplicationId] = gKs;
+
+    // Stamp the member's geometry K(s) onto its object row — the join receive needs to get from a definition's
+    // DEFINES geometry back to the object holding the member's layer. ALL of them, not just the first: receive
+    // picks the authoritative 3dm solid OR its display mesh(es) per member (see GroupDefinesByMember), and
+    // whichever it picks has to resolve [ENG-9110].
+    if (isDefinitionMember)
+    {
+      pipeline.AddProperties(
+        co.ApplicationId,
+        DefinitionMemberStamps.NoProperties,
+        DefinitionMemberStamps.GeometryStamp(gKs)
+      );
+    }
 
     // Every display fragment was dropped and neither a standalone SOLID nor a member solid landed (gKs would
     // carry the member solid) → nothing renderable made the bundle; report it instead of standing on the

--- a/Sdk/Speckle.Connectors.Common.Tests/Instances/DefinitionMemberStampsTests.cs
+++ b/Sdk/Speckle.Connectors.Common.Tests/Instances/DefinitionMemberStampsTests.cs
@@ -1,0 +1,131 @@
+using FluentAssertions;
+using NUnit.Framework;
+using Speckle.Connectors.Common.Instances;
+
+namespace Speckle.Connectors.Common.Tests.Instances;
+
+/// <summary>
+/// ENG-9110: the eav stamps that join a block-definition member's object row (which holds its layer, via the
+/// ordinary object-sourced IN_COLLECTION) back to the geometry / INSTANCE K its definition reaches it by. A member
+/// has no DISPLAY edge, so <c>ArtefactRelations.ObjectByGeometry()</c> cannot invert that — these stamps are the
+/// only route, and if they don't round-trip the member silently lands on the base layer.
+/// </summary>
+public class DefinitionMemberStampsTests
+{
+  private static Dictionary<string, object?> Stamped(params KeyValuePair<string, object?>[] stamps)
+  {
+    // Mirrors what the eav reader hands back: a dotted path arrives as nested dictionaries, so
+    // "@speckle.geometry_k" is ["@speckle"]["geometry_k"].
+    var leaves = new Dictionary<string, object?>();
+    foreach (var stamp in stamps)
+    {
+      leaves[stamp.Key[(DefinitionMemberStamps.STAMP_ROOT.Length + 1)..]] = stamp.Value;
+    }
+    return new Dictionary<string, object?> { [DefinitionMemberStamps.STAMP_ROOT] = leaves };
+  }
+
+  [Test]
+  public void GeometryStamp_AllKsPointBackAtTheMember()
+  {
+    // A Rhino member owns several geometry Ks — a lossless 3dm solid AND its display mesh(es) — and receive picks
+    // between them per member, so every one of them has to resolve to the same member object.
+    var stamp = DefinitionMemberStamps.GeometryStamp(new[] { 7, 8, 9 });
+
+    var index = DefinitionMemberStamps.Read(new Dictionary<int, Dictionary<string, object?>> { [4] = Stamped(stamp) });
+
+    index.ObjectByGeometry.Should().HaveCount(3);
+    index.ObjectByGeometry[7].Should().Be(4);
+    index.ObjectByGeometry[8].Should().Be(4);
+    index.ObjectByGeometry[9].Should().Be(4);
+    index.ObjectByInstance.Should().BeEmpty();
+  }
+
+  [Test]
+  public void GeometryStamp_NoGeometry_EmitsNothing()
+  {
+    // A member whose every display fragment failed to encode has no K to join to — stamping "" would produce a
+    // row that parses to nothing.
+    DefinitionMemberStamps.GeometryStamp(Array.Empty<int>()).Should().BeEmpty();
+  }
+
+  [Test]
+  public void InstanceStamp_JoinsANestedBlockMember()
+  {
+    var index = DefinitionMemberStamps.Read(
+      new Dictionary<int, Dictionary<string, object?>> { [2] = Stamped(DefinitionMemberStamps.InstanceStamp(11)) }
+    );
+
+    index.ObjectByInstance[11].Should().Be(2);
+    index.ObjectByGeometry.Should().BeEmpty();
+  }
+
+  [Test]
+  public void Read_AcceptsABareNumber_TheSketchUpForm()
+  {
+    // SketchUp (ENG-8851) writes a single geometry K as an integer, and eav hands any numeric back as a double.
+    // The two connectors share these keys, so a SketchUp bundle must read here unchanged.
+    var index = DefinitionMemberStamps.Read(
+      new Dictionary<int, Dictionary<string, object?>>
+      {
+        [3] = new() { [DefinitionMemberStamps.STAMP_ROOT] = new Dictionary<string, object?> { ["geometry_k"] = 5.0 } },
+      }
+    );
+
+    index.ObjectByGeometry[5].Should().Be(3);
+  }
+
+  [Test]
+  public void Read_UnstampedBundle_YieldsEmptyMaps()
+  {
+    // Every top-level object, and every member of a pre-ENG-9110 bundle. Callers fall back to the base layer.
+    var index = DefinitionMemberStamps.Read(
+      new Dictionary<int, Dictionary<string, object?>>
+      {
+        [0] = new() { ["name"] = "Wall" },
+        [1] = new() { ["@speckle"] = "not a dictionary" },
+      }
+    );
+
+    index.ObjectByGeometry.Should().BeEmpty();
+    index.ObjectByInstance.Should().BeEmpty();
+  }
+
+  [Test]
+  public void Read_GarbageFragments_AreSkippedNotThrown()
+  {
+    // A stamp is an optimisation over a lost layer; a malformed one must never fail a whole receive.
+    var index = DefinitionMemberStamps.Read(
+      new Dictionary<int, Dictionary<string, object?>>
+      {
+        [6] = new()
+        {
+          [DefinitionMemberStamps.STAMP_ROOT] = new Dictionary<string, object?>
+          {
+            ["geometry_k"] = "12, oops, 13",
+            ["instance_k"] = null,
+          },
+        },
+      }
+    );
+
+    index.ObjectByGeometry.Keys.Should().BeEquivalentTo(new[] { 12, 13 });
+    index.ObjectByInstance.Should().BeEmpty();
+  }
+
+  [Test]
+  public void Read_TwoMembers_KeepTheirOwnOwners()
+  {
+    var index = DefinitionMemberStamps.Read(
+      new Dictionary<int, Dictionary<string, object?>>
+      {
+        [1] = Stamped(DefinitionMemberStamps.GeometryStamp(new[] { 0 })),
+        [2] = Stamped(DefinitionMemberStamps.GeometryStamp(new[] { 1 })),
+      }
+    );
+
+    // Note the deliberate numeric overlap: geometry K 1 and object K 1 are different things. Keying the map by
+    // geometry K is what keeps them apart.
+    index.ObjectByGeometry[0].Should().Be(1);
+    index.ObjectByGeometry[1].Should().Be(2);
+  }
+}

--- a/Sdk/Speckle.Connectors.Common/Instances/DefinitionMemberStamps.cs
+++ b/Sdk/Speckle.Connectors.Common/Instances/DefinitionMemberStamps.cs
@@ -1,0 +1,117 @@
+using System.Globalization;
+
+namespace Speckle.Connectors.Common.Instances;
+
+/// <summary>
+/// The eav stamps that join a block/definition MEMBER's object row back to the K it is addressable by from inside
+/// its definition: the member's geometry K (<c>DEFINES</c>) or, for a nested-block member, its INSTANCE node K
+/// (<c>DEFINES_INSTANCE</c>).
+/// <para><b>Why a stamp and not a relation.</b> A member deliberately carries no top-level <c>DISPLAY</c> /
+/// <c>DISPLAY_INSTANCE</c> — it renders solely through a placed instance, and a top-level render edge draws it
+/// untransformed at the model origin [ENG-8782]. But <c>ArtefactRelations.ObjectByGeometry()</c> is built from
+/// <c>DISPLAY</c> edges alone, so nothing can get from a definition's member geometry back to the member's object
+/// row — and therefore nothing can reach what that row carries: its LAYER (<c>IN_COLLECTION</c>) and its
+/// properties. The stamp restores the geometry → object direction using eav only, so the member keeps the ordinary
+/// object-sourced <c>IN_COLLECTION</c> every top-level object already emits — no new relation, no spec change
+/// [ENG-9110].</para>
+/// <para><b>Cross-connector contract.</b> The keys and the join are the SketchUp connector's, which solved the
+/// same problem for tags first [ENG-8851]. A SketchUp member owns exactly one geometry so it writes a bare
+/// integer; a Rhino member can own several (a lossless 3dm solid AND its display meshes, which receive chooses
+/// between per member), so the geometry stamp is a comma-joined list. <see cref="Read"/> accepts both forms.</para>
+/// <para><b>The invariant this relies on.</b> A member's object row has no render edge, so every consumer that
+/// walks objects must skip render-less ones or the member bakes twice. Both C# receive paths already do —
+/// the Rhino native builder gates on DISPLAY/SOLID/DISPLAY_INSTANCE, and <c>ObjectsArtifactReader</c> drops an
+/// object whose geometry build returns null. Keep it that way.</para>
+/// </summary>
+public static class DefinitionMemberStamps
+{
+  /// <summary>The eav path prefix both stamps live under. Read back as a nested dictionary: the eav reader splits
+  /// a dotted path into levels, so <c>@speckle.geometry_k</c> arrives as <c>["@speckle"]["geometry_k"]</c>.</summary>
+  public const string STAMP_ROOT = "@speckle";
+
+  /// <summary>Leaf key of the geometry stamp — the member's geometry K(s), comma-joined.</summary>
+  public const string GEOMETRY_KEY = "geometry_k";
+
+  /// <summary>Leaf key of the nested-block member stamp — the member's INSTANCE node K.</summary>
+  public const string INSTANCE_KEY = "instance_k";
+
+  private const string GEOMETRY_PATH = STAMP_ROOT + "." + GEOMETRY_KEY;
+  private const string INSTANCE_PATH = STAMP_ROOT + "." + INSTANCE_KEY;
+
+  /// <summary>An empty property tree, for stamping an object that has nothing else to add (the stamp rides the
+  /// root scalars). Handy at the call site: <c>AddProperties(appId, NoProperties, GeometryStamp(gKs))</c>.</summary>
+  public static IReadOnlyDictionary<string, object?> NoProperties { get; } = new Dictionary<string, object?>();
+
+  /// <summary>Root scalars stamping a definition member with the geometry K(s) it owns. Empty when there are
+  /// none — a member whose geometry all failed to encode has nothing to join to.</summary>
+  public static KeyValuePair<string, object?>[] GeometryStamp(IReadOnlyCollection<int> geometryKs) =>
+    geometryKs.Count == 0
+      ? []
+      : [new(GEOMETRY_PATH, string.Join(",", geometryKs.Select(k => k.ToString(CultureInfo.InvariantCulture))))];
+
+  /// <summary>Root scalars stamping a NESTED-block member with its INSTANCE node K — the member owns no geometry
+  /// of its own, so this is the only handle its definition has on it.</summary>
+  public static KeyValuePair<string, object?>[] InstanceStamp(int instanceK) =>
+    [new(INSTANCE_PATH, instanceK.ToString(CultureInfo.InvariantCulture))];
+
+  /// <summary>
+  /// Inverts the stamps of a whole bundle in one pass: geometry K → owning member object K, and INSTANCE node K →
+  /// owning member object K. Feed it <c>ArtefactBundle.Properties</c>. Objects with no stamp (every top-level
+  /// object, and every member in a pre-ENG-9110 bundle) contribute nothing, so both maps are empty on older
+  /// bundles and callers fall back to their previous behaviour.
+  /// </summary>
+  public static DefinitionMemberIndex Read(IReadOnlyDictionary<int, Dictionary<string, object?>> propertiesByObject)
+  {
+    var byGeometry = new Dictionary<int, int>();
+    var byInstance = new Dictionary<int, int>();
+    foreach (var kv in propertiesByObject)
+    {
+      if (kv.Value.TryGetValue(STAMP_ROOT, out var root) && root is Dictionary<string, object?> stamps)
+      {
+        foreach (int geometryK in ParseKs(stamps, GEOMETRY_KEY))
+        {
+          byGeometry[geometryK] = kv.Key; // a member owns several geometry Ks; all of them point back at it
+        }
+        foreach (int instanceK in ParseKs(stamps, INSTANCE_KEY))
+        {
+          byInstance[instanceK] = kv.Key;
+        }
+      }
+    }
+    return new DefinitionMemberIndex(byGeometry, byInstance);
+  }
+
+  // A stamp value arrives either as a comma-joined string or as a bare number, and BOTH occur for bundles this very
+  // class wrote: eav infers a type per value, so "7,8" stays a string (no thousands separator is admitted under the
+  // invariant culture) while a single-K "7" is coerced to a number and read back as a double. SketchUp's integer
+  // stamp lands in the same numeric branch. Unparseable fragments are skipped rather than thrown: a stamp is an
+  // optimisation over a lost layer, never a reason to fail a receive.
+  private static List<int> ParseKs(Dictionary<string, object?> stamps, string key)
+  {
+    var result = new List<int>();
+    if (!stamps.TryGetValue(key, out var value) || value is null)
+    {
+      return result;
+    }
+    if (value is double d)
+    {
+      result.Add((int)d);
+      return result;
+    }
+    foreach (var part in Convert.ToString(value, CultureInfo.InvariantCulture)?.Split(',') ?? [])
+    {
+      if (int.TryParse(part.Trim(), NumberStyles.Integer, CultureInfo.InvariantCulture, out int k))
+      {
+        result.Add(k);
+      }
+    }
+    return result;
+  }
+}
+
+/// <summary>The inverted <see cref="DefinitionMemberStamps"/> of one bundle: from a K reachable inside a
+/// definition to the member OBJECT K that owns it, which is where the member's layer and properties live.</summary>
+public sealed record DefinitionMemberIndex(
+  IReadOnlyDictionary<int, int> ObjectByGeometry,
+  IReadOnlyDictionary<int, int> ObjectByInstance
+);

--- a/docs/artifact-object-model.md
+++ b/docs/artifact-object-model.md
@@ -146,7 +146,7 @@ graph LR
   classDef nd fill:#b3a8f0,stroke:#5647bd,color:#211648;
 ```
 
-Members have **no `DISPLAY` and no `IN_COLLECTION`** — deliberate suppression, otherwise they'd draw untransformed at the origin (ENG-8782). A placement's transform composes onto the definition's geometry at receive. `DEFINES_INSTANCE` (node → node) handles a block nested inside another block.
+Members have **no `DISPLAY` / `DISPLAY_INSTANCE`** — deliberate suppression, otherwise they'd draw untransformed at the origin (ENG-8782). A placement's transform composes onto the definition's geometry at receive. `DEFINES_INSTANCE` (node → node) handles a block nested inside another block. A member does keep its ordinary object row and `IN_COLLECTION`; see [member layers](#member-layers--a-carrier-row-and-a-stamp).
 
 ## Groups — a second, overlapping axis
 
@@ -210,11 +210,37 @@ Rooms are _objects_, not nodes — so `IN_ROOM` and `BOUNDS` point at an object 
 
 ---
 
-## The member-layer gap
+## Member layers — a carrier row and a stamp
 
-A definition member reaches the bundle _only_ as a **geometry** K, via `DEFINES`. It has no `DISPLAY` edge — so there is no path from its geometry K back to its object K — and no `IN_COLLECTION`, so it carries no layer at all.
+A definition member is _reachable from its definition_ only as a **geometry** K (`DEFINES`) or, if it is itself a nested placement, as an **INSTANCE node** K (`DEFINES_INSTANCE`). It has no `DISPLAY` edge, so `ObjectByGeometry()` — built from `DISPLAY` alone — cannot invert either one. That was the gap: whatever the member's object row held, nothing could find it.
 
-`IN_COLLECTION` can't reach it: that rel is _object_-sourced, and the member is only addressable as geometry. Adding it would also wrongly place the member in the scene tree (a phantom node). The shape that fits is a proposed **`ON_LAYER` · geometry → node** — the geometry-sourced sibling of `ON_LEVEL`. It would say only "this geometry's host layer is X" without asserting scene-tree membership, letting a receiver set the member's layer + `ByLayer` colour by inheritance. The limit: it fixes layer-shaped attributes only; per-member _properties_ still need member-object identity carried through `DEFINES`.
+The fix needs no new relation. The member keeps a **carrier object row** with the same object-sourced `IN_COLLECTION` every top-level object emits, and an **eav stamp** supplies the missing direction back to it — `@speckle.geometry_k` (or `@speckle.instance_k` for a nested member). SketchUp did this first for tags (ENG-8851); Rhino reuses the same keys (ENG-9110).
+
+```mermaid
+graph LR
+  R([obj·0 · placement]):::obj
+  INST{{node·2 · INSTANCE}}:::nd
+  DEF{{node·3 · DEFINITION}}:::nd
+  GA[geo·0 · member mesh]:::geo
+  M([obj·1 · member carrier]):::obj
+  LA{{node·0 · CONTAINER Layer A}}:::nd
+  LB{{node·1 · CONTAINER Layer B}}:::nd
+  R -->|DISPLAY_INSTANCE| INST
+  INST -.->|def_ref| DEF
+  DEF -->|DEFINES| GA
+  R -->|IN_COLLECTION| LA
+  M -->|IN_COLLECTION| LB
+  M -.->|"eav @speckle.geometry_k"| GA
+  classDef obj fill:#eac36a,stroke:#9a5f0c,color:#2a1c04;
+  classDef geo fill:#5fc7b8,stroke:#0a7369,color:#052723;
+  classDef nd fill:#b3a8f0,stroke:#5647bd,color:#211648;
+```
+
+The placement sits on Layer A; the member drawn through it belongs to Layer B. Receive walks `DEFINES` to `geo·0`, the stamp back to `obj·1`, then that carrier's ordinary `IN_COLLECTION` — no special-case projection anywhere.
+
+**The invariant this rests on:** a carrier has no render edge, so every consumer that walks objects must skip render-less ones. Both C# receive paths already do (the Rhino native builder gates on `DISPLAY`/`SOLID`/`DISPLAY_INSTANCE`; `ObjectsArtifactReader` drops an object whose geometry build returns null). Break that and members bake twice — and show up in the scene explorer.
+
+Two wrinkles worth knowing. A Rhino member owns **several** geometry Ks (a lossless 3dm solid _and_ its display mesh, chosen between per member), so the stamp is a comma-joined list where SketchUp writes a bare integer — and eav coerces a numeric-looking single value, so a one-K stamp reads back as a `double`. Any reader accepts both. And because the carrier is a real object row, member **properties** are now reachable by the same route — the piece that used to be listed as a separate gap.
 
 ---
 

--- a/docs/connector-relations.md
+++ b/docs/connector-relations.md
@@ -131,7 +131,7 @@ graph LR
   classDef nd fill:#b3a8f0,stroke:#5647bd,color:#211648;
 ```
 
-A placement points at an INSTANCE (transform) that references a DEFINITION; the definition owns its geometry and can nest another block placement. Members get no top-level edges (ENG-8782).
+A placement points at an INSTANCE (transform) that references a DEFINITION; the definition owns its geometry and can nest another block placement. Members get no top-level **render** edges (ENG-8782), but keep a carrier object row — ordinary `IN_COLLECTION` for their layer, plus an `@speckle.geometry_k` / `@speckle.instance_k` eav stamp joining it back to the K the definition reaches them by (ENG-9110, mirroring SketchUp's ENG-8851).
 
 **Groups overlap layers** — `IN_COLLECTION` · `IN_GROUP`
 
@@ -508,7 +508,8 @@ Members group by member-type (Beam, Column, Slab…) into flat collections. Resu
 **Known gaps.**
 - **Civil3D topology is send-only** — SUBELEMENT/IN_SYSTEM/CONNECTS_TO survive in the graph but aren't rebuilt as native Civil relationships on receive.
 - **TSD SUBELEMENT is dead code** (elements always empty); **TSD results don't object-join** (location-keyed).
-- The member-layer gap (definition members carry no layer) is still open — a proposed geometry-sourced `ON_LAYER` edge would close it.
+- **Member layers are Rhino + SketchUp only.** Both carry a definition member's layer/tag on a carrier object row joined back to its geometry by an `@speckle.geometry_k` / `@speckle.instance_k` eav stamp (SketchUp ENG-8851, Rhino ENG-9110). AutoCAD blocks have the identical gap and pin only the resolved member _colour_ (ENG-8825).
+- **Carriers depend on an unenforced invariant.** A carrier object row has no render edge, so any consumer walking objects must skip render-less ones or a member bakes twice and lands in the scene explorer. Every current reader does; nothing checks it.
 
 ---
 


### PR DESCRIPTION
Closes ENG-9110.

Objects inside a Rhino block definition came back on the base layer. After receive + explode, every member had lost its layer.

### Cause

ENG-8782 suppressed a definition member's top-level `DISPLAY` / `SOLID` / `DISPLAY_INSTANCE` **and** its `IN_COLLECTION`. Only the render edges caused the bug it was fixing (definition geometry drawing untransformed at the model origin) — but dropping the membership left the member's layer with nowhere to travel, so it never reached the bundle.

### Approach — SketchUp's, no spec change

`docs/artifact-object-model.md` proposed a new geometry-sourced `ON_LAYER` relation for this. It isn't needed, and the SketchUp connector had already solved the identical problem for tags (specklesystems/speckle-sketchup ENG-8851, `6df45ed`) without touching the spec:

- A member keeps a **carrier object row** — the same object-sourced `IN_COLLECTION` every top-level object emits.
- An **eav stamp** supplies the one direction nothing else can: from the K its definition reaches it by, back to that row. A member has no `DISPLAY` edge, so `ArtefactRelations.ObjectByGeometry()` cannot invert it.

**Send.** Restore `IN_COLLECTION` for members, then stamp `@speckle.geometry_k` with **every** geometry K the member owns — receive picks the authoritative 3dm solid *or* its display mesh(es) per member (`GroupDefinesByMember`), so whichever it picks has to resolve. A member that is itself a nested block owns no geometry, so it gets `@speckle.instance_k` with its INSTANCE node K instead.

**Receive.** `BuildDefinitions` resolves each member through its stamp to the carrier row, then through the **same** `ResolveLayer` every top-level object uses — shared `layerCache`, so a layer used by both a member and a scene object is created once — and sets it on the member's `ObjectAttributes`. Exploding a received instance now puts each member back on its source layer.

Keys and join are SketchUp's verbatim, so one reader serves both connectors. The only divergence: a Rhino member can own several geometries where a SketchUp one owns exactly one, hence the comma-joined list (a single value parses identically, so SketchUp bundles read here unchanged).

### Why the join lives in `Speckle.Connectors.Common`

`DefinitionMemberStamps` is host-agnostic: the keys are a cross-connector contract with SketchUp, AutoCAD blocks have the same gap waiting, and it's the only placement that makes the logic testable in this repo.

### The load-bearing invariant

Members stay out of the scene explorer because a carrier has **no render edge**, and every consumer that walks objects skips those — the Rhino native builder gates on `DISPLAY`/`SOLID`/`DISPLAY_INSTANCE`, and `ObjectsArtifactReader` drops an object whose geometry build returns null (both verified). Nothing in the spec or validator enforces this; it's called out in `DefinitionMemberStamps` and in both docs. Same exposure SketchUp has carried since 28 Jul, so if it turns out the viewer *does* show carriers, it's one fleet-wide fix rather than a Rhino-specific design flaw.

### Compatibility

Unstamped input — a pre-ENG-9110 bundle, or a member whose geometry didn't encode — falls back to the base layer, exactly the current behaviour.

### Tests

- **7 NUnit tests** (`Sdk/Speckle.Connectors.Common.Tests/Instances/`): multi-K fan-out to one owner, empty-geometry member, nested-instance join, SketchUp's bare-numeric form, unstamped bundle, malformed fragments skipped rather than thrown, and two members with a deliberate object-K/geometry-K numeric overlap.
- **SDK round-trip** pinning the carrier shape through parquet: specklesystems/speckle-sharp-sdk#530 (test-only, independent — this PR needs no SDK change).
- `Speckle.Rhino.slnx -c Local` builds clean; csharpier clean.

There is no Rhino test project, so the host-side bake is covered by manual round trips. On receive the session log (`%TEMP%\Speckle\sessions\*.summary.txt`) reports a new `memberStamps` stat — zero on a model with block members means the join was lost.

### Known gaps, documented not fixed

- **AutoCAD and SketchUp parity.** AutoCAD blocks have the same gap and today pin only the resolved member *colour* (ENG-8825); the mirror of this change is small and now shares the helper.
- **Member properties** are reachable as a side effect — the stamp is a genuine geometry→object route, which is what previously capped ENG-9111 for members. Nothing here consumes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)