### PR TITLE
fix(grasshopper): rebuild data objects when legacy Load falls back to artefacts

### DIFF
--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Receive/ReceiveAsyncComponentBase.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Receive/ReceiveAsyncComponentBase.cs
@@ -605,7 +605,9 @@ public sealed class ReceiveComponentWorker : WorkerInstance<ReceiveAsyncComponen
         new GrasshopperArtefactObjectBuilder().Build(
           bundle,
           receiveInfo.ModelName,
-          new SpeckleModelContext(receiveInfo.ProjectId, receiveInfo.SelectedVersionId)
+          new SpeckleModelContext(receiveInfo.ProjectId, receiveInfo.SelectedVersionId),
+          // only the deprecated variant reaches here as a fallback, and its scripts expect DataObjects
+          groupAsDataObjects: !Parent.PreferArtefacts
         );
 
       foreach (var warning in buildWarnings)

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Receive/ReceiveComponentBase.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Receive/ReceiveComponentBase.cs
@@ -331,7 +331,9 @@ public abstract class ReceiveComponentBase(
         new GrasshopperArtefactObjectBuilder().Build(
           bundle,
           receiveInfo.ModelName,
-          new SpeckleModelContext(receiveInfo.ProjectId, receiveInfo.SelectedVersionId)
+          new SpeckleModelContext(receiveInfo.ProjectId, receiveInfo.SelectedVersionId),
+          // only the deprecated variant reaches here as a fallback, and its scripts expect DataObjects
+          groupAsDataObjects: !PreferArtefacts
         );
 
       foreach (var warning in buildWarnings)

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Operations/Receive/GrasshopperArtefactObjectBuilder.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Operations/Receive/GrasshopperArtefactObjectBuilder.cs
@@ -13,6 +13,7 @@ using Speckle.Sdk.Models.Collections;
 using Speckle.Sdk.Models.Instances;
 using Speckle.Sdk.Pipelines;
 using Speckle.Sdk.Pipelines.Receive.Artifacts;
+using DataObject = Speckle.Objects.Data.DataObject;
 using RG = Rhino.Geometry;
 using SpeckleRenderMaterial = Speckle.Objects.Other.RenderMaterial;
 
@@ -32,10 +33,16 @@ internal sealed class GrasshopperArtefactObjectBuilder
 {
   // (root, per-fragment decode/convert warnings) — the caller (ReceiveComponent/ReceiveAsyncComponent) surfaces these
   // as GH runtime messages so an undecodable fragment is visible instead of a silent skip.
+  /// <param name="groupAsDataObjects">
+  /// Regroups an object's geometry into a single <see cref="SpeckleDataObjectWrapper"/> instead of emitting one
+  /// wrapper per geometry. The deprecated Load components pass true so a script that was written against v3 sees the
+  /// object counts and shapes it already expects; the 4.0 components pass false and get the flat geometry.
+  /// </param>
   public (SpeckleCollectionWrapper Root, IReadOnlyList<string> Warnings) Build(
     ArtefactBundle bundle,
     string rootName,
-    SpeckleModelContext context
+    SpeckleModelContext context,
+    bool groupAsDataObjects
   )
   {
     var warnings = new List<string>();
@@ -114,7 +121,7 @@ internal sealed class GrasshopperArtefactObjectBuilder
       );
 
       int totalCount = geometries.Count + instCount;
-      int ord = EmitGeometryWrappers(
+      var (ord, geometryWrappers) = EmitGeometryWrappers(
         objK,
         geometries,
         totalCount,
@@ -126,6 +133,18 @@ internal sealed class GrasshopperArtefactObjectBuilder
         materialByObject,
         materialByGeometry
       );
+
+      if (groupAsDataObjects && geometryWrappers.Count > 0 && WasDataObject(props, geometryWrappers.Count))
+      {
+        collection.Elements.Add(BuildDataObject(appId, name, props, geometryWrappers, collection));
+      }
+      else
+      {
+        foreach (var geometryWrapper in geometryWrappers)
+        {
+          collection.Elements.Add(geometryWrapper);
+        }
+      }
 
       if (validInstEdges is not null)
       {
@@ -197,7 +216,7 @@ internal sealed class GrasshopperArtefactObjectBuilder
 
   // Converts and emits this object's own direct geometry as SpeckleGeometryWrappers. Returns the ordinal reached, so
   // any instance placements emitted afterward for the same object continue the same `:gN` numbering.
-  private static int EmitGeometryWrappers(
+  private static (int Ord, List<SpeckleGeometryWrapper> Wrappers) EmitGeometryWrappers(
     int objK,
     List<(int GeomK, RG.GeometryBase Geom)> geometries,
     int totalCount,
@@ -210,6 +229,8 @@ internal sealed class GrasshopperArtefactObjectBuilder
     Dictionary<int, SpeckleMaterialWrapper> materialByGeometry
   )
   {
+    // returned rather than added to the collection - the caller decides whether these stand alone or get wrapped
+    var created = new List<SpeckleGeometryWrapper>();
     int ord = 0;
     foreach (var (geomK, rg) in geometries)
     {
@@ -249,9 +270,53 @@ internal sealed class GrasshopperArtefactObjectBuilder
       {
         wrapper.Properties = new SpecklePropertyGroupGoo(props);
       }
-      collection.Elements.Add(wrapper);
+      created.Add(wrapper);
     }
-    return ord;
+    return (ord, created);
+  }
+
+  /// <summary>
+  /// Whether the v3 graph would have carried this object as a DataObject. Producers write <c>speckle_type</c> as a
+  /// root scalar, so this is read rather than guessed. A bundle without it falls back to the shape of the problem:
+  /// more than one geometry for one object is the many-to-one case the legacy path expressed as a DataObject.
+  /// </summary>
+  private static bool WasDataObject(Dictionary<string, object?>? props, int geometryCount) =>
+    props is not null && props.TryGetValue("speckle_type", out var raw) && raw is string speckleType
+      ? speckleType.StartsWith("Objects.Data.", StringComparison.Ordinal)
+      : geometryCount > 1;
+
+  /// <summary>
+  /// Rebuilds the DataObject the v3 graph would have had, keyed on the source object's application id so anything
+  /// downstream matching on ids still lines up. The geometry lives on the wrapper, so displayValue stays empty -
+  /// same as the v1 receive path does.
+  /// </summary>
+  private static SpeckleDataObjectWrapper BuildDataObject(
+    string appId,
+    string? name,
+    Dictionary<string, object?>? props,
+    List<SpeckleGeometryWrapper> geometries,
+    SpeckleCollectionWrapper collection
+  )
+  {
+    var properties = props is null ? new Dictionary<string, object?>() : new Dictionary<string, object?>(props);
+    var dataObject = new DataObject
+    {
+      name = name ?? "",
+      displayValue = [],
+      properties = properties,
+      applicationId = appId,
+    };
+
+    return new SpeckleDataObjectWrapper
+    {
+      Base = dataObject,
+      Geometries = geometries,
+      Path = collection.Path,
+      Parent = collection,
+      Name = dataObject.name,
+      Properties = new SpecklePropertyGroupGoo(properties),
+      ApplicationId = appId,
+    };
   }
 
   // Builds a SpeckleBlockInstanceWrapper per resolved DISPLAY_INSTANCE placement, referencing the shared


### PR DESCRIPTION
## Description

The deprecated Load falls back to the artefact path when a version is 4.0-native, because there's no v3 model to read. That path emits one wrapper per geometry, so a wall with four meshes came back as four objects. Scripts written against Data Objects broke.

This regroups them: one Data Object per source object, keyed on its application id.

## User Value

Old scripts keep working when the model they point at gets republished with 4.0.

## Changes:

- `GrasshopperArtefactObjectBuilder` takes a `groupAsDataObjects` flag. On, it wraps an object's geometry into a single `SpeckleDataObjectWrapper` instead of emitting one wrapper per geometry.
- Grouping decides off `speckle_type`, which every producer writes into the EAV. So we regroup exactly what v3 carried as `Objects.Data.*` — including single-mesh objects that a geometry count would miss — and leave plain Rhino geometry alone. Bundles without it fall back to "more than one geometry".
- The synthetic Data Object takes the source object's unsuffixed application id, so anything matching on ids still lines up. `displayValue` stays empty since the wrapper holds the geometry, same as the v3 receive.
- Only the deprecated components pass the flag (`!PreferArtefacts`). The 4.0 components still get flat geometry.

Known limitation: objects with no geometry at all (Revit rooms, levels, areas) are still dropped on the artefact path — see validation below. Separate fix.

## Screenshots:

| box | what |
| --- | --- |
| 🟠 orange | v3 commit via legacy Load, filtered to data objects that have geometry — 454 |
| 🟢 green | republished with the new Publish component |
| 🔵 blue | new Load on that version — 796, the fan-out |
| 🟡 yellow | legacy Load on the same version — 454, back to matching |

## Validation of changes:

1. 🟠 Load a v3 commit with the legacy Load. 501 objects, of which 47 have no geometry — **454** with geometry.
2. 🟢 Publish that collection straight back with the new Publish component, so the new version is 4.0-native.
3. 🔵 Load it with the new Load. **796** — the fan-out, one item per geometry. Expected.
4. 🟡 Load it with the legacy Load. **454** — matches step 1. Grouping restored the object shape.

454 → 796 → 454 is the whole point: same bundle, two components, and the deprecated one gives back what v3 gave.

The 47 missing against the raw 501 are the geometry-less objects noted above, dropped before either component groups anything — both loads agree on the same 454 object set.

<img width="1280" height="684" alt="image" src="https://github.com/user-attachments/assets/e49107b9-27a7-49c2-abd4-06f806cfe0ae" />

## Checklist:

- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [ ] I have added appropriate tests. — none; validation is manual in the host app.
- [ ] I have updated or added relevant documentation. — n/a