### PR TITLE
fix(grasshopper): artefact fidelity gaps

### DIFF
--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Objects/ExploreComponent.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Objects/ExploreComponent.cs
@@ -68,7 +68,8 @@ public class ExploreComponent : GH_Component, IGH_VariableParameterComponent
       if (Params.Input[0].VolatileData.DataCount > 0)
       {
         var resolved = Params
-          .Input[0].VolatileData.AllData(true)
+          .Input[0]
+          .VolatileData.AllData(true)
           .Select(Resolve)
           .Where(r => r is not null)
           .Cast<Dictionary<string, object?>>()
@@ -78,15 +79,8 @@ public class ExploreComponent : GH_Component, IGH_VariableParameterComponent
         {
           // input arrived but none of it resolved - name what turned up, so an unhandled type is obvious rather
           // than looking like the component is broken
-          var types = Params
-            .Input[0].VolatileData.AllData(true)
-            .Select(g => g.GetType().Name)
-            .Distinct()
-            .ToList();
-          AddRuntimeMessage(
-            GH_RuntimeMessageLevel.Remark,
-            $"Nothing resolved from: {string.Join(", ", types)}."
-          );
+          var types = Params.Input[0].VolatileData.AllData(true).Select(g => g.GetType().Name).Distinct().ToList();
+          AddRuntimeMessage(GH_RuntimeMessageLevel.Remark, $"Nothing resolved from: {string.Join(", ", types)}.");
         }
 
         var names = new List<string>();
@@ -284,8 +278,7 @@ public class ExploreComponent : GH_Component, IGH_VariableParameterComponent
       );
     }
 
-    var models = bundle
-      .Relations.ObjectNodeByRel.TryGetValue(RelKind.InModel, out var byObject)
+    var models = bundle.Relations.ObjectNodeByRel.TryGetValue(RelKind.InModel, out var byObject)
       ? byObject.Values.Distinct().Select(k => NodeNameAt(bundle, k)).Where(n => n is not null).ToList()
       : [];
     Add(values, "Models", models);

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Receive/ReceiveArtefactAsyncComponent.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Receive/ReceiveArtefactAsyncComponent.cs
@@ -16,19 +16,15 @@ public class ReceiveArtefactAsyncComponent : ReceiveAsyncComponentBase
 
   // TODO: needs its own icon - currently shares the deprecated component's, so the two look alike on canvas
   protected override Bitmap Icon => Resources.speckle_operations_load;
+
   // mirrors what the deprecated component had before it was hidden
   public override GH_Exposure Exposure => GH_Exposure.secondary;
 
   public override bool PreferArtefacts => true;
 
   public ReceiveArtefactAsyncComponent()
-    : base(
-      "Load",
-      "L",
-      "Load a model from Speckle",
-      ComponentCategories.PRIMARY_RIBBON,
-      ComponentCategories.OPERATIONS
-    ) { }
+    : base("Load", "L", "Load a model from Speckle", ComponentCategories.PRIMARY_RIBBON, ComponentCategories.OPERATIONS)
+  { }
 
   protected override void RegisterOutputParams(GH_OutputParamManager pManager) =>
     pManager.AddParameter(

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Receive/ReceiveArtefactComponent.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Receive/ReceiveArtefactComponent.cs
@@ -16,6 +16,7 @@ public class ReceiveArtefactComponent : ReceiveComponentBase
 
   // TODO: needs its own icon - currently shares the deprecated component's, so the two are indistinguishable on canvas
   protected override Bitmap Icon => Resources.speckle_operations_syncload;
+
   // the deprecated component had no override, i.e. the default, before it was hidden
   public override GH_Exposure Exposure => GH_Exposure.primary;
 

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Receive/ReceiveAsyncComponentBase.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Receive/ReceiveAsyncComponentBase.cs
@@ -632,10 +632,7 @@ public sealed class ReceiveComponentWorker : WorkerInstance<ReceiveAsyncComponen
         );
       }
 
-      Output = new ReceiveComponentOutput
-      {
-        RootObject = new SpeckleCollectionWrapperGoo(rootWrapper),
-      };
+      Output = new ReceiveComponentOutput { RootObject = new SpeckleCollectionWrapperGoo(rootWrapper) };
       return true;
     }
     catch (Exception ex) when (!ex.IsFatal())

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Receive/ReceiveComponentBase.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Receive/ReceiveComponentBase.cs
@@ -53,13 +53,14 @@ public abstract class ReceiveComponentBase(
   string description,
   string category,
   string subCategory
-) : SpeckleTaskCapableComponent<ReceiveComponentInput, ReceiveComponentOutput>(
-  name,
-  nickname,
-  description,
-  category,
-  subCategory
 )
