### PR TITLE
feat(grasshopper): make Load and Publish legacy-first and deprecate them

### DIFF
--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Receive/ReceiveAsyncComponent.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Receive/ReceiveAsyncComponent.cs
@@ -93,6 +93,8 @@ public class ReceiveAsyncComponent : GH_AsyncComponent<ReceiveAsyncComponent>
 
   protected override void SolveInstance(IGH_DataAccess da)
   {
+    AddRuntimeMessage(GH_RuntimeMessageLevel.Remark, Constants.DEPRECATED_LOAD_MESSAGE);
+
     MultipleResources = Params.Input[0].VolatileData.HasInputCountGreaterThan(1);
     if (MultipleResources)
     {

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Receive/ReceiveAsyncComponent.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Receive/ReceiveAsyncComponent.cs
@@ -41,7 +41,13 @@ public class ReceiveAsyncComponent : GH_AsyncComponent<ReceiveAsyncComponent>
   public override Guid ComponentGuid => GetType().GUID;
   protected override Bitmap Icon => Resources.speckle_operations_load;
 
-  public override GH_Exposure Exposure => GH_Exposure.secondary;
+  public override GH_Exposure Exposure => GH_Exposure.hidden;
+
+  /// <remarks>
+  /// Marks this component as obsolete in the Grasshopper UI (hides it from the ribbon, adds the
+  /// "obsolete" overlay icon on canvas).
+  /// </remarks>
+  public override bool Obsolete => true;
 
   public string InputType { get; set; }
   public bool AutoReceive { get; set; }
@@ -461,79 +467,27 @@ public sealed class ReceiveComponentWorker : WorkerInstance<ReceiveAsyncComponen
 
     using var scope = PriorityLoader.CreateScopeForActiveDocument();
 
-    // Speckle 4.0 artefact receive (opportunistic; mirrors the sync (Sync) Load component). If a parquet bundle
-    // exists for this version, build the wrapper tree directly from it and return. Any failure (no bundle, broken
-    // bundle, 404) is non-fatal — we surface a warning and fall through to the v1 receive path below.
-    var artifactReceiver = scope.ServiceProvider.GetService<IArtifactReceiver>();
-    if (artifactReceiver != null)
-    {
-      try
-      {
-        var bundle = await artifactReceiver
-          .TryGetBundleAsync(Parent.ApiClient.Account, receiveInfo, progress, CancellationToken)
-          .ConfigureAwait(false);
-        if (bundle != null)
-        {
-          SpeckleConversionContext.SetupCurrent(scope);
-          try
-          {
-            (SpeckleCollectionWrapper rootWrapper, IReadOnlyList<string> buildWarnings) =
-              new GrasshopperArtefactObjectBuilder().Build(bundle, receiveInfo.ModelName);
-            foreach (var warning in buildWarnings)
-            {
-              RuntimeMessages.Add((GH_RuntimeMessageLevel.Warning, warning));
-            }
-            try
-            {
-              await Parent
-                .ApiClient.Version.Received(
-                  new(receiveInfo.SelectedVersionId, receiveInfo.ProjectId, receiveInfo.ReceivingApplicationSlug),
-                  CancellationToken
-                )
-                .ConfigureAwait(false);
-            }
-            catch (Exception ex) when (!ex.IsFatal())
-            {
-              RuntimeMessages.Add(
-                (
-                  GH_RuntimeMessageLevel.Warning,
-                  $"Loaded via 4.0 artefacts, but could not mark the version as received ({ex.Message})."
-                )
-              );
-            }
-            Result = new SpeckleCollectionWrapperGoo(rootWrapper);
-            return;
-          }
-          finally
-          {
-            SpeckleConversionContext.EndCurrent();
-          }
-        }
-
-        RuntimeMessages.Add(
-          (
-            GH_RuntimeMessageLevel.Warning,
-            "No 4.0 artefact bundle found for this version; using the legacy receive path."
-          )
-        );
-      }
-      catch (Exception ex) when (!ex.IsFatal())
-      {
-        RuntimeMessages.Add(
-          (
-            GH_RuntimeMessageLevel.Warning,
-            $"4.0 artefact load unavailable ({ex.Message}); loading via the legacy path."
-          )
-        );
-      }
-    }
-
     try
     {
-      Root = await scope
-        .Get<GrasshopperReceiveOperation>()
-        .ReceiveCommitObject(receiveInfo, progress, CancellationToken)
-        .ConfigureAwait(false);
+      // deprecated component: v3 first, on purpose. a migrated version keeps its v1 root, so preferring v3 means
+      // migration never changes what an existing script outputs. only a 4.0-native version has no v1 root to read.
+      try
+      {
+        Root = await scope
+          .Get<GrasshopperReceiveOperation>()
+          .ReceiveCommitObject(receiveInfo, progress, CancellationToken)
+          .ConfigureAwait(false);
+      }
+      catch (Exception ex) when (!ex.IsFatal() && !CancellationToken.IsCancellationRequested)
+      {
+        if (!await TryLoadFromArtefacts(scope, receiveInfo).ConfigureAwait(false))
+        {
+          throw; // no bundle either - the v3 failure is the real error
+        }
+
+        RuntimeMessages.Add((GH_RuntimeMessageLevel.Warning, Constants.DEPRECATED_LOAD_FALLBACK_MESSAGE));
+        return;
+      }
 
       CancellationToken.ThrowIfCancellationRequested();
 
@@ -611,6 +565,71 @@ public sealed class ReceiveComponentWorker : WorkerInstance<ReceiveAsyncComponen
     finally
     {
       SpeckleConversionContext.EndCurrent();
+    }
+  }
+
+  /// <summary>
+  /// Loads a 4.0-native version (no v1 root) from its artefact bundle into <see cref="Result"/>. Returns false when
+  /// there's no bundle either, so the caller can rethrow the v3 failure. Never throws.
+  /// </summary>
+  /// <remarks>Leaves RootProperties and ProxiesGoo null - neither survives into the bundle. Caller warns.</remarks>
+  private async Task<bool> TryLoadFromArtefacts(IServiceScope scope, ReceiveInfo receiveInfo)
+  {
+    try
+    {
+      var artifactReceiver = scope.ServiceProvider.GetService<IArtifactReceiver>();
+      if (artifactReceiver is null)
+      {
+        return false;
+      }
+
+      var bundle = await artifactReceiver
+        .TryGetBundleAsync(
+          Parent.ApiClient.Account,
+          receiveInfo,
+          new Progress<CardProgress>(_ => { }),
+          CancellationToken
+        )
+        .ConfigureAwait(false);
+      if (bundle is null)
+      {
+        return false;
+      }
+
+      // Receive's finally disposes the conversion context
+      SpeckleConversionContext.SetupCurrent(scope);
+      (SpeckleCollectionWrapper rootWrapper, IReadOnlyList<string> buildWarnings) =
+        new GrasshopperArtefactObjectBuilder().Build(bundle, receiveInfo.ModelName);
+
+      foreach (var warning in buildWarnings)
+      {
+        RuntimeMessages.Add((GH_RuntimeMessageLevel.Warning, warning));
+      }
+
+      // best-effort: this endpoint 404s on some servers, don't lose an already-built receive over it
+      try
+      {
+        await Parent
+          .ApiClient.Version.Received(
+            new(receiveInfo.SelectedVersionId, receiveInfo.ProjectId, receiveInfo.ReceivingApplicationSlug),
+            CancellationToken
+          )
+          .ConfigureAwait(false);
+      }
+      catch (Exception ex) when (!ex.IsFatal())
+      {
+        RuntimeMessages.Add(
+          (GH_RuntimeMessageLevel.Warning, $"Could not mark the version as received ({ex.Message}).")
+        );
+      }
+
+      Result = new SpeckleCollectionWrapperGoo(rootWrapper);
+      return true;
+    }
+    catch (Exception ex) when (!ex.IsFatal())
+    {
+      RuntimeMessages.Add((GH_RuntimeMessageLevel.Warning, $"4.0 artefact load also failed ({ex.Message})."));
+      return false;
     }
   }
 }

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Receive/ReceiveComponent.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Receive/ReceiveComponent.cs
@@ -15,6 +15,7 @@ using Speckle.Sdk;
 using Speckle.Sdk.Api;
 using Speckle.Sdk.Api.GraphQL.Models;
 using Speckle.Sdk.Credentials;
+using Speckle.Sdk.Models;
 using Speckle.Sdk.Models.Collections;
 using Speckle.Sdk.Pipelines.Progress;
 
@@ -49,6 +50,13 @@ public class ReceiveComponent : SpeckleTaskCapableComponent<ReceiveComponentInpu
   private SpeckleUrlModelResource? _lastResource;
   public override Guid ComponentGuid => new("74954F59-B1B7-41FD-97DE-4C6B005F2801");
   protected override Bitmap Icon => Resources.speckle_operations_syncload;
+  public override GH_Exposure Exposure => GH_Exposure.hidden;
+
+  /// <remarks>
+  /// Marks this component as obsolete in the Grasshopper UI (hides it from the ribbon, adds the
+  /// "obsolete" overlay icon on canvas).
+  /// </remarks>
+  public override bool Obsolete => true;
 
   public ReceiveComponent()
     : base(
@@ -174,89 +182,40 @@ public class ReceiveComponent : SpeckleTaskCapableComponent<ReceiveComponentInpu
       // store version id for tracking
       _lastVersionId = receiveInfo.SelectedVersionId;
 
-      // Speckle 4.0 artefact receive: if a parquet bundle exists for this version, build the wrapper tree directly
-      // from it (skips the v1 deserialize + RootObjectUnpacker + LocalToGlobalMapHandler). This path is opportunistic:
-      // any failure (no bundle, a broken/partial bundle, a 404 on a presigned download, a parse error) is non-fatal —
-      // we surface a remark and fall through to the proven v1 receive path below rather than crashing the receive.
-      var artifactReceiver = scope.ServiceProvider.GetService<IArtifactReceiver>();
-      if (artifactReceiver != null)
-      {
-        try
-        {
-          var bundleProgress = new Progress<CardProgress>(_ => { });
-          var bundle = await artifactReceiver
-            .TryGetBundleAsync(account, receiveInfo, bundleProgress, cancellationToken)
-            .ConfigureAwait(false);
-          if (bundle != null)
-          {
-            SpeckleConversionContext.SetupCurrent(scope);
-            SpeckleCollectionWrapper rootWrapper;
-            IReadOnlyList<string> buildWarnings;
-            try
-            {
-              (rootWrapper, buildWarnings) = new GrasshopperArtefactObjectBuilder().Build(
-                bundle,
-                receiveInfo.ModelName
-              );
-            }
-            finally
-            {
-              SpeckleConversionContext.EndCurrent();
-            }
-            foreach (var warning in buildWarnings)
-            {
-              AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, warning);
-            }
-
-            // Marking the version received is a best-effort side-effect — its endpoint may 404 on some servers, and
-            // that must NEVER discard an already-built receive (otherwise we'd wrongly fall through to the v1 path,
-            // which 404s on the synthetic root of an artefact-only version).
-            try
-            {
-              await client
-                .Version.Received(
-                  new(receiveInfo.SelectedVersionId, receiveInfo.ProjectId, receiveInfo.ReceivingApplicationSlug),
-                  cancellationToken
-                )
-                .ConfigureAwait(false);
-            }
-            catch (Exception ex) when (!ex.IsFatal())
-            {
-              AddRuntimeMessage(
-                GH_RuntimeMessageLevel.Warning,
-                $"Loaded via 4.0 artefacts, but could not mark the version as received ({ex.Message})."
-              );
-            }
-
-            return new ReceiveComponentOutput { RootObject = new SpeckleCollectionWrapperGoo(rootWrapper) };
-          }
-
-          // No parquet bundle for this version — the artefacts list endpoint returned nothing. If the version was
-          // actually sent via artefacts, its v1 root is synthetic and the legacy path below will 404 fetching it;
-          // surface a warning so that failure mode is legible rather than a bare 404.
-          AddRuntimeMessage(
-            GH_RuntimeMessageLevel.Warning,
-            "No 4.0 artefact bundle found for this version; using the legacy receive path."
-          );
-        }
-        catch (Exception ex) when (!ex.IsFatal())
-        {
-          AddRuntimeMessage(
-            GH_RuntimeMessageLevel.Warning,
-            $"4.0 artefact load unavailable ({ex.Message}); loading via the legacy path."
-          );
-        }
-      }
-
       var progress = new Progress<CardProgress>(_ =>
       {
         // TODO: Progress only makes sense in non-blocking async receive, which is not supported yet.
         // Message = $"{progress.Status}: {progress.Progress}";
       });
 
-      var root = await receiveOperation
-        .ReceiveCommitObject(receiveInfo, progress, cancellationToken)
-        .ConfigureAwait(false);
+      // deprecated component: v3 first, on purpose. a migrated version keeps its v1 root, so preferring v3 means
+      // migration never changes what an existing script outputs. only a 4.0-native version has no v1 root to read.
+      Base root;
+      try
+      {
+        root = await receiveOperation
+          .ReceiveCommitObject(receiveInfo, progress, cancellationToken)
+          .ConfigureAwait(false);
+      }
+      catch (Exception ex) when (!ex.IsFatal() && !cancellationToken.IsCancellationRequested)
+      {
+        ReceiveComponentOutput? fallback = await TryLoadFromArtefacts(
+            scope,
+            account,
+            client,
+            receiveInfo,
+            cancellationToken
+          )
+          .ConfigureAwait(false);
+
+        if (fallback is null)
+        {
+          throw; // no bundle either - the v3 failure is the real error
+        }
+
+        AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, Constants.DEPRECATED_LOAD_FALLBACK_MESSAGE);
+        return fallback;
+      }
 
       // extract model-wide root properties (see cnx-2722)
       SpecklePropertyGroupGoo? rootPropertiesGoo = null;
