### PR TITLE
fix(autocad): three artefact round-trip gaps (ENG-9116, ENG-9117, ENG-9118)

### DIFF
--- a/Connectors/Autocad/Speckle.Connectors.AutocadShared/HostApp/AutocadColorSemanticKeys.cs
+++ b/Connectors/Autocad/Speckle.Connectors.AutocadShared/HostApp/AutocadColorSemanticKeys.cs
@@ -1,0 +1,17 @@
+namespace Speckle.Connectors.Autocad.HostApp;
+
+/// <summary>
+/// Object-property keys carrying the AutoCAD colour semantics an artefact COLOR node cannot express — it stores a
+/// plain ARGB, so an AutoCAD→AutoCAD round trip flattened every ACI colour to truecolor and every explicit ByBlock
+/// to a fixed value [ENG-9117]. The send builder writes these alongside the ARGB edge (so the viewer and non-AutoCAD
+/// consumers are unaffected); the receive builder prefers them when rebuilding the entity colour.
+/// </summary>
+internal static class AutocadColorSemanticKeys
+{
+  /// <summary><c>"aci"</c> (an AutoCAD Color Index colour, index in <see cref="Index"/>) or <c>"block"</c> (the
+  /// entity was explicitly set to ByBlock). Absent for a plain truecolor object, whose ARGB is already lossless.</summary>
+  public const string SOURCE = "autocadColorSource";
+
+  /// <summary>The original AutoCAD Color Index (0..256), present only when <see cref="SOURCE"/> is <c>"aci"</c>.</summary>
+  public const string INDEX = "autocadColorIndex";
+}

--- a/Connectors/Autocad/Speckle.Connectors.AutocadShared/Operations/Receive/AutocadHostObjectArtefactBuilder.cs
+++ b/Connectors/Autocad/Speckle.Connectors.AutocadShared/Operations/Receive/AutocadHostObjectArtefactBuilder.cs
@@ -206,6 +206,8 @@ public class AutocadHostObjectArtefactBuilder : IArtifactHostObjectBuilder
           }
           materialIdByObject.TryGetValue(appId, out ObjectId objMaterial);
           bool hasObjColor = colorArgbByObject.TryGetValue(appId, out int objArgb);
+          // ACI index / explicit ByBlock, when the sender recorded them — they outrank the flattened ARGB [ENG-9117].
+          AcadColor? nativeColor = NativeColorFromProperties(props);
 
           // (ObjectId, handle) per baked entity: the ObjectId drives native grouping below, while the model card and
           // the conversion report identify entities by their HANDLE — see the note on bakedObjectIds [ENG-8833].
@@ -239,7 +241,11 @@ public class AutocadHostObjectArtefactBuilder : IArtifactHostObjectBuilder
                   {
                     entity.MaterialId = materialId;
                   }
-                  if (argb is int a)
+                  if (nativeColor is AcadColor native)
+                  {
+                    entity.Color = native;
+                  }
+                  else if (argb is int a)
                   {
                     entity.Color = ToAcadColor(a);
                   }
@@ -1011,7 +1017,11 @@ public class AutocadHostObjectArtefactBuilder : IArtifactHostObjectBuilder
         {
           blockRef.MaterialId = objMaterial;
         }
-        if (colorArgbByObject.TryGetValue(appId, out int objArgb))
+        if (NativeColorFromProperties(props) is AcadColor nativeColor)
+        {
+          blockRef.Color = nativeColor; // ACI / explicit ByBlock recorded by the sender [ENG-9117]
+        }
+        else if (colorArgbByObject.TryGetValue(appId, out int objArgb))
         {
           blockRef.Color = ToAcadColor(objArgb); // ByBlock members pick this up from the reference
         }