+  : SpeckleTaskCapableComponent<ReceiveComponentInput, ReceiveComponentOutput>(
+    name,
+    nickname,
+    description,
+    category,
+    subCategory
+  )
 {
   private IClient? _apiClient;
   private string? _lastVersionId;
@@ -356,10 +357,7 @@ public abstract class ReceiveComponentBase(
         AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, $"Could not mark the version as received ({ex.Message}).");
       }
 
-      return new ReceiveComponentOutput
-      {
-        RootObject = new SpeckleCollectionWrapperGoo(rootWrapper),
-      };
+      return new ReceiveComponentOutput { RootObject = new SpeckleCollectionWrapperGoo(rootWrapper) };
     }
     catch (Exception ex) when (!ex.IsFatal())
     {

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Send/SendAsyncComponentBase.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Send/SendAsyncComponentBase.cs
@@ -345,16 +345,13 @@ public abstract class SendAsyncComponentBase : GH_AsyncComponent<SendAsyncCompon
           dataObjectWrapper.Parent = rootBase;
           rootBase.Elements.Add(dataObjectWrapper);
         }
-        // reject bare geometry — collections may only contain Data Objects or sub-collections.
-        // SpeckleGeometry is easily wrapped: wire your geometry through a 'Speckle Data Object' component first.
-        else if (obj?.ToSpeckleGeometryWrapper() is not null)
+        // handle bare geometry and block instances directly (deep copy to avoid mutations), same as Create Collection
+        else if (obj?.ToSpeckleGeometryWrapper() is SpeckleGeometryWrapper geometryWrapper)
         {
-          AddRuntimeMessage(
-            GH_RuntimeMessageLevel.Error,
-            "Speckle Geometry cannot be added directly to a Collection. "
-              + "Use a 'Speckle Data Object' component to wrap your geometry first, then pipe it into the Collection."
-          );
-          return false;
+          var geometryCopy = geometryWrapper.DeepCopy();
+          geometryCopy.Path = rootBase.Path;
+          geometryCopy.Parent = rootBase;
+          rootBase.Elements.Add(geometryCopy);
         }
         else
         {

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Send/SendComponentBase.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Send/SendComponentBase.cs
@@ -211,13 +211,13 @@ public abstract class SendComponentBase(
         dataObjectWrapper.Parent = rootBase;
         rootBase.Elements.Add(dataObjectWrapper);
       }
-      else if (obj?.ToSpeckleGeometryWrapper() is not null)
+      // handle bare geometry and block instances directly (deep copy to avoid mutations), same as Create Collection
+      else if (obj?.ToSpeckleGeometryWrapper() is SpeckleGeometryWrapper geometryWrapper)
       {
-        const string GEOMETRY_ERROR_MESSAGE =
-          "Speckle Geometry cannot be added directly to a Collection. "
-          + "Use a 'Speckle Data Object' component to wrap your geometry first, then pipe it into the Collection.";
-        AddRuntimeMessage(GH_RuntimeMessageLevel.Error, GEOMETRY_ERROR_MESSAGE);
-        throw new SpeckleException(GEOMETRY_ERROR_MESSAGE);
+        var geometryCopy = geometryWrapper.DeepCopy();
+        geometryCopy.Path = rootBase.Path;
+        geometryCopy.Parent = rootBase;
+        rootBase.Elements.Add(geometryCopy);
       }
       else
       {

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Send/SendComponentBase.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Send/SendComponentBase.cs
@@ -56,13 +56,14 @@ public abstract class SendComponentBase(
   string description,
   string category,
   string subCategory
-) : SpeckleTaskCapableComponent<SendComponentInput, SendComponentOutput>(
-  name,
-  nickname,
-  description,
-  category,
-  subCategory
 )
+  : SpeckleTaskCapableComponent<SendComponentInput, SendComponentOutput>(
+    name,
+    nickname,
+    description,
+    category,
+    subCategory
+  )
 {
   public string? Url { get; private set; }
   public string? VersionMessage { get; private set; }

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Operations/Receive/GrasshopperArtefactObjectBuilder.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Operations/Receive/GrasshopperArtefactObjectBuilder.cs
@@ -70,7 +70,7 @@ internal sealed class GrasshopperArtefactObjectBuilder
     // solid/display happened to be decoded. materialByGeometry still covers DEFINITION/instance content, which has no
     // owning object reachable this way (mirrors Rhino's "standalone definition geometry" byGeometry fallback).
     var objByGeom = rels.ObjectByGeometry();
-    var (materialByObject, materialByGeometry) = CreateMaterials(bundle, objByGeom);
+    var (materialByObject, materialByGeometry, materialByInstance) = CreateMaterials(bundle, objByGeom);
     var colorByObject = CreateColors(bundle, objByGeom);
 
     // Instances (skip entirely if the bundle has none, mirrors RhinoHostObjectArtefactBuilder.BakeAll's gate): one
@@ -181,7 +181,8 @@ internal sealed class GrasshopperArtefactObjectBuilder
           props,
           collection,
           colorByObject,
-          materialByObject
+          materialByObject,
+          materialByInstance
         );
       }
     }