@@ -328,6 +287,69 @@ public class ReceiveComponent : SpeckleTaskCapableComponent<ReceiveComponentInpu
     finally
     {
       SpeckleConversionContext.EndCurrent();
+    }
+  }
+
+  /// <summary>
+  /// Loads a 4.0-native version (no v1 root) from its artefact bundle. Returns null when there's no bundle either, so
+  /// the caller can rethrow the v3 failure. Never throws.
+  /// </summary>
+  /// <remarks>Leaves RootProperties and ProxiesGoo null - neither survives into the bundle. Caller warns.</remarks>
+  private async Task<ReceiveComponentOutput?> TryLoadFromArtefacts(
+    IServiceScope scope,
+    Account account,
+    IClient client,
+    ReceiveInfo receiveInfo,
+    CancellationToken cancellationToken
+  )
+  {
+    try
+    {
+      var artifactReceiver = scope.ServiceProvider.GetService<IArtifactReceiver>();
+      if (artifactReceiver is null)
+      {
+        return null;
+      }
+
+      var bundle = await artifactReceiver
+        .TryGetBundleAsync(account, receiveInfo, new Progress<CardProgress>(_ => { }), cancellationToken)
+        .ConfigureAwait(false);
+      if (bundle is null)
+      {
+        return null;
+      }
+
+      // PerformTask's finally disposes the conversion context
+      SpeckleConversionContext.SetupCurrent(scope);
+      (SpeckleCollectionWrapper rootWrapper, IReadOnlyList<string> buildWarnings) =
+        new GrasshopperArtefactObjectBuilder().Build(bundle, receiveInfo.ModelName);
+
+      foreach (var warning in buildWarnings)
+      {
+        AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, warning);
+      }
+
+      // best-effort: this endpoint 404s on some servers, don't lose an already-built receive over it
+      try
+      {
+        await client
+          .Version.Received(
+            new(receiveInfo.SelectedVersionId, receiveInfo.ProjectId, receiveInfo.ReceivingApplicationSlug),
+            cancellationToken
+          )
+          .ConfigureAwait(false);
+      }
+      catch (Exception ex) when (!ex.IsFatal())
+      {
+        AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, $"Could not mark the version as received ({ex.Message}).");
+      }
+
+      return new ReceiveComponentOutput { RootObject = new SpeckleCollectionWrapperGoo(rootWrapper) };
+    }
+    catch (Exception ex) when (!ex.IsFatal())
+    {
+      AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, $"4.0 artefact load also failed ({ex.Message}).");
+      return null;
     }
   }
 

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Receive/ReceiveComponent.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Receive/ReceiveComponent.cs
@@ -100,6 +100,12 @@ public class ReceiveComponent : SpeckleTaskCapableComponent<ReceiveComponentInpu
     );
   }
 
