### PR TITLE
hotfix(navisworks): ENG-9219 - Enhances property handling with hierarchical and inherited support

### DIFF
--- a/Converters/Navisworks/Speckle.Converters.NavisworksShared/DataHandlers/HierarchicalPropertyHandler.cs
+++ b/Converters/Navisworks/Speckle.Converters.NavisworksShared/DataHandlers/HierarchicalPropertyHandler.cs
@@ -57,7 +57,7 @@ public class HierarchicalPropertyHandler(
     }
 
     var hierarchy = GetObjectHierarchy(modelItem);
-    var propertyCollection = new Dictionary<string, Dictionary<string, HashSet<object?>>>();
+    var propertyCollection = new Dictionary<string, Dictionary<string, List<object?>>>();
 
     foreach (var item in hierarchy)
     {
@@ -99,7 +99,7 @@ public class HierarchicalPropertyHandler(
 
   private void CollectHierarchicalProperties(
     NAV.ModelItem item,
-    Dictionary<string, Dictionary<string, HashSet<object?>>> propertyCollection,
+    Dictionary<string, Dictionary<string, List<object?>>> propertyCollection,
     bool storeInCache
   )
   {

--- a/Converters/Navisworks/Speckle.Converters.NavisworksShared/DataHandlers/HierarchicalPropertyHandler.cs
+++ b/Converters/Navisworks/Speckle.Converters.NavisworksShared/DataHandlers/HierarchicalPropertyHandler.cs
@@ -164,10 +164,27 @@ public class HierarchicalPropertyHandler(
 
     if (
       !propertyDict.TryGetValue(PseudoClassPropertiesKey, out var pseudoPropsObj)
-      || pseudoPropsObj is not Dictionary<string, object> pseudoProps
+      || pseudoPropsObj is not Dictionary<string, object?> pseudoProps
     )
     {
       return;
+    }
+
+    // the pseudo bucket flattens onto the root, so its inherited values must honour the same exclusions
+    if (
+      pseudoProps.TryGetValue(InheritedPropertiesKey, out var inheritedObj)
+      && inheritedObj is Dictionary<string, object?> inherited
+    )
+    {
+      foreach (var bannedName in bannedNamesForProps)
+      {
+        inherited.Remove(bannedName);
+      }
+
+      if (inherited.Count == 0)
+      {
+        pseudoProps.Remove(InheritedPropertiesKey);
+      }
     }
 
     foreach (var prop in pseudoProps.Where(prop => !bannedNamesForProps.Contains(prop.Key)))

--- a/Converters/Navisworks/Speckle.Converters.NavisworksShared/DataHandlers/HierarchicalPropertyHandler.cs
+++ b/Converters/Navisworks/Speckle.Converters.NavisworksShared/DataHandlers/HierarchicalPropertyHandler.cs
@@ -28,6 +28,7 @@ public class HierarchicalPropertyHandler(
   )
 {
   private static string PseudoClassPropertiesKey => "_pseudoClassProperties";
+  private static string InheritedPropertiesKey => "_inherited";
   private readonly bool _mapRevit = settingsStore.Current.User.RevitCategoryMapping;
   private readonly IConverterSettingsStore<NavisworksConversionSettings> _settingsStore = settingsStore;
   private IQuickPropertyDefinitionsCache _quickPropertyDefinitionsCache = quickPropertyDefinitionsCache;
@@ -110,41 +111,43 @@ public class HierarchicalPropertyHandler(
 
     foreach (var kvp in categoryDictionaries)
     {
-      if (!propertyCollection.TryGetValue(kvp.Key, out var categoryProperties))
-      {
-        categoryProperties = [];
-        propertyCollection.Add(kvp.Key, categoryProperties);
-      }
-
       if (kvp.Value is not Dictionary<string, object?> properties)
       {
-        if (!propertyCollection.TryGetValue(PseudoClassPropertiesKey, out var pseudoProperties))
-        {
-          pseudoProperties = [];
-          propertyCollection.Add(PseudoClassPropertiesKey, pseudoProperties);
-        }
-
-        if (!pseudoProperties.TryGetValue(kvp.Key, out var valueSet))
-        {
-          valueSet = [];
-          pseudoProperties.Add(kvp.Key, valueSet);
-        }
-
-        valueSet.Add(kvp.Value);
+        AppendValue(propertyCollection, PseudoClassPropertiesKey, kvp.Key, kvp.Value);
         continue;
       }
 
       foreach (var prop in properties.Where(prop => IsValidPropertyValue(prop.Value)))
       {
-        if (!categoryProperties.TryGetValue(prop.Key, out var valueSet))
-        {
-          valueSet = [];
-          categoryProperties.Add(prop.Key, valueSet);
-        }
-
-        valueSet.Add(prop.Value);
+        AppendValue(propertyCollection, kvp.Key, prop.Key, prop.Value);
       }
     }
+  }
+
+  /// <summary>
+  /// Appends a value to the ordered value list for a category/property pair. Callers walk the hierarchy from
+  /// root to leaf, so the resulting list is in ancestor-first order.
+  /// </summary>
+  private static void AppendValue(
+    Dictionary<string, Dictionary<string, List<object?>>> propertyCollection,
+    string category,
+    string propertyName,
+    object? value
+  )
+  {
+    if (!propertyCollection.TryGetValue(category, out var categoryProperties))
+    {
+      categoryProperties = [];
+      propertyCollection.Add(category, categoryProperties);
+    }
+
+    if (!categoryProperties.TryGetValue(propertyName, out var values))
+    {
+      values = [];
+      categoryProperties.Add(propertyName, values);
+    }
+
+    values.Add(value);
   }
 
   private static void FlattenPseudoClassProperties(Dictionary<string, object?> propertyDict)
@@ -180,27 +183,73 @@ public class HierarchicalPropertyHandler(
     propertyDict.Remove(PseudoClassPropertiesKey);
   }
 
+  /// <summary>
+  /// Collapses the values gathered across the hierarchy into a single value per property. The most specific
+  /// (leaf-most) value wins; any differing ancestor values are preserved under <see cref="InheritedPropertiesKey"/>
+  /// rather than being discarded.
+  /// </summary>
   private static void ApplyFilteredProperties(
     Dictionary<string, object?> propertyDict,
-    Dictionary<string, Dictionary<string, HashSet<object?>>> propertyCollection
+    Dictionary<string, Dictionary<string, List<object?>>> propertyCollection
   )
   {
     foreach (var kvp in propertyCollection)
     {
       var categoryDict = new Dictionary<string, object?>();
-      bool hasProperties = false;
+      var inherited = new Dictionary<string, object?>();
 
-      foreach (var kvS in kvp.Value.Where(kvS => kvS.Value.Count == 1))
+      foreach (var kvS in kvp.Value)
       {
-        categoryDict[kvS.Key] = kvS.Value.First();
-        hasProperties = true;
+        var values = kvS.Value;
+        if (values.Count == 0)
+        {
+          continue;
+        }
+
+        // values are collected root -> leaf, so the last one is the item's own (or nearest ancestor's) value
+        var effective = values[^1];
+        categoryDict[kvS.Key] = effective;
+
+        var ancestorValues = GetDistinctAncestorValues(values, effective);
+        if (ancestorValues.Count > 0)
+        {
+          inherited[kvS.Key] = ancestorValues;
+        }
       }
 
-      if (hasProperties)
+      if (categoryDict.Count == 0)
       {
-        propertyDict[kvp.Key] = categoryDict;
+        continue;
       }
+
+      if (inherited.Count > 0)
+      {
+        categoryDict[InheritedPropertiesKey] = inherited;
+      }
+
+      propertyDict[kvp.Key] = categoryDict;
     }
+  }
+
+  /// <summary>
+  /// Returns the distinct ancestor values that differ from the effective value, in root-to-leaf order.
+  /// </summary>
+  private static List<object?> GetDistinctAncestorValues(List<object?> values, object? effective)
+  {
+    var ancestorValues = new List<object?>();
+
+    for (int i = 0; i < values.Count - 1; i++)
+    {
+      var value = values[i];
+      if (Equals(value, effective) || ancestorValues.Any(existing => Equals(existing, value)))
+      {
+        continue;
+      }
+
+      ancestorValues.Add(value);
+    }
+
+    return ancestorValues;
   }
 
   private static void OmitStandardExcludedClassProperties(


### PR DESCRIPTION
## Summary

This update enhances the handling of properties in the Navisworks converter by introducing hierarchical and inherited property support. It refactors parts of the code to use lists instead of hash sets and flattens pseudo properties to the property root.

## Why this change was needed

The previous implementation did not effectively manage inherited properties, resulting in potential data loss or misinterpretation of hierarchical property structures.

## What changed

- Replaced `HashSet` with `List` for property collections, ensuring ordered property values.
- Introduced inherited property support by maintaining a list of ancestor values.
- Flattened pseudo properties to the property root for consistent property handling.

## Notes for reviewers

- Pay special attention to the handling of inherited properties, as it affects the data structure and potentially the behaviour of downstream consumers.
- Consider the impact of list-based storage on performance and data consistency.