### PR TITLE
fix(revit): make family receive artifact-native

### DIFF
--- a/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/FamilyGeometryBaker.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/FamilyGeometryBaker.cs
@@ -1,4 +1,5 @@
-﻿using Autodesk.Revit.DB;
+﻿using System.Globalization;
+using Autodesk.Revit.DB;
 using Microsoft.Extensions.Logging;
 using Speckle.Converters.Common.Objects;
 using Speckle.Objects.Other;
@@ -261,6 +262,60 @@ public class FamilyGeometryBaker
       foreach (var item in displayValues)
       {
         BakeGeometry(famDoc, item, subcategory, materialManager, materialMap, placeNestedInstanceAction);
+      }
+    }
+  }
+
+  // ENG-9101: bundle-native counterpart of BakeFamilyGeometry above — bakes already-decoded GeometryObjects (the
+  // caller resolved these from the artifact bundle via the same DecodeGeometry path DirectShape receive uses)
+  // instead of walking a Base/TraversalContext graph. No subcategory grouping (that's cosmetic, tied to the v1
+  // Collection tree, which the bundle's DEFINES members don't carry) — materials still apply via family parameters.
+  public void BakeFamilyGeometryFromArtifact(
+    Document famDoc,
+    IReadOnlyList<(GeometryObject geometry, int? materialNodeKey)> members,
+    FamilyMaterialManager materialManager
+  )
+  {
+    foreach (var (geometry, materialNodeKey) in members)
+    {
+      try
+      {
+        if (geometry is Solid solid && !solid.Faces.IsEmpty)
+        {
+          using var freeFormElement = FreeFormElement.Create(famDoc, solid);
+          if (
+            materialNodeKey is int mk
+            && materialManager.FamilyParameters.TryGetValue(mk.ToString(CultureInfo.InvariantCulture), out var famParam)
+          )
+          {
+            Parameter ffeMatParam = freeFormElement.get_Parameter(BuiltInParameter.MATERIAL_ID_PARAM);
+            if (ffeMatParam != null && famDoc.FamilyManager.CanElementParameterBeAssociated(ffeMatParam))
+            {
+              famDoc.FamilyManager.AssociateElementParameterToFamilyParameter(ffeMatParam, famParam);
+            }
+          }
+          continue;
+        }
+
+        ElementId categoryId = famDoc.OwnerFamily.FamilyCategory?.Id ?? new ElementId(BuiltInCategory.OST_GenericModel);
+        if (!DirectShape.IsValidCategoryId(categoryId, famDoc))
+        {
+          categoryId = new ElementId(BuiltInCategory.OST_GenericModel);
+        }
+        try
+        {
+          using var ds = DirectShape.CreateElement(famDoc, categoryId);
+          ds.SetShape([geometry]);
+        }
+        catch (Autodesk.Revit.Exceptions.ArgumentException)
+        {
+          using var fallbackDs = DirectShape.CreateElement(famDoc, new ElementId(BuiltInCategory.OST_GenericModel));
+          fallbackDs.SetShape([geometry]);
+        }
+      }
+      catch (Autodesk.Revit.Exceptions.ApplicationException ex)
+      {
+        _logger.LogWarning(ex, "Revit API error baking artifact geometry into family");
       }
     }
   }

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/FamilyMaterialManager.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/FamilyMaterialManager.cs
@@ -1,4 +1,5 @@
-﻿using Autodesk.Revit.DB;
+﻿using System.Globalization;
+using Autodesk.Revit.DB;
 using Microsoft.Extensions.Logging;
 using Speckle.Objects.Other;
 using Speckle.Sdk;
@@ -143,6 +144,69 @@ public class FamilyMaterialManager
         {
           _logger.LogWarning(ex, "Failed to setup family material {MatName}", renderMat.name);
         }
+      }
+    }
+  }
+
+  // ENG-9101: bundle-native counterparts of the two methods above, keyed by MATERIAL node index instead of a
+  // sanitized material name — the artifact bundle already gives us a stable int key, so no name-collision handling
+  // is needed. "Material_a{node}" (not "Material_{node}") so it can never collide with a v1 safeName-derived param.
+  public void SetupFamilyMaterialsFromArtifact(
+    Document famDoc,
+    IEnumerable<int> materialNodeKeys,
+    IReadOnlyDictionary<int, RenderMaterial> materialsByNode
+  )
+  {
+    foreach (var matNodeK in materialNodeKeys)
+    {
+      if (!materialsByNode.TryGetValue(matNodeK, out var renderMat))
+      {
+        continue;
+      }
+      string key = matNodeK.ToString(CultureInfo.InvariantCulture);
+      if (BakedMaterials.ContainsKey(key))
+      {
+        continue;
+      }
+
+      try
+      {
+        ElementId famMatId = _materialBaker.BakeMaterial(renderMat, famDoc);
+        BakedMaterials[key] = famMatId;
+
+        string paramName = $"Material_a{key}";
+        FamilyParameters[key] =
+          famDoc.FamilyManager.get_Parameter(paramName)
+          ?? famDoc.FamilyManager.AddParameter(paramName, GroupTypeId.Materials, SpecTypeId.Reference.Material, false);
+      }
+      catch (Exception ex) when (!ex.IsFatal())
+      {
+        _logger.LogWarning(ex, "Failed to setup family material for node {MaterialNodeKey}", matNodeK);
+      }
+    }
+  }
+
+  public static void AssignProjectMaterialsToFamilyFromArtifact(
+    FamilySymbol symbol,
+    IReadOnlyDictionary<int, ElementId> projectMaterialIdByNode
+  )
+  {
+    foreach (Parameter p in symbol.Parameters)
+    {
+      if (
+        p.Definition.Name.StartsWith("Material_a", StringComparison.Ordinal)
+        && p.StorageType == StorageType.ElementId
+        && !p.IsReadOnly
+        && int.TryParse(
+          p.Definition.Name["Material_a".Length..],
+          NumberStyles.Integer,
+          CultureInfo.InvariantCulture,
+          out int matNodeK
+        )
+        && projectMaterialIdByNode.TryGetValue(matNodeK, out var projMatId)
+      )
+      {
+        p.Set(projMatId);
       }
     }
   }

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/RevitFamilyBaker.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/RevitFamilyBaker.cs
@@ -315,6 +315,170 @@ public sealed class RevitFamilyBaker : IDisposable
     return (family, symbol);
   }
 