+  protected override void SolveInstance(IGH_DataAccess da)
+  {
+    AddRuntimeMessage(GH_RuntimeMessageLevel.Remark, Constants.DEPRECATED_LOAD_MESSAGE);
+    base.SolveInstance(da);
+  }
+
   protected override ReceiveComponentInput GetInput(IGH_DataAccess da)
   {
     SpeckleUrlModelResource? url = null;

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Send/SendAsyncComponent.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Send/SendAsyncComponent.cs
@@ -157,6 +157,8 @@ public class SendAsyncComponent : GH_AsyncComponent<SendAsyncComponent>
 
   protected override void SolveInstance(IGH_DataAccess da)
   {
+    AddRuntimeMessage(GH_RuntimeMessageLevel.Remark, Constants.DEPRECATED_PUBLISH_MESSAGE);
+
     var multipleResources = Params.Input[0].VolatileData.HasInputCountGreaterThan(1);
 
     HasMultipleInputs = multipleResources;
@@ -442,7 +444,7 @@ public class SendComponentWorker : WorkerInstance<SendAsyncComponent>
     // not added to RuntimeMessages - the success remarks below are gated on that list being empty
     if (OutputVersionId != null)
     {
-      Parent.AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, Constants.DEPRECATED_PUBLISH_MESSAGE);
+      Parent.AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, Constants.PUBLISHED_LEGACY_VERSION_MESSAGE);
     }
 
     Parent.CurrentComponentState = ComponentState.UpToDate;

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Send/SendAsyncComponent.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Send/SendAsyncComponent.cs
@@ -44,7 +44,13 @@ public class SendAsyncComponent : GH_AsyncComponent<SendAsyncComponent>
   public override Guid ComponentGuid => GetType().GUID;
 
   protected override Bitmap Icon => Resources.speckle_operations_publish;
-  public override GH_Exposure Exposure => GH_Exposure.secondary;
+  public override GH_Exposure Exposure => GH_Exposure.hidden;
+
+  /// <remarks>
+  /// Marks this component as obsolete in the Grasshopper UI (hides it from the ribbon, adds the
+  /// "obsolete" overlay icon on canvas).
+  /// </remarks>
+  public override bool Obsolete => true;
 
   public ComponentState CurrentComponentState { get; set; } = ComponentState.NeedsInput;
   public bool AutoSend { get; set; }
@@ -433,6 +439,12 @@ public class SendComponentWorker : WorkerInstance<SendAsyncComponent>
     da.SetData(0, OutputParam);
     da.SetData(1, OutputVersionId);
 
+    // not added to RuntimeMessages - the success remarks below are gated on that list being empty
+    if (OutputVersionId != null)
+    {
+      Parent.AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, Constants.DEPRECATED_PUBLISH_MESSAGE);
+    }
+
     Parent.CurrentComponentState = ComponentState.UpToDate;
     Parent.OutputParam = OutputParam; // ref the outputs in the parent too, so we can serialise them on write/read
     Parent.OverallProgress = 0;
@@ -524,7 +536,8 @@ public class SendComponentWorker : WorkerInstance<SendAsyncComponent>
         Parent.VersionMessage,
         progress,
         true,
-        CancellationToken
+        CancellationToken,
+        useArtifacts: false // deprecated component: keep writing v3 so older connectors can still read it
       )
       .ConfigureAwait(false);
 

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Send/SendComponent.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Send/SendComponent.cs
@@ -105,6 +105,12 @@ public class SendComponent : SpeckleTaskCapableComponent<SendComponentInput, Sen
     pManager.AddTextParameter("Version ID", "V", "ID of the created version", GH_ParamAccess.item);
   }
 
+  protected override void SolveInstance(IGH_DataAccess da)
+  {
+    AddRuntimeMessage(GH_RuntimeMessageLevel.Remark, Constants.DEPRECATED_PUBLISH_MESSAGE);
+    base.SolveInstance(da);
+  }
+
   protected override SendComponentInput GetInput(IGH_DataAccess da)
   {
     if (da.Iteration != 0)
@@ -266,7 +272,7 @@ public class SendComponent : SpeckleTaskCapableComponent<SendComponentInput, Sen
       return new(null);
     }
 
-    AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, Constants.DEPRECATED_PUBLISH_MESSAGE);
+    AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, Constants.PUBLISHED_LEGACY_VERSION_MESSAGE);
 
     // safe to always create new wrapper since users cannot create SpeckleRootCollectionWrapper directly
     var rootWrapper = new SpeckleRootCollectionWrapper(input.Input.Value, input.RootProperties?.Unwrap());

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Send/SendComponent.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Send/SendComponent.cs
@@ -52,6 +52,13 @@ public class SendComponent : SpeckleTaskCapableComponent<SendComponentInput, Sen
   public string? Url { get; private set; }
   public string? VersionMessage { get; private set; }
   protected override Bitmap Icon => Resources.speckle_operations_syncpublish;
+  public override GH_Exposure Exposure => GH_Exposure.hidden;
+
+  /// <remarks>
+  /// Marks this component as obsolete in the Grasshopper UI (hides it from the ribbon, adds the
+  /// "obsolete" overlay icon on canvas).
+  /// </remarks>
+  public override bool Obsolete => true;
 
   public SendComponent()
     : base(
@@ -259,6 +266,8 @@ public class SendComponent : SpeckleTaskCapableComponent<SendComponentInput, Sen
       return new(null);
     }
 
+    AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, Constants.DEPRECATED_PUBLISH_MESSAGE);
+
     // safe to always create new wrapper since users cannot create SpeckleRootCollectionWrapper directly
     var rootWrapper = new SpeckleRootCollectionWrapper(input.Input.Value, input.RootProperties?.Unwrap());
     var collectionToSend = new SpeckleRootCollectionWrapperGoo(rootWrapper);
@@ -284,7 +293,17 @@ public class SendComponent : SpeckleTaskCapableComponent<SendComponentInput, Sen
     using var client = clientFactory.Create(account);
     var sendInfo = await input.Resource.GetSendInfo(client, cancellationToken).ConfigureAwait(false);
     var (result, versionId, ingestionId) = await sendOperation
-      .Send([collectionToSend], sendInfo, fileName, fileBytes, VersionMessage, progress, true, cancellationToken)
+      .Send(
+        [collectionToSend],
+        sendInfo,
+        fileName,
+        fileBytes,
+        VersionMessage,
+        progress,
+        true,
+        cancellationToken,
+        useArtifacts: false // deprecated component: keep writing v3 so older connectors can still read it
+      )
       .ConfigureAwait(false);
 
     if (ingestionId != null)

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/HostApp/Globals.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/HostApp/Globals.cs
@@ -7,4 +7,15 @@ public static class Constants
   public const string TOPOLOGY_PROP = "topology";
   public const string NAME_PROP = "name";
   public const string PROPERTIES_PROP = "properties";
+
+  /// <summary>Raised by the deprecated Publish components on every run.</summary>
+  public const string DEPRECATED_PUBLISH_MESSAGE =
+    "This Publish component is deprecated and creates a Speckle 3.0 version, so teammates on older connectors can "
+    + "still read it. Switch to the new Publish component when your team is ready for 4.0.";
+
+  /// <summary>Raised by the deprecated Load components when a version only exists as 4.0 artefacts.</summary>
+  public const string DEPRECATED_LOAD_FALLBACK_MESSAGE =
+    "This version was published with Speckle 4.0, so there is no 3.0 model to load. It has been loaded from 4.0 "
+    + "artefacts instead: 'Properties' and 'Proxies' are unavailable, and objects may be split differently to what "
+    + "this script expects. Switch to the new Load component for full 4.0 support.";
 }

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/HostApp/Globals.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/HostApp/Globals.cs
@@ -8,10 +8,18 @@ public static class Constants
   public const string NAME_PROP = "name";
   public const string PROPERTIES_PROP = "properties";
 
-  /// <summary>Raised by the deprecated Publish components on every run.</summary>
+  /// <summary>Remark raised by the deprecated Load components on every solve.</summary>
+  public const string DEPRECATED_LOAD_MESSAGE =
+    "This Load component is deprecated. Switch to the new Load component for Speckle 4.0 support.";
+
+  /// <summary>Remark raised by the deprecated Publish components on every solve.</summary>
   public const string DEPRECATED_PUBLISH_MESSAGE =
-    "This Publish component is deprecated and creates a Speckle 3.0 version, so teammates on older connectors can "
-    + "still read it. Switch to the new Publish component when your team is ready for 4.0.";
+    "This Publish component is deprecated. Switch to the new Publish component for Speckle 4.0 support.";
+
+  /// <summary>Warning raised by the deprecated Publish components when they actually publish.</summary>
+  public const string PUBLISHED_LEGACY_VERSION_MESSAGE =
+    "This publish creates a Speckle 3.0 version so teammates on older connectors can still read it. The new Publish "
+    + "component creates 4.0 versions.";
 
   /// <summary>Raised by the deprecated Load components when a version only exists as 4.0 artefacts.</summary>
   public const string DEPRECATED_LOAD_FALLBACK_MESSAGE =

--- a/Sdk/Speckle.Connectors.Common/Operations/SendOperation.cs
+++ b/Sdk/Speckle.Connectors.Common/Operations/SendOperation.cs
@@ -41,6 +41,12 @@ public sealed class SendOperation<T>(
   IArtifactRootObjectBuilder<T>? artifactRootObjectBuilder = null
 ) : ISendOperation<T>
 {
+  /// <param name="useArtifacts">
+  /// Grasshopper-only escape hatch, don't use elsewhere. False skips the 4.0 artefact path and falls through to the
+  /// v3 routes below. GH's deprecated Publish components pass false because a saved .gh file outlives the connector
+  /// upgrade - an upgraded author shouldn't silently create versions their teammates can't read. Remove this
+  /// parameter when those components go.
+  /// </param>
   public async Task<(SendOperationResult sendResult, string versionId, string? ingestionId)> Send(
     IReadOnlyList<T> objects,
     SendInfo sendInfo,
@@ -49,7 +55,8 @@ public sealed class SendOperation<T>(
     string? versionMessage,
     IProgress<CardProgress> uiProgress,
     bool saveToCache,
-    CancellationToken cancellationToken
+    CancellationToken cancellationToken,
+    bool useArtifacts = true
   )
   {
     bool useModelIngestionSend = await CheckUseModelIngestionSend(sendInfo);
@@ -59,7 +66,8 @@ public sealed class SendOperation<T>(
       // connector registers IArtifactRootObjectBuilder<T> — today Revit + Rhino; the SDK producer now builds on
       // netstandard2.0 too, so it runs on the net48 plugins as well as net8), it owns the whole write+upload and
       // creates the version via the v2 endpoints. Takes precedence over the packfile / legacy ingestion paths.
-      if (artifactRootObjectBuilder != null)
+      // useArtifacts is a Grasshopper-only opt-out - see the param docs.
+      if (artifactRootObjectBuilder != null && useArtifacts)
       {
         return await SendViaArtifacts(objects, sendInfo, fileName, fileSizeBytes, uiProgress, cancellationToken);
       }


### PR DESCRIPTION
## Description

The 4.0 artefact path currently wins on every receive, so the shape of what an existing script outputs changes the moment someone migrates a version — silently, with no user action. Rather than warn about that, this removes it: the four existing operation components keep their old behaviour and are deprecated, and artefact-first twins will take the ribbon in a follow-up.

[ENG-9171](https://linear.app/speckle/issue/ENG-9171/grasshopper-make-load-and-publish-legacy-first-and-deprecate-them)

## User Value

Upgrading the connector doesn't change what existing scripts produce.

## Changes:

- Both `Load` components try the `v3` path first and only read an artefact bundle when there is no `v1` root (i.e. a 4.0-native version). A migrated version keeps its `v1` root, so migration no longer reshapes an existing script's output.
- On a 4.0-native version, `Load` falls back to artefacts with a warning instead of erroring. `Properties` and `Proxies` are left null — neither survives into the bundle.
- Both `Publish` components keep writing `v3` versions, and warn on every run, so an upgraded author doesn't create versions their teammates on older connectors can't read.
- New `useArtifacts` opt-out on `SendOperation.Send(...)`, defaulted to `true` and documented as a Grasshopper-only escape hatch. No other connector's call sites change.
- All four components are now `Obsolete` + `Exposure.hidden` — gone from the ribbon so no new script can place one, fully functional in existing scripts.

## Screenshots:

### Load: Existing script, unmigrated version
<img width="851" height="308" alt="image" src="https://github.com/user-attachments/assets/3a01e05d-4829-464d-a1e3-437967ea17ad" />

### Load: Existing script, migrated version
<img width="879" height="415" alt="image" src="https://github.com/user-attachments/assets/aa8f36f0-3586-433c-a81c-87baa22db45f" />

### Load: Existing script, 4.0 version

<img width="680" height="297" alt="image" src="https://github.com/user-attachments/assets/602f41ef-dd95-4bb6-9704-232a229d8db7" />

### Publish: Existing script, 3.0 version

<img width="811" height="464" alt="image" src="https://github.com/user-attachments/assets/43d64aaf-855e-4e9e-8c49-c730fd1001ff" />

## Validation of changes:

- [x] An existing script loading an unmigrated version produces identical output to today, with no warning. We still read proxies as before, SDO still come through etc.
- [x] The same script and version **after migration** still produces identical output, with no warning.
- [x] The same script against a 4.0-native version loads, nulls `Properties` and `Proxies`, warns, and does not error.
- [x] Publishing from the old components creates a version a v3 connector can read. Then re-read back via load and could receive objects as before
- [x] No component or param GUID changes. No output params added, removed or reordered.
- [x] Opening a pre-upgrade `.gh` file shows no missing and no red components.

## Checklist:

- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] I have added appropriate tests. — none; validation is manual in the host app.
- [x] I have updated or added relevant documentation. — design doc lives in Notion.