@@ -1332,6 +1342,64 @@ public class AutocadHostObjectArtefactBuilder : IArtifactHostObjectBuilder
   {
     var c = System.Drawing.Color.FromArgb(argb);
     return AcadColor.FromRgb(c.R, c.G, c.B);
+  }
+
+  /// <summary>The AutoCAD colour METHOD, when the sender recorded it as object properties — the ARGB-only COLOR
+  /// node cannot express either. An ACI colour comes back as <see cref="ColorMethod.ByAci"/> with its original
+  /// index (so CTB plot styles, standards checks and index-reading scripts keep working), and an explicitly
+  /// ByBlock entity comes back inheriting rather than pinned to a fixed RGB [ENG-9117]. A bundle from any other
+  /// host (or an older AutoCAD send) carries neither key, and the caller falls back to the ARGB edge.</summary>
+  private static AcadColor? NativeColorFromProperties(Dictionary<string, object?>? props)
+  {
+    if (
+      props is null
+      || !props.TryGetValue(AutocadColorSemanticKeys.SOURCE, out var source)
+      || source is not string src
+    )
+    {
+      return null;
+    }
+    if (src == "block")
+    {
+      return AcadColor.FromColorIndex(ColorMethod.ByBlock, 0);
+    }
+    // ACI is a 0..256 index (0 = ByBlock, 256 = ByLayer); anything else is not an index we can restore.
+    if (
+      src == "aci"
+      && props.TryGetValue(AutocadColorSemanticKeys.INDEX, out var raw)
+      && TryReadInt(raw, out int aci)
+      && aci is >= 0 and <= 256
+    )
+    {
+      return AcadColor.FromColorIndex(ColorMethod.ByAci, (short)aci);
+    }
+    return null;
+  }
+
+  // eav round-trips a numeric scalar as whichever width the parquet column landed on, so accept the lot.
+  private static bool TryReadInt(object? value, out int result)
+  {
+    switch (value)
+    {
+      case int i:
+        result = i;
+        return true;
+      case long l:
+        result = (int)l;
+        return true;
+      case short s:
+        result = s;
+        return true;
+      case double d:
+        result = (int)d;
+        return true;
+      case string text when int.TryParse(text, NumberStyles.Integer, CultureInfo.InvariantCulture, out int parsed):
+        result = parsed;
+        return true;
+      default:
+        result = 0;
+        return false;
+    }
   }
 
   // ── helpers ───────────────────────────────────────────────────────────────────────────────────────────

--- a/Connectors/Autocad/Speckle.Connectors.AutocadShared/Operations/Send/AutocadArtifactRootObjectBuilder.cs
+++ b/Connectors/Autocad/Speckle.Connectors.AutocadShared/Operations/Send/AutocadArtifactRootObjectBuilder.cs
@@ -184,10 +184,12 @@ public class AutocadArtifactRootObjectBuilder(
       throw new SpeckleException("Failed to convert all objects.");
     }
 
-    // Materials/colors are keyed by name and list OBJECT ids (resolved to geometry K(s) in phase 2). Only explicit
-    // object-level sources are emitted (the unpacker skips ByLayer) — layer colours ride the layer COLLECTION nodes'
-    // argb instead (mirrors Rhino), so ByLayer objects inherit the restored layer colour on receive with no edge.
-    var materials = materialUnpacker.UnpackMaterials(atomicObjects, new List<LayerTableRecord>());
+    // Materials/colors are keyed by name and list OBJECT ids (resolved to geometry K(s) in phase 2). Colours: only
+    // explicit object-level sources are emitted (the unpacker skips ByLayer) — layer colours ride the layer
+    // COLLECTION nodes' argb instead (mirrors Rhino), so ByLayer objects inherit the restored layer colour on
+    // receive with no edge. Materials have no such container channel, so the layer stage IS unpacked and its
+    // proxies are resolved onto the inheriting objects' geometry in phase 2 [ENG-9118].
+    var (materials, layerMaterialInheritors) = UnpackMaterialsWithLayers(atomicObjects);
     var colors = colorUnpacker.UnpackColors(atomicObjects, new List<LayerTableRecord>());
     var layerArgbByName = CollectLayerColors(atomicObjects);
 
@@ -202,9 +204,75 @@ public class AutocadArtifactRootObjectBuilder(
       layerArgbByName,
       instanceDefinitionProxies,
       groups,
+      layerMaterialInheritors,
       results
     );
   }
