### PR TITLE
chore: mark Base-graph reconstruction receive as Obsolete

### DIFF
--- a/Sdk/Speckle.Connectors.Common/Operations/ArtifactReceiver.cs
+++ b/Sdk/Speckle.Connectors.Common/Operations/ArtifactReceiver.cs
@@ -74,10 +74,16 @@ public class ArtifactReceiver(
   }
 
   /// <summary>
-  /// Maps a parsed bundle into a <see cref="Base"/>/<c>Collection</c> graph for the v1 host-build path. Used by
-  /// connectors without a dedicated <c>IArtifactHostObjectBuilder</c> (e.g. Revit). Honours the
-  /// <c>ArtifactReceiveOptions.PreferSolids</c> flag.
+  /// Maps a parsed bundle into a <see cref="Base"/>/<c>Collection</c> graph for the v1 host-build path. Honours the
+  /// <c>ArtifactReceiveOptions.PreferSolids</c> flag. Obsolete: every connector that receives the new object model
+  /// bakes the bundle directly (<c>IArtifactHostObjectBuilder</c>); reconstruct-then-convert loses data and speed at
+  /// the seam and must not be the starting point for new connectors.
   /// </summary>
+  [Obsolete(
+    "Reconstruct-then-convert is not the way forward for new-object-model receives: register a dedicated "
+      + "IArtifactHostObjectBuilder (direct bundle bake) instead. This fallback remains only so a connector without "
+      + "a direct-bake builder still receives; no new callers."
+  )]
   public Base Reconstruct(ArtefactBundle bundle, CancellationToken cancellationToken) =>
     new ObjectsArtifactReader().Build(bundle, options, cancellationToken);
 }

--- a/Sdk/Speckle.Connectors.Common/Operations/ReceiveOperation.cs
+++ b/Sdk/Speckle.Connectors.Common/Operations/ReceiveOperation.cs
@@ -61,10 +61,13 @@ public sealed class ReceiveOperation(
         }
         else
         {
-          // reconstruction path: map the bundle to a Base graph + run the v1 host builder.
+          // OBSOLETE reconstruction path — kept only so a connector without a direct-bake builder still receives.
+          // New-object-model receives register an IArtifactHostObjectBuilder; do not lean on this branch for new work.
+#pragma warning disable CS0618
           var artefactRoot = await threadContext.RunOnWorkerAsync(() =>
             Task.FromResult(artifactReceiver.Reconstruct(bundle, cancellationToken))
           );
+#pragma warning restore CS0618
           artefactRes = await ConvertObjects(artefactRoot, receiveInfo, onOperationProgressed, cancellationToken)
             .ConfigureAwait(false);
         }


### PR DESCRIPTION
Every connector that receives the new object model bakes the bundle directly (IArtifactHostObjectBuilder); the reconstruct-then-convert fallback in ReceiveOperation has no remaining production callers. Mark ArtifactReceiver.Reconstruct [Obsolete] so new connectors start from a direct-bake builder instead of leaning on this branch.