@@ -354,7 +355,8 @@ internal sealed class GrasshopperArtefactObjectBuilder
     Dictionary<string, object?>? props,
     SpeckleCollectionWrapper collection,
     Dictionary<string, int> colorByObject,
-    Dictionary<string, SpeckleMaterialWrapper> materialByObject
+    Dictionary<string, SpeckleMaterialWrapper> materialByObject,
+    Dictionary<int, SpeckleMaterialWrapper> materialByInstance
   )
   {
     foreach (var e in validInstEdges)
@@ -382,7 +384,11 @@ internal sealed class GrasshopperArtefactObjectBuilder
         ObjectIndex = objK,
         ApplicationId = totalCount == 1 ? appId : $"{appId}:g{ord++}",
         Color = colorByObject.TryGetValue(appId, out var iArgb) ? System.Drawing.Color.FromArgb(iArgb) : null,
-        Material = materialByObject.TryGetValue(appId, out var iMat) ? iMat : null,
+        // the placement's own material sources the INSTANCE node, so try that before the object-keyed map [ENG-9163]
+        Material =
+          materialByInstance.TryGetValue(e.Dst, out var instMat) ? instMat
+          : materialByObject.TryGetValue(appId, out var iMat) ? iMat
+          : null,
       };
       if (name is not null)
       {
@@ -490,7 +496,8 @@ internal sealed class GrasshopperArtefactObjectBuilder
   // construction path the v1 GH receive uses (GrasshopperMaterialUnpacker), so a bake/re-send round-trips the same way.
   private static (
     Dictionary<string, SpeckleMaterialWrapper> ByObject,
-    Dictionary<int, SpeckleMaterialWrapper> ByGeometry
+    Dictionary<int, SpeckleMaterialWrapper> ByGeometry,
+    Dictionary<int, SpeckleMaterialWrapper> ByInstance
   ) CreateMaterials(ArtefactBundle bundle, Dictionary<int, int> objByGeom)
   {
     var wrapperByMaterialNode = new Dictionary<int, SpeckleMaterialWrapper>();
@@ -546,14 +553,24 @@ internal sealed class GrasshopperArtefactObjectBuilder
         byObject[appId] = wrapper; // object → material (atomic display objects)
       }
     }
-    return (byObject, byGeometry);
+
+    // Instance-sourced: a material painted on a block placement, keyed by its INSTANCE node K. A placement owns no
+    // geometry of its own, so it's invisible to the loop above [ENG-9163]. Mirrors RhinoHostObjectArtefactBuilder.
+    var byInstance = new Dictionary<int, SpeckleMaterialWrapper>();
+    foreach (var kv in bundle.Relations.MaterialByInstance)
+    {
+      if (wrapperByMaterialNode.TryGetValue(kv.Value, out var wrapper))
+      {
+        byInstance[kv.Key] = wrapper;
+      }
+    }
+    return (byObject, byGeometry, byInstance);
   }
 
   // Resolves HAS_COLOR (Relations.ColorByGeometry: display-mesh geometry K → COLOR node) to the owning object's
   // appId → argb — the object's by-object display colour, distinct from a render material. Resolved via the same
   // Display-edges reverse map as materials, for the same reason (HAS_COLOR only ever targets the display-mesh K, not
-  // a SOLID blob's). Mirrors RhinoHostObjectArtefactBuilder.CreateColors, which likewise only resolves to the owning
-  // object (definition/instance geometry doesn't get a colour in the Rhino reference either).
+  // a SOLID blob's). Mirrors RhinoHostObjectArtefactBuilder.CreateColors.
   private static Dictionary<string, int> CreateColors(ArtefactBundle bundle, Dictionary<int, int> objByGeom)
   {
     var byObject = new Dictionary<string, int>();
@@ -564,6 +581,21 @@ internal sealed class GrasshopperArtefactObjectBuilder
         continue;
       }
       if (objByGeom.TryGetValue(kv.Key, out int objK) && bundle.ObjectAppIds.TryGetValue(objK, out var appId))
