### PR TITLE
feat(revit): preserve model group membership in bundles (ENG-9079)

### DIFF
--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/RevitArtifactRootObjectBuilder.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/RevitArtifactRootObjectBuilder.cs
@@ -13,6 +13,7 @@ using Speckle.Connectors.DUI.Exceptions;
 using Speckle.Connectors.Revit.HostApp;
 using Speckle.Converters.Common;
 using Speckle.Converters.RevitShared;
+using Speckle.Converters.RevitShared.Extensions;
 using Speckle.Converters.RevitShared.Helpers;
 using Speckle.Converters.RevitShared.Services;
 using Speckle.Converters.RevitShared.Settings;
@@ -239,6 +240,11 @@ public class RevitArtifactRootObjectBuilder(
         )
       )
       {
+        // (element, its object K) for every element of THIS document that actually made it into the bundle —
+        // the input to the group pass below, which needs the exact K per document placement (a linked element
+        // sent under N link instances is interned N times, once per transform).
+        var sentElements = new List<(Element Element, int ObjK)>();
+
         foreach (Element revitElement in documentContext.Elements)
         {
           cancellationToken.ThrowIfCancellationRequested();
@@ -282,7 +288,8 @@ public class RevitArtifactRootObjectBuilder(
             Base converted = converter.Convert(revitElement);
             converted.applicationId = applicationId;
 
-            EmitObject(pipeline, converted, modelK, revitElement, applicationId, objectKsByElementUniqueId);
+            int objK = EmitObject(pipeline, converted, modelK, revitElement, applicationId, objectKsByElementUniqueId);
+            sentElements.Add((revitElement, objK));
             results.Add(new(Status.SUCCESS, applicationId, sourceType, converted));
             session.RecordObject(applicationId, sourceType, Status.SUCCESS, null, sw.ElapsedMilliseconds);
           }
@@ -295,6 +302,10 @@ public class RevitArtifactRootObjectBuilder(
 
           onOperationProgressed.Report(new("Converting", (double)++countProgress / atomicObjectCount));
         }
+
+        // Model-group topology for this document, keyed by its model container so a linked file placed twice
+        // yields one group tier per placement rather than one shared, cross-wired tier.
+        EmitGroups(pipeline, modelKey, sentElements);
 
         // Named 3D views (perspective AND orthographic) of this document → camera_views rows. Collected inside
         // this settings push so linked-model cameras ride the exact ReferencePointTransform + scaling path the
@@ -424,7 +435,8 @@ public class RevitArtifactRootObjectBuilder(
 
   // Emits one atomic object: its eav labels + IN_MODEL edge + per-fragment DISPLAY (→ geometry) /
   // DISPLAY_INSTANCE (→ INSTANCE node). Instance definitions + materials + levels are wired post-loop.
-  private void EmitObject(
+  // Returns the interned object K so the caller can wire per-document topology (groups) to this exact placement.
+  private int EmitObject(
     ObjectsArtifactPipeline pipeline,
     Base converted,
     int modelK,
@@ -448,7 +460,7 @@ public class RevitArtifactRootObjectBuilder(
       // Not a DataObject (no properties / displayValue to flatten) — keep the object in the eav set with
       // just its scalar labels, no geometry/topology.
       pipeline.AddProperties(applicationId, s_emptyProperties, RootScalars(converted, null));
-      return;
+      return objK;
     }
 
     var revitObject = converted as RevitObject;
@@ -474,6 +486,8 @@ public class RevitArtifactRootObjectBuilder(
         EmitChild(pipeline, child, modelK, objK, childOrd++);
       }
     }
+
+    return objK;
   }
 
   // ENG-8947: record the MAIN-model reference point in the bundle meta — the SINGLE source for both federation and
@@ -770,6 +784,86 @@ public class RevitArtifactRootObjectBuilder(
       }
     }
   }
+
+  // Revit model groups → CONTAINER("Group") nodes + IN_GROUP membership [ENG-9079]. A SEPARATE axis from the
+  // scene tree (IN_MODEL / ON_LEVEL / category eav): an element keeps its model AND its group, exactly as in
+  // Rhino/AutoCAD. ElementUnpacker explodes every Group into its members before conversion, so the group
+  // INSTANCE is never itself an object in the bundle — the membership survives only on each member's
+  // Element.GroupId. Because that unpacking recurses, GroupId always names the INNERMOST group, which is
+  // precisely the "at most one IN_GROUP edge per element" contract; the nesting is reproduced as a CONTAINER
+  // parent chain (def_ref) walked from each group's own GroupId. The container name is the group TYPE name —
+  // the same string ClassPropertiesExtractor publishes as the `groupName` property.
+  // Guarded per element: group topology is best-effort and must never fail the geometry send.
+  private static void EmitGroups(
+    ObjectsArtifactPipeline pipeline,
+    string modelKey,
+    List<(Element Element, int ObjK)> sentElements
+  )
+  {
+    var containerKByGroupUniqueId = new Dictionary<string, int?>(StringComparer.Ordinal);
+    var ordByContainerK = new Dictionary<int, int>();
+
+    foreach (var (element, objK) in sentElements)
+    {
+      try
+      {
+        // An ungrouped element's GroupId is InvalidElementId, which resolves to null.
+        if (element.Document.GetElement(element.GroupId) is not Group group)
+        {
+          continue;
+        }
+
+        // null = attached detail group: annotation, not model-group membership.
+        if (ResolveGroupContainer(pipeline, modelKey, group, containerKByGroupUniqueId) is not int groupK)
+        {
+          continue;
+        }
+
+        int ord = ordByContainerK.TryGetValue(groupK, out int next) ? next : 0;
+        pipeline.InGroup(objK, groupK, ord);
+        ordByContainerK[groupK] = ord + 1;
+      }
+      catch (Exception ex) when (!ex.IsFatal())
+      {
+        // best-effort: a group whose type or parent can't be read is skipped; the element still ships.
+      }
+    }
+  }
+
+  // Interns the CONTAINER("Group") for a placed group, minting its ancestor chain FIRST so a nested group hangs
+  // off its parent through def_ref. Keyed by model container as well as group, so a linked file placed twice
+  // gets one group tier per placement instead of one shared, cross-wired tier. Memoized per document pass:
+  // resolving is a Revit API round-trip and every member of a group asks the same question.
+  private static int? ResolveGroupContainer(
+    ObjectsArtifactPipeline pipeline,
+    string modelKey,
+    Group group,
+    Dictionary<string, int?> cache
+  )
+  {
+    if (cache.TryGetValue(group.UniqueId, out int? cached))
+    {
+      return cached;
+    }
+
+    int? containerK = null;
+    if (!IsAttachedDetailGroup(group))
+    {
+      int? parentK = group.Document.GetElement(group.GroupId) is Group parent
+        ? ResolveGroupContainer(pipeline, modelKey, parent, cache)
+        : null;
+      containerK = pipeline.AddContainer($"{modelKey}:{group.UniqueId}", group.GroupType.Name, parentK, "Group");
+    }
+
+    cache[group.UniqueId] = containerK;
+    return containerK;
+  }
+
+  // Attached detail groups name the model group they annotate in AttachedParentId; standalone detail groups are
+  // caught by category. Both are view-specific annotation and stay out of the model-group tier.
+  private static bool IsAttachedDetailGroup(Group group) =>
+    group.AttachedParentId != ElementId.InvalidElementId
+    || (group.Category is { } category && category.GetBuiltInCategory() == BuiltInCategory.OST_IOSDetailGroups);
 
   private static KeyValuePair<string, object?>[] RootScalars(Base converted, RevitObject? revitObject) =>
     new KeyValuePair<string, object?>[]

--- a/docs/connector-relations.md
+++ b/docs/connector-relations.md
@@ -62,7 +62,7 @@ What each connector actually emits, verified in the send builders. `●` emitted
 | **10 IN_COLLECTION** | ● | ● | ● | ● | ● | ● | · | ● | ● | ● |
 | **11 IN_MODEL** | · | · | · | · | · | · | ● | · | · | · |
 | **7 ON_LEVEL** | · | · | · | · | · | · | ● | · | · | · |
-| **17 IN_GROUP** | ● | · | ● | · | ● | · | · | · | · | · |
+| **17 IN_GROUP** | ● | · | ● | · | ● | · | ● | · | · | · |
 | **3 SUBELEMENT** | · | · | · | · | ● | · | ● | ● | · | ◐¹ |
 | **14 IN_SYSTEM** | · | · | · | · | ● | · | · | · | · | · |
 | **12 IN_ROOM** | · | · | · | · | · | · | ● | · | · | · |
@@ -317,9 +317,9 @@ A SketchUp group emits DISPLAY_INSTANCE like a component — so **IN_GROUP is ne
 
 ---
 
-### Revit — BIM · emits 10
+### Revit — BIM · emits 11
 
-The richest BIM producer: display geometry + instances/materials/levels, per-document model containers for federation, and a best-effort host-API topology layer (sub-elements, rooms, room-adjacency).
+The richest BIM producer: display geometry + instances/materials/levels, per-document model containers for federation, and a best-effort host-API topology layer (sub-elements, rooms, room-adjacency, model groups).
 
 **Wall on a level** — `DISPLAY` · `HAS_MATERIAL` · `ON_LEVEL` · `IN_MODEL`
 
@@ -381,7 +381,24 @@ graph LR
 
 Hosting and ownership are **separate rels** (ENG-9081): `FamilyInstance.Host` → `HOSTED_ON` (hosted→host), `SuperComponent` / composite `elements` children → `SUBELEMENT` (owner→child). Ownership wins when an element has both, matching rvextract's `owningElemId` → `getHostId` precedence, so connector and file-upload publishes of the same model agree. Occupancy is `IN_ROOM` (rooms are _objects_, not nodes); a door's FromRoom→ToRoom becomes `CONNECTS_TO` scoped by the opening. All best-effort in try/catch — topology never fails the geometry send.
 
-- **Nodes:** CONTAINER `"Model"` (per source doc) · LEVEL (name+elev) · DEFINITION/INSTANCE · MATERIAL
+**Model groups** — `IN_GROUP` (ENG-9079)
+
+```mermaid
+graph LR
+  A([obj · chair]):::obj
+  B([obj · desk]):::obj
+  INNER{{node · Group · "Workstation"}}:::nd
+  OUTER{{node · Group · "Office bay"}}:::nd
+  A -->|IN_GROUP| INNER
+  B -->|IN_GROUP| INNER
+  INNER -.->|def_ref| OUTER
+  classDef obj fill:#eac36a,stroke:#9a5f0c,color:#2a1c04;
+  classDef nd fill:#b3a8f0,stroke:#5647bd,color:#211648;
+```
+
+`ElementUnpacker` explodes every placed group into its members before conversion, so the group instance is never an object — membership is recovered from each member's `Element.GroupId`, and because that unpacking recurses, `GroupId` always names the **innermost** group (one `IN_GROUP` edge per element). Nesting is the CONTAINER parent chain (`def_ref`), walked from each group's own `GroupId`. Containers are keyed per model container, so a linked file placed twice gets one group tier per placement. Attached detail groups are excluded (annotation, not model topology). The container name is the group TYPE name — the same string that ships as the `groupName` property.
+
+- **Nodes:** CONTAINER `"Model"` (per source doc) · CONTAINER `"Group"` (per placed model group) · LEVEL (name+elev) · DEFINITION/INSTANCE · MATERIAL
 - **Sidecar:** `camera_views` ← 3D views (ENG-8802) · `reference_point` meta (ENG-8808)
 - **Receive:** ● native — DirectShape + DirectShapeLibrary instances, reference-point reversal
 - **Watch out:** linked models intern per-placement; Shared Coordinates deliberately not recorded (can't be one offset)
@@ -499,7 +516,7 @@ Members group by member-type (Beam, Column, Slab…) into flat collections. Resu
 
 **Three families.**
 - _Free-form CAD_ (Rhino, GH, AutoCAD, Plant3D, SketchUp) shares one profile: DISPLAY + instancing + IN_COLLECTION + materials/colours, ± groups & solids.
-- _BIM_ (Revit) is the only user of ON_LEVEL, IN_MODEL and IN_ROOM — the storey/federation/spatial tier.
+- _BIM_ (Revit) is the only user of ON_LEVEL, IN_MODEL and IN_ROOM — the storey/federation/spatial tier. It shares the CAD family's `IN_GROUP` axis, sourced from model groups rather than authored scene groups (ENG-9079).
 - _Structural_ (Tekla, CSi, TSD) is lean geometry + one topology or results channel; CSi & TSD own `structural_results`.
 
 **Deliberate folds & substitutions.**

--- a/docs/connector-topology.md
+++ b/docs/connector-topology.md
@@ -24,13 +24,14 @@
 | IN_MODEL (11) | object → node | — | source/linked model | `InModel` |
 | IN_ROOM (12) | **object → object** | — | element → room object | `InRoom` |
 | IN_SYSTEM (14) | object → node | — | MEP System / Network | `InSystem` + `AddContainer(…,"MEP System"\|"Network")` |
+| IN_GROUP (17) | object → node | ordinal | authored / model group membership | `InGroup` + `AddContainer(…,"Group")` |
 | CONNECTS_TO (21) | object → object | **scope** | connectivity (ord = system-K / opening-K / 0) | `ConnectsTo(s,t[,scope])` |
 | HOSTED_ON (22) | object → object | — | hosted element → its host | `HostedOn(hosted, host)` |
 | BOUNDS (23) | object → object | — | bounding wall → room | `Bounds` |
 
-Node kinds: DEFINITION, INSTANCE, MATERIAL, COLOR, LEVEL, CONTAINER (subtype `Collection｜Model｜MEP System｜Network`).
-**Retired — do NOT use:** IN_SPACE(13), IN_NETWORK(15), IN_LINE(16), **IN_GROUP(17)**, IN_ASSEMBLY(18),
-IN_SUBASSEMBLY(19), XREF(20), COLLECTION-node(6).
+Node kinds: DEFINITION, INSTANCE, MATERIAL, COLOR, LEVEL, CONTAINER (subtype `Collection｜Group｜Model｜MEP System｜Network`).
+**Retired — do NOT use:** IN_SPACE(13), IN_NETWORK(15), IN_LINE(16), IN_ASSEMBLY(18),
+IN_SUBASSEMBLY(19), XREF(20), COLLECTION-node(6). (`IN_GROUP(17)` was **un-retired** post-v5 — see decision 1.)
 
 **SUBELEMENT is ownership, HOSTED_ON is placement** — and they are not interchangeable. A curtain panel is a
 *component of* its curtain wall (SUBELEMENT); a door is *placed on* its wall (HOSTED_ON). Ownership takes
@@ -55,6 +56,10 @@ opening-K for room adjacency, 0 unscoped. The façade `ConnectsTo(s,t,scope)` ov
   [ENG-9081]. An owner that exists but wasn't sent drops the edge rather than falling back to HOSTED_ON.
 - ✅ **IN_ROOM** — `FamilyInstance.Room ?? .Space` → room object.
 - ✅ **CONNECTS_TO (spatial)** — door/window `FromRoom → ToRoom`, scope = opening object K.
+- ✅ **IN_GROUP** — `Element.GroupId` → `CONTAINER("Group")` named after the group TYPE, one edge per element
+  (`ElementUnpacker` recursion means `GroupId` is always the innermost group), nesting via the container
+  `def_ref` chain, containers keyed per model container so linked placements stay distinct, attached detail
+  groups excluded [ENG-9079].
 - 🔶 **BOUNDS** — `Room.GetBoundarySegments → BoundarySegment.ElementId` (new API walk; the Areas pattern
   exists in `DisplayValueExtractor`). Rooms must be sent.
 - 🔶 **IN_SYSTEM** — `MEPCurve.MEPSystem` / `FamilyInstance.MEPModel.ConnectorManager…MEPSystem`
@@ -113,20 +118,20 @@ The managed connectors have the same host-API affordances; the ODA extractors ar
 | BOUNDS | `OdBmRoomElem::getBoundarySegments()` → segment `getElementId()` | — |
 | CONNECTS_TO | MEP: `getBaseConnectorManager→getConnectors→getRefs/getDirection`, ord=system-K; spatial: `getRoomId(From/To)`, ord=opening-K | IFC port reconstruction (coincident `IfcDistributionPort` + FlowDirection), ord=0 |
 | IN_SYSTEM | `getMEPSystem()` → CONTAINER subtype "MEP System" | network components → CONTAINER subtype "Network" |
+| IN_GROUP | `OdBmElement::getGroupId()` → `OdBmElementGroup` (≈ `Element.GroupId`), skipping `getIsAttached()` detail groups — 🔶 not emitted yet (ENG-9079) | — |
 | DISPLAY_INSTANCE / DEFINES / DEFINES_INSTANCE | `OdBmGElement` geometry-node walk | fragment grouping (no DEFINES_INSTANCE) |
 | IN_MODEL | — (single native model) | `OdNwPartition::getSourceFileName()` → CONTAINER subtype "Model" |
 
 ## Modeling decisions
 
-1. **Grouping needs a relation reintroduction (⛔ blocked).** The only live obj→CONTAINER "grouping"
+1. **Grouping got its own relation back (✅ resolved).** The only other live obj→CONTAINER "grouping"
    relation is `IN_COLLECTION`, and the receive side stores it **last-wins single-valued**
    (`ArtefactRelations.CollectionByObject[src]=dst`) — it *is* the scene tree. Reusing it for groups would
    make members land in the group **instead of** their layer/type collection, regressing the scene tree and
-   .NET round-trip receive. The clean home is the **retired `IN_GROUP` (17)** — reintroducing it is a
-   **shared bundle-format change** (spec + regenerate + façade + receive handling + viewer/server support),
-   so it is deferred to a team decision rather than shipped blind. Affects Rhino/AutoCAD scene groups and
-   the semantic-grouping variants (CSi groups). (CSi pier/spandrel and Civil networks use `IN_SYSTEM`, which
-   is a *distinct* rel/map and does not conflict.)
+   .NET round-trip receive. So `IN_GROUP` (17) was **un-retired** in the spec instead: a separate, overlapping
+   axis onto `CONTAINER(subtype "Group")`, nesting through the container parent chain (`def_ref`). Rhino and
+   AutoCAD emit authored scene groups; Revit emits **model groups** off `Element.GroupId` (ENG-9079). (CSi
+   pier/spandrel and Civil networks use `IN_SYSTEM`, which is a *distinct* rel/map and does not conflict.)
 2. **Ownership and hosting are separate rels.** `SUBELEMENT` carries ownership (`SuperComponent`, composite
    children); `HOSTED_ON(22)` — un-retired post-v5 — carries hosting (`Host`). Ownership wins when both exist.
    Folding them into one rel made a model's topology depend on whether it was published through the connector
@@ -138,10 +143,10 @@ The managed connectors have the same host-API affordances; the ODA extractors ar
 
 - **Phase 0** (SDK) — ✅ `Bounds` façade + scoped `ConnectsTo(…,scope)` overload + `InRoom` doc fix.
 - **Phase 1** (SUBELEMENT lift) — ✅ Tekla, Revit (recovers dropped child geometry), Civil3D.
-- **Phase 3** (Revit) — ✅ IN_ROOM, ownership SUBELEMENT, hosting HOSTED_ON, spatial CONNECTS_TO. 🔶 BOUNDS / MEP IN_SYSTEM+connectivity / assemblies.
+- **Phase 3** (Revit) — ✅ IN_ROOM, ownership SUBELEMENT, hosting HOSTED_ON, spatial CONNECTS_TO, model-group IN_GROUP. 🔶 BOUNDS / MEP IN_SYSTEM+connectivity / assemblies.
 - **Phase 4** (Civil3D) — ✅ network IN_SYSTEM, pipe→structure CONNECTS_TO. 🔶 Plant3D IN_SYSTEM + ports.
 - **Phase 5** (CSi) — ✅ member↔joint CONNECTS_TO. 🔶 ON_LEVEL / pier-spandrel IN_SYSTEM / section HAS_MATERIAL; Tekla assemblies + welds.
-- **Phase 2** (grouping) — ⛔ blocked on the `IN_GROUP` decision above.
+- **Phase 2** (grouping) — ✅ Rhino / AutoCAD authored groups, Revit model groups (ENG-9079). 🔶 CSi groups; rvextract's `OdBmElement::getGroupId()` side of ENG-9079 is still open.
 
 The 🔶 items all require **new host-API walks in the collect phase** (main-thread Revit/Plant3D/Tekla API);
 they were left as a **tested** follow-up rather than shipped blind, and each is wrapped/guarded so it can


### PR DESCRIPTION
## Description

Revit model-group topology was not preserved in published bundles. `ElementUnpacker` explodes every placed `Group` into its members before conversion, so members shipped flat with only a `groupName` property — there was no way to navigate from an element to the group it belongs to, and no group tier in the graph at all.

This emits one `CONTAINER(subtype "Group")` per placed model group plus an `IN_GROUP` edge per member, recovering the membership from each member's `Element.GroupId`. `IN_GROUP` (17) was un-retired in the spec post-v5 and is already emitted by Rhino/AutoCAD for authored scene groups; Revit now shares that axis, sourced from model groups.

This is the **send/extraction** half of the ticket, connector side only. The rvextract half (`OdBmElement::getGroupId()` + the legacy `groupName` property + adding `rvextract` to `IN_GROUP.emitted_by`) is still open and lives in `speckle-converters`. Receive-side group handling is [ENG-8805](https://linear.app/speckle/issue/ENG-8805), untouched here.

Connects [ENG-9079](https://linear.app/speckle/issue/ENG-9079/rvextract-and-revit-connector-preserve-model-group-membership-in)

## User Value

Elements published from Revit can be filtered, grouped and navigated by the model group they belong to — the group structure the modeller authored survives into the viewer, dashboards and automations instead of being flattened away on send.

## Changes:

- `RevitArtifactRootObjectBuilder.EmitGroups` — new pass, run per source document right after that document's element loop.
  - **Membership** from `Element.GroupId`. Because `ElementUnpacker` recurses into nested groups, `GroupId` always names the **innermost** group, which gives exactly one `IN_GROUP` edge per element.
  - **Nesting** through the CONTAINER parent chain (`def_ref`): each group's own `GroupId` names its parent, so containers are minted parent-first. Memoized per document pass — resolving is a Revit API round-trip and every member of a group asks the same question.
  - **Attached detail groups excluded** — `AttachedParentId` valid, or category `OST_IOSDetailGroups`. Annotation, not model topology.
  - **Linked models**: containers are keyed `{modelKey}:{group.UniqueId}`, so a linked file placed twice gets one group tier per placement rather than one shared, cross-wired tier.
  - Guarded per element (`catch when (!ex.IsFatal())`) like the rest of `EmitElementTopology` — group topology must never fail a geometry send.
- `EmitObject` now **returns its interned object K**, so the group pass wires the exact placement instead of resolving through the many-valued `objectKsByElementUniqueId` map (a linked element sent under N link instances is interned N times).
- Container name is the group **TYPE** name — the same string `ClassPropertiesExtractor` already publishes as the `groupName` property, so property and topology agree.
- Docs: `docs/connector-relations.md` (Revit flipped to ● for IN_GROUP, new section + diagram, `emits 10` → `11`) and `docs/connector-topology.md`, whose "⛔ blocked on the `IN_GROUP` decision" note and "IN_GROUP (17) — retired, do NOT use" line were both stale.

### Design calls worth a reviewer's eye

- **Top-level group containers are roots** (`def_ref = null`), not parented under the document's `Model` container. Deliberate: rvextract has no Model container, and the ticket asks for equivalent group topology between the two producers.
- **Folded children** (curtain panels, mullions, stacked-wall members) get no `IN_GROUP` of their own — their parent carries the edge and they hang off it via `SUBELEMENT`.
- **Ungrouped models** mint no Group containers and no edges.

## Validation of changes:

The Revit connector has no test project (the group walk needs live `Document`/`Group`/`Element` API objects, which aren't mockable), so this was validated by build + manual test:

- `Speckle.Connectors.Revit2023` (net48) and `Speckle.Connectors.Revit2026` (net8.0-windows) both build `-c Local` with **0 warnings / 0 errors**. Those two cover both sides of the `REVIT2024_OR_GREATER` split, so the remaining versions are compile-safe by construction.
- `dotnet csharpier check ./` clean; no `packages.lock.json` churn.
- Manual: send a model with a nested model group and confirm one container per group instance, the `def_ref` chain, one `IN_GROUP` edge per element, and no containers for an ungrouped model.

## Checklist:
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [ ] I have added appropriate tests. — no Revit connector test project exists; see Validation above.
- [x] I have updated or added relevant documentation.
