### PR TITLE
fix(revit): scope linked-model placement identity and relations (ENG-9212)

### DIFF
--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/RevitArtifactRootObjectBuilder.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/RevitArtifactRootObjectBuilder.cs
@@ -197,10 +197,12 @@ public class RevitArtifactRootObjectBuilder(
     ZstdNativeLoader.Ensure(logger); // net48: ensure the parquet Zstd native is loaded (no-op on net8+)
     using var pipeline = new ObjectsArtifactPipeline(outputDir, versionId, producer: speckleApplication);
 
-    // element.UniqueId -> the object K(s) it was interned as. A linked element placed by N link instances
-    // yields N interned objects (disambiguated by transform hash), so the value is a list. Used to resolve
-    // ON_LEVEL post-loop (LevelUnpacker keys by the plain UniqueId).
-    var objectKsByElementUniqueId = new Dictionary<string, List<int>>(StringComparer.Ordinal);
+    // placement (modelKey) -> element.UniqueId -> the object K it was interned as [ENG-9212]. A linked element
+    // placed by N link instances yields N interned objects, ONE per placement — so the identity of an occurrence
+    // is (placement, UniqueId), never UniqueId alone. Element topology resolves inside a single placement's map
+    // (a door's host is a wall in the same placement); only value-node edges (ON_LEVEL) deliberately span
+    // placements, and they flatten this post-loop.
+    var objectKsByPlacement = new Dictionary<string, Dictionary<string, int>>(StringComparer.Ordinal);
     var modelContainerKeys = new HashSet<string>(StringComparer.Ordinal);
     var cameraViews = new List<CameraView>();
     var countProgress = 0;
@@ -227,6 +229,15 @@ public class RevitArtifactRootObjectBuilder(
 
       int modelK = pipeline.AddContainer(modelKey, modelName, null, "Model");
       modelContainerKeys.Add(modelKey);
+
+      // This placement's own identity map. Keyed per modelKey rather than freshly allocated so two contexts that
+      // DO share a placement key (coincident transforms — see ENG-9263) degrade to merging, exactly as their
+      // interned object Ks already merge, instead of silently splitting the topology of one merged model.
+      if (!objectKsByPlacement.TryGetValue(modelKey, out var placementIndex))
+      {
+        placementIndex = new Dictionary<string, int>(StringComparer.Ordinal);
+        objectKsByPlacement[modelKey] = placementIndex;
+      }
 
       EmitMainModelReferencePoint(pipeline, documentContext);
 
@@ -288,7 +299,7 @@ public class RevitArtifactRootObjectBuilder(
             Base converted = converter.Convert(revitElement);
             converted.applicationId = applicationId;
 
-            int objK = EmitObject(pipeline, converted, modelK, revitElement, applicationId, objectKsByElementUniqueId);
+            int objK = EmitObject(pipeline, converted, modelK, revitElement, applicationId, placementIndex);
             sentElements.Add((revitElement, objK));
             results.Add(new(Status.SUCCESS, applicationId, sourceType, converted));
             session.RecordObject(applicationId, sourceType, Status.SUCCESS, null, sw.ElapsedMilliseconds);
@@ -307,6 +318,13 @@ public class RevitArtifactRootObjectBuilder(
         // yields one group tier per placement rather than one shared, cross-wired tier.
         EmitGroups(pipeline, modelKey, sentElements);
 
+        // Host-API element topology for this placement. MUST run after the element loop (a door can be converted
+        // before the wall it is hosted on) but needs nothing from any OTHER document: every endpoint Revit reports
+        // — SuperComponent, Host, Room, FromRoom/ToRoom — lives in the same document, hence the same placement. So
+        // resolving against this placement's map alone is both sufficient and the thing that keeps edges from
+        // crossing placements [ENG-9212].
+        EmitElementTopology(pipeline, sentElements, placementIndex);
+
         // Named 3D views (perspective AND orthographic) of this document → camera_views rows. Collected inside
         // this settings push so linked-model cameras ride the exact ReferencePointTransform + scaling path the
         // document's element geometry does; linked views get the model display name as a prefix.
@@ -323,7 +341,7 @@ public class RevitArtifactRootObjectBuilder(
       throw new SpeckleException("Failed to convert all objects.");
     }
 
-    EmitValueNodes(pipeline, atomicObjectsByDocument, objectKsByElementUniqueId);
+    EmitValueNodes(pipeline, atomicObjectsByDocument, objectKsByPlacement);
 
     // Default scene view: Level → Category → Family (the familiar Revit explorer). Prepend the Model tier
     // only when the send actually federates more than one document (linked models) — a single-model send
@@ -442,18 +460,15 @@ public class RevitArtifactRootObjectBuilder(
     int modelK,
     Element revitElement,
     string applicationId,
-    Dictionary<string, List<int>> objectKsByElementUniqueId
+    Dictionary<string, int> placementIndex
   )
   {
     int objK = pipeline.InternObject(applicationId);
     pipeline.InModel(objK, modelK, 0);
 
-    if (!objectKsByElementUniqueId.TryGetValue(revitElement.UniqueId, out var ks))
-    {
-      ks = new List<int>();
-      objectKsByElementUniqueId[revitElement.UniqueId] = ks;
-    }
-    ks.Add(objK);
+    // Indexer, not Add: ElementUnpacker already dedups by ElementId so one UniqueId maps to one K per placement,
+    // but a coincident-transform placement key (ENG-9263) must degrade quietly rather than throw mid-send.
+    placementIndex[revitElement.UniqueId] = objK;
 
     if (converted is not DataObject dataObject)
     {
@@ -663,7 +678,7 @@ public class RevitArtifactRootObjectBuilder(
   private void EmitValueNodes(
     ObjectsArtifactPipeline pipeline,
     List<DocumentToConvert> atomicObjectsByDocument,
-    Dictionary<string, List<int>> objectKsByElementUniqueId
+    Dictionary<string, Dictionary<string, int>> objectKsByPlacement
   )
   {
     var flatElements = atomicObjectsByDocument.SelectMany(t => t.Elements).ToList();
@@ -711,13 +726,19 @@ public class RevitArtifactRootObjectBuilder(
       }
     }
 
-    // 4) levels → ON_LEVEL. LevelUnpacker keys by the plain element UniqueId, so resolve through the
-    // interned-K map to cover linked instances (which were interned with a transform-hash suffix).
+    // 4) levels → ON_LEVEL. A VALUE-node edge, so this is the one place the fan-out across placements is
+    // intentional: a linked element placed N times puts all N occurrences on the (shared) level node. LevelUnpacker
+    // keys by the plain element UniqueId, so flatten the per-placement index to reach every occurrence's K
+    // (linked ones were interned with a transform-hash suffix).
+    var objectKsByElementUniqueId = FlattenPlacementIndexes(objectKsByPlacement);
     foreach (var levelProxy in levelUnpacker.Unpack(flatElements))
     {
       double elevation = levelProxy.value["elevation"] is double d ? d : 0.0;
       int lvlK = pipeline.AddLevel(levelProxy.applicationId.NotNull(), levelProxy.value.name, elevation);
-      foreach (var elementUniqueId in levelProxy.objects)
+      // flatElements repeats a linked element once per link instance, so LevelUnpacker lists its UniqueId once per
+      // placement too. Dedup here or every occurrence's edge is written N times (relations.parquet is an append-only
+      // log — nothing downstream collapses duplicate rows) [ENG-9212].
+      foreach (var elementUniqueId in levelProxy.objects.Distinct(StringComparer.Ordinal))
       {
         if (objectKsByElementUniqueId.TryGetValue(elementUniqueId, out var objKs))
         {
@@ -728,12 +749,32 @@ public class RevitArtifactRootObjectBuilder(
         }
       }
     }
-
-    // 5) host-API topology from the Revit element graph (rooms / hosting / room-adjacency).
-    EmitElementTopology(pipeline, flatElements, objectKsByElementUniqueId);
   }
 
-  // Host-API topology, guarded to sent objects via objectKsByElementUniqueId (only interned targets get an edge):
+  // Per-placement identity maps → one element.UniqueId -> every occurrence's object K, across all placements. ONLY
+  // for value-node edges, where reaching every occurrence of a repeated linked element is the point; element→element
+  // topology must never resolve through this (that is what crossed placements before ENG-9212).
+  private static Dictionary<string, List<int>> FlattenPlacementIndexes(
+    Dictionary<string, Dictionary<string, int>> objectKsByPlacement
+  )
+  {
+    var objectKsByElementUniqueId = new Dictionary<string, List<int>>(StringComparer.Ordinal);
+    foreach (var placementIndex in objectKsByPlacement.Values)
+    {
+      foreach (var entry in placementIndex)
+      {
+        if (!objectKsByElementUniqueId.TryGetValue(entry.Key, out var ks))
+        {
+          ks = new List<int>();
+          objectKsByElementUniqueId[entry.Key] = ks;
+        }
+        ks.Add(entry.Value);
+      }
+    }
+    return objectKsByElementUniqueId;
+  }
+
+  // Host-API topology, guarded to sent objects via the placement index (only interned targets get an edge):
   //   SUBELEMENT   super-component → element: OWNERSHIP (a nested shared family → its super-component).
   //                Complements the RevitObject.elements lift, which covers children folded INTO a parent object
   //                (curtain panels / mullions / stacked-wall members — ownership too, emitted by EmitChild).
@@ -743,18 +784,21 @@ public class RevitArtifactRootObjectBuilder(
   //   CONNECTS_TO  a door/window's FromRoom → ToRoom, scoped by the opening's object K (the room-adjacency graph).
   // Same accessors as ClassPropertiesExtractor; wrapped defensively — Room/ToRoom/FromRoom can throw without an
   // active phase, and topology is best-effort (must never fail the geometry send).
+  //
+  // Scoped to ONE placement [ENG-9212]: <paramref name="sentElements"/> are the objects interned for this document
+  // context and <paramref name="placementIndex"/> resolves UniqueId → K within that same context, so every endpoint
+  // is unambiguous — exactly one K per element, no list to fan out over and no [0] to guess with. Resolving against
+  // a global UniqueId → K-list map instead produced a cartesian product of edges (placement A's door HOSTED_ON
+  // placement B's wall) and pinned every IN_ROOM / CONNECTS_TO to the first placement.
   private static void EmitElementTopology(
     ObjectsArtifactPipeline pipeline,
-    List<Element> flatElements,
-    Dictionary<string, List<int>> objectKsByElementUniqueId
+    List<(Element Element, int ObjK)> sentElements,
+    Dictionary<string, int> placementIndex
   )
   {
-    foreach (var element in flatElements)
+    foreach (var (element, elementK) in sentElements)
     {
-      if (
-        element is not FamilyInstance fi
-        || !objectKsByElementUniqueId.TryGetValue(element.UniqueId, out var elementKs)
-      )
+      if (element is not FamilyInstance fi)
       {
         continue;
       }
@@ -766,45 +810,30 @@ public class RevitArtifactRootObjectBuilder(
         // falling through to it — the element is owned, and the edge is simply dropped as dangling.
         if (fi.SuperComponent is { } owner)
         {
-          if (objectKsByElementUniqueId.TryGetValue(owner.UniqueId, out var ownerKs))
+          if (placementIndex.TryGetValue(owner.UniqueId, out int ownerK))
           {
-            foreach (var oK in ownerKs)
-            {
-              foreach (var eK in elementKs)
-              {
-                pipeline.Subelement(oK, eK, 0);
-              }
-            }
+            pipeline.Subelement(ownerK, elementK, 0);
           }
         }
-        else if (fi.Host is { } host && objectKsByElementUniqueId.TryGetValue(host.UniqueId, out var hostKs))
+        else if (fi.Host is { } host && placementIndex.TryGetValue(host.UniqueId, out int hostK))
         {
-          foreach (var hK in hostKs)
-          {
-            foreach (var eK in elementKs)
-            {
-              pipeline.HostedOn(eK, hK);
-            }
-          }
+          pipeline.HostedOn(elementK, hostK);
         }
 
         Element? room = fi.Room ?? (Element?)fi.Space;
-        if (room is not null && objectKsByElementUniqueId.TryGetValue(room.UniqueId, out var roomKs))
+        if (room is not null && placementIndex.TryGetValue(room.UniqueId, out int roomK))
         {
-          foreach (var eK in elementKs)
-          {
-            pipeline.InRoom(eK, roomKs[0], 0);
-          }
+          pipeline.InRoom(elementK, roomK, 0);
         }
 
         if (
           fi.FromRoom is { } fromRoom
           && fi.ToRoom is { } toRoom
-          && objectKsByElementUniqueId.TryGetValue(fromRoom.UniqueId, out var fromKs)
-          && objectKsByElementUniqueId.TryGetValue(toRoom.UniqueId, out var toKs)
+          && placementIndex.TryGetValue(fromRoom.UniqueId, out int fromK)
+          && placementIndex.TryGetValue(toRoom.UniqueId, out int toK)
         )
         {
-          pipeline.ConnectsTo(fromKs[0], toKs[0], elementKs[0]);
+          pipeline.ConnectsTo(fromK, toK, elementK);
         }
       }
       catch (Exception ex) when (!ex.IsFatal())

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/RevitArtifactRootObjectBuilder.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/RevitArtifactRootObjectBuilder.cs
@@ -239,6 +239,17 @@ public class RevitArtifactRootObjectBuilder(
         objectKsByPlacement[modelKey] = placementIndex;
       }
 
+      // Transformed (linked) elements get a transform hash appended so occurrences of the same linked file under
+      // different placements stay distinct — same convention as the v1 builder. Constant per placement, so hash
+      // once here instead of per element, and apply it to children as well as atomic objects [ENG-9212].
+      var placement = new PlacementContext(
+        documentContext.Transform is { } placementTransform
+          ? $"_t{linkedModelHandler.GetTransformHash(placementTransform)}"
+          : string.Empty,
+        placementIndex,
+        new HashSet<string>(documentContext.Elements.Select(e => e.UniqueId), StringComparer.Ordinal)
+      );
+
       EmitMainModelReferencePoint(pipeline, documentContext);
 
       using (
@@ -259,7 +270,7 @@ public class RevitArtifactRootObjectBuilder(
         foreach (Element revitElement in documentContext.Elements)
         {
           cancellationToken.ThrowIfCancellationRequested();
-          string applicationId = revitElement.UniqueId;
+          string applicationId = revitElement.UniqueId + placement.Suffix;
           string sourceType = revitElement.GetType().Name;
           var sw = Stopwatch.StartNew();
           try
@@ -287,19 +298,10 @@ public class RevitArtifactRootObjectBuilder(
               continue;
             }
 
-            // Transformed (linked) elements get a transform hash appended so instances of the same linked
-            // file under different placements stay distinct — same convention as the v1 builder.
-            bool hasTransform = documentContext.Transform != null;
-            if (hasTransform)
-            {
-              string transformHash = linkedModelHandler.GetTransformHash(documentContext.Transform.NotNull());
-              applicationId = $"{applicationId}_t{transformHash}";
-            }
-
             Base converted = converter.Convert(revitElement);
             converted.applicationId = applicationId;
 
-            int objK = EmitObject(pipeline, converted, modelK, revitElement, applicationId, placementIndex);
+            int objK = EmitObject(pipeline, converted, modelK, revitElement, applicationId, placement);
             sentElements.Add((revitElement, objK));
             results.Add(new(Status.SUCCESS, applicationId, sourceType, converted));
             session.RecordObject(applicationId, sourceType, Status.SUCCESS, null, sw.ElapsedMilliseconds);
@@ -323,7 +325,7 @@ public class RevitArtifactRootObjectBuilder(
         // — SuperComponent, Host, Room, FromRoom/ToRoom — lives in the same document, hence the same placement. So
         // resolving against this placement's map alone is both sufficient and the thing that keeps edges from
         // crossing placements [ENG-9212].
-        EmitElementTopology(pipeline, sentElements, placementIndex);
+        EmitElementTopology(pipeline, sentElements, placement.ObjectKsByUniqueId);
 
         // Named 3D views (perspective AND orthographic) of this document → camera_views rows. Collected inside
         // this settings push so linked-model cameras ride the exact ReferencePointTransform + scaling path the
@@ -460,7 +462,7 @@ public class RevitArtifactRootObjectBuilder(
     int modelK,
     Element revitElement,
     string applicationId,
-    Dictionary<string, int> placementIndex
+    PlacementContext placement
   )
   {
     int objK = pipeline.InternObject(applicationId);
@@ -468,7 +470,7 @@ public class RevitArtifactRootObjectBuilder(
 
     // Indexer, not Add: ElementUnpacker already dedups by ElementId so one UniqueId maps to one K per placement,
     // but a coincident-transform placement key (ENG-9263) must degrade quietly rather than throw mid-send.
-    placementIndex[revitElement.UniqueId] = objK;
+    placement.ObjectKsByUniqueId[revitElement.UniqueId] = objK;
 
     if (converted is not DataObject dataObject)
     {
@@ -498,7 +500,7 @@ public class RevitArtifactRootObjectBuilder(
       int childOrd = 0;
       foreach (RevitObject child in revitObject.elements)
       {
-        EmitChild(pipeline, child, modelK, objK, childOrd++);
+        EmitChild(pipeline, child, modelK, objK, childOrd++, placement);
       }
     }
 
@@ -656,12 +658,44 @@ public class RevitArtifactRootObjectBuilder(
   // A hosted/nested child RevitObject: its own interned object (geometry + properties), a SUBELEMENT edge to its
   // owner, and recursion into its own children. Children are NOT in the atomic loop (stripped when the parent is
   // present), so they get no separate ON_LEVEL/type-key resolution here — geometry + hierarchy + materials suffice.
-  private void EmitChild(ObjectsArtifactPipeline pipeline, RevitObject child, int modelK, int parentObjK, int subOrd)
+  //
+  // Identity is the child's Revit UniqueId (stamped by the converter) qualified by the SAME placement suffix its
+  // parent got, so two placements of one linked file keep distinct child identities, a re-send reproduces them, and
+  // the child can be the endpoint of a hosting/ownership relation [ENG-9212]. The Guid fallback survives only for a
+  // converter that emits an unidentified child — such an object is unreferenceable, but still ships its geometry.
+  private void EmitChild(
+    ObjectsArtifactPipeline pipeline,
+    RevitObject child,
+    int modelK,
+    int parentObjK,
+    int subOrd,
+    PlacementContext placement
+  )
   {
-    string childAppId = child.applicationId ?? Guid.NewGuid().ToString();
+    string? childUniqueId = child.applicationId;
+    string childAppId = childUniqueId is null ? Guid.NewGuid().ToString() : childUniqueId + placement.Suffix;
     int childK = pipeline.InternObject(childAppId);
-    pipeline.InModel(childK, modelK, 0);
     pipeline.Subelement(parentObjK, childK, subOrd);
+
+    if (childUniqueId is not null)
+    {
+      // Reachable as a relation endpoint now that the id is the source UniqueId: a fixture hosted on a curtain
+      // panel, or owned by a nested shared family, resolves here instead of being dropped as dangling.
+      placement.ObjectKsByUniqueId[childUniqueId] = childK;
+
+      // A composite child can ALSO be atomic in this placement — a basic wall used as a curtain panel is both, and
+      // RemoveKnownChildElementsWhenParentPresent only strips Mullion / Panel / curtain-hosted FamilyInstance /
+      // stacked-wall member / TopRail. Both emissions now intern to the same deterministic id, so re-emitting the
+      // payload here would write its properties twice and hang a second DISPLAY edge (pointing at a second copy of
+      // the same mesh) off one object. Keep the ownership edge, let the atomic pass own the payload — it carries
+      // ON_LEVEL and the type key on top.
+      if (placement.AtomicUniqueIds.Contains(childUniqueId))
+      {
+        return;
+      }
+    }
+
+    pipeline.InModel(childK, modelK, 0);
     pipeline.AddProperties(childAppId, child.properties, RootScalars(child, child));
 
     EmitDisplayValue(pipeline, childK, childAppId, child.displayValue);
@@ -669,7 +703,7 @@ public class RevitArtifactRootObjectBuilder(
     int grandOrd = 0;
     foreach (RevitObject grandChild in child.elements)
     {
-      EmitChild(pipeline, grandChild, modelK, childK, grandOrd++);
+      EmitChild(pipeline, grandChild, modelK, childK, grandOrd++, placement);
     }
   }
 
@@ -968,6 +1002,23 @@ public class RevitArtifactRootObjectBuilder(
     };
 
   private static readonly IReadOnlyDictionary<string, object?> s_emptyProperties = new Dictionary<string, object?>();
+
+  /// <summary>
+  /// Everything an object — or a child emitted recursively beneath it — needs to be identified and indexed within
+  /// ONE linked-model placement [ENG-9212]. A linked file placed N times produces N of these over the same source
+  /// document, and nothing may leak between them.
+  /// </summary>
+  /// <param name="Suffix">Appended to every source UniqueId in this placement: <c>_t{transformHash}</c> for a linked
+  /// document, empty for the host document.</param>
+  /// <param name="ObjectKsByUniqueId">Source UniqueId → interned object K, for THIS placement only. Element→element
+  /// relations resolve here, which is what keeps them from crossing placements.</param>
+  /// <param name="AtomicUniqueIds">The UniqueIds converted as atomic objects in this placement — a composite child
+  /// that also appears here must not re-emit its payload (see <see cref="EmitChild"/>).</param>
+  private sealed record PlacementContext(
+    string Suffix,
+    Dictionary<string, int> ObjectKsByUniqueId,
+    HashSet<string> AtomicUniqueIds
+  );
 
   private sealed record BundleResult(
     IReadOnlyDictionary<string, string> Bundle,

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/RevitArtifactRootObjectBuilder.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/RevitArtifactRootObjectBuilder.cs
@@ -9,6 +9,7 @@ using Speckle.Connectors.Common.Conversion;
 using Speckle.Connectors.Common.Diagnostics;
 using Speckle.Connectors.Common.Operations;
 using Speckle.Connectors.Common.Threading;
+using Speckle.Connectors.Common.Topology;
 using Speckle.Connectors.DUI.Exceptions;
 using Speckle.Connectors.Revit.HostApp;
 using Speckle.Converters.Common;
@@ -820,59 +821,80 @@ public class RevitArtifactRootObjectBuilder(
   // active phase, and topology is best-effort (must never fail the geometry send).
   //
   // Scoped to ONE placement [ENG-9212]: <paramref name="sentElements"/> are the objects interned for this document
-  // context and <paramref name="placementIndex"/> resolves UniqueId → K within that same context, so every endpoint
-  // is unambiguous — exactly one K per element, no list to fan out over and no [0] to guess with. Resolving against
-  // a global UniqueId → K-list map instead produced a cartesian product of edges (placement A's door HOSTED_ON
-  // placement B's wall) and pinned every IN_ROOM / CONNECTS_TO to the first placement.
+  // context and <paramref name="placementIndex"/> resolves UniqueId → K within that same context. This half is the
+  // Revit read; PlacementTopology owns the resolution (precedence, dangling-endpoint drops, placement scoping) so
+  // that logic is testable without a live Revit document — which is what ENG-9212 needed and could not have.
   private static void EmitElementTopology(
     ObjectsArtifactPipeline pipeline,
     List<(Element Element, int ObjK)> sentElements,
     Dictionary<string, int> placementIndex
   )
   {
+    var placementElements = new List<PlacementElement>(sentElements.Count);
     foreach (var (element, elementK) in sentElements)
     {
       if (element is not FamilyInstance fi)
       {
         continue;
       }
+
+      string? ownerUniqueId = null;
+      string? hostUniqueId = null;
+      string? roomUniqueId = null;
+      string? fromRoomUniqueId = null;
+      string? toRoomUniqueId = null;
       try
       {
-        // Ownership wins over hosting, matching rvextract's precedence (owningElemId first, getHostId as the
-        // fallback) so the same fixture gets the same relation whether it is published through the connector or
-        // extracted from an uploaded file. An owner that exists but was NOT sent suppresses HOSTED_ON rather than
-        // falling through to it — the element is owned, and the edge is simply dropped as dangling.
-        if (fi.SuperComponent is { } owner)
-        {
-          if (placementIndex.TryGetValue(owner.UniqueId, out int ownerK))
-          {
-            pipeline.Subelement(ownerK, elementK, 0);
-          }
-        }
-        else if (fi.Host is { } host && placementIndex.TryGetValue(host.UniqueId, out int hostK))
-        {
-          pipeline.HostedOn(elementK, hostK);
-        }
-
-        Element? room = fi.Room ?? (Element?)fi.Space;
-        if (room is not null && placementIndex.TryGetValue(room.UniqueId, out int roomK))
-        {
-          pipeline.InRoom(elementK, roomK, 0);
-        }
-
-        if (
-          fi.FromRoom is { } fromRoom
-          && fi.ToRoom is { } toRoom
-          && placementIndex.TryGetValue(fromRoom.UniqueId, out int fromK)
-          && placementIndex.TryGetValue(toRoom.UniqueId, out int toK)
-        )
-        {
-          pipeline.ConnectsTo(fromK, toK, elementK);
-        }
+        ownerUniqueId = fi.SuperComponent?.UniqueId;
+        hostUniqueId = fi.Host?.UniqueId;
       }
       catch (Exception ex) when (!ex.IsFatal())
       {
-        // best-effort: Room/ToRoom/FromRoom can throw without an active phase — skip this element's topology.
+        // best-effort: topology must never fail the geometry send.
+      }
+      try
+      {
+        // Read SEPARATELY from ownership/hosting above: Room/Space/FromRoom/ToRoom throw without an active phase,
+        // and a phase-less model should still get its SUBELEMENT / HOSTED_ON edges.
+        roomUniqueId = (fi.Room ?? (Element?)fi.Space)?.UniqueId;
+        fromRoomUniqueId = fi.FromRoom?.UniqueId;
+        toRoomUniqueId = fi.ToRoom?.UniqueId;
+      }
+      catch (Exception ex) when (!ex.IsFatal())
+      {
+        // best-effort: no active phase → this element ships without room topology.
+      }
+
+      placementElements.Add(
+        new PlacementElement(
+          element.UniqueId,
+          elementK,
+          ownerUniqueId,
+          hostUniqueId,
+          roomUniqueId,
+          fromRoomUniqueId,
+          toRoomUniqueId
+        )
+      );
+    }
+
+    foreach (var edge in PlacementTopology.Resolve(placementElements, placementIndex))
+    {
+      switch (edge.Kind)
+      {
+        case PlacementEdgeKind.Subelement:
+          pipeline.Subelement(edge.Src, edge.Dst, edge.Ord);
+          break;
+        case PlacementEdgeKind.HostedOn:
+          pipeline.HostedOn(edge.Src, edge.Dst);
+          break;
+        case PlacementEdgeKind.InRoom:
+          pipeline.InRoom(edge.Src, edge.Dst, edge.Ord);
+          break;
+        default:
+          // ConnectsTo — Ord is the opening's K (a scope, not an ordinal).
+          pipeline.ConnectsTo(edge.Src, edge.Dst, edge.Ord);
+          break;
       }
     }
   }

--- a/Converters/Revit/Speckle.Converters.RevitShared/ToSpeckle/TopLevel/RevitElementTopLevelConverterToSpeckle.cs
+++ b/Converters/Revit/Speckle.Converters.RevitShared/ToSpeckle/TopLevel/RevitElementTopLevelConverterToSpeckle.cs
@@ -140,7 +140,15 @@ public class ElementTopLevelConverterToSpeckle : IToSpeckleTopLevelConverter
     foreach (var childrenId in childrenIds)
     {
       var childElement = _converterSettings.Current.Document.GetElement(childrenId);
-      yield return Convert(childElement);
+      RevitObject child = Convert(childElement);
+
+      // Only the ROOT conversion result gets an applicationId stamped (RevitRootToSpeckleConverter), so nested
+      // children — curtain panels/mullions, stacked-wall members, top rails — arrived with none, and the artefact
+      // send fell back to a fresh Guid per emission: identity that could not be traced back to Revit, was not
+      // stable across sends, and could never be the endpoint of a hosting/ownership relation [ENG-9212]. Stamp the
+      // source UniqueId here so it recurses to grandchildren too; the send qualifies it per linked-model placement.
+      child.applicationId = childElement.UniqueId;
+      yield return child;
     }
   }
 

--- a/Sdk/Speckle.Connectors.Common.Tests/Topology/PlacementTopologyTests.cs
+++ b/Sdk/Speckle.Connectors.Common.Tests/Topology/PlacementTopologyTests.cs
@@ -1,0 +1,146 @@
+using FluentAssertions;
+using NUnit.Framework;
+using Speckle.Connectors.Common.Topology;
+
+namespace Speckle.Connectors.Common.Tests.Topology;
+
+/// <summary>
+/// ENG-9212: when the same file is placed more than once (a Revit link placed twice, one linked apartment per
+/// floor) every occurrence repeats the same source element ids, so identity is (placement, sourceId). Resolving on
+/// sourceId alone produced a cartesian product of hosting/ownership edges across placements and pinned every room
+/// relation to the first placement — a bundle that renders correctly while its relations point at the wrong
+/// occurrence. These tests pin the placement scoping, which no Revit-document test could reach.
+/// </summary>
+public class PlacementTopologyTests
+{
+  // The same two source elements — a door and the wall it is hosted on — as they appear in BOTH placements of one
+  // linked file. Identical UniqueIds; only the interned Ks differ.
+  private const string DOOR = "door-uid";
+  private const string WALL = "wall-uid";
+  private const string ROOM = "room-uid";
+  private const string ROOM_B = "room-b-uid";
+
+  private static PlacementElement Hosted(string uniqueId, int objectK, string hostUniqueId) =>
+    new(uniqueId, objectK, null, hostUniqueId, null, null, null);
+
+  private static Dictionary<string, int> Index(params (string UniqueId, int ObjectK)[] entries)
+  {
+    var index = new Dictionary<string, int>(StringComparer.Ordinal);
+    foreach (var (uniqueId, objectK) in entries)
+    {
+      index[uniqueId] = objectK;
+    }
+    return index;
+  }
+
+  [Test]
+  public void TwoPlacements_HostingStaysInsideItsOwnPlacement()
+  {
+    // Placement A interned door→1 / wall→2, placement B the same elements as 11 / 12. Resolved per placement, each
+    // door reaches its OWN wall: 2 edges total. A global sourceId → K-list index gave 4 (both cross pairs included).
+    var a = PlacementTopology.Resolve([Hosted(DOOR, 1, WALL)], Index((DOOR, 1), (WALL, 2)));
+    var b = PlacementTopology.Resolve([Hosted(DOOR, 11, WALL)], Index((DOOR, 11), (WALL, 12)));
+
+    a.Should().ContainSingle().Which.Should().Be(new PlacementEdge(PlacementEdgeKind.HostedOn, 1, 2, 0));
+    b.Should().ContainSingle().Which.Should().Be(new PlacementEdge(PlacementEdgeKind.HostedOn, 11, 12, 0));
+
+    // And explicitly: nothing crosses. No edge pairs a K from one placement with a K from the other.
+    a.Concat(b)
+      .Should()
+      .OnlyContain(e => (e.Src < 10 && e.Dst < 10) || (e.Src >= 10 && e.Dst >= 10), "no edge may cross placements");
+  }
+
+  [Test]
+  public void TwoPlacements_RoomResolvesToTheMatchingOccurrenceNotTheFirst()
+  {
+    // The regression this replaces indexed [0] — so a fixture in placement B was reported inside placement A's room.
+    var fixtureInB = new PlacementElement("fixture-uid", 11, null, null, ROOM, null, null);
+
+    var edges = PlacementTopology.Resolve([fixtureInB], Index(("fixture-uid", 11), (ROOM, 12)));
+
+    edges.Should().ContainSingle().Which.Should().Be(new PlacementEdge(PlacementEdgeKind.InRoom, 11, 12, 0));
+  }
+
+  [Test]
+  public void TwoPlacements_AdjacencyKeepsAllThreeEndpointsInOnePlacement()
+  {
+    // CONNECTS_TO carries the opening's K as its SCOPE, so the scope is a third endpoint that must not cross either.
+    var door = new PlacementElement(DOOR, 11, null, null, null, ROOM, ROOM_B);
+
+    var edges = PlacementTopology.Resolve([door], Index((DOOR, 11), (ROOM, 12), (ROOM_B, 13)));
+
+    edges.Should().ContainSingle().Which.Should().Be(new PlacementEdge(PlacementEdgeKind.ConnectsTo, 12, 13, 11));
+  }
+
+  [Test]
+  public void OwnershipWinsOverHosting()
+  {
+    // rvextract's precedence (owningElemId before getHostId) so a connector publish and a file-upload extract of the
+    // same model agree. Note the argument order flips: Subelement is owner→child, HostedOn is child→host.
+    var ownedAndHosted = new PlacementElement("fixture-uid", 1, "owner-uid", WALL, null, null, null);
+
+    var edges = PlacementTopology.Resolve([ownedAndHosted], Index(("fixture-uid", 1), ("owner-uid", 2), (WALL, 3)));
+
+    edges.Should().ContainSingle().Which.Should().Be(new PlacementEdge(PlacementEdgeKind.Subelement, 2, 1, 0));
+  }
+
+  [Test]
+  public void UnsentOwner_SuppressesHostingRatherThanFallingThroughToIt()
+  {
+    // The element IS owned; that its owner was filtered out of the send does not make it hosted. The ownership edge
+    // is dropped as dangling and no HOSTED_ON takes its place.
+    var owned = new PlacementElement("fixture-uid", 1, "owner-not-sent", WALL, null, null, null);
+
+    var edges = PlacementTopology.Resolve([owned], Index(("fixture-uid", 1), (WALL, 3)));
+
+    edges.Should().BeEmpty();
+  }
+
+  [Test]
+  public void UnsentEndpoints_AreDroppedNotDangled()
+  {
+    // A publish filter that excludes walls and rooms must not leave edges pointing at Ks that are not in the bundle.
+    var door = new PlacementElement(DOOR, 1, null, WALL, ROOM, ROOM, ROOM_B);
+
+    var edges = PlacementTopology.Resolve([door], Index((DOOR, 1)));
+
+    edges.Should().BeEmpty();
+  }
+
+  [Test]
+  public void SinglePlacement_BehavesExactlyLikeTheGlobalIndexDid()
+  {
+    // Host-document elements and single-placement links are the one-placement case: the per-placement index is
+    // precisely what the global one used to be, so their edges are unchanged by the ENG-9212 rework.
+    var door = new PlacementElement(DOOR, 1, null, WALL, ROOM, ROOM, ROOM_B);
+
+    var edges = PlacementTopology.Resolve([door], Index((DOOR, 1), (WALL, 2), (ROOM, 3), (ROOM_B, 4)));
+
+    edges
+      .Should()
+      .Equal(
+        new PlacementEdge(PlacementEdgeKind.HostedOn, 1, 2, 0),
+        new PlacementEdge(PlacementEdgeKind.InRoom, 1, 3, 0),
+        new PlacementEdge(PlacementEdgeKind.ConnectsTo, 3, 4, 1)
+      );
+  }
+
+  [Test]
+  public void RepeatedPlacements_EmitOneEdgeEachRatherThanNSquared()
+  {
+    // Four placements of one linked file: 4 HOSTED_ON edges, not 16. relations.parquet is an append-only log with no
+    // dedup, so a count regression here ships as duplicate rows rather than an error.
+    var edges = Enumerable
+      .Range(0, 4)
+      .SelectMany(placement =>
+      {
+        int doorK = placement * 10;
+        int wallK = doorK + 1;
+        return PlacementTopology.Resolve([Hosted(DOOR, doorK, WALL)], Index((DOOR, doorK), (WALL, wallK)));
+      })
+      .ToList();
+
+    edges.Should().HaveCount(4);
+    edges.Should().OnlyContain(e => e.Dst == e.Src + 1);
+  }
+}

--- a/Sdk/Speckle.Connectors.Common/Operations/SendOperation.cs
+++ b/Sdk/Speckle.Connectors.Common/Operations/SendOperation.cs
@@ -317,10 +317,16 @@ public sealed class SendOperation<T>(
     {
       SendOperationResult result = await ConvertAndSend(objects, sendInfo, progress, saveToCache, cancellationToken);
 
+      // NOTE: Ingestion.Complete is obsolete (ENG-9221) - completeWithVersion bypasses the v2 REST uploads/complete
+      // seam, so the version it creates is not viewer-consumable in the bundle era. This is the legacy fallback path,
+      // only reached when the connector has neither an artefact builder nor packfile endpoints, so it keeps using it.
+      // ENG-9264 tracks migrating this path to the v2 REST flow (or deleting it) and dropping the suppression.
+#pragma warning disable CS0618
       string createdVersionId = await sendInfo.Client.Ingestion.Complete(
         new(ingestion.id, sendInfo.ProjectId, result.RootObjId, versionMessage),
         CancellationToken.None
       );
+#pragma warning restore CS0618
 
       // NOTE: it might seem weird to pass null for ingestion.id 'null' here but there is a reason.
       // Because we complete ingestion here in .NET which is safe to pass null ingestion id that we don't want DUI explicitly subscribe to ingestion changes.

--- a/Sdk/Speckle.Connectors.Common/Topology/PlacementTopology.cs
+++ b/Sdk/Speckle.Connectors.Common/Topology/PlacementTopology.cs
@@ -1,0 +1,123 @@
+namespace Speckle.Connectors.Common.Topology;
+
+/// <summary>The element→element relation kinds <see cref="PlacementTopology.Resolve"/> can produce.</summary>
+public enum PlacementEdgeKind
+{
+  /// <summary>Owner → owned component (a nested shared family → its super-component). Ownership, not placement.</summary>
+  Subelement,
+
+  /// <summary>Hosted element → its host (a door → its wall). Placement, not ownership.</summary>
+  HostedOn,
+
+  /// <summary>Element → the ROOM object containing it.</summary>
+  InRoom,
+
+  /// <summary>Room → adjacent room, scoped by the opening between them.</summary>
+  ConnectsTo,
+}
+
+/// <summary>
+/// What one sent element reports about its neighbours, as plain ids — the host-API read (Revit
+/// <c>SuperComponent</c> / <c>Host</c> / <c>Room</c> / <c>FromRoom</c> / <c>ToRoom</c>) already done and the host
+/// types left behind.
+/// </summary>
+/// <param name="ObjectK">The K this element was interned as, in this placement.</param>
+/// <param name="OwnerUniqueId">Its super-component, if any. Non-null SUPPRESSES hosting even when unresolvable —
+/// see <see cref="PlacementTopology.Resolve"/>.</param>
+/// <param name="HostUniqueId">What it is placed on, if anything.</param>
+/// <param name="RoomUniqueId">The room (or MEP space) containing it, if any.</param>
+/// <param name="FromRoomUniqueId">For an opening: the room on one side.</param>
+/// <param name="ToRoomUniqueId">For an opening: the room on the other side.</param>
+public readonly record struct PlacementElement(
+  string UniqueId,
+  int ObjectK,
+  string? OwnerUniqueId,
+  string? HostUniqueId,
+  string? RoomUniqueId,
+  string? FromRoomUniqueId,
+  string? ToRoomUniqueId
+);
+
+/// <summary>One resolved edge, in interned Ks.</summary>
+/// <param name="Ord">Ordinal for most kinds; for <see cref="PlacementEdgeKind.ConnectsTo"/> it is a SCOPE (the
+/// opening's object K), matching <c>rel_types.ord_semantics='scope'</c>.</param>
+public readonly record struct PlacementEdge(PlacementEdgeKind Kind, int Src, int Dst, int Ord);
+
+/// <summary>
+/// Resolves element→element topology WITHIN ONE PLACEMENT of a source document [ENG-9212].
+///
+/// <para><b>Why this exists as its own boundary.</b> When the same file is placed more than once — a Revit link
+/// placed twice, one linked apartment per floor — every occurrence repeats the same source element ids. Identity is
+/// therefore <i>(placement, sourceId)</i>, never sourceId alone, and a resolver keyed on sourceId alone gets it
+/// wrong in two directions at once: a sourceId that maps to N candidate Ks either fans out over all of them
+/// (placement A's door reported as hosted on placement B's wall — a cartesian product of edges, N² for N placements)
+/// or picks the first (every placement's furniture reported in the FIRST placement's room). Both produce a bundle
+/// whose geometry renders correctly while its hierarchy and relations are quietly wrong.</para>
+///
+/// <para>The fix is a per-placement index, which makes every endpoint unambiguous — exactly one K per source id, no
+/// list to fan out over and no <c>[0]</c> to guess with. That resolution is what this class holds, free of any host
+/// API, so it can be tested against duplicate source ids across placements; the caller does the host-API read and
+/// turns the returned edges into pipeline calls. A host document, or a file placed exactly once, is just the
+/// one-placement case — the index is then what a global one would have been.</para>
+///
+/// <para><b>Not for value nodes.</b> Levels, materials, definitions and the like are SHARED across placements, so
+/// their edges legitimately fan out to every occurrence. Those resolve through a flattened index instead; only
+/// element→element topology belongs here.</para>
+/// </summary>
+public static class PlacementTopology
+{
+  /// <summary>
+  /// Resolves <paramref name="elements"/> against <paramref name="objectKsByUniqueId"/> — the source id → object K
+  /// index for THIS placement, and only this placement.
+  ///
+  /// <para><b>Ownership wins over hosting</b>, matching rvextract's precedence (<c>owningElemId</c> first,
+  /// <c>getHostId</c> as the fallback) so the same fixture gets the same relation whether it is published through a
+  /// connector or extracted from an uploaded file. An owner that exists but was NOT sent suppresses
+  /// <see cref="PlacementEdgeKind.HostedOn"/> rather than falling through to it: the element IS owned, and the edge
+  /// is simply dropped as dangling.</para>
+  ///
+  /// <para>Every other endpoint must also be present in the index — an edge to something that was not sent would
+  /// dangle, so it is dropped. Order is the input order, then ownership/hosting → room → adjacency per element.</para>
+  /// </summary>
+  public static IReadOnlyList<PlacementEdge> Resolve(
+    IReadOnlyCollection<PlacementElement> elements,
+    IReadOnlyDictionary<string, int> objectKsByUniqueId
+  )
+  {
+    var edges = new List<PlacementEdge>();
+    foreach (var element in elements)
+    {
+      int elementK = element.ObjectK;
+
+      if (element.OwnerUniqueId is { } ownerUniqueId)
+      {
+        if (objectKsByUniqueId.TryGetValue(ownerUniqueId, out int ownerK))
+        {
+          edges.Add(new PlacementEdge(PlacementEdgeKind.Subelement, ownerK, elementK, 0));
+        }
+      }
+      else if (element.HostUniqueId is { } hostUniqueId && objectKsByUniqueId.TryGetValue(hostUniqueId, out int hostK))
+      {
+        edges.Add(new PlacementEdge(PlacementEdgeKind.HostedOn, elementK, hostK, 0));
+      }
+
+      if (element.RoomUniqueId is { } roomUniqueId && objectKsByUniqueId.TryGetValue(roomUniqueId, out int roomK))
+      {
+        edges.Add(new PlacementEdge(PlacementEdgeKind.InRoom, elementK, roomK, 0));
+      }
+
+      // The opening's own K is the SCOPE of the adjacency, so all three endpoints come from this placement.
+      if (
+        element.FromRoomUniqueId is { } fromRoomUniqueId
+        && element.ToRoomUniqueId is { } toRoomUniqueId
+        && objectKsByUniqueId.TryGetValue(fromRoomUniqueId, out int fromK)
+        && objectKsByUniqueId.TryGetValue(toRoomUniqueId, out int toK)
+      )
+      {
+        edges.Add(new PlacementEdge(PlacementEdgeKind.ConnectsTo, fromK, toK, elementK));
+      }
+    }
+
+    return edges;
+  }
+}

--- a/docs/connector-relations.md
+++ b/docs/connector-relations.md
@@ -401,7 +401,7 @@ graph LR
 - **Nodes:** CONTAINER `"Model"` (per source doc) · CONTAINER `"Group"` (per placed model group) · LEVEL (name+elev) · DEFINITION/INSTANCE · MATERIAL
 - **Sidecar:** `camera_views` ← 3D views (ENG-8802) · `reference_point` meta (ENG-8808)
 - **Receive:** ● native — DirectShape + DirectShapeLibrary instances, reference-point reversal
-- **Watch out:** linked models intern per-placement; Shared Coordinates deliberately not recorded (can't be one offset)
+- **Watch out:** linked models intern per-placement — atomic objects, recursive children, and element→element relations alike (ENG-9212); a placement's element topology resolves only within its own placement index. Shared Coordinates deliberately not recorded (can't be one offset)
 
 ---
 


### PR DESCRIPTION
﻿## Description

When the same RVT is linked more than once, relations between the linked file's elements crossed placements: placement A's door came out `HOSTED_ON` placement B's wall, and every placement's furniture came out inside the *first* placement's room. Geometry still renders at the right transforms, so the model looks correct while its hierarchy and relations are quietly wrong.

Root cause was identity. `objectKsByElementUniqueId` was global and keyed only by Revit `UniqueId`, so a linked element placed by N link instances mapped to N object Ks with nothing recording which placement each belonged to. `EmitElementTopology` then either fanned out over every candidate K or picked `[0]`:

- ownership/hosting looped `ownerKs × elementKs` / `hostKs × elementKs` — a cartesian product;
- `IN_ROOM`, and both endpoints plus the scope of `CONNECTS_TO`, indexed `[0]`.

On top of that the loop ran over `flatElements`, which repeats a linked element once per link instance, so the whole thing was emitted N times. `relations.parquet` is an append-only log with no dedup, so **a two-placement link wrote 8 `HOSTED_ON` rows where 2 were correct**. `ON_LEVEL` was already writing 4 rows for 2 objects the same way.

Identity of an occurrence is `(placement, UniqueId)`, so the index is keyed that way.

**The child half of the ticket was misdiagnosed, and the audit is recorded [in a comment on ENG-9212](https://linear.app/speckle/issue/ENG-9212/revit-repeated-linked-model-placements-share-child-identities-and).** Children did not reuse the raw Revit id — they had *no* id at all. Only the root conversion result gets one stamped (`RevitRootToSpeckleConverter`), so `child.applicationId ?? Guid.NewGuid()` fell through on every child, every time. Two placements therefore did get distinct child Ks, but by accident: the id was untraceable to Revit, different on every re-send, unmappable on receive, and invisible to `_t<hash>` linked-model probes. Children were also absent from the index, so any relation *pointing at* one was silently dropped — a fixture hosted on a curtain panel lost its `HOSTED_ON`.

Connects ENG-9212. Also filed ENG-9263 while auditing: the placement key itself is a hash of a lossy transform summary (origin at `F2`, only the 3 diagonal basis components at `F1`), so two placements at one origin rotated +90°/−90° collide and merge before any of this runs. That is the ceiling on how correct this PR can be, and it is deliberately not touched here — changing the hash rewrites every linked element's application ID and invalidates the suffix-based base-ID recovery ENG-9077 depends on.

<img width="1037" height="663" alt="image" src="https://github.com/user-attachments/assets/6d2ed0ea-dc20-46d4-b8c6-d7fd0d21afb7" />


## User Value

Repeated linked models — floors, wings, apartments, modules — publish with hierarchy and relations that point at the right occurrence, so selection, queries, quantities, graph traversal and receive stop silently mixing placements.

## Changes:

- **`d56c6f38`** — per-placement `UniqueId → objK` index (`objectKsByPlacement`); `EmitElementTopology` runs per document context alongside `EmitGroups` instead of once globally. Every endpoint Revit reports (`SuperComponent`, `Host`, `Room`, `FromRoom`/`ToRoom`) lives in the same document as the element, hence the same placement, so single lookups replace both the nested loops and every `[0]`. `ON_LEVEL` keeps its cross-placement fan-out — correct for a value node — but dedups its UniqueId list.
- **`cfb7a6ea`** — the converter stamps each child's source `UniqueId` (recursing to grandchildren for free); the send qualifies it with the same placement suffix its parent gets. Children register in the index and become resolvable relation endpoints. The suffix is now hashed once per placement rather than once per element, and rides a `PlacementContext` through the emit recursion.
- **`07067269`** — resolution extracted into `PlacementTopology` in `Speckle.Connectors.Common`, plus 8 tests.
- **`acb553d6`** — `docs/connector-relations.md`: the "linked models intern per-placement" watch-out now states what per-placement interning covers, since it held only for top-level atomic objects before this PR.
- **`3f4c043c`** — unrelated to the fix, and carried here only because it blocked building this branch: the sibling SDK merged ENG-9221 (speckle-sharp-sdk#535), marking `ModelIngestionResource.Complete` `[Obsolete]`; with `TreatWarningsAsErrors=true` that broke every `Local` build of `big-truck`. CS0618 is suppressed at the one call site in `SendOperation.SendViaIngestion` rather than relaxing warnings-as-errors for the whole compilation, so a second use of a deprecated API still fails the build. No behaviour change — that call is the legacy fallback, reached only when a connector has neither an artefact builder nor packfile endpoints, so nothing on the Revit artefact path touches it. **ENG-9264** (low priority) tracks migrating the path to the v2 REST uploads/complete flow, or deleting it, and dropping the suppression.

Deterministic ids expose an overlap the GUIDs hid: a composite child can also be atomic in the same placement — a basic wall used as a curtain panel is both, and `RemoveKnownChildElementsWhenParentPresent` only strips Mullion / Panel / curtain-hosted FamilyInstance / stacked-wall member / TopRail. Both emissions now intern to the same id, so the child pass keeps the `SUBELEMENT` edge and returns, leaving the payload to the atomic pass. This previously shipped as two objects with duplicate geometry.

## To-do before merge:

- [x] ~~**`big-truck` does not currently build in `Local`, independent of this PR.**~~ Fixed in `3f4c043c`, see above. No `-p:WarningsNotAsErrors=CS0618` needed any more.

## Validation of changes:

Revit connector code has **no runnable test host**: `Speckle.Converters.RevitShared.Tests` is a shared project referenced by the four `.slnx` files but by no `.csproj`, so it never builds, and the Autodesk types the resolution reads through (`FamilyInstance`, `SuperComponent`, `Host`, `Room`) are neither constructible nor mockable. So the ticket's own escape hatch: the Revit read stays in the builder, and the resolution — precedence, dangling-endpoint drops, placement scoping — moves to `PlacementTopology` as plain ids, next to `DefinitionMemberStamps`, which solved the same untestable-in-the-connector problem for block members. The API shape is the guardrail: `Resolve()` takes ONE placement's index, so there is no global map to accidentally resolve against again.

8 tests in `PlacementTopologyTests`, covering the ACs: duplicate source `UniqueId`s across two placements resolving to their own occurrence only (hosting, room containment, adjacency including its scope endpoint), no edge pairing Ks from different placements, edge counts staying linear rather than N², ownership precedence, an unsent owner suppressing `HOSTED_ON` instead of falling through, unsent endpoints dropped rather than dangled, and the single-placement case resolving exactly as the old global index did. Full suite: 136/136.

Room reads are now separated from ownership/hosting reads in the builder, so a model with no active phase — where `Room`/`FromRoom`/`ToRoom` throw — keeps its `SUBELEMENT` and `HOSTED_ON` edges instead of losing the element's whole topology.

**Not yet exercised in Revit** — bundle inspection against the ticket's repro file is the next step: `HOSTED_ON` row counts, `IN_ROOM` resolving to the matching placement, `CONNECTS_TO` endpoints and scope, child app IDs identical across two sends, `ON_LEVEL` at 2 rows rather than 4.

**One behaviour change outside the artefact path:** v1 send payloads now carry child `applicationId`s. On receive that makes `MapLayersRenderMaterials` treat children the way it already treats atomic objects (layer-material fallback) instead of skipping them on the null check. I could not exercise that path — worth a curtain-wall v1 round-trip if we still support it.

## Checklist:

- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] I have added appropriate tests.
- [x] I have updated or added relevant documentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

