### PR TITLE
fix(revit): distinguish hosting from ownership in artefact topology (ENG-9081)

### DIFF
--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/RevitArtifactRootObjectBuilder.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/RevitArtifactRootObjectBuilder.cs
@@ -691,8 +691,11 @@ public class RevitArtifactRootObjectBuilder(
   }
 
   // Host-API topology, guarded to sent objects via objectKsByElementUniqueId (only interned targets get an edge):
-  //   SUBELEMENT   host / super-component → element (a fixture hosted on a ceiling; a nested family → its super).
-  //                Complements the RevitObject.elements lift, which covers children folded INTO a parent object.
+  //   SUBELEMENT   super-component → element: OWNERSHIP (a nested shared family → its super-component).
+  //                Complements the RevitObject.elements lift, which covers children folded INTO a parent object
+  //                (curtain panels / mullions / stacked-wall members — ownership too, emitted by EmitChild).
+  //   HOSTED_ON    element → its host: PLACEMENT (a door/window → its wall, a fixture → its ceiling). A different
+  //                relationship from ownership — a door is placed ON a wall, not a component OF it [ENG-9081].
   //   IN_ROOM      element → its containing Room (or MEP Space) object.
   //   CONNECTS_TO  a door/window's FromRoom → ToRoom, scoped by the opening's object K (the room-adjacency graph).
   // Same accessors as ClassPropertiesExtractor; wrapped defensively — Room/ToRoom/FromRoom can throw without an