+
+  // Unpacks render materials INCLUDING the layer stage, and records which objects inherit a layer's material.
+  //
+  // An entity whose material is ByLayer gets no object-level proxy (the unpacker's object stage skips it by design);
+  // its material rides the proxy the LAYER stage builds, which lists the LAYER id — and a layer id resolves to no
+  // geometry in phase 2, so the inherited material was dropped from the bundle entirely and the object drew with the
+  // default material [ENG-9118]. Recording object → the id of the layer whose material it inherits lets phase 2 land
+  // HAS_MATERIAL on the object's own geometry instead. The inheritance is only recorded when the layer actually
+  // carries a (non-default) material — the same condition the unpacker's layer stage uses to build the proxy — so
+  // every recorded object is guaranteed to resolve to a MATERIAL node.
+  //
+  // AutoCAD-API-bound (transaction) → phase 1 only. The layer records must stay OPEN across the UnpackMaterials call,
+  // hence the single transaction wrapping both.
+  private (
+    List<RenderMaterialProxy> Materials,
+    Dictionary<string, string> LayerMaterialInheritors
+  ) UnpackMaterialsWithLayers(List<AutocadRootObject> atomicObjects)
+  {
+    var inheritors = new Dictionary<string, string>(StringComparer.Ordinal);
+    var usedLayers = new List<LayerTableRecord>();
+    try
+    {
+      var db = converterSettings.Current.Document.Database;
+      using var tr = db.TransactionManager.StartTransaction();
+      var layerTable = (LayerTable)tr.GetObject(db.LayerTableId, OpenMode.ForRead);
+      var recordsByName = new Dictionary<string, LayerTableRecord>(StringComparer.Ordinal);
+
+      foreach (var (entity, applicationId) in atomicObjects)
+      {
+        string layerName = entity.Layer;
+        if (!recordsByName.TryGetValue(layerName, out LayerTableRecord? record))
+        {
+          if (!layerTable.Has(layerName))
+          {
+            continue;
+          }
+          record = (LayerTableRecord)tr.GetObject(layerTable[layerName], OpenMode.ForRead);
+          recordsByName[layerName] = record;
+          usedLayers.Add(record);
+        }
+
+        if (entity.Material == "ByLayer" && LayerHasRenderMaterial(record, tr))
+        {
+          inheritors[applicationId] = record.GetSpeckleApplicationId();
+        }
+      }
+
+      var unpacked = materialUnpacker.UnpackMaterials(atomicObjects, usedLayers);
+      tr.Commit();
+      return (unpacked, inheritors);
+    }
+    catch (Exception ex) when (!ex.IsFatal())
+    {
+      logger.LogError(ex, "Failed to unpack layer render materials for the artefact bundle");
+      // Object-level materials must still make it into the bundle even if the layer pass fell over.
+      return (materialUnpacker.UnpackMaterials(atomicObjects, new List<LayerTableRecord>()), inheritors);
+    }
+  }
+
+  // True when the layer itself carries a render material worth sending — mirrors the skip the material unpacker's
+  // layer stage applies ("Global" is AutoCAD's default material, present on every layer) [ENG-9118].
+  private static bool LayerHasRenderMaterial(LayerTableRecord layer, Transaction tr) =>
+    !layer.MaterialId.IsNull
+    && tr.GetObject(layer.MaterialId, OpenMode.ForRead) is Material material
+    && material.Name != "Global";
 
   // AutoCAD groups → plain snapshot records. Membership rides persistent reactors on each entity (a Group is a
   // reactor on its members); AutoCAD groups don't nest, so each membership is one flat IN_GROUP edge.