+  /// <summary>
+  /// Bundle-native counterpart of <see cref="CreateFamilyFromDefinition"/> (ENG-9101): builds/reuses a real Revit
+  /// family straight from already-decoded artifact geometry — no Base graph, no <see cref="TraversalContext"/>.
+  /// </summary>
+  /// <remarks>Deliberately does NOT use <see cref="_cache"/> (a DI singleton, so it outlives one receive): its keys
+  /// are stable source applicationIds in the v1 pipeline, but <paramref name="definitionKey"/> here is a bundle
+  /// position index that can be reassigned to a different definition on the next send. <see cref="FindFamilyByName"/>
+  /// (stable — Revit family identity) is what makes reuse across receives safe; the caller's own per-receive
+  /// dictionary already memoizes within one receive.</remarks>
+  public (Family family, FamilySymbol symbol)? BakeDefinitionFromArtifact(
+    Document document,
+    string definitionKey,
+    string? definitionName,
+    string? categoryString,
+    IReadOnlyList<(GeometryObject geometry, int? materialNodeKey)> members,
+    IReadOnlyDictionary<int, RenderMaterial> familyMaterialsByNode,
+    IReadOnlyDictionary<int, ElementId> projectMaterialIdByNode,
+    IReadOnlyList<(string childDefinitionKey, Matrix4x4 transform, string units)> nestedPlacements
+  )
+  {
+    var familyName = GetFamilyName(definitionName, definitionKey);
+
+    var family = FindFamilyByName(document, familyName);
+    bool isNewFamily = family == null;
+    if (family == null)
+    {
+      family = CreateFamilyFromArtifact(
+        document,
+        familyName,
+        definitionKey,
+        categoryString,
+        members,
+        familyMaterialsByNode,
+        nestedPlacements
+      );
+    }
+
+    if (family == null)
+    {
+      _logger.LogWarning("Failed to create family for artifact definition {DefinitionKey}", definitionKey);
+      return null;
+    }
+
+    var symbolId = family.GetFamilySymbolIds().FirstOrDefault();
+    if (symbolId == null || symbolId == ElementId.InvalidElementId)
+    {
+      return null;
+    }
+
+    if (document.GetElement(symbolId) is not FamilySymbol symbol)
+    {
+      return null;
+    }
+
+    if (!symbol.IsActive)
+    {
+      symbol.Activate();
+      document.Regenerate();
+    }
+
+    if (isNewFamily)
+    {
+      FamilyMaterialManager.AssignProjectMaterialsToFamilyFromArtifact(symbol, projectMaterialIdByNode);
+    }
+
+    return (family, symbol);
+  }
+
+  private Family? CreateFamilyFromArtifact(
+    Document document,
+    string familyName,
+    string definitionKey,
+    string? categoryString,
+    IReadOnlyList<(GeometryObject geometry, int? materialNodeKey)> members,
+    IReadOnlyDictionary<int, RenderMaterial> familyMaterialsByNode,
+    IReadOnlyList<(string childDefinitionKey, Matrix4x4 transform, string units)> nestedPlacements
+  )
+  {
+    var templatePath = GetFamilyTemplatePath(document);
+    var famDoc = document.Application.NewFamilyDocument(templatePath);
+    var tempPath = Path.Combine(_tempDirectory, $"{familyName}.rfa");
+
+    try
+    {
+      using (var t = new Transaction(famDoc, "Populate Family"))
+      {
+        t.Start();
+
+        var materialManager = new FamilyMaterialManager(_materialBaker, _logger);
+        var usedMaterialNodeKeys = members.Where(m => m.materialNodeKey is not null).Select(m => m.materialNodeKey!.Value).Distinct();
+        materialManager.SetupFamilyMaterialsFromArtifact(famDoc, usedMaterialNodeKeys, familyMaterialsByNode);
+
+        _familyGeometryBaker.BakeFamilyGeometryFromArtifact(famDoc, members, materialManager);
+
+        foreach (var (childDefinitionKey, transform, units) in nestedPlacements)
+        {
+          PlaceNestedInstanceFromArtifact(famDoc, childDefinitionKey, transform, units);
+        }
+
+        SetFamilyWorkPlaneBased(famDoc, true);
+        _familyCategoryUtils.SetFamilyCategory(famDoc, categoryString);
+        t.Commit();
+      }
+
+      var saveOptions = new SaveAsOptions { OverwriteExistingFile = true };
+      famDoc.SaveAs(tempPath, saveOptions);
+      famDoc.Close(false);
+
+      _bakedFamilyPaths[definitionKey] = tempPath;
+
+      document.LoadFamily(tempPath, new FamilyLoadOptions(), out var loadedFamily);
+      return loadedFamily;
+    }
+    catch (Autodesk.Revit.Exceptions.ApplicationException ex)
+    {
+      _logger.LogError(ex, "Revit API error creating artifact family {FamilyName}", familyName);
+      famDoc.Close(false);
+      SafeDelete(tempPath);
+      throw;
+    }
+    catch (IOException ex)
+    {
+      _logger.LogError(ex, "IO error creating artifact family {FamilyName}", familyName);
+      famDoc.Close(false);
+      SafeDelete(tempPath);
+      throw;
+    }
+  }
+
+  // Bundle-native counterpart of PlaceNestedInstance: the child definition was already baked (depth-first) by the
+  // caller, so we only need its saved .rfa path — loaded a second time here because a family document can't
+  // reference a symbol living in a different document. Doesn't propagate the child's material params onto the
+  // parent (a secondary nicety for swapping a nested block's materials from the parent) — the child still renders
+  // with whatever materials it baked internally.
+  private void PlaceNestedInstanceFromArtifact(Document famDoc, string childDefinitionKey, Matrix4x4 transform, string units)
+  {
+    if (!_bakedFamilyPaths.TryGetValue(childDefinitionKey, out var rfaPath) || !File.Exists(rfaPath))
+    {
+      return;
+    }
+
+    var familyName = Path.GetFileNameWithoutExtension(rfaPath);
+    Family? childFamily = FindFamilyByName(famDoc, familyName) ?? LoadFamilyWrapper(famDoc, rfaPath);
+
+    using var _ = childFamily;
+    if (childFamily == null)
+    {
+      return;
+    }
+
+    var symbolId = childFamily.GetFamilySymbolIds().FirstOrDefault();
+    if (symbolId == null || famDoc.GetElement(symbolId) is not FamilySymbol symbol)
+    {
+      return;
+    }
+
+    if (!symbol.IsActive)
+    {
+      symbol.Activate();
+    }
+
+    CreateAndPlaceFamilyInstance(famDoc, transform, units, symbol, referencePointTransform: null);
+  }
+
   private Family? CreateFamily(
     Document document,
     string familyName,
@@ -452,20 +616,27 @@ public sealed class RevitFamilyBaker : IDisposable
     InstanceProxy instanceProxy,
     FamilySymbol symbol,
     DB.Transform? referencePointTransform
+  ) => CreateAndPlaceFamilyInstance(doc, instanceProxy.transform, instanceProxy.units, symbol, referencePointTransform);
+
+  // Matrix/units core shared by the Base-graph (InstanceProxy) and bundle-native placement call sites.
+  private FamilyInstance? CreateAndPlaceFamilyInstance(
+    Document doc,
+    Matrix4x4 transform,
+    string units,
+    FamilySymbol symbol,
+    DB.Transform? referencePointTransform
   )
   {
-    var isMirrored = _familyTransformUtils.GetMirrorState(instanceProxy.transform).X;
-    var hasScaleOrSkew = _familyTransformUtils.HasScaleOrSkew(instanceProxy.transform);
+    var isMirrored = _familyTransformUtils.GetMirrorState(transform).X;
+    var hasScaleOrSkew = _familyTransformUtils.HasScaleOrSkew(transform);
 
     var cleanMatrix =
-      (hasScaleOrSkew || isMirrored)
-        ? _familyTransformUtils.RemoveScaleAndSkew(instanceProxy.transform)
-        : instanceProxy.transform;
+      (hasScaleOrSkew || isMirrored) ? _familyTransformUtils.RemoveScaleAndSkew(transform) : transform;
 
-    var revitTransform = _transformConverter.Convert((cleanMatrix, instanceProxy.units));
+    var revitTransform = _transformConverter.Convert((cleanMatrix, units));
     if (referencePointTransform is not null)
     {
-      // instanceProxy.transform is sent in world/shared-coordinate space (same frame as atomic geometry) — compose
+      // the placement transform is sent in world/shared-coordinate space (same frame as atomic geometry) — compose
       // the reference-point transform onto this OUTERMOST placement to land back in the document's internal
       // coordinates, mirroring RevitHostObjectArtefactBuilder.BuildInstanceTransform [ENG-9099].
       revitTransform = referencePointTransform.Multiply(revitTransform);
@@ -496,7 +667,7 @@ public sealed class RevitFamilyBaker : IDisposable
     }
 
     doc.Regenerate();
-    var mirrorState = _familyTransformUtils.GetMirrorState(instanceProxy.transform);
+    var mirrorState = _familyTransformUtils.GetMirrorState(transform);
     _familyTransformUtils.ApplyMirroring(doc, instance.Id, plane, mirrorState);
 
     return instance;
@@ -518,6 +689,15 @@ public sealed class RevitFamilyBaker : IDisposable
     _logger.LogWarning("No family symbol found for definition {DefinitionId}", definitionId);
     return null;
   }
+
+  /// <summary>Places one instance of an already-baked artifact-native family symbol (ENG-9101; no InstanceProxy).</summary>
+  public FamilyInstance? PlaceInstanceFromArtifact(
+    Document document,
+    FamilySymbol symbol,
+    Matrix4x4 transform,
+    string units,
+    DB.Transform? referencePointTransform
+  ) => CreateAndPlaceFamilyInstance(document, transform, units, symbol, referencePointTransform);
 
   private static void SetFamilyWorkPlaneBased(Document famDoc, bool enabled)
   {
@@ -554,12 +734,19 @@ public sealed class RevitFamilyBaker : IDisposable
     return templatePath;
   }
 
-  private static string GetFamilyName(InstanceDefinitionProxy definitionProxy)
+  // useFallbackIdWhenUnnamed: false here, preserving the original v1 behavior verbatim (every unnamed definition
+  // collapses to the literal "Unnamed_Block", a pre-existing limitation left untouched). The bundle-native overload
+  // below defaults to true — it has a cheap, always-unique fallbackId (the bundle definition key) available, so an
+  // unnamed artifact definition doesn't need to share that literal with every other unnamed one in the same bundle.
+  private static string GetFamilyName(InstanceDefinitionProxy definitionProxy) =>
+    GetFamilyName(definitionProxy.name, definitionProxy.id, useFallbackIdWhenUnnamed: false);
+
+  private static string GetFamilyName(string? name, string? fallbackId, bool useFallbackIdWhenUnnamed = true)
   {
-    var baseName = definitionProxy.name;
+    var baseName = name;
     if (string.IsNullOrWhiteSpace(baseName))
     {
-      return "Unnamed_Block";
+      return useFallbackIdWhenUnnamed && fallbackId is { Length: > 0 } id ? $"Unnamed_Block_{id}" : "Unnamed_Block";
     }
 
     char[] buffer = baseName.ToCharArray();
@@ -580,7 +767,7 @@ public sealed class RevitFamilyBaker : IDisposable
     if (safeName.Length > 100)
     {
       // Append a short hash of the definition ID to guarantee uniqueness after truncation
-      var shortId = definitionProxy.id?[..8] ?? Guid.NewGuid().ToString("N")[..8];
+      var shortId = fallbackId?[..8] ?? Guid.NewGuid().ToString("N")[..8];
       return $"{safeName[..90]}_{shortId}";
     }
 

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/RevitFamilyBaker.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/RevitFamilyBaker.cs
@@ -404,7 +404,10 @@ public sealed class RevitFamilyBaker : IDisposable
         t.Start();
 
         var materialManager = new FamilyMaterialManager(_materialBaker, _logger);
-        var usedMaterialNodeKeys = members.Where(m => m.materialNodeKey is not null).Select(m => m.materialNodeKey!.Value).Distinct();
+        var usedMaterialNodeKeys = members
+          .Where(m => m.materialNodeKey is not null)
+          .Select(m => m.materialNodeKey!.Value)
+          .Distinct();
         materialManager.SetupFamilyMaterialsFromArtifact(famDoc, usedMaterialNodeKeys, familyMaterialsByNode);
 
         _familyGeometryBaker.BakeFamilyGeometryFromArtifact(famDoc, members, materialManager);
@@ -449,7 +452,12 @@ public sealed class RevitFamilyBaker : IDisposable
   // reference a symbol living in a different document. Doesn't propagate the child's material params onto the
   // parent (a secondary nicety for swapping a nested block's materials from the parent) — the child still renders
   // with whatever materials it baked internally.
-  private void PlaceNestedInstanceFromArtifact(Document famDoc, string childDefinitionKey, Matrix4x4 transform, string units)
+  private void PlaceNestedInstanceFromArtifact(
+    Document famDoc,
+    string childDefinitionKey,
+    Matrix4x4 transform,
+    string units
+  )
   {
     if (!_bakedFamilyPaths.TryGetValue(childDefinitionKey, out var rfaPath) || !File.Exists(rfaPath))
     {
@@ -630,8 +638,7 @@ public sealed class RevitFamilyBaker : IDisposable
     var isMirrored = _familyTransformUtils.GetMirrorState(transform).X;
     var hasScaleOrSkew = _familyTransformUtils.HasScaleOrSkew(transform);
 
-    var cleanMatrix =
-      (hasScaleOrSkew || isMirrored) ? _familyTransformUtils.RemoveScaleAndSkew(transform) : transform;
+    var cleanMatrix = (hasScaleOrSkew || isMirrored) ? _familyTransformUtils.RemoveScaleAndSkew(transform) : transform;
 
     var revitTransform = _transformConverter.Convert((cleanMatrix, units));
     if (referencePointTransform is not null)

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Receive/RevitHostObjectArtefactBuilder.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Receive/RevitHostObjectArtefactBuilder.cs
@@ -6,7 +6,6 @@ using Microsoft.Extensions.Logging;
 using Speckle.Connectors.Common.Builders;
 using Speckle.Connectors.Common.Conversion;
 using Speckle.Connectors.Common.Diagnostics;
-using Speckle.Connectors.Common.Operations;
 using Speckle.Connectors.Common.Threading;
 using Speckle.Connectors.Revit.HostApp;
 using Speckle.Converters.Common;
@@ -15,6 +14,7 @@ using Speckle.Converters.RevitShared;
 using Speckle.Converters.RevitShared.Helpers;
 using Speckle.Converters.RevitShared.Services;
 using Speckle.Converters.RevitShared.Settings;
+using Speckle.DoubleNumerics;
 using Speckle.Objects.Utils;
 using Speckle.Sdk;
 using Speckle.Sdk.Common.Exceptions;
@@ -23,36 +23,30 @@ using Speckle.Sdk.Models;
 using Speckle.Sdk.Pipelines;
 using Speckle.Sdk.Pipelines.Progress;
 using Speckle.Sdk.Pipelines.Receive.Artifacts;
+using RenderMaterial = Speckle.Objects.Other.RenderMaterial;
+using SMesh = Speckle.Objects.Geometry.Mesh;
 
 namespace Speckle.Connectors.Revit.Operations.Receive;
 
 /// <summary>
-/// Bakes a Speckle 4.0 artefact <see cref="ArtefactBundle"/> <b>directly</b> into the Revit document as native
-/// <see cref="DirectShape"/>s — talking only to the neutral dense-int graph + raw Revit API, skipping the v1
-/// <c>RootObjectUnpacker</c> / traversal / per-type converter dispatch. SGEO meshes are tessellated straight into
-/// DirectShape geometry (mirroring <c>MeshConverterToHost</c>); non-mesh SGEO primitives (points, curves, regions,
-/// …) decode to a Speckle geometry object and convert via the shared Revit ToHost geometry converter. Materials are
-/// created directly from MATERIAL nodes, and instances are placed per <c>DISPLAY_INSTANCE</c> edge via the
-/// <see cref="DirectShapeLibrary"/>. The receive-side twin of the send-side <c>RevitArtifactRootObjectBuilder</c> —
-/// except when <c>ReceiveInstancesAsFamilies</c> is on (see remarks).
+/// Bakes a Speckle 4.0 artefact <see cref="ArtefactBundle"/> <b>directly</b> into the Revit document — talking only
+/// to the neutral dense-int graph + raw Revit API, skipping the v1 <c>RootObjectUnpacker</c> / traversal / per-type
+/// converter dispatch. SGEO meshes are tessellated straight into geometry (mirroring <c>MeshConverterToHost</c>);
+/// non-mesh SGEO primitives (points, curves, regions, …) decode to a Speckle geometry object and convert via the
+/// shared Revit ToHost geometry converter. Materials are created directly from MATERIAL nodes. The receive-side
+/// twin of the send-side <c>RevitArtifactRootObjectBuilder</c>.
 /// </summary>
 /// <remarks>
 /// <para><b>Grouping.</b> Revit has no layers; each baked element is stamped with its model marker in the Comments
 /// parameter so a re-receive can collect-and-delete the prior bake cheaply (a deliberate choice to avoid the slow v1
 /// Revit-Group baking). Element category comes from the object's <c>category</c>/<c>builtInCategory</c> property.</para>
-/// <para><b>ReceiveInstancesAsFamilies.</b> The dense-int graph has no notion of families — <see cref="RevitFamilyBaker"/>
-/// needs <c>IInstanceComponent</c>s and a <c>TraversalContext</c> lookup built from a <c>Base</c> graph, so it
-/// can't consume bundle data directly. When the setting is on, this builder instead reconstructs a <c>Base</c> graph
-/// (<see cref="IArtifactReceiver.Reconstruct"/>) and delegates the whole receive to the v1
-/// <see cref="RevitHostObjectBuilder"/> — slower than the direct bake, but the only way to get real families across
-/// all Revit versions.</para>
-/// <para><b>Known limitation (tracked separately, "Revit: Make family receive artifact-native"):</b> the
-/// reconstruction bridge above resolves each object's placement via a last-wins <c>objectK → instanceNodeK</c> map,
-/// not the full edge list, so an object that places <i>several</i> instances (e.g. a Railing → many balusters) only
-/// keeps the last one — the rest are silently dropped from the reconstructed graph, not merely mis-transformed.
-/// Fixing this properly means reworking the bridge (and a matching last-wins lookup in
-/// <see cref="RevitHostObjectBuilder"/> itself) to synthesize a unique id per placement — out of scope here; the
-/// planned fix is to remove this bridge entirely in favour of bundle-native family baking.</para>
+/// <para><b>ReceiveInstancesAsFamilies (ENG-9101).</b> Atomic objects always bake as <see cref="DirectShape"/>s,
+/// regardless of the setting. Only instance/definition handling branches: off bakes <see cref="DirectShape"/>
+/// instances via the <see cref="DirectShapeLibrary"/> (<see cref="BakeInstances"/>); on bakes real Revit families
+/// via <see cref="RevitFamilyBaker"/> (<see cref="BakeInstancesAsFamilies"/>), reading the same
+/// DEFINES/DEFINES_INSTANCE/DISPLAY_INSTANCE edges and the same <see cref="DecodeGeometry"/>-derived geometry
+/// selection. Neither branch reconstructs a <c>Base</c> graph or delegates to the v1
+/// <see cref="RevitHostObjectBuilder"/>.</para>
 /// </remarks>
 public sealed class RevitHostObjectArtefactBuilder : IArtifactHostObjectBuilder
 {
@@ -64,11 +58,11 @@ public sealed class RevitHostObjectArtefactBuilder : IArtifactHostObjectBuilder
   private readonly RevitUtils _revitUtils;
   private readonly ISdkActivityFactory _activityFactory;
   private readonly ILogger<RevitHostObjectArtefactBuilder> _logger;
-  private readonly IArtifactReceiver _artifactReceiver;
-  private readonly IHostObjectBuilder _hostObjectBuilder;
   private readonly RevitGroupBaker _groupBaker;
   private readonly RevitViewBaker _viewBaker;
   private readonly ITypedConverter<Base, List<GeometryObject>> _geometryConverter;
+  private readonly RevitFamilyBaker _familyBaker;
+  private readonly ITypedConverter<SMesh, GeometryObject> _freeformMeshConverter;
 
   // Set by DecodeGeometry when the non-mesh SGEO fallback fails; surfaced by callers as the ERROR reason for an
   // empty geometry result instead of the generic "did not convert to any native geometry" message.
@@ -83,11 +77,11 @@ public sealed class RevitHostObjectArtefactBuilder : IArtifactHostObjectBuilder
     RevitUtils revitUtils,
     ISdkActivityFactory activityFactory,
     ILogger<RevitHostObjectArtefactBuilder> logger,
-    IArtifactReceiver artifactReceiver,
-    IHostObjectBuilder hostObjectBuilder,
     RevitGroupBaker groupBaker,
     RevitViewBaker viewBaker,
-    ITypedConverter<Base, List<GeometryObject>> geometryConverter
+    ITypedConverter<Base, List<GeometryObject>> geometryConverter,
+    RevitFamilyBaker familyBaker,
+    ITypedConverter<SMesh, GeometryObject> freeformMeshConverter
   )
   {
     _converterSettings = converterSettings;
@@ -98,38 +92,22 @@ public sealed class RevitHostObjectArtefactBuilder : IArtifactHostObjectBuilder
     _revitUtils = revitUtils;
     _activityFactory = activityFactory;
     _logger = logger;
-    _artifactReceiver = artifactReceiver;
-    _hostObjectBuilder = hostObjectBuilder;
     _groupBaker = groupBaker;
     _viewBaker = viewBaker;
     _geometryConverter = geometryConverter;
+    _familyBaker = familyBaker;
+    _freeformMeshConverter = freeformMeshConverter;
   }
 
-  public async Task<HostObjectBuilderResult> Build(
+  public Task<HostObjectBuilderResult> Build(
     ArtefactBundle bundle,
     string projectName,
     string modelName,
     IProgress<CardProgress> onOperationProgressed,
     CancellationToken cancellationToken
-  )
-  {
-    if (_converterSettings.Current.ReceiveInstancesAsFamilies)
-    {
-      // No bundle-native family baking yet (see remarks) — reconstruct a Base graph off the main thread (mirrors
-      // ReceiveOperation's own reconstruction branch) and hand the whole receive to the v1 builder.
-      var rootObject = await _threadContext
-        .RunOnWorkerAsync(() => Task.FromResult(_artifactReceiver.Reconstruct(bundle, cancellationToken)))
-        .ConfigureAwait(false);
-      return await _hostObjectBuilder
-        .Build(rootObject, projectName, modelName, onOperationProgressed, cancellationToken)
-        .ConfigureAwait(false);
-    }
-
+  ) =>
     // Revit API is main-thread-affine and mutations require a transaction → everything runs on the main thread.
-    return await _threadContext
-      .RunOnMain(() => BakeAll(bundle, projectName, modelName, onOperationProgressed, cancellationToken))
-      .ConfigureAwait(false);
-  }
+    _threadContext.RunOnMain(() => BakeAll(bundle, projectName, modelName, onOperationProgressed, cancellationToken));
 
   [SuppressMessage("Maintainability", "CA1506:Avoid excessive class coupling")]
   private HostObjectBuilderResult BakeAll(
@@ -233,25 +211,43 @@ public sealed class RevitHostObjectArtefactBuilder : IArtifactHostObjectBuilder
         );
       }
 
-      // 3 — instances: build definitions from DEFINES → geometry, place one per DISPLAY_INSTANCE edge.
+      // 3 — instances: build definitions from DEFINES → geometry, place one per DISPLAY_INSTANCE edge. Only this
+      // step branches on ReceiveInstancesAsFamilies — atomic objects above are unaffected by the setting.
       if (rels.DisplayInstanceEdges.Count > 0)
       {
         onOperationProgressed.Report(new("Converting instances", null));
         using (session.Phase("Instances"))
         {
-          BakeInstances(
-            doc,
-            bundle,
-            rels,
-            materialIdByGeometry,
-            validCategories,
-            categoryCache,
-            marker,
-            bakedObjectIds,
-            conversionResults,
-            session,
-            cancellationToken
-          );
+          if (_converterSettings.Current.ReceiveInstancesAsFamilies)
+          {
+            BakeInstancesAsFamilies(
+              doc,
+              bundle,
+              rels,
+              materialIdByNode,
+              marker,
+              bakedObjectIds,
+              conversionResults,
+              session,
+              cancellationToken
+            );
+          }
+          else
+          {
+            BakeInstances(
+              doc,
+              bundle,
+              rels,
+              materialIdByGeometry,
+              validCategories,
+              categoryCache,
+              marker,
+              bakedObjectIds,
+              conversionResults,
+              session,
+              cancellationToken
+            );
+          }
         }
       }
 
@@ -531,6 +527,335 @@ public sealed class RevitHostObjectArtefactBuilder : IArtifactHostObjectBuilder
         conversionResults.Add(new(Status.ERROR, source, null, null, ex, srcType));
       }
     }
+  }
+
+  // ── instances (as families) ──────────────────────────────────────────────────────────────────────────
+  // ENG-9101: bundle-native counterpart of BakeInstances — same DEFINES/DEFINES_INSTANCE/DISPLAY_INSTANCE
+  // traversal and the same DecodeGeometry-derived geometry selection, but bakes real Revit families via
+  // RevitFamilyBaker instead of DirectShapeLibrary geometry instances. No Base graph, no v1 delegation.
+  // Split into BuildFamilyDefinitions + PlaceFamilyInstances (below) to keep each under the complexity budget.
+  [SuppressMessage("Maintainability", "CA1506:Avoid excessive class coupling")]
+  private void BakeInstancesAsFamilies(
+    Document doc,
+    ArtefactBundle bundle,
+    ArtefactRelations rels,
+    Dictionary<int, ElementId> materialIdByNode,
+    string marker,
+    List<string> bakedObjectIds,
+    HashSet<ReceiveConversionResult> conversionResults,
+    ArtefactSessionLog session,
+    CancellationToken cancellationToken
+  )
+  {
+    var familyMaterialsByNode = BuildFamilyMaterialsByNode(bundle);
+    // definitions built depth-first (memoized here) so a parent can nest an already-baked child.
+    var symbolByDefNode = new Dictionary<int, FamilySymbol>();
+    var defBuilding = new HashSet<int>();
+
+    foreach (var kv in bundle.Nodes)
+    {
+      if (kv.Value.Kind == NodeKind.Definition)
+      {
+        BuildFamilyDefinition(doc, bundle, rels, materialIdByNode, familyMaterialsByNode, kv.Key, symbolByDefNode, defBuilding, session);
+      }
+    }
+
+    PlaceFamilyInstances(doc, bundle, rels, symbolByDefNode, marker, bakedObjectIds, conversionResults, session, cancellationToken);
+  }
+
+  // One DEFINITION node → one real Revit family, built depth-first (a nested block/family's definition must exist
+  // before its parent can place it). Mirrors BakeInstances' local BuildDefinition, extracted to its own method
+  // (rather than a local closure) to keep BakeInstancesAsFamilies' complexity down.
+  [SuppressMessage("Maintainability", "CA1506:Avoid excessive class coupling")]
+  private FamilySymbol? BuildFamilyDefinition(
+    Document doc,
+    ArtefactBundle bundle,
+    ArtefactRelations rels,
+    Dictionary<int, ElementId> materialIdByNode,
+    Dictionary<int, RenderMaterial> familyMaterialsByNode,
+    int defNodeK,
+    Dictionary<int, FamilySymbol> symbolByDefNode,
+    HashSet<int> defBuilding,
+    ArtefactSessionLog session
+  )
+  {
+    if (symbolByDefNode.TryGetValue(defNodeK, out var already))
+    {
+      return already;
+    }
+    if (!bundle.Nodes.TryGetValue(defNodeK, out var defNode) || defNode.Kind != NodeKind.Definition)
+    {
+      return null;
+    }
+    if (!defBuilding.Add(defNodeK))
+    {
+      return null; // cycle guard — never stack-overflow on a bad bundle
+    }
+    session.Increment("definitionsSeen");
+
+    var docUnits = _converterSettings.Current.SpeckleUnits;
+
+    // direct geometry members (DEFINES → geometry). Definition/local-space — no reference-point re-basing here;
+    // it's applied once, to the outer instance placement, in PlaceFamilyInstances [ENG-9099].
+    var members = new List<(GeometryObject geometry, int? materialNodeKey)>();
+    _lastDecodeFailure = null;
+    if (rels.DefinesByDefinition.TryGetValue(defNodeK, out var geomKs))
+    {
+      foreach (var geomK in geomKs)
+      {
+        int? matNodeK = rels.MaterialByGeometry.TryGetValue(geomK, out var mk) ? mk : null;
+        foreach (var geom in DecodeFamilyGeometry(bundle, geomK))
+        {
+          members.Add((geom, matNodeK));
+        }
+      }
+    }
+    var directGeometryFailure = _lastDecodeFailure;
+
+    // nested block/family members (DEFINES_INSTANCE → INSTANCE node): build the child definition first
+    // (depth-first), then place it as a nested family instance inside this definition's family document.
+    var nestedPlacements = new List<(string childDefinitionKey, Matrix4x4 transform, string units)>();
+    if (rels.DefinesInstanceByDefinition.TryGetValue(defNodeK, out var nestedInstNodeKs))
+    {
+      foreach (var instNodeK in nestedInstNodeKs)
+      {
+        if (!bundle.Nodes.TryGetValue(instNodeK, out var nestedInst) || nestedInst.DefRef is not int childDefNodeK)
+        {
+          continue;
+        }
+        if (
+          BuildFamilyDefinition(doc, bundle, rels, materialIdByNode, familyMaterialsByNode, childDefNodeK, symbolByDefNode, defBuilding, session)
+          is null
+        )
+        {
+          session.Increment("nestedInstancesUnresolved");
+          continue;
+        }
+        nestedPlacements.Add(
+          (
+            DefinitionKey(childDefNodeK),
+            ParseInstanceMatrix(nestedInst.Transform),
+            nestedInst.Units is { Length: > 0 } u ? u : docUnits
+          )
+        );
+        session.Increment("nestedInstancesPlaced");
+      }
+    }
+
+    defBuilding.Remove(defNodeK);
+
+    if (members.Count == 0 && nestedPlacements.Count == 0)
+    {
+      session.Increment("definitionsEmpty");
+      if (directGeometryFailure is not null)
+      {
+        _logger.LogWarning("Definition {DefNodeK} built with no geometry: {Reason}", defNodeK, directGeometryFailure);
+      }
+      return null;
+    }
+
+    var result = _familyBaker.BakeDefinitionFromArtifact(
+      doc,
+      DefinitionKey(defNodeK),
+      defNode.Name,
+      ResolveDefinitionCategory(bundle, rels, defNodeK),
+      members,
+      familyMaterialsByNode,
+      materialIdByNode,
+      nestedPlacements
+    );
+    if (result is null)
+    {
+      return null;
+    }
+    symbolByDefNode[defNodeK] = result.Value.symbol;
+    return result.Value.symbol;
+  }
+
+  // One FamilyInstance per DISPLAY_INSTANCE edge (object → INSTANCE node); an object may place several.
+  [SuppressMessage("Maintainability", "CA1506:Avoid excessive class coupling")]
+  private void PlaceFamilyInstances(
+    Document doc,
+    ArtefactBundle bundle,
+    ArtefactRelations rels,
+    Dictionary<int, FamilySymbol> symbolByDefNode,
+    string marker,
+    List<string> bakedObjectIds,
+    HashSet<ReceiveConversionResult> conversionResults,
+    ArtefactSessionLog session,
+    CancellationToken cancellationToken
+  )
+  {
+    var docUnits = _converterSettings.Current.SpeckleUnits;
+    foreach (var edge in rels.DisplayInstanceEdges)
+    {
+      cancellationToken.ThrowIfCancellationRequested();
+      session.Increment("placementsAttempted");
+      int objK = edge.Src;
+      int instNodeK = edge.Dst;
+      if (
+        !bundle.Nodes.TryGetValue(instNodeK, out var instNode) || !bundle.ObjectAppIds.TryGetValue(objK, out var appId)
+      )
+      {
+        continue;
+      }
+      bundle.Properties.TryGetValue(objK, out var props);
+      var source = Source(appId);
+      var srcType = SrcType(props);
+      var sw = Stopwatch.StartNew();
+      if (instNode.DefRef is not int defNodeK || !symbolByDefNode.TryGetValue(defNodeK, out var symbol))
+      {
+        session.RecordObject(
+          appId,
+          srcType,
+          Status.ERROR,
+          "references a definition with no geometry",
+          sw.ElapsedMilliseconds
+        );
+        conversionResults.Add(
+          new(
+            Status.ERROR,
+            source,
+            null,
+            null,
+            new ConversionException("Instance references a definition with no geometry"),
+            srcType
+          )
+        );
+        continue;
+      }
+
+      try
+      {
+        var transform = ParseInstanceMatrix(instNode.Transform);
+        var units = instNode.Units is { Length: > 0 } u ? u : docUnits;
+        var instance =
+          _familyBaker.PlaceInstanceFromArtifact(
+            doc,
+            symbol,
+            transform,
+            units,
+            _converterSettings.Current.ReferencePointTransform
+          ) ?? throw new ConversionException("Failed to place family instance");
+        StampMarker(instance, marker);
+
+        bakedObjectIds.Add(instance.UniqueId);
+        conversionResults.Add(new(Status.SUCCESS, source, instance.UniqueId, "FamilyInstance", null, srcType));
+        session.RecordObject(appId, srcType, Status.SUCCESS, null, sw.ElapsedMilliseconds);
+      }
+      catch (Exception ex) when (!ex.IsFatal())
+      {
+        session.RecordObject(appId, srcType, Status.ERROR, ex.Message, sw.ElapsedMilliseconds);
+        conversionResults.Add(new(Status.ERROR, source, null, null, ex, srcType));
+      }
+    }
+  }
+
+  private static string DefinitionKey(int defNodeK) =>
+    $"artifact-def-{defNodeK.ToString(CultureInfo.InvariantCulture)}";
+
+  // Family-local placeholder materials, one per MATERIAL node — baked into each temp family document during
+  // authoring, then overwritten with the real project material (materialIdByNode) once the family is loaded.
+  private static Dictionary<int, RenderMaterial> BuildFamilyMaterialsByNode(ArtefactBundle bundle)
+  {
+    var map = new Dictionary<int, RenderMaterial>();
+    foreach (var kv in bundle.Nodes)
+    {
+      if (kv.Value.Kind != NodeKind.Material)
+      {
+        continue;
+      }
+      var n = kv.Value;
+      var key = kv.Key.ToString(CultureInfo.InvariantCulture);
+      map[kv.Key] = new RenderMaterial
+      {
+        name = n.Name ?? $"material-{key}",
+        diffuse = n.Argb ?? unchecked((int)0xFFFFFFFF),
+        opacity = n.Opacity ?? 1.0,
+        metalness = n.Metalness ?? 0.0,
+        roughness = n.Roughness ?? 1.0,
+        applicationId = $"mat-{key}",
+      };
+    }
+    return map;
+  }
+
+  // The first object that places this definition determines its Revit category — mirrors ResolveCategory's
+  // prop-reading convention. Kept separate because FamilyCategoryUtils needs the raw builtInCategory string up
+  // front (before the family document exists), not a resolved ElementId.
+  private static string? ResolveDefinitionCategory(ArtefactBundle bundle, ArtefactRelations rels, int defNodeK)
+  {
+    foreach (var edge in rels.DisplayInstanceEdges)
+    {
+      if (!bundle.Nodes.TryGetValue(edge.Dst, out var instNode) || instNode.DefRef != defNodeK)
+      {
+        continue;
+      }
+      bundle.Properties.TryGetValue(edge.Src, out var props);
+      return PropString(props, "builtInCategory") ?? PropString(props, "category");
+    }
+    return null;
+  }
+
+  // Family geometry needs a Solid for FreeFormElement, unlike BakeAtomic/BakeInstances' Mesh-targeted BuildMesh —
+  // reuses the same freeform mesh converter the v1 family pipeline already relies on for that. Always local space
+  // (no applyReferencePoint — a definition's own shape never gets the outer reference-point correction).
+  private List<GeometryObject> DecodeFamilyGeometry(ArtefactBundle bundle, int geomK)
+  {
+    if (!bundle.Geometries.TryGetValue(geomK, out var g) || !g.IsSgeo)
+    {
+      return [];
+    }
+    if (SgeoDecoder.TryDecodeMesh(g.Content, out var sm))
+    {
+      try
+      {
+        var mesh = new SMesh { vertices = sm.Vertices.ToList(), faces = sm.Faces.ToList(), units = sm.Units };
+        return [_freeformMeshConverter.Convert(mesh)];
+      }
+      catch (Exception ex) when (!ex.IsFatal())
+      {
+        _lastDecodeFailure = $"geom {geomK} (SGEO mesh) freeform convert failed — {ex.GetType().Name}: {ex.Message}";
+        return [];
+      }
+    }
+
+    Base? decoded = null;
+    try
+    {
+      decoded = SgeoDecoder.Decode(g.Content);
+      using var referencePointSuppression = _converterSettings.Push(s => s with { ReferencePointTransform = null });
+      return _geometryConverter.Convert(decoded);
+    }
+    catch (Exception ex) when (!ex.IsFatal())
+    {
+      string stage = decoded is null ? "decode" : $"convert of {decoded.speckle_type}";
+      _lastDecodeFailure = $"geom {geomK} ({g.Type}) {stage} failed — {ex.GetType().Name}: {ex.Message}";
+      return [];
+    }
+  }
+
+  private static Matrix4x4 ParseInstanceMatrix(string? csv)
+  {
+    var d = ParseMatrix(csv);
+    return new Matrix4x4(
+      d[0],
+      d[1],
+      d[2],
+      d[3],
+      d[4],
+      d[5],
+      d[6],
+      d[7],
+      d[8],
+      d[9],
+      d[10],
+      d[11],
+      d[12],
+      d[13],
+      d[14],
+      d[15]
+    );
   }
 
   // ── camera views ──────────────────────────────────────────────────────────────────────────────────────
@@ -1017,34 +1342,41 @@ public sealed class RevitHostObjectArtefactBuilder : IArtifactHostObjectBuilder
   private void PreClean(Document doc, string marker)
   {
     DirectShapeLibrary.GetDirectShapeLibrary(doc).Reset();
-    // A previous receive of this model may have gone through the family-baking fallback (setting was on) and left a
-    // pinned top-level Group of real families — not tracked by the Comments marker below, so purge it here too.
+    // A previous receive of this model may predate ENG-9101, when the family setting delegated the whole receive to
+    // the v1 builder and left a pinned top-level Group of real families — not tracked by the Comments marker below.
     _groupBaker.PurgeGroups(marker);
     // Same marker convention, but View3D isn't a DirectShape, so it's not covered by the collector loop below either.
     _viewBaker.PurgeArtefactViews(marker);
     var toDelete = new List<ElementId>();
-    using (var collector = new FilteredElementCollector(doc))
-    {
-      foreach (var element in collector.OfClass(typeof(DirectShape)))
-      {
-        if (
-          element.get_Parameter(BuiltInParameter.ALL_MODEL_INSTANCE_COMMENTS)?.AsString() is string c
-          && string.Equals(c, marker, StringComparison.Ordinal)
-        )
-        {
-          toDelete.Add(element.Id);
-        }
-      }
-    }
+    // DirectShape (BakeAtomic/BakeInstances) and FamilyInstance (BakeInstancesAsFamilies) both stamp the same
+    // Comments marker, so cleaning up both covers whichever setting the prior receive used.
+    CollectMarked(doc, typeof(DirectShape), marker, toDelete);
+    CollectMarked(doc, typeof(FamilyInstance), marker, toDelete);
     if (toDelete.Count > 0)
     {
       doc.Delete(toDelete);
     }
   }
 
+  private static void CollectMarked(Document doc, Type elementClass, string marker, List<ElementId> toDelete)
+  {
+    using var collector = new FilteredElementCollector(doc);
+    foreach (var element in collector.OfClass(elementClass))
+    {
+      if (
+        element.get_Parameter(BuiltInParameter.ALL_MODEL_INSTANCE_COMMENTS)?.AsString() is string c
+        && string.Equals(c, marker, StringComparison.Ordinal)
+      )
+      {
+        toDelete.Add(element.Id);
+      }
+    }
+  }
+
   // ── helpers ───────────────────────────────────────────────────────────────────────────────────────────
-  private static void StampMarker(DirectShape ds, string marker) =>
-    ds.get_Parameter(BuiltInParameter.ALL_MODEL_INSTANCE_COMMENTS)?.Set(marker);
+  // Element, not DirectShape, so the same stamp works for FamilyInstances baked by BakeInstancesAsFamilies.
+  private static void StampMarker(Element element, string marker) =>
+    element.get_Parameter(BuiltInParameter.ALL_MODEL_INSTANCE_COMMENTS)?.Set(marker);
 
   private void SetNameSafe(DirectShape ds, string? name)
   {

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Receive/RevitHostObjectArtefactBuilder.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Receive/RevitHostObjectArtefactBuilder.cs
@@ -556,11 +556,31 @@ public sealed class RevitHostObjectArtefactBuilder : IArtifactHostObjectBuilder
     {
       if (kv.Value.Kind == NodeKind.Definition)
       {
-        BuildFamilyDefinition(doc, bundle, rels, materialIdByNode, familyMaterialsByNode, kv.Key, symbolByDefNode, defBuilding, session);
+        BuildFamilyDefinition(
+          doc,
+          bundle,
+          rels,
+          materialIdByNode,
+          familyMaterialsByNode,
+          kv.Key,
+          symbolByDefNode,
+          defBuilding,
+          session
+        );
       }
     }
 
-    PlaceFamilyInstances(doc, bundle, rels, symbolByDefNode, marker, bakedObjectIds, conversionResults, session, cancellationToken);
+    PlaceFamilyInstances(
+      doc,
+      bundle,
+      rels,
+      symbolByDefNode,
+      marker,
+      bakedObjectIds,
+      conversionResults,
+      session,
+      cancellationToken
+    );
   }
 
   // One DEFINITION node → one real Revit family, built depth-first (a nested block/family's definition must exist
@@ -624,7 +644,17 @@ public sealed class RevitHostObjectArtefactBuilder : IArtifactHostObjectBuilder
           continue;
         }
         if (
-          BuildFamilyDefinition(doc, bundle, rels, materialIdByNode, familyMaterialsByNode, childDefNodeK, symbolByDefNode, defBuilding, session)
+          BuildFamilyDefinition(
+            doc,
+            bundle,
+            rels,
+            materialIdByNode,
+            familyMaterialsByNode,
+            childDefNodeK,
+            symbolByDefNode,
+            defBuilding,
+            session
+          )
           is null
         )
         {
@@ -810,7 +840,12 @@ public sealed class RevitHostObjectArtefactBuilder : IArtifactHostObjectBuilder
     {
       try
       {
-        var mesh = new SMesh { vertices = sm.Vertices.ToList(), faces = sm.Faces.ToList(), units = sm.Units };
+        var mesh = new SMesh
+        {
+          vertices = sm.Vertices.ToList(),
+          faces = sm.Faces.ToList(),
+          units = sm.Units,
+        };
         return [_freeformMeshConverter.Convert(mesh)];
       }
       catch (Exception ex) when (!ex.IsFatal())

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/RevitArtifactRootObjectBuilder.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/RevitArtifactRootObjectBuilder.cs
@@ -194,7 +194,7 @@ public class RevitArtifactRootObjectBuilder(
     }
 
     ZstdNativeLoader.Ensure(logger); // net48: ensure the parquet Zstd native is loaded (no-op on net8+)
-    using var pipeline = new ObjectsArtifactPipeline(outputDir, versionId, producedBy: speckleApplication.Slug);
+    using var pipeline = new ObjectsArtifactPipeline(outputDir, versionId, speckleApplication);
 
     // element.UniqueId -> the object K(s) it was interned as. A linked element placed by N link instances
     // yields N interned objects (disambiguated by transform hash), so the value is a list. Used to resolve


### PR DESCRIPTION
## Description

When "Receive instances as families" was on, Revit's artifact receive reconstructed the legacy `Base` graph and delegated to the v1 `RevitHostObjectBuilder`, bypassing the artifact-native path and making receive behavior depend on the setting. That reconstruction bridge also dropped repeated instance placements (last-wins lookup instead of the full edge list).

Family receive is now fully artifact-native: atomic objects always bake as `DirectShape`s; only instance/definition handling branches, and the "on" path now bakes real Revit families directly from the bundle, sharing the same geometry-decode/selection rules as `DirectShape` receive. Every `DISPLAY_INSTANCE` edge is placed, so repeated and nested placements survive.

## Changes:

**speckle-sharp-connectors:**
- `RevitHostObjectArtefactBuilder.cs`: removed the reconstruct-and-delegate branch; added bundle-native family/instance baking (`BuildFamilyDefinition`, `PlaceFamilyInstances`); pre-clean now also tracks `FamilyInstance`s from prior receives.
- `RevitFamilyBaker.cs`, `FamilyGeometryBaker.cs`, `FamilyMaterialManager.cs`: bundle-native counterparts to the existing Base-graph family/geometry/material methods, sharing the underlying Revit-API mechanics.
- `RevitArtifactRootObjectBuilder.cs`: unrelated one-line fix for the `ObjectsArtifactPipeline` constructor mismatch.

**speckle-sharp-sdk:**
- `ObjectsArtifactReader.cs`: fixed the last-wins `DisplayInstanceByObject` lookup to iterate the full `DisplayInstanceEdges` list, preserving repeated placements.

## To-do before merge:

- [ ] Merge SDK PR 

## Screenshots:

- Receiving instances as families (published as shared coordinates to check translation and rotation transforms for `SharedCoordinates`)
- Received rhino objects too

<img width="1920" height="1049" alt="image" src="https://github.com/user-attachments/assets/db908deb-7ace-4fab-be7b-93b52806fc96" />

## Checklist:
- [x] My commits are related to the pull request and do not amend unrelated code or documentation. *(one drive-by exception — see Description)*
- [x] I have added appropriate tests.
- [x] I have updated or added relevant documentation. *(inline/XML doc comments only)*