@@ -714,14 +717,30 @@ public class RevitArtifactRootObjectBuilder(
       }
       try
       {
-        Element? parent = fi.Host ?? fi.SuperComponent;
-        if (parent is not null && objectKsByElementUniqueId.TryGetValue(parent.UniqueId, out var parentKs))
+        // Ownership wins over hosting, matching rvextract's precedence (owningElemId first, getHostId as the
+        // fallback) so the same fixture gets the same relation whether it is published through the connector or
+        // extracted from an uploaded file. An owner that exists but was NOT sent suppresses HOSTED_ON rather than
+        // falling through to it — the element is owned, and the edge is simply dropped as dangling.
+        if (fi.SuperComponent is { } owner)
         {
-          foreach (var pK in parentKs)
+          if (objectKsByElementUniqueId.TryGetValue(owner.UniqueId, out var ownerKs))
+          {
+            foreach (var oK in ownerKs)
+            {
+              foreach (var eK in elementKs)
+              {
+                pipeline.Subelement(oK, eK, 0);
+              }
+            }
+          }
+        }
+        else if (fi.Host is { } host && objectKsByElementUniqueId.TryGetValue(host.UniqueId, out var hostKs))
+        {
+          foreach (var hK in hostKs)
           {
             foreach (var eK in elementKs)
             {
-              pipeline.Subelement(pK, eK, 0);
+              pipeline.HostedOn(eK, hK);
             }
           }
         }

--- a/docs/connector-relations.md
+++ b/docs/connector-relations.md
@@ -24,7 +24,7 @@ A bundle is a graph of flat parquet rows across **three ID spaces**. A bare numb
 |---:|---|---|---|
 | 1 | `DISPLAY` | object → geometry | object's own display mesh |
 | 2 | `SOLID` | object → geometry | lossless raw body (3dm / SAT) |
-| 3 | `SUBELEMENT` | object → object | parent owns child (railing→baluster, corridor→region) |
+| 3 | `SUBELEMENT` | object → object | parent **owns** child (railing→baluster, corridor→region) |
 | 4 | `DEFINES` | node → geometry | DEFINITION owns shared geometry |
 | 5 | `HAS_MATERIAL` | geometry → node | mesh → MATERIAL (full PBR) |
 | 6 | `HAS_COLOR` | geometry \| object → node | display color · `ord` tags the src namespace |
@@ -37,7 +37,7 @@ A bundle is a graph of flat parquet rows across **three ID spaces**. A bare numb
 | 14 | `IN_SYSTEM` | object → node | object → CONTAINER (MEP system / network) |
 | 17 | `IN_GROUP` | object → node | object → CONTAINER (group) · overlapping axis |
 | 21 | `CONNECTS_TO` | object → object | directed connectivity (frame→joint, pipe→structure, room adjacency) |
-| 22 | `HOSTED_ON` | object → object | hosted element → host (managed Revit folds into SUBELEMENT) |
+| 22 | `HOSTED_ON` | object → object | hosted element **placed on** host (door→wall) · distinct from ownership |
 | 23 | `BOUNDS` | object → object | bounding wall → room |
 
 Plus four **value / sidecar files** outside the relation graph: `camera_views` (named viewpoints), `structural_results` (analysis rows), `reference_point` (meta columns), and the Civil3D **property-set definitions carrier**.
@@ -67,8 +67,8 @@ What each connector actually emits, verified in the send builders. `●` emitted
 | **14 IN_SYSTEM** | · | · | · | · | ● | · | · | · | · | · |
 | **12 IN_ROOM** | · | · | · | · | · | · | ● | · | · | · |
 | **21 CONNECTS_TO** | · | · | · | · | ● | · | ● | · | ● | · |
-| **22 HOSTED_ON** | · | · | · | · | · | · | ◐² | · | · | · |
-| **23 BOUNDS** | · | · | · | · | · | · | ◐³ | · | · | · |
+| **22 HOSTED_ON** | · | · | · | · | · | · | ● | · | · | · |
+| **23 BOUNDS** | · | · | · | · | · | · | ◐² | · | · | · |
 | _camera_views_ | ● | · | · | · | · | ● | ● | · | · | · |
 | _structural_results_ | · | · | · | · | · | · | · | · | ● | ● |
 | _reference_point (meta)_ | · | · | · | · | · | · | ● | · | · | · |
@@ -76,8 +76,7 @@ What each connector actually emits, verified in the send builders. `●` emitted
 | **native receive** | ● | · | ● | · | ● | ● | ● | · | · | · |
 
 ¹ TSD `SUBELEMENT` is wired but unreachable — `elements` is always empty.
-² Revit folds `HOSTED_ON` into `SUBELEMENT` (managed builder reuses the richer rel).
-³ Revit folds `BOUNDS` into `IN_ROOM`.
+² Revit folds `BOUNDS` into `IN_ROOM`.
 
 Civil3D's `SUBELEMENT`/`IN_SYSTEM`/`CONNECTS_TO` emitters live in the shared AutoCAD builder but only fire for `Civil3dObject`s — so **AutoCAD & Plant3D never produce them**. Plant3D is send-only. SketchUp is a pure-Ruby producer.
 
@@ -318,7 +317,7 @@ A SketchUp group emits DISPLAY_INSTANCE like a component — so **IN_GROUP is ne
 
 ---
 
-### Revit — BIM · emits 9
+### Revit — BIM · emits 10
 
 The richest BIM producer: display geometry + instances/materials/levels, per-document model containers for federation, and a best-effort host-API topology layer (sub-elements, rooms, room-adjacency).
 
@@ -360,24 +359,27 @@ graph LR
 
 Repeated families place one DEFINITION many times; receive uses a DirectShapeLibrary geometry instance per DISPLAY_INSTANCE rather than re-tessellating.
 
-**Hosting & rooms** — `SUBELEMENT` (← folds `HOSTED_ON`) · `IN_ROOM` (← folds `BOUNDS`) · `CONNECTS_TO`
+**Hosting, ownership & rooms** — `HOSTED_ON` · `SUBELEMENT` · `IN_ROOM` (← folds `BOUNDS`) · `CONNECTS_TO`
 
 ```mermaid
 graph LR
   WIN([obj · window]):::obj
   WALL([obj · host wall]):::obj
+  CW([obj · curtain wall]):::obj
+  PNL([obj · curtain panel]):::obj
   F([obj · furniture]):::obj
   RA([obj · Room A]):::obj
   D([obj · door]):::obj
   RB([obj · Room B]):::obj
-  WIN -->|SUBELEMENT · hosting| WALL
+  WIN -->|HOSTED_ON · placement| WALL
+  CW -->|SUBELEMENT · ownership| PNL
   F -->|IN_ROOM| RA
   D -->|IN_ROOM| RA
   D -->|CONNECTS_TO · adjacency| RB
   classDef obj fill:#eac36a,stroke:#9a5f0c,color:#2a1c04;
 ```
 
-The managed builder reuses `SUBELEMENT` for both ownership and hosting (window→wall) rather than emitting the rvextract-only `HOSTED_ON`. Occupancy is `IN_ROOM` (rooms are _objects_, not nodes); a door's FromRoom→ToRoom becomes `CONNECTS_TO` scoped by the opening. All best-effort in try/catch — topology never fails the geometry send.
+Hosting and ownership are **separate rels** (ENG-9081): `FamilyInstance.Host` → `HOSTED_ON` (hosted→host), `SuperComponent` / composite `elements` children → `SUBELEMENT` (owner→child). Ownership wins when an element has both, matching rvextract's `owningElemId` → `getHostId` precedence, so connector and file-upload publishes of the same model agree. Occupancy is `IN_ROOM` (rooms are _objects_, not nodes); a door's FromRoom→ToRoom becomes `CONNECTS_TO` scoped by the opening. All best-effort in try/catch — topology never fails the geometry send.
 
 - **Nodes:** CONTAINER `"Model"` (per source doc) · LEVEL (name+elev) · DEFINITION/INSTANCE · MATERIAL
 - **Sidecar:** `camera_views` ← 3D views (ENG-8802) · `reference_point` meta (ENG-8808)
@@ -501,7 +503,7 @@ Members group by member-type (Beam, Column, Slab…) into flat collections. Resu
 - _Structural_ (Tekla, CSi, TSD) is lean geometry + one topology or results channel; CSi & TSD own `structural_results`.
 
 **Deliberate folds & substitutions.**
-- Revit **folds HOSTED_ON into SUBELEMENT** and **BOUNDS into IN_ROOM** — reuses richer rels rather than emit the rvextract-only pair.
+- Revit **folds BOUNDS into IN_ROOM** — reuses the richer rel rather than emit the rvextract-only one. `HOSTED_ON` is **no longer folded** into `SUBELEMENT` (ENG-9081): hosting and ownership are distinct, and collapsing them made topology depend on the publish route.
 - SketchUp maps **groups to component instances**, so it never emits IN_GROUP. CSi maps **stories to Collections**, not LEVEL nodes.
 - The spec's `emitted_by` hint (`rvextract`/`nwextract`/`managed`) is coarse — this map is the precise managed-connector truth.
 

--- a/docs/connector-topology.md
+++ b/docs/connector-topology.md
@@ -13,7 +13,7 @@
 |---|---|---|---|---|
 | DISPLAY (1) | object → geometry | ordinal | object's own mesh | `Display` |
 | SOLID (2) | object → geometry | ordinal | lossless solid blob | `Solid` |
-| SUBELEMENT (3) | object → object | ordinal | parent → child (host/nested) | `Subelement` |
+| SUBELEMENT (3) | object → object | ordinal | owner → owned child (nested/composite) | `Subelement` |
 | DEFINES (4) | node → geometry | — | DEFINITION → mesh | `Defines` |
 | HAS_MATERIAL (5) | geometry → node | — | mesh → MATERIAL | `HasMaterial` |
 | HAS_COLOR (6) | geo\|obj → node | — | colour override | `HasColor` |
@@ -25,11 +25,17 @@
 | IN_ROOM (12) | **object → object** | — | element → room object | `InRoom` |
 | IN_SYSTEM (14) | object → node | — | MEP System / Network | `InSystem` + `AddContainer(…,"MEP System"\|"Network")` |
 | CONNECTS_TO (21) | object → object | **scope** | connectivity (ord = system-K / opening-K / 0) | `ConnectsTo(s,t[,scope])` |
+| HOSTED_ON (22) | object → object | — | hosted element → its host | `HostedOn(hosted, host)` |
 | BOUNDS (23) | object → object | — | bounding wall → room | `Bounds` |
 
 Node kinds: DEFINITION, INSTANCE, MATERIAL, COLOR, LEVEL, CONTAINER (subtype `Collection｜Model｜MEP System｜Network`).
 **Retired — do NOT use:** IN_SPACE(13), IN_NETWORK(15), IN_LINE(16), **IN_GROUP(17)**, IN_ASSEMBLY(18),
-IN_SUBASSEMBLY(19), XREF(20), HOSTED_ON(22), COLLECTION-node(6).
+IN_SUBASSEMBLY(19), XREF(20), COLLECTION-node(6).
+
+**SUBELEMENT is ownership, HOSTED_ON is placement** — and they are not interchangeable. A curtain panel is a
+*component of* its curtain wall (SUBELEMENT); a door is *placed on* its wall (HOSTED_ON). Ownership takes
+precedence when an element has both. `HostedOn` takes the hosted element FIRST (child → parent), the opposite
+argument order from `Subelement(parent, child, ord)`.
 
 **`CONNECTS_TO.ord` is a scope, not an order** (`rel_types.ord_semantics='scope'`): system-K for MEP flow,
 opening-K for room adjacency, 0 unscoped. The façade `ConnectsTo(s,t,scope)` overload carries it.
@@ -38,10 +44,15 @@ opening-K for room adjacency, 0 unscoped. The façade `ConnectsTo(s,t,scope)` ov
 
 ### Revit — `RevitArtifactRootObjectBuilder`
 - ✅ IN_MODEL, DISPLAY, DISPLAY_INSTANCE, DEFINES, HAS_MATERIAL, ON_LEVEL (pre-existing).
-- ✅ **SUBELEMENT** — (a) `RevitObject.elements` nested children (curtain wall→mullions/panels, railing→top
-  rail, stacked wall→members) — these are stripped from the atomic list by
+- ✅ **SUBELEMENT** (ownership) — (a) `RevitObject.elements` nested children (curtain wall→mullions/panels,
+  railing→top rail, stacked wall→members) — these are stripped from the atomic list by
   `RemoveKnownChildElementsWhenParentPresent`, so the lift also **recovered dropped child geometry**;
-  (b) host/super-component → element (`FamilyInstance.Host ?? .SuperComponent`).
+  (b) super-component → element (`FamilyInstance.SuperComponent`) for nested shared families, which survive as
+  their own atomic elements.
+- ✅ **HOSTED_ON** (placement) — element → `FamilyInstance.Host` (door/window→wall, fixture→ceiling/floor),
+  emitted only when the element has **no** `SuperComponent`. Ownership wins; hosting is the fallback — the same
+  precedence as rvextract's `owningElemId` → `getHostId`, so connector and file-upload topology agree
+  [ENG-9081]. An owner that exists but wasn't sent drops the edge rather than falling back to HOSTED_ON.
 - ✅ **IN_ROOM** — `FamilyInstance.Room ?? .Space` → room object.
 - ✅ **CONNECTS_TO (spatial)** — door/window `FromRoom → ToRoom`, scope = opening object K.
 - 🔶 **BOUNDS** — `Room.GetBoundarySegments → BoundarySegment.ElementId` (new API walk; the Areas pattern
@@ -95,7 +106,8 @@ The managed connectors have the same host-API affordances; the ODA extractors ar
 
 | rel | rvextract (Revit / BimRv) | nwextract (Navis) |
 |---|---|---|
-| SUBELEMENT | `OdBmElement::owningElemId()` (≈ `Element.GetHostId`) | — |
+| SUBELEMENT | `OdBmElement::owningElemId()` (≈ `FamilyInstance.SuperComponent`) | — |
+| HOSTED_ON | `getHostId()` (≈ `FamilyInstance.Host`), only when `owningElemId()` is unset | — |
 | ON_LEVEL | `getAssocLevelId()` + level params → `addLevelNode` | "Level" property group |
 | IN_ROOM | `OdBmFamilyInstance::getRoomId(Room)` | — |
 | BOUNDS | `OdBmRoomElem::getBoundarySegments()` → segment `getElementId()` | — |
@@ -115,7 +127,10 @@ The managed connectors have the same host-API affordances; the ODA extractors ar
    so it is deferred to a team decision rather than shipped blind. Affects Rhino/AutoCAD scene groups and
    the semantic-grouping variants (CSi groups). (CSi pier/spandrel and Civil networks use `IN_SYSTEM`, which
    is a *distinct* rel/map and does not conflict.)
-2. **Host / hosted uses SUBELEMENT** (object→object), not the retired `HOSTED_ON(22)`.
+2. **Ownership and hosting are separate rels.** `SUBELEMENT` carries ownership (`SuperComponent`, composite
+   children); `HOSTED_ON(22)` — un-retired post-v5 — carries hosting (`Host`). Ownership wins when both exist.
+   Folding them into one rel made a model's topology depend on whether it was published through the connector
+   or extracted from an uploaded file [ENG-9081].
 3. **Civil pipe networks use CONTAINER subtype `Network`**; Revit MEP systems use `MEP System`.
 4. **Assemblies (Tekla) use SUBELEMENT** (main → secondary), avoiding a new CONTAINER subtype.
 
@@ -123,7 +138,7 @@ The managed connectors have the same host-API affordances; the ODA extractors ar
 
 - **Phase 0** (SDK) — ✅ `Bounds` façade + scoped `ConnectsTo(…,scope)` overload + `InRoom` doc fix.
 - **Phase 1** (SUBELEMENT lift) — ✅ Tekla, Revit (recovers dropped child geometry), Civil3D.
-- **Phase 3** (Revit) — ✅ IN_ROOM, host SUBELEMENT, spatial CONNECTS_TO. 🔶 BOUNDS / MEP IN_SYSTEM+connectivity / assemblies.
+- **Phase 3** (Revit) — ✅ IN_ROOM, ownership SUBELEMENT, hosting HOSTED_ON, spatial CONNECTS_TO. 🔶 BOUNDS / MEP IN_SYSTEM+connectivity / assemblies.
 - **Phase 4** (Civil3D) — ✅ network IN_SYSTEM, pipe→structure CONNECTS_TO. 🔶 Plant3D IN_SYSTEM + ports.
 - **Phase 5** (CSi) — ✅ member↔joint CONNECTS_TO. 🔶 ON_LEVEL / pier-spandrel IN_SYSTEM / section HAS_MATERIAL; Tekla assemblies + welds.
 - **Phase 2** (grouping) — ⛔ blocked on the `IN_GROUP` decision above.


### PR DESCRIPTION
Closes ENG-9081.

`EmitElementTopology` emitted `SUBELEMENT` for both `FamilyInstance.Host` and `SuperComponent`, so a wall-hosted door came out as a *component of* its wall. rvextract and the bundle spec keep these apart (`owningElemId` → `SUBELEMENT`, `getHostId` → `HOSTED_ON`), which meant a model's topology depended on whether it was published through the connector or extracted from an uploaded file.

## The change

`RevitArtifactRootObjectBuilder.EmitElementTopology`, replacing `fi.Host ?? fi.SuperComponent → Subelement`:

- `SuperComponent` → `Subelement(owner, element)` — ownership
- else `Host` → `HostedOn(element, host)` — placement, child→parent direction

Ownership takes precedence, matching rvextract. An owner that exists but wasn't sent **suppresses** `HOSTED_ON` rather than falling back to it — otherwise the connector and a file upload of the same model would disagree on the same fixture, which is the bug this ticket is about.

No SDK or spec work was needed: the `HostedOn` façade and `SpecRel.HOSTED_ON` already exist (un-retired in ENG-8867).

## Acceptance criteria

- [x] A wall-hosted door emits `HOSTED_ON` from door to wall, not `SUBELEMENT`.
- [x] Curtain panels and nested shared family members continue to emit `SUBELEMENT`. Panels/mullions/stacked-wall members are stripped from the atomic list by `RemoveKnownChildElementsWhenParentPresent` and emitted by `EmitChild` via the `RevitObject.elements` lift, so they never reach this walk. Nested *shared* families do survive as atomic elements and are covered by the `SuperComponent` branch.
- [x] Ownership takes precedence when an element has both an owner and a host.
- [x] Connector and rvextract output use the same relations for the same fixture.
- [x] Hosted elements are preserved on receive — verified by inspection: `BakeAtomic` iterates all of `bundle.ObjectAppIds` keyed on DISPLAY/SOLID edges and never reads `SUBELEMENT`, and `ArtefactRelations` has a `default: break;` for rel kinds it doesn't consume, so the new kind can't disturb it.

## Docs

`connector-topology.md` and `connector-relations.md` both still listed `HOSTED_ON(22)` as retired and documented the fold as a deliberate modeling decision. Updated, including the ODA blueprint mapping. The Revit hosting diagram in `connector-relations.md` also had `WIN -->|SUBELEMENT| WALL` drawn child→parent, which was backwards for `SUBELEMENT`; it is now correct for both rels.

## Verification note

`big-truck` on this repo does not currently compile against SDK `big-truck` — all seven artefact builders call `new ObjectsArtifactPipeline(…, producedBy: …Slug)` (from #1495) but the SDK constructor takes `ISpeckleApplication producer`, and the SDK checkout is level with `origin/big-truck`, so the SDK-side counterpart looks unmerged. Pre-existing and unrelated to this change.

This change was compile-verified by temporarily adapting that one call site (`dotnet build Speckle.Connectors.Revit2025 -c Local` → 0 warnings, 0 errors), then reverting the shim — the diff here is the fix only. Not yet exercised against a live Revit model; the reproduction model in the ticket is the fixture to check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)