### PR TITLE
fix(artifacts): pass ISpeckleApplication producer to ObjectsArtifactPipeline

### DIFF
--- a/Connectors/Autocad/Speckle.Connectors.AutocadShared/Operations/Send/AutocadArtifactRootObjectBuilder.cs
+++ b/Connectors/Autocad/Speckle.Connectors.AutocadShared/Operations/Send/AutocadArtifactRootObjectBuilder.cs
@@ -298,7 +298,7 @@ public class AutocadArtifactRootObjectBuilder(
   )
   {
     ZstdNativeLoader.Ensure(logger); // net48: ensure the parquet Zstd native is loaded (no-op on net8+)
-    using var pipeline = new ObjectsArtifactPipeline(outputDir, versionId, producedBy: speckleApplication.Slug);
+    using var pipeline = new ObjectsArtifactPipeline(outputDir, versionId, producer: speckleApplication);
 
     // Pre-create DEFINITION nodes so they carry their proper name (the per-object pass only has the definitionId).
     foreach (var defProxy in model.Definitions)

--- a/Connectors/CSi/Speckle.Connectors.CSiShared/Operations/Send/CsiArtifactRootObjectBuilder.cs
+++ b/Connectors/CSi/Speckle.Connectors.CSiShared/Operations/Send/CsiArtifactRootObjectBuilder.cs
@@ -413,7 +413,7 @@ public class CsiArtifactRootObjectBuilder(
   )
   {
     ZstdNativeLoader.Ensure(logger); // net48: ensure the parquet Zstd native is loaded (no-op on net8+)
-    using var pipeline = new ObjectsArtifactPipeline(outputDir, versionId, producedBy: speckleApplication.Slug);
+    using var pipeline = new ObjectsArtifactPipeline(outputDir, versionId, producer: speckleApplication);
     var collectionKByPath = new Dictionary<string, int>(StringComparer.Ordinal);
 
     int count = 0;

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/RevitArtifactRootObjectBuilder.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/RevitArtifactRootObjectBuilder.cs
@@ -194,7 +194,7 @@ public class RevitArtifactRootObjectBuilder(
     }
 
     ZstdNativeLoader.Ensure(logger); // net48: ensure the parquet Zstd native is loaded (no-op on net8+)
-    using var pipeline = new ObjectsArtifactPipeline(outputDir, versionId, producedBy: speckleApplication.Slug);
+    using var pipeline = new ObjectsArtifactPipeline(outputDir, versionId, producer: speckleApplication);
 
     // element.UniqueId -> the object K(s) it was interned as. A linked element placed by N link instances
     // yields N interned objects (disambiguated by transform hash), so the value is a list. Used to resolve

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Operations/Send/GrasshopperArtifactRootObjectBuilder.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Operations/Send/GrasshopperArtifactRootObjectBuilder.cs
@@ -112,7 +112,7 @@ public class GrasshopperArtifactRootObjectBuilder(
   )
   {
     ZstdNativeLoader.Ensure(); // net48: ensure the parquet Zstd native is loaded (no-op on net8+)
-    using var pipeline = new ObjectsArtifactPipeline(outputDir, versionId, producedBy: speckleApplication.Slug);
+    using var pipeline = new ObjectsArtifactPipeline(outputDir, versionId, producer: speckleApplication);
     var units = converterSettings.Current.SpeckleUnits;
 
     // Reused as-is from the v1 send path — they derive the color/material/instance proxies whose `.objects` arrays are

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/Operations/Send/RhinoArtifactRootObjectBuilder.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/Operations/Send/RhinoArtifactRootObjectBuilder.cs
@@ -482,7 +482,7 @@ public class RhinoArtifactRootObjectBuilder(
   )
   {
     ZstdNativeLoader.Ensure(logger); // net48: ensure the parquet Zstd native is loaded (no-op on net8+)
-    using var pipeline = new ObjectsArtifactPipeline(outputDir, versionId, producedBy: speckleApplication.Slug);
+    using var pipeline = new ObjectsArtifactPipeline(outputDir, versionId, producer: speckleApplication);
 
     // Pre-create DEFINITION nodes so they carry their proper name (the per-object pass only has the definitionId).
     foreach (var defProxy in model.Definitions)

--- a/Connectors/TSD/Speckle.Connectors.TSDShared/Operations/Send/TsdArtifactRootObjectBuilder.cs
+++ b/Connectors/TSD/Speckle.Connectors.TSDShared/Operations/Send/TsdArtifactRootObjectBuilder.cs
@@ -316,7 +316,7 @@ internal sealed class TsdArtifactRootObjectBuilder : IArtifactRootObjectBuilder<
     CancellationToken cancellationToken
   )
   {
-    using var pipeline = new ObjectsArtifactPipeline(outputDir, versionId, producedBy: _speckleApplication.Slug);
+    using var pipeline = new ObjectsArtifactPipeline(outputDir, versionId, producer: _speckleApplication);
     var collectionKByName = new Dictionary<string, int>(StringComparer.Ordinal);
 
     int count = 0;

--- a/Connectors/Tekla/Speckle.Connector.TeklaShared/Operations/Send/TeklaArtifactRootObjectBuilder.cs
+++ b/Connectors/Tekla/Speckle.Connector.TeklaShared/Operations/Send/TeklaArtifactRootObjectBuilder.cs
@@ -168,7 +168,7 @@ public class TeklaArtifactRootObjectBuilder(
   )
   {
     ZstdNativeLoader.Ensure(logger); // net48: ensure the parquet Zstd native is loaded (no-op on net8+)
-    using var pipeline = new ObjectsArtifactPipeline(outputDir, versionId, producedBy: speckleApplication.Slug);
+    using var pipeline = new ObjectsArtifactPipeline(outputDir, versionId, producer: speckleApplication);
     var collectionKByName = new Dictionary<string, int>(StringComparer.Ordinal);
     var geometryKsByAppId = new Dictionary<string, List<int>>(StringComparer.Ordinal);
 


### PR DESCRIPTION
## What
The SDK's `ObjectsArtifactPipeline` constructor changed its third parameter from `string producedBy` (a slug) to `ISpeckleApplication producer`. This updates all seven artifact root object builders — Autocad, Revit, CSi, Tekla, TSD, Rhino, and Grasshopper — to pass the injected `ISpeckleApplication` instance directly instead of `speckleApplication.Slug`.

## Why
Connectors no longer compiled against the current `speckle-sharp-sdk` (`Local` configuration): every send-path builder failed with "does not have a parameter named 'producedBy'".

## Verification
`dotnet build Local.slnx -c Local` succeeds with 0 errors against the local SDK checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)