@@ -721,7 +789,7 @@ public class AutocadArtifactRootObjectBuilder(
 
   // Definition members (DEFINES / DEFINES_INSTANCE) → render materials (HAS_MATERIAL) → object colors (HAS_COLOR).
   // Order matters: all referenced meshes/instances must exist (added in the object loop) before the edges resolve them.
-  private static void EmitValueNodes(
+  private void EmitValueNodes(
     ObjectsArtifactPipeline pipeline,
     CollectedModel model,
     Dictionary<string, List<int>> geometryKsByObjectId,
@@ -753,6 +821,18 @@ public class AutocadArtifactRootObjectBuilder(
     }
 
     // 2) render materials → HAS_MATERIAL (geometry → material node). Material proxies list OBJECT ids.
+    // A LAYER-sourced proxy lists a LAYER id instead, which owns no geometry — invert the object → layer map so
+    // those land on the geometry of every object inheriting that layer's material (ByLayer) [ENG-9118].
+    var inheritorsByLayerId = new Dictionary<string, List<string>>(StringComparer.Ordinal);
+    foreach (var kv in model.LayerMaterialInheritors)
+    {
+      if (!inheritorsByLayerId.TryGetValue(kv.Value, out var forLayer))
+      {
+        inheritorsByLayerId[kv.Value] = forLayer = new List<string>();
+      }
+      forLayer.Add(kv.Key);
+    }
+
     foreach (var materialProxy in model.Materials)
     {
       var value = materialProxy.value;
@@ -774,6 +854,39 @@ public class AutocadArtifactRootObjectBuilder(
           {
             pipeline.HasMaterial(gK, matK);
           }
+        }
+        else if (inheritorsByLayerId.TryGetValue(objectId, out var inheritors))
+        {
+          // layer-sourced: the layer owns no geometry, so the inherited material lands on each object that draws
+          // with it — block-definition members included, since their geometry Ks are registered too.
+          foreach (var inheritorId in inheritors)
+          {
+            if (geometryKsByObjectId.TryGetValue(inheritorId, out var inheritorGKs))
+            {
+              foreach (var gK in inheritorGKs)
+              {
+                pipeline.HasMaterial(gK, matK);
+              }
+            }
+            else
+            {
+              // A block INSTANCE inheriting from its layer: it owns no geometry, and an object-sourced
+              // HAS_MATERIAL needs the namespace tag HAS_COLOR got in ENG-8822 — tracked as ENG-9119.
+              logger.LogWarning(
+                "Layer material '{Material}' not applied to {AppId}: the object owns no geometry to carry it",
+                materialProxy.value.name,
+                inheritorId
+              );
+            }
+          }
+        }
+        else
+        {
+          logger.LogWarning(
+            "Render material '{Material}' lists {AppId}, which resolved to no geometry — the material is not in the bundle for it",
+            materialProxy.value.name,
+            objectId
+          );
         }
       }
     }
@@ -921,6 +1034,8 @@ public class AutocadArtifactRootObjectBuilder(
     IReadOnlyDictionary<string, int> LayerArgbByName,
     IReadOnlyList<InstanceDefinitionProxy> Definitions,
     IReadOnlyList<CollectedGroup> Groups,
+    // object id → the id of the layer whose render material it inherits (ByLayer material only) [ENG-9118]
+    IReadOnlyDictionary<string, string> LayerMaterialInheritors,
     IReadOnlyList<SendConversionResult> Results
   );
 

--- a/Connectors/Autocad/Speckle.Connectors.AutocadShared/Operations/Send/AutocadArtifactRootObjectBuilder.cs
+++ b/Connectors/Autocad/Speckle.Connectors.AutocadShared/Operations/Send/AutocadArtifactRootObjectBuilder.cs
@@ -422,6 +422,9 @@ public class AutocadArtifactRootObjectBuilder(
     // (via a placed instance's transform). They get NO standalone top-level render edges — suppressed in EmitObject.
     var definitionMemberIds = model.Definitions.SelectMany(d => d.objects).ToHashSet(StringComparer.Ordinal);
 
+    // AutoCAD colour SEMANTICS the ARGB-only COLOR node cannot carry [ENG-9117] — see CollectColorSemantics.
+    var colorSemantics = CollectColorSemantics(model.Colors);
+
     // The Collect-phase results are provisional: the write phase can still drop an object's entire geometry
     // (SGEO-unencodable types). Amend those to ERROR so the report card matches the bundle contents [ENG-8826].
     var results = model.Results.ToList();
@@ -449,7 +452,8 @@ public class AutocadArtifactRootObjectBuilder(
         geometryKsByObjectId,
         instanceKByObjectId,
         definitionMemberIds,
-        memberLayerArgb
+        memberLayerArgb,
+        colorSemantics.TryGetValue(co.ApplicationId, out var semantics) ? semantics : null
       );
       if (dropReason is not null && resultIndexByAppId.TryGetValue(co.ApplicationId, out int ri))
       {
@@ -500,7 +504,8 @@ public class AutocadArtifactRootObjectBuilder(
     Dictionary<string, List<int>> geometryKsByObjectId,
     Dictionary<string, int> instanceKByObjectId,
     HashSet<string> definitionMemberIds,
-    int? memberLayerArgb
+    int? memberLayerArgb,
+    ColorSemantics? colorSemantics
   )
   {
     // A block-definition member renders ONLY through its definition (via a placed instance's transform), so it gets
@@ -516,7 +521,7 @@ public class AutocadArtifactRootObjectBuilder(
     pipeline.AddProperties(
       co.ApplicationId,
       co.Properties,
-      RootScalars(co.Converted.speckle_type, ObjectName(co), units, co.SourceType)
+      RootScalars(co.Converted.speckle_type, ObjectName(co), units, co.SourceType, colorSemantics)
     );
 
     // ── block instance: object → INSTANCE node (transform + definition) via DISPLAY_INSTANCE ──────────
@@ -982,15 +987,58 @@ public class AutocadArtifactRootObjectBuilder(
     string speckleType,
     string name,
     string units,
-    string sourceType
-  ) =>
-    new KeyValuePair<string, object?>[]
+    string sourceType,
+    ColorSemantics? colorSemantics = null
+  )
+  {
+    var scalars = new List<KeyValuePair<string, object?>>(6)
     {
       new("speckle_type", speckleType),
       new("name", name),
       new("units", units),
       new("type", sourceType),
     };
+    if (colorSemantics is { } cs)
+    {
+      scalars.Add(new(AutocadColorSemanticKeys.SOURCE, cs.ByBlock ? "block" : "aci"));
+      if (cs.Aci is int aci)
+      {
+        scalars.Add(new(AutocadColorSemanticKeys.INDEX, aci));
+      }
+    }
+    return scalars.ToArray();
+  }
+
+  /// <summary>The AutoCAD colour facts an ARGB-only COLOR node cannot express: the ACI index behind a
+  /// <c>ColorMethod.ByAci</c> colour, and whether the entity was explicitly set to <c>ByBlock</c>.</summary>
+  private sealed record ColorSemantics(int? Aci, bool ByBlock);
+
+  // The bundle's COLOR node stores ARGB only, so an AutoCAD→AutoCAD round trip flattened every ACI colour to
+  // truecolor (same pixels, but the plot-style/standards-relevant index and method were gone) and every explicit
+  // ByBlock to a fixed value [ENG-9117]. The unpacker already recorded both on the proxy — carry them through as
+  // object properties, which every other consumer simply ignores while the ARGB edge keeps rendering unchanged.
+  //
+  // Only reaches objects that own the colour themselves (atomic entities + block references). A block-DEFINITION
+  // member is not addressable this way: its geometry carries no back-reference to an object in the bundle, so it
+  // still round-trips as truecolor.
+  private static Dictionary<string, ColorSemantics> CollectColorSemantics(IReadOnlyList<ColorProxy> colors)
+  {
+    var result = new Dictionary<string, ColorSemantics>(StringComparer.Ordinal);
+    foreach (ColorProxy proxy in colors)
+    {
+      bool byBlock = proxy["source"] is "block";
+      int? aci = proxy["autocadColorIndex"] as int?;
+      if (!byBlock && aci is null)
+      {
+        continue; // a plain truecolor (ByColor) object: the ARGB edge is already lossless
+      }
+      foreach (string objectId in proxy.objects)
+      {
+        result[objectId] = new ColorSemantics(aci, byBlock);
+      }
+    }
+    return result;
+  }
 
   // Matrix4x4 (row-major) → 16 doubles, matching SerializerV2 / Transform.ToArray order.
   private static double[] Flatten(Matrix4x4 m) =>

--- a/Connectors/Autocad/Speckle.Connectors.AutocadShared/Operations/Send/AutocadArtifactRootObjectBuilder.cs
+++ b/Connectors/Autocad/Speckle.Connectors.AutocadShared/Operations/Send/AutocadArtifactRootObjectBuilder.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using Autodesk.AutoCAD.DatabaseServices;
+using Autodesk.AutoCAD.Geometry;
 using Microsoft.Extensions.Logging;
 using Speckle.Connectors.Autocad.HostApp;
 using Speckle.Connectors.Autocad.HostApp.Extensions;
@@ -10,6 +11,7 @@ using Speckle.Connectors.Common.Diagnostics;
 using Speckle.Connectors.Common.Operations;
 using Speckle.Connectors.Common.Threading;
 using Speckle.Converters.Autocad;
+using Speckle.Converters.Autocad.Helpers;
 using Speckle.Converters.Common;
 using Speckle.DoubleNumerics;
 using Speckle.Objects.Data;
@@ -137,7 +139,15 @@ public class AutocadArtifactRootObjectBuilder(
     var units = converterSettings.Current.SpeckleUnits;
 
     // Unpack instances → atomic objects (incl. block-definition members) + instance/definition proxies.
-    var (atomicObjects, _, instanceProxies, instanceDefinitionProxies) = instanceUnpacker.UnpackSelection(objects);
+    var (atomicObjects, atomicDefinitionObjectIds, instanceProxies, instanceDefinitionProxies) =
+      instanceUnpacker.UnpackSelection(objects);
+
+    // Publishing from a custom UCS: the converter rebases every point/vector it emits through
+    // ReferencePointConverter (the inverse of the settings' UCS matrix). Two compensations are needed on top of
+    // that, exactly as the v1 AutocadRootObjectBaseBuilder does them [ENG-9116] — see CollectObject.
+    Matrix3d? referencePointInverse = converterSettings.Current.ReferencePointTransform is Matrix3d ucs
+      ? ucs.Inverse()
+      : null;
 
     var collectedObjects = new List<CollectedObject>(atomicObjects.Count);
     var results = new List<SendConversionResult>(atomicObjects.Count);
@@ -150,7 +160,11 @@ public class AutocadArtifactRootObjectBuilder(
       var sw = Stopwatch.StartNew();
       try
       {
-        CollectedObject collected = CollectObject(entity, applicationId, sourceType, instanceProxies);
+        CollectedObject collected = atomicDefinitionObjectIds.Contains(applicationId)
+          // Definition members live in DEFINITION-LOCAL coordinates and are placed by their instance's transform.
+          // Rebasing them into the UCS too would transform them twice, so convert them with no reference point.
+          ? CollectWithoutReferencePoint(entity, applicationId, sourceType, instanceProxies)
+          : CollectObject(entity, applicationId, sourceType, instanceProxies, referencePointInverse);
         collectedObjects.Add(collected);
         results.Add(new(Status.SUCCESS, applicationId, sourceType, collected.Converted));
         session.RecordObject(applicationId, sourceType, Status.SUCCESS, null, sw.ElapsedMilliseconds);
@@ -255,6 +269,22 @@ public class AutocadArtifactRootObjectBuilder(
     return result;
   }
 
+  // A block-definition member, converted with the reference point switched off so it stays in definition-local
+  // coordinates. Mirrors the v1 builder's atomicDefinitionObjectIds branch [ENG-9116]. The push is scoped to this
+  // one conversion — the settings store is restored on dispose, so the next top-level object rebases as usual.
+  private CollectedObject CollectWithoutReferencePoint(
+    Entity entity,
+    string applicationId,
+    string sourceType,
+    IReadOnlyDictionary<string, InstanceProxy> instanceProxies
+  )
+  {
+    using (converterSettings.Push(current => current with { ReferencePointTransform = null }))
+    {
+      return CollectObject(entity, applicationId, sourceType, instanceProxies, null);
+    }
+  }
+
   // Converts one AutoCAD entity to its Speckle representation (instance proxy or AutocadObject carrier). The
   // AutocadObject is a transient carrier — phase 2 reads its displayValue/rawEncoding/properties and never serializes
   // it (the same way Rhino transiently uses InstanceProxy/RenderMaterialProxy).
@@ -262,11 +292,21 @@ public class AutocadArtifactRootObjectBuilder(
     Entity entity,
     string applicationId,
     string sourceType,
-    IReadOnlyDictionary<string, InstanceProxy> instanceProxies
+    IReadOnlyDictionary<string, InstanceProxy> instanceProxies,
+    Matrix3d? referencePointInverse
   )
   {
     if (instanceProxies.TryGetValue(applicationId, out InstanceProxy? instanceProxy))
     {
+      // A block placement's transform is authored in WORLD coordinates, while the definition members it places were
+      // converted into the (UCS-rebased) coordinates the rest of the send speaks. Pre-multiplying a TOP-LEVEL
+      // placement by the inverse UCS puts the two back in the same frame — without it the instance drifts away from
+      // the loose geometry it was drawn against [ENG-9116]. A nested placement is already definition-local.
+      if (instanceProxy.maxDepth == 0 && referencePointInverse is Matrix3d inverse && entity is BlockReference br)
+      {
+        instanceProxy.transform = TransformHelper.ConvertToInstanceMatrix4x4(br.BlockTransform.PreMultiplyBy(inverse));
+      }
+
       var instanceProps =
         instanceProxy["properties"] as Dictionary<string, object?> ?? new Dictionary<string, object?>();
       return new CollectedObject(

--- a/Connectors/Autocad/Speckle.Connectors.AutocadShared/Speckle.Connectors.AutocadShared.projitems
+++ b/Connectors/Autocad/Speckle.Connectors.AutocadShared/Speckle.Connectors.AutocadShared.projitems
@@ -19,6 +19,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)DependencyInjection\AutocadConnectorModule.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Filters\AutocadSelectionFilter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HostApp\AutocadColorBaker.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)HostApp\AutocadColorSemanticKeys.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HostApp\AutocadColorUnpacker.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HostApp\AutocadGroupBaker.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HostApp\AutocadGroupUnpacker.cs" />

--- a/docs/eng-9119-block-reference-materials-skipped.md
+++ b/docs/eng-9119-block-reference-materials-skipped.md
@@ -1,0 +1,73 @@
+# ENG-9119 — AutoCAD block-reference materials: not fixed in this pass
+
+**Ticket:** [ENG-9119 — AutoCAD: preserve materials assigned to block references](https://linear.app/speckle/issue/ENG-9119/autocad-preserve-materials-assigned-to-block-references)
+
+**Status:** left in progress, no code change. The fix cannot be completed inside
+`speckle-sharp-connectors` — it needs a bundle-spec decision plus matching SDK work first.
+
+## What the ticket asks for
+
+Emit an object-sourced `HAS_MATERIAL` edge when a render-material proxy member resolves to an
+instance K, so a material assigned directly to a `BlockReference` survives publish and its ByBlock
+members inherit it. The ticket itself flags the precondition:
+
+> Verify first that the SDK pipeline supports the equivalent of `HasColor(srcIsObject: true)`.
+
+## Why it is blocked
+
+It does not. `HAS_COLOR` got a source-namespace tag in ENG-8822; `HAS_MATERIAL` never did, and the
+`ord` column is the only place such a tag can live.
+
+| | `HAS_COLOR` | `HAS_MATERIAL` |
+| --- | --- | --- |
+| Write API | `HasColor(int srcK, int colorK, bool srcIsObject = false)` — writes `ord` 0/1 | `HasMaterial(int geometryK, int materialK)` — writes `ord` 0, always |
+| Read API | `ArtefactBundle.ColorByGeometry` **and** `ColorByObject`, split on `ord` | `ArtefactBundle.MaterialByGeometry` only |
+
+(`src/Speckle.Objects/Utils/ObjectsArtifactPipeline.cs` and
+`src/Speckle.Sdk.Parquet/Pipelines/Receive/Artifacts/ArtefactBundle.cs` in `speckle-sharp-sdk`.)
+
+An `InstanceProxy` owns no geometry, so it never enters `geometryKsByObjectId` — there is simply no
+geometry K to hang the edge on, and writing the object K into the geometry slot without a namespace
+tag is exactly the ambiguity ENG-8822 was raised to remove. The two K-spaces are both dense ints
+from 0, so an untagged edge would silently apply the block's material to whichever unrelated
+geometry happens to share that number.
+
+The receive side is ready and needs no change: `PlaceInstances` already applies
+`materialIdByObject[appId]` to the baked `BlockReference`, and `MapMaterials` already builds that
+dictionary — it just never gets an entry for an instance, because no such edge exists in the bundle.
+
+## What is needed to unblock
+
+1. **Spec decision** (`speckle-bundle-spec`): declare `HAS_MATERIAL.src` as `geometry | object` with
+   `ord` as the namespace tag (`0` = geometry, `1` = object), mirroring the `HAS_COLOR` wording. Old
+   bundles all wrote `ord = 0`, so the change is backward compatible by construction — same argument
+   ENG-8822 used.
+2. **SDK** (`speckle-sharp-sdk`):
+   - `ObjectsArtifactPipeline.HasMaterial(int srcK, int materialK, bool srcIsObject = false)`.
+   - `ArtefactBundle.MaterialByObject`, populated from the `RelKind.HasMaterial` case on `ord == 1`,
+     alongside the existing `MaterialByGeometry`.
+   - Whatever the viewer/`ObjectsArtifactReader` path needs to resolve the object-sourced edge (the
+     reader currently walks `MaterialByGeometry` only).
+3. **Connector** (this repo) — small, once the above exists:
+   - `AutocadArtifactRootObjectBuilder.EmitValueNodes`: in the material loop, add the
+     `instanceKByObjectId` branch next to the existing geometry branch, exactly as the colour loop
+     below it already does:
+     `pipeline.HasMaterial(pipeline.InternObject(objectId), matK, srcIsObject: true);`
+   - `AutocadHostObjectArtefactBuilder.MapMaterials`: fold `rels.MaterialByObject` into `byObject`,
+     mirroring what `MapColors` does with `rels.ColorByObject`.
+   - Same two edits in `RhinoArtifactRootObjectBuilder` / `RhinoHostObjectArtefactBuilder` closes the
+     Rhino twin, [ENG-9109](https://linear.app/speckle/issue/ENG-9109), which is blocked on the same
+     missing tag (see the note at the end of the ENG-9108 commit message, b10f446e).
+
+## Also worth deciding at the same time
+
+A ByLayer material on a block reference has the same shape and the same blocker. ENG-9118 (fixed in
+this branch) resolves layer materials onto each inheriting object's geometry, but it explicitly
+skips an inheriting block instance for this reason — the send builder now logs a warning naming the
+object when that happens, rather than dropping it silently.
+
+## Interim behaviour
+
+Unchanged: a material assigned directly to a block reference is absent from the bundle, the placed
+instance has no material, and its ByBlock members have nothing to inherit. Colour on a block
+reference is unaffected — that path works, via the ENG-8822 object-sourced `HAS_COLOR` edge.


### PR DESCRIPTION
Three AutoCAD artefact publish/receive gaps from the Speckle 7.0 backlog. Each is its own commit.

## ENG-9116 — block placement from a custom UCS

Publishing with a non-identity UCS misaligned block instances against the loose geometry they were drawn with, and transformed geometry inside block definitions twice.

The converter rebases every point/vector through `ReferencePointConverter`. The v1 builder pairs that with two compensations the artefact builder never carried over, both restored here:

- Definition members convert under a scoped `ReferencePointTransform = null` push, so they stay definition-local instead of being rebased a second time on top of their instance's transform. (`UnpackSelection`'s `atomicDefinitionObjectIds` is no longer discarded.)
- A top-level placement's transform is pre-multiplied by the inverse UCS, putting the world-authored transform back in the same frame as everything around it. Nested placements are already definition-local and untouched.

Identity-UCS documents are unaffected — `ReferencePointTransform` is null there and both branches collapse to the previous behaviour.

**Not covered:** the acceptance criterion asking for a unit test on the transform composition. It is `Matrix3d.PreMultiplyBy` + `TransformHelper.ConvertToInstanceMatrix4x4`, both AutoCAD API, and there is no AutoCAD-referencing test project in the repo to host an API-free test of it.

## ENG-9118 — ByLayer render materials

A ByLayer object got no material at all in the bundle. The unpacker's object stage skips those by design and its layer stage was never run — the artefact builder passed an empty layer list.

Running the layer stage alone isn't enough: a layer-sourced proxy lists the LAYER id, and phase 2 resolves proxy members only through `geometryKsByObjectId` (keyed by OBJECT id), so the MATERIAL node would land with no edge. Phase 1 now also records object → the layer whose material it inherits, gated on the layer carrying a non-Global material (the same condition the unpacker's layer stage uses, so every recorded object resolves to a MATERIAL node). Phase 2 inverts that and expands the layer-sourced member onto each inheriting object's geometry. Mirrors the Rhino ENG-9108 fix.

Layer records must stay open across the `UnpackMaterials` call, so collection and unpacking share one transaction. Directly assigned entity materials take the unchanged path. Definition members inherit through the same edge. A proxy member resolving to no geometry is now logged rather than dropped silently.

## ENG-9117 — ACI and explicit ByBlock colour semantics

An AutoCAD→AutoCAD round trip flattened every ACI colour to truecolor — same pixels, but the `ColorMethod` and index were gone, which breaks CTB plot styles, standards checks and index-reading scripts. Explicit ByBlock entities lost their inheritance too.

Widening the COLOR node is a spec decision, so this takes the AutoCAD-specific route the ticket describes: send writes the colour method (+ ACI index) as object properties alongside the unchanged ARGB edge; receive prefers them when rebuilding entity colour. Viewer rendering and non-AutoCAD consumers are unaffected — same `HAS_COLOR` edge, two extra eav scalars they ignore. Bundles without the keys (other hosts, older sends) take the existing ARGB path.

**Scope:** entities and block references, i.e. everything owning its colour as an object. Block-**definition members** are out of reach this way — their geometry carries no back-reference to an object in the bundle (which is why ENG-8825 resolved member layer colours at send time), so an ACI-coloured member still round-trips as truecolor. Members with no colour edge keep arriving ByBlock, unchanged.

## ENG-9119 — not fixed, documented

`docs/eng-9119-block-reference-materials-skipped.md`. The ticket's precondition fails: `HasMaterial` has no `srcIsObject` tag and there's no `MaterialByObject` on the read side, so an `InstanceProxy` (which owns no geometry) has nothing to hang the edge on. Needs a bundle-spec decision + SDK work first; the connector edits are ~3 lines after that. Rhino's ENG-9109 is blocked on the same tag. Analysis also posted on the ticket.

## Testing

Compile-verified only — **none of this has been run in AutoCAD yet.**

Heads-up for whoever builds this: `Local` does not build on `big-truck` as it stands, independently of this PR. All seven connectors call `new ObjectsArtifactPipeline(..., producedBy: slug)` but the SDK's ctor takes `ISpeckleApplication producer` (SDK `big-truck` @ `1d2201c`; `producedBy` only exists on `origin/bjorn/eng-9101-…`). To verify these changes I temporarily patched that one line, built AutoCAD 2026 / Civil3D 2026 / Plant3D 2026 clean (0 errors, 0 warnings), then reverted it rather than folding an unrelated repo-wide API fix into these commits.

Manual checks worth doing:
- rotated UCS (`UCS → Z → 45`), a line + a block touching its endpoint → publish → view and receive; they should stay coincident, and definition geometry should not be doubly transformed
- material on a layer, a `Solid3d` on it left ByLayer → publish → view and receive
- one line ACI 1, one explicitly ByBlock → publish → receive → inspect `ColorMethod` and index
- a plain identity-UCS send with truecolor objects, to confirm nothing regressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)