+      {
+        byObject[appId] = argb;
+      }
+    }
+
+    // Object-sourced: a block placement's own colour. A placement owns no geometry, so it never appears in objByGeom -
+    // resolve it straight through the object dictionary [ENG-9163]. Mirrors RhinoHostObjectArtefactBuilder.
+    foreach (var kv in bundle.Relations.ColorByObject)
+    {
+      if (
+        bundle.Nodes.TryGetValue(kv.Value, out var n)
+        && n.Kind == NodeKind.Color
+        && n.Argb is int argb
+        && bundle.ObjectAppIds.TryGetValue(kv.Key, out var appId)
+      )
       {
         byObject[appId] = argb;
       }

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Operations/Receive/GrasshopperArtefactObjectBuilder.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Operations/Receive/GrasshopperArtefactObjectBuilder.cs
@@ -15,6 +15,7 @@ using Speckle.Sdk.Pipelines;
 using Speckle.Sdk.Pipelines.Receive.Artifacts;
 using DataObject = Speckle.Objects.Data.DataObject;
 using RG = Rhino.Geometry;
+using SOG = Speckle.Objects.Geometry;
 using SpeckleRenderMaterial = Speckle.Objects.Other.RenderMaterial;
 
 namespace Speckle.Connectors.GrasshopperShared.Operations.Receive;
@@ -95,20 +96,34 @@ internal sealed class GrasshopperArtefactObjectBuilder
       int objK = kv.Key;
       string appId = kv.Value;
 
-      var geometries = DecodeObjectGeometry(objK, bundle, rels, ObjectUnits(bundle, objK), warnings);
+      var geometries = DecodeObjectGeometry(
+        objK,
+        bundle,
+        rels,
+        ObjectUnits(bundle, objK),
+        ObjectSourceType(bundle, objK),
+        warnings
+      );
 
       // An object placed as a block carries no direct SOLID/DISPLAY geometry — resolve its placement(s) to the shared
       // SpeckleBlockDefinitionWrapper built above instead. Without this, instance-only sub-models receive as empty.
       var validInstEdges = ResolveValidInstanceEdges(objK, instEdgesByObject, nestedInstanceNodes, bundle, definitions);
       int instCount = validInstEdges?.Count ?? 0;
 
-      if (geometries.Count == 0 && instCount == 0)
-      {
-        continue; // non-geometric element (room/level/area) or a definition with no decodable geometry
-      }
-
       bundle.Properties.TryGetValue(objK, out var props);
       var name = ObjectName(props);
+
+      if (geometries.Count == 0 && instCount == 0)
+      {
+        // A room, level or area carried properties and no geometry in v3, and still counts as an object [ENG-9159].
+        // Only re-emit one when the source really was a DataObject: WasDataObject reads speckle_type, so the
+        // property-carrying sidecars we intern ourselves (__collection_topology_, which have none) stay out.
+        if (!groupAsDataObjects || !WasDataObject(props, 0))
+        {
+          continue;
+        }
+      }
+
       var segments = SceneViewResolver.Segments(bundle, objK);
       var collection = GetOrCreateCollection(
         root,
@@ -134,7 +149,13 @@ internal sealed class GrasshopperArtefactObjectBuilder
         materialByGeometry
       );
 
-      if (groupAsDataObjects && geometryWrappers.Count > 0 && WasDataObject(props, geometryWrappers.Count))
+      // An empty DataObject is only right for a genuinely property-only object: one placed as a block already comes
+      // through as its instance wrapper, and adding an empty one beside it would double the count.
+      if (
+        groupAsDataObjects
+        && WasDataObject(props, geometryWrappers.Count)
+        && (geometryWrappers.Count > 0 || instCount == 0)
+      )
       {
         collection.Elements.Add(BuildDataObject(appId, name, props, geometryWrappers, collection));
       }
@@ -384,6 +405,7 @@ internal sealed class GrasshopperArtefactObjectBuilder
     ArtefactBundle bundle,
     ArtefactRelations rels,
     string fallbackUnits,
+    string? sourceType,
     List<string> warnings
   )
   {
@@ -392,7 +414,7 @@ internal sealed class GrasshopperArtefactObjectBuilder
     {
       foreach (var solidK in solidKs)
       {
-        foreach (var g in DecodeGeometryIndex(solidK, bundle, fallbackUnits, warnings))
+        foreach (var g in DecodeGeometryIndex(solidK, bundle, fallbackUnits, sourceType, warnings))
         {
           result.Add((solidK, g));
         }
@@ -402,7 +424,7 @@ internal sealed class GrasshopperArtefactObjectBuilder
     {
       foreach (var e in displayEdges.OrderBy(x => x.Ord))
       {
-        foreach (var g in DecodeGeometryIndex(e.Dst, bundle, fallbackUnits, warnings))
+        foreach (var g in DecodeGeometryIndex(e.Dst, bundle, fallbackUnits, sourceType, warnings))
         {
           result.Add((e.Dst, g));
         }
@@ -410,6 +432,26 @@ internal sealed class GrasshopperArtefactObjectBuilder
     }
     return result;
   }
+
+  /// <summary>The owning object's source type, where the SGEO primitive alone is ambiguous - see <see cref="AsSourceType"/>.</summary>
+  private static string? ObjectSourceType(ArtefactBundle bundle, int objK) =>
+    bundle.Properties.TryGetValue(objK, out var props)
+    && props.TryGetValue("type", out var v)
+    && v is string s
+    && s.Length > 0
+      ? s
+      : null;
+
+  // SGEO encodes a single point and a whole point cloud under the same Points primitive, so Decode can only ever hand
+  // back a Pointcloud - and a Speckle Point came back as a one-point cloud, a different type to everything downstream
+  // [ENG-9162]. The object's source type is the discriminator the blob lacks. Mirrors RhinoHostObjectArtefactBuilder,
+  // which keys on Rhino's own ObjectType; here the send stamps the Speckle type instead.
+  private static Base AsSourceType(Base decoded, string? sourceType) =>
+    sourceType is not null
+    && sourceType.EndsWith(".Point", StringComparison.Ordinal)
+    && decoded is SOG.Pointcloud { points.Count: 3 } cloud
+      ? new SOG.Point(cloud.points[0], cloud.points[1], cloud.points[2], cloud.units)
+      : decoded;
 
   // The send side stores "units" per object as an EAV property, falling back to the bundle's overall units when absent
   // (mirrors RhinoHostObjectArtefactBuilder.ObjectUnits).
@@ -580,7 +622,8 @@ internal sealed class GrasshopperArtefactObjectBuilder
             // Definition geometry is in the model's source units; pass the bundle (source) units as the fallback, NOT
             // DocUnits — otherwise a 3dm member isn't rescaled and a block sent from a metre model lands 1000x too
             // small in a millimetre GH doc (mirrors RhinoHostObjectArtefactBuilder.BuildDefinitions).
-            foreach (var g in DecodeGeometryIndex(geomK, bundle, bundle.Units, warnings))
+            // no owning object row for a definition member, so no source type to disambiguate points with
+            foreach (var g in DecodeGeometryIndex(geomK, bundle, bundle.Units, null, warnings))
             {
               Base? converted;
               try
@@ -757,6 +800,7 @@ internal sealed class GrasshopperArtefactObjectBuilder
     int geomK,
     ArtefactBundle bundle,
     string fallbackUnits,
+    string? sourceType,
     List<string> warnings
   )
   {
@@ -786,7 +830,7 @@ internal sealed class GrasshopperArtefactObjectBuilder
       Base? decoded = null;
       try
       {
-        decoded = SgeoDecoder.Decode(g.Content);
+        decoded = AsSourceType(SgeoDecoder.Decode(g.Content), sourceType);
         var converted = ConvertSpeckleGeometry(decoded);
         if (converted.Count == 0)
         {

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Operations/Send/GrasshopperArtifactRootObjectBuilder.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Operations/Send/GrasshopperArtifactRootObjectBuilder.cs
@@ -488,20 +488,23 @@ public class GrasshopperArtifactRootObjectBuilder(
     foreach (var defProxy in blockPacker.InstanceDefinitionProxies.Values)
     {
       int defK = pipeline.AddDefinition(defProxy.applicationId.NotNull(), defProxy.name);
-      int o = 0;
+      int memberOrd = 0;
       foreach (var memberId in defProxy.objects)
       {
         if (instanceKByAppId.TryGetValue(memberId, out var instK))
         {
-          pipeline.DefinesInstance(defK, instK, o++);
+          pipeline.DefinesInstance(defK, instK, memberOrd);
         }
         else if (geometryKsByAppId.TryGetValue(memberId, out var memberGKs))
         {
+          // All geometry of one member shares its member ordinal, so receive can group the member's authoritative solid
+          // + its display mesh(es) and pick the solid over its shadow (mirrors RhinoArtifactRootObjectBuilder).
           foreach (var gK in memberGKs)
           {
-            pipeline.Defines(defK, gK, o++);
+            pipeline.Defines(defK, gK, memberOrd);
           }
         }
+        memberOrd++;
       }
     }
 

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Operations/Send/GrasshopperArtifactRootObjectBuilder.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Operations/Send/GrasshopperArtifactRootObjectBuilder.cs
@@ -123,6 +123,7 @@ public class GrasshopperArtifactRootObjectBuilder(
 
     var geometryKsByAppId = new Dictionary<string, List<int>>(StringComparer.Ordinal);
     var instanceKByAppId = new Dictionary<string, int>(StringComparer.Ordinal);
+    var instanceObjectKByAppId = new Dictionary<string, int>(StringComparer.Ordinal);
     var results = new List<SendConversionResult>();
 
     // Deep-copy so the walk (which stamps applicationIds + drives the block packer) never mutates canvas objects.
@@ -138,6 +139,7 @@ public class GrasshopperArtifactRootObjectBuilder(
       blockPacker,
       geometryKsByAppId,
       instanceKByAppId,
+      instanceObjectKByAppId,
       results,
       session,
       onOperationProgressed,
@@ -145,7 +147,15 @@ public class GrasshopperArtifactRootObjectBuilder(
     );
     WalkCollection(ctx, root, null);
 
-    EmitValueNodes(pipeline, colorPacker, materialPacker, blockPacker, geometryKsByAppId, instanceKByAppId);
+    EmitValueNodes(
+      pipeline,
+      colorPacker,
+      materialPacker,
+      blockPacker,
+      geometryKsByAppId,
+      instanceKByAppId,
+      instanceObjectKByAppId
+    );
 
     // Default scene view: the GH collection tree (IN_COLLECTION); the CONTAINER parent chain carries the nesting.
     pipeline.AddSceneView(new SceneView(0, "Default", true, new[] { SceneViewKey.Rel(RelKind.InCollection) }));
@@ -322,7 +332,7 @@ public class GrasshopperArtifactRootObjectBuilder(
           // nested instances are already registered by ProcessInstance above → emit their node only.
           if (definitionObject is SpeckleBlockInstanceWrapper nested)
           {
-            EmitInstanceNode(ctx, nested, collK, ord);
+            EmitInstanceNode(ctx, nested, collK, ord, isNested: true);
           }
           else
           {
@@ -344,7 +354,20 @@ public class GrasshopperArtifactRootObjectBuilder(
   }
 
   // Emits pipeline calls for an already-registered instance (object → INSTANCE node via DISPLAY_INSTANCE).
-  private void EmitInstanceNode(WalkContext ctx, SpeckleBlockInstanceWrapper instance, int collK, int ord)
+  //
+  // A NESTED instance is a member of its parent definition and reaches the scene only through that definition's
+  // DEFINES_INSTANCE, applied under the parent placement's transform. Giving it IN_COLLECTION and its own
+  // DISPLAY_INSTANCE would place it a second time, at its definition-local transform: Grasshopper filters that
+  // duplicate out on receive, but the Viewer, Rhino and AutoCAD do not, so they draw it twice - once in place and
+  // once adrift near the origin [ENG-9161]. The INSTANCE node itself is still emitted, since DEFINES_INSTANCE
+  // needs something to point at.
+  private void EmitInstanceNode(
+    WalkContext ctx,
+    SpeckleBlockInstanceWrapper instance,
+    int collK,
+    int ord,
+    bool isNested = false
+  )
   {
     string appId = instance.ApplicationId.NotNull();
     if (ctx.InstanceKByAppId.ContainsKey(appId))
@@ -352,7 +375,10 @@ public class GrasshopperArtifactRootObjectBuilder(
       return; // a shared nested definition can be reached twice; place it once
     }
     int objK = ctx.Pipeline.InternObject(appId);
-    ctx.Pipeline.InCollection(objK, collK, ord);
+    if (!isNested)
+    {
+      ctx.Pipeline.InCollection(objK, collK, ord);
+    }
     ctx.Pipeline.AddProperties(
       appId,
       PropertiesOf(instance.InstanceProxy),
@@ -365,8 +391,18 @@ public class GrasshopperArtifactRootObjectBuilder(
       Flatten(instance.InstanceProxy.transform),
       instance.InstanceProxy.units
     );
-    ctx.Pipeline.DisplayInstance(objK, instK, 0);
+    if (!isNested)
+    {
+      ctx.Pipeline.DisplayInstance(objK, instK, 0);
+    }
+
+    // A placement's own colour and material are object-sourced, so they carry the ord=1 namespace tag the reader
+    // expects (HAS_COLOR / HAS_MATERIAL on the object, not on a geometry) [ENG-9163].
+    ctx.ColorPacker.ProcessColor(appId, instance.Color);
+    ctx.MaterialPacker.ProcessMaterial(appId, instance.Material);
+
     ctx.InstanceKByAppId[appId] = instK;
+    ctx.InstanceObjectKByAppId[appId] = objK;
   }
 
   // Splits a clean Speckle object into its lossless raw 3dm SOLID blob (if any) + DISPLAY geometry; records the display
@@ -397,17 +433,33 @@ public class GrasshopperArtifactRootObjectBuilder(
       displayGeometry = [clean];
     }
 
-    // A definition member is never a standalone solid; it renders only through its definition's display meshes (DEFINES).
-    if (!isDefinitionMember && rawEncoding is not null && rawEncoding.format == RawEncodingFormats.RHINO_3DM)
+    // The authoritative 3dm blob, kept verbatim so a closed Brep, Extrusion or SubD comes back as itself rather than
+    // as its display mesh. A standalone object links it with a SOLID edge; a definition member has no standalone
+    // placement, so its solid rides DEFINES instead - added to gKs below, alongside the display meshes, and the
+    // receiver prefers it per member [ENG-9160]. Mirrors RhinoArtifactRootObjectBuilder.
+    int? memberSolidK = null;
+    if (rawEncoding is not null && rawEncoding.format == RawEncodingFormats.RHINO_3DM)
     {
       byte[] solidBytes = Convert.FromBase64String(rawEncoding.contents);
       int solidK = ctx.Pipeline.AddRawGeometry($"{geometryAppId}:solid", solidBytes, RawEncodingFormats.RHINO_3DM);
-      ctx.Pipeline.Solid(objK, solidK, solidOrd++);
+      if (isDefinitionMember)
+      {
+        memberSolidK = solidK;
+      }
+      else
+      {
+        ctx.Pipeline.Solid(objK, solidK, solidOrd++);
+      }
     }
 
     var gKs = ctx.GeometryKsByAppId.TryGetValue(geometryAppId, out var existing)
       ? existing
       : ctx.GeometryKsByAppId[geometryAppId] = new List<int>();
+
+    if (memberSolidK is int msk)
+    {
+      gKs.Add(msk);
+    }
 
     int fragOrd = 0;
     foreach (Base fragment in displayGeometry)
@@ -429,7 +481,8 @@ public class GrasshopperArtifactRootObjectBuilder(
     GrasshopperMaterialPacker materialPacker,
     GrasshopperBlockPacker blockPacker,
     Dictionary<string, List<int>> geometryKsByAppId,
-    Dictionary<string, int> instanceKByAppId
+    Dictionary<string, int> instanceKByAppId,
+    Dictionary<string, int> instanceObjectKByAppId
   )
   {
     foreach (var defProxy in blockPacker.InstanceDefinitionProxies.Values)
@@ -474,6 +527,11 @@ public class GrasshopperArtifactRootObjectBuilder(
             pipeline.HasMaterial(gK, matK);
           }
         }
+        else if (instanceKByAppId.TryGetValue(objectId, out var instK))
+        {
+          // a placement paints its own material: no geometry of its own, so the edge sources the INSTANCE node
+          pipeline.HasMaterial(instK, matK, srcIsInstance: true);
+        }
       }
     }
 
@@ -488,6 +546,11 @@ public class GrasshopperArtifactRootObjectBuilder(
           {
             pipeline.HasColor(gK, colorK);
           }
+        }
+        else if (instanceObjectKByAppId.TryGetValue(objectId, out var objK))
+        {
+          // by-object colour on a placement: the object and geometry namespaces overlap, hence the tag
+          pipeline.HasColor(objK, colorK, srcIsObject: true);
         }
       }
     }
@@ -546,6 +609,8 @@ public class GrasshopperArtifactRootObjectBuilder(
     GrasshopperBlockPacker BlockPacker,
     Dictionary<string, List<int>> GeometryKsByAppId,
     Dictionary<string, int> InstanceKByAppId,
+    // a placement's colour tags on its OBJECT and its material on its INSTANCE node, so both Ks are needed
+    Dictionary<string, int> InstanceObjectKByAppId,
     List<SendConversionResult> Results,
     ArtefactSessionLog Session,
     IProgress<CardProgress> Progress,

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/Operations/Receive/RhinoHostObjectArtefactBuilder.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/Operations/Receive/RhinoHostObjectArtefactBuilder.cs
@@ -461,8 +461,7 @@ public class RhinoHostObjectArtefactBuilder : IArtifactHostObjectBuilder
   // doesn't carry, so a blob with either has to go through the full decoder instead [ENG-9214]. n-gons are safe here —
   // they ride the face array, and BuildMesh rebuilds their MeshNgon records.
   private static bool IsFastPathMesh(SgeoHeader header) =>
-    header.PrimitiveType == SgeoPrimitiveType.Mesh
-    && (header.Flags & (SgeoFlags.HasNormals | SgeoFlags.HasUvs)) == 0;
+    header.PrimitiveType == SgeoPrimitiveType.Mesh && (header.Flags & (SgeoFlags.HasNormals | SgeoFlags.HasUvs)) == 0;
 
   // SGEO neutral mesh → Rhino mesh (Speckle count-prefixed face format; matches MeshToHostConverter).
   private static RG.Mesh BuildMesh(SgeoMesh sm)


### PR DESCRIPTION
## Description

Five acceptance-testing tickets raised against the Grasshopper artefact path, fixed together, plus one unticketed fix found while testing them. Some are send-side (the bundle we write was wrong), some receive-side (the bundle was fine, we dropped things reading it), and one was both.

## User Value

Blocks, points and property-only objects survive a Grasshopper round trip instead of quietly changing type or disappearing.

## Changes:

- **[ENG-9159](https://linear.app/speckle/issue/ENG-9159/preserve-property-only-grasshopper-data-objects-on-artifact-receive)** — receive kept only objects with geometry, so Revit rooms, levels and areas vanished. The send already wrote them; they're now rebuilt as property-only Data Objects. Guarded on `speckle_type`, so our own `__collection_topology_` sidecars stay out, and skipped for objects that arrive as block placements so nothing is double-counted.
- **[ENG-9160](https://linear.app/speckle/issue/ENG-9160/preserve-solid-geometry-in-grasshopper-artifact-block-definitions)** — definition members were published with display meshes only, so a Brep inside a block came back as a mesh. The 3dm solid is now written and rides DEFINES alongside the meshes, and all of a member's geometry shares one member ordinal so the reader can group them and pick the solid over its shadow. GH was incrementing that ordinal per fragment rather than per member, which put every fragment in a bucket of its own and defeated the grouping. Same shape Rhino already uses.
- **[ENG-9161](https://linear.app/speckle/issue/ENG-9161/keep-nested-block-instances-out-of-the-top-level-artifact-scene)** — nested block instances were given `IN_COLLECTION` and their own `DISPLAY_INSTANCE`, placing them a second time at their definition-local transform. GH filtered the duplicate on receive; Viewer/Rhino/AutoCAD didn't. They now reach the scene only through `DEFINES_INSTANCE`.
- **[ENG-9162](https://linear.app/speckle/issue/ENG-9162/preserve-point-and-pointcloud-types-in-grasshopper-sgeo)** — SGEO stores a point and a point cloud identically, so a Point returned as a one-point Pointcloud. Now disambiguated from the object's recorded type. Mirrors the Rhino fix in #1515 , keyed on the Speckle type since that's what GH stamps.
- **[ENG-9163](https://linear.app/speckle/issue/ENG-9163/preserve-appearance-for-grasshopper-artifact-instances)** — block placements published no colour or material at all, and the reader wouldn't have found them anyway. Send now emits both with the namespace tag the reader expects: colour on the object, material on the instance node. Receive resolved appearance only by walking geometry-sourced edges and mapping geometry back to its owning object — a placement owns no geometry, so it never matched. It now also resolves ColorByObject and MaterialByInstance directly, instance-first so a placement's own paint wins. The other two parts of that ticket (per-geometry appearance on multi-geometry Data Objects, definition-member appearance) were already working — confirmed by test, no code change.
- Unticketed — Publish rejected bare geometry and block instances piped straight into it, with an error telling you to wrap them in a Speckle Data Object. Create Collection was loosened to accept both when Speckle Data Object was deprecated; the two Publish components were left behind. They now mirror Create Collection's branch. Found while testing ENG-9161.

## Notes / To-do before merge:

- [x] **ENG-9157 marked as Won't Do, not implementing.** It asks for Data Object grouping on artefact receive — we shipped that in #1518, but only for the deprecated Load. The 4.0 Load emits flat geometry deliberately: that's the 4.0 object model, and the point of splitting the components was one stable shape each. Close as done-for-legacy and note the fan-out is intentional (for now).

## Validation of changes:

### ENG-9159 — property-only data objects
1. Load a v3 Revit commit with the legacy Load. Note the total, and the count of data objects with no geometry.
2. Publish straight back with the new Publish.
3. Load with the legacy Load. Total now matches step 1 — previously it was short by exactly the geometry-less count.

<img width="1382" height="1044" alt="image" src="https://github.com/user-attachments/assets/bb07c658-f2dd-47a6-8730-46337a912491" />

### ENG-9160 — solids in block definitions
1. Build a block containing a closed Brep, an Extrusion and a SubD. Publish.
2. Load back. Each member returns as its original type, not a mesh.
3. Repeat with a block nested inside another block.

<img width="1411" height="554" alt="image" src="https://github.com/user-attachments/assets/51e4c296-35c5-48ee-a8d9-61c4069082c7" />

### ENG-9161 — nested instances
1. Block B nested inside block A. Publish.
2. **Open the version in the web Viewer.** B appears once, inside A. Nothing stranded near the origin. This is the real check — GH already masked the duplicate, so it has to be seen in another consumer.
3. Load in Rhino for the same result.
5. Load back in GH: count and placement unchanged from before this PR.

### ENG-9162 — point vs pointcloud
1. A Speckle Point and a one-point Pointcloud on the canvas. Publish.
2. Load back and Deconstruct. The Point is a Point; the one-point cloud is still a Pointcloud.

<img width="1148" height="594" alt="image" src="https://github.com/user-attachments/assets/18c42ac5-bb5a-4e16-8335-82517002d7ab" />

### ENG-9163 — instance appearance
1. A block instance with a colour set, and another with a material. Publish.
2. Load back. Both survive on the placement.
4. A multi-geometry Data Object with a different colour per geometry — still preserved (no regression).

<img width="1025" height="634" alt="image" src="https://github.com/user-attachments/assets/cdff563a-7b11-43d2-8870-a2e87d8fe596" />

## Checklist:

- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] I have added appropriate tests.
- [x] I have updated or added relevant documentation.