### PR TITLE
fix(tekla): re-send objects after a coordinate frame change

### DIFF
--- a/Connectors/Tekla/Speckle.Connector.TeklaShared/Bindings/TeklaSendBinding.cs
+++ b/Connectors/Tekla/Speckle.Connector.TeklaShared/Bindings/TeklaSendBinding.cs
@@ -10,6 +10,7 @@ using Speckle.Connectors.DUI.Models;
 using Speckle.Connectors.DUI.Models.Card;
 using Speckle.Connectors.DUI.Models.Card.SendFilter;
 using Speckle.Connectors.DUI.Settings;
+using Speckle.Connectors.TeklaShared.HostApp;
 using Speckle.Connectors.TeklaShared.Operations.Send.Settings;
 using Speckle.Converters.Common;
 using Speckle.Converters.TeklaShared;
@@ -36,6 +37,7 @@ public sealed class TeklaSendBinding : ISendBinding
   private readonly ToSpeckleSettingsManager _toSpeckleSettingsManager;
   private readonly Events _events;
   private readonly ISendOperationManagerFactory _sendOperationManagerFactory;
+  private readonly TeklaCoordinateSystemTracker _coordinateSystemTracker;
 
   private ConcurrentDictionary<string, byte> ChangedObjectIds { get; set; } = new();
 
@@ -48,7 +50,8 @@ public sealed class TeklaSendBinding : ISendBinding
     ILogger<TeklaSendBinding> logger,
     ITeklaConversionSettingsFactory teklaConversionSettingsFactory,
     ToSpeckleSettingsManager toSpeckleSettingsManager,
-    ISendOperationManagerFactory sendOperationManagerFactory
+    ISendOperationManagerFactory sendOperationManagerFactory,
+    TeklaCoordinateSystemTracker coordinateSystemTracker
   )
   {
     _store = store;
@@ -61,6 +64,7 @@ public sealed class TeklaSendBinding : ISendBinding
     Commands = new SendBindingUICommands(parent);
     _toSpeckleSettingsManager = toSpeckleSettingsManager;
     _sendOperationManagerFactory = sendOperationManagerFactory;
+    _coordinateSystemTracker = coordinateSystemTracker;
 
     _model = new Model();
     _events = new Events();
@@ -104,10 +108,14 @@ public sealed class TeklaSendBinding : ISendBinding
       Commands,
       modelCardId,
       (sp, card) =>
+      {
+        // objects cached in a different coordinate frame carry the wrong coordinates, so they go before we convert
+        _coordinateSystemTracker.ClearCacheIfCoordinateSystemChanged(_model);
         sp.GetRequiredService<IConverterSettingsStore<TeklaConversionSettings>>()
           .Initialize(
             _teklaConversionSettingsFactory.Create(_model, _toSpeckleSettingsManager.GetSendRebarsAsSolid(card))
-          ),
+          );
+      },
       card =>
         card.SendFilter.NotNull()
           .RefreshObjectIds()

--- a/Connectors/Tekla/Speckle.Connector.TeklaShared/HostApp/TeklaCoordinateSystemTracker.cs
+++ b/Connectors/Tekla/Speckle.Connector.TeklaShared/HostApp/TeklaCoordinateSystemTracker.cs
@@ -1,0 +1,92 @@
+using Microsoft.Extensions.Logging;
+using Speckle.Connectors.Common.Caching;
+using Speckle.Sdk;
+
+namespace Speckle.Connectors.TeklaShared.HostApp;
+
+/// <summary>
+/// Detects changes to the coordinate frame Tekla reports geometry in, and clears the send conversion cache
+/// when it moves.
+/// </summary>
+/// <remarks>
+/// All geometry we read from the Tekla API is expressed in the model's current coordinate frame: the work plane,
+/// plus the current base point and its angle to north. Moving that frame rewrites the coordinates of every object
+/// without changing any object, so <c>ModelObjectChanged</c> never fires and cached objects are re-published with
+/// the old orientation. Tekla raises no event for frame changes either, so we re-read the frame before every send.
+/// </remarks>
+public class TeklaCoordinateSystemTracker
+{
+  private readonly ISendConversionCache _sendConversionCache;
+  private readonly ILogger<TeklaCoordinateSystemTracker> _logger;
+
+  private double[]? _lastKnownFrame;
+
+  public TeklaCoordinateSystemTracker(
+    ISendConversionCache sendConversionCache,
+    ILogger<TeklaCoordinateSystemTracker> logger
+  )
+  {
+    _sendConversionCache = sendConversionCache;
+    _logger = logger;
+  }
+
+  /// <summary>
+  /// Clears the send conversion cache unless the model's coordinate frame is provably unchanged since the last
+  /// send. Must be called before objects are converted.
+  /// </summary>
+  public void ClearCacheIfCoordinateSystemChanged(TSM.Model model)
+  {
+    double[]? currentFrame = null;
+    try
+    {
+      currentFrame = GetCoordinateFrame(model);
+    }
+    catch (Exception ex) when (!ex.IsFatal())
+    {
+      _logger.LogWarning(ex, "Failed to read the Tekla coordinate frame, clearing the send conversion cache.");
+    }
+
+    // an unknown frame on either side means we cannot prove cached objects are still valid, so we assume they are
+    // not. The frame is model wide, so a change invalidates every cached object, not just the current card's.
+    if (currentFrame is null || _lastKnownFrame is null || !_lastKnownFrame.SequenceEqual(currentFrame))
+    {
+      _sendConversionCache.ClearCache();
+    }
+
+    _lastKnownFrame = currentFrame;
+  }
+
+  private static double[] GetCoordinateFrame(TSM.Model model)
+  {
+    var workPlane = model.GetWorkPlaneHandler().GetCurrentTransformationPlane().TransformationMatrixToGlobal;
+    TSM.BasePoint? basePoint = TSM.ProjectInfo.GetCurrentCoordsysBasePoint();
+
+    // a base point shifts and rotates reported coordinates by where it sits in the model, what coordinates it
+    // assigns to that spot, and how far it is turned from north. Compared by value, so swapping between two
+    // identically defined base points counts as no change.
+    return
+    [
+      .. GetMatrixValues(workPlane),
+      model.GetInfo().NorthDirection,
+      basePoint?.LocationInModelX ?? 0,
+      basePoint?.LocationInModelY ?? 0,
+      basePoint?.LocationInModelZ ?? 0,
+      basePoint?.EastWest ?? 0,
+      basePoint?.NorthSouth ?? 0,
+      basePoint?.Elevation ?? 0,
+      basePoint?.AngleToNorth ?? 0,
+    ];
+  }
+
+  // Tekla matrices are 4 rows by 3 columns (rotation then translation) and do not implement value equality
+  private static IEnumerable<double> GetMatrixValues(Tekla.Structures.Geometry3d.Matrix matrix)
+  {
+    for (int row = 0; row < 4; row++)
+    {
+      for (int column = 0; column < 3; column++)
+      {
+        yield return matrix[row, column];
+      }
+    }
+  }
+}

--- a/Connectors/Tekla/Speckle.Connector.TeklaShared/ServiceRegistration.cs
+++ b/Connectors/Tekla/Speckle.Connector.TeklaShared/ServiceRegistration.cs
@@ -58,6 +58,7 @@ public static class ServiceRegistration
     services.AddScoped<SendOperation<ModelObject>>();
 
     services.AddSingleton<ToSpeckleSettingsManager>();
+    services.AddSingleton<TeklaCoordinateSystemTracker>();
 
     services.AddSingleton<IOperationProgressManager, OperationProgressManager>();
 

--- a/Connectors/Tekla/Speckle.Connector.TeklaShared/Speckle.Connectors.TeklaShared.projitems
+++ b/Connectors/Tekla/Speckle.Connector.TeklaShared/Speckle.Connectors.TeklaShared.projitems
@@ -32,6 +32,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Filters\TeklaSelectionFilter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)GlobalUsing.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HostApp\SendCollectionManager.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)HostApp\TeklaCoordinateSystemTracker.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HostApp\TeklaDocumentModelStore.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HostApp\TeklaIdleManager.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HostApp\TeklaMaterialUnpacker.cs" />

--- a/Converters/Tekla/Speckle.Converters.TeklaShared/ToSpeckle/Raw/GridToSpeckleConverter.cs
+++ b/Converters/Tekla/Speckle.Converters.TeklaShared/ToSpeckle/Raw/GridToSpeckleConverter.cs
@@ -15,12 +15,10 @@ public class GridToSpeckleConverter : ITypedConverter<TSM.Grid, IEnumerable<Base
     _settingsStore = settingsStore;
   }
 
-  // this function gets the scale factor from the coordinate system
-  // helps us to avoid conflicts between "," and "."
-  private double GetScaleFactor(TG.CoordinateSystem coordinateSystem)
-  {
-    return coordinateSystem.AxisX.X / 1000.0;
-  }
+  // NOTE: from the axis length, not its X component. The component shrinks as the grid rotates, which silently
+  // scaled grids and divided by zero at 90 degrees.
+  private static double GetScaleFactor(TG.CoordinateSystem coordinateSystem) =>
+    coordinateSystem.AxisX.GetLength() / 1000.0;
 
   private IEnumerable<double> ParseCoordinateString(string coordinateString)
   {
@@ -77,52 +75,62 @@ public class GridToSpeckleConverter : ITypedConverter<TSM.Grid, IEnumerable<Base
     double conversionFactor = Units.GetConversionFactor(Units.Millimeters, _settingsStore.Current.SpeckleUnits);
     var scale = GetScaleFactor(coordinateSystem);
 
-    var xCoordinates = ParseCoordinateString(target.CoordinateX).Select(x => (x / scale) * conversionFactor).ToList();
-    var yCoordinates = ParseCoordinateString(target.CoordinateY).Select(y => (y / scale) * conversionFactor).ToList();
+    var xCoordinates = ParseCoordinateString(target.CoordinateX).Select(x => x / scale).ToList();
+    var yCoordinates = ParseCoordinateString(target.CoordinateY).Select(y => y / scale).ToList();
 
     double minX = xCoordinates.Min();
     double maxX = xCoordinates.Max();
     double minY = yCoordinates.Min();
     double maxY = yCoordinates.Max();
 
-    double extendedMinX = minX - ((target.ExtensionLeftX / scale) * conversionFactor);
-    double extendedMaxX = maxX + ((target.ExtensionRightX / scale) * conversionFactor);
-    double extendedMinY = minY - ((target.ExtensionLeftY / scale) * conversionFactor);
-    double extendedMaxY = maxY + ((target.ExtensionRightY / scale) * conversionFactor);
+    double extendedMinX = minX - (target.ExtensionLeftX / scale);
+    double extendedMaxX = maxX + (target.ExtensionRightX / scale);
+    double extendedMinY = minY - (target.ExtensionLeftY / scale);
+    double extendedMaxY = maxY + (target.ExtensionRightY / scale);
 
-    double scaledZ = (coordinateSystem.Origin.Z / scale) * conversionFactor;
+    // the coordinates are local to the grid, so we place them through its coordinate system to land in the same
+    // frame as every other object we send
+    var xAxis = coordinateSystem.AxisX.GetNormal();
+    var yAxis = coordinateSystem.AxisY.GetNormal();
 
     foreach (var x in xCoordinates)
     {
-      var startPoint = new TG.Point(x, extendedMinY, scaledZ);
-      var endPoint = new TG.Point(x, extendedMaxY, scaledZ);
-
-      // we're using the Point converter indirectly through the Line converter
-      // since we've already applied the conversion factor to the coordinates,
-      // we need to tell the Point converter not to apply it again
-      var line = new SOG.Line
+      yield return new SOG.Line
       {
-        start = new SOG.Point(startPoint.X, startPoint.Y, startPoint.Z, _settingsStore.Current.SpeckleUnits),
-        end = new SOG.Point(endPoint.X, endPoint.Y, endPoint.Z, _settingsStore.Current.SpeckleUnits),
+        start = ToSpecklePoint(coordinateSystem, xAxis, yAxis, x, extendedMinY, conversionFactor),
+        end = ToSpecklePoint(coordinateSystem, xAxis, yAxis, x, extendedMaxY, conversionFactor),
         units = _settingsStore.Current.SpeckleUnits,
       };
-
-      yield return line;
     }
 
     foreach (var y in yCoordinates)
     {
-      var startPoint = new TG.Point(extendedMinX, y, scaledZ);
-      var endPoint = new TG.Point(extendedMaxX, y, scaledZ);
-
-      var line = new SOG.Line
+      yield return new SOG.Line
       {
-        start = new SOG.Point(startPoint.X, startPoint.Y, startPoint.Z, _settingsStore.Current.SpeckleUnits),
-        end = new SOG.Point(endPoint.X, endPoint.Y, endPoint.Z, _settingsStore.Current.SpeckleUnits),
+        start = ToSpecklePoint(coordinateSystem, xAxis, yAxis, extendedMinX, y, conversionFactor),
+        end = ToSpecklePoint(coordinateSystem, xAxis, yAxis, extendedMaxX, y, conversionFactor),
         units = _settingsStore.Current.SpeckleUnits,
       };
-
-      yield return line;
     }
+  }
+
+  // we build the points directly rather than through the point converter, as the conversion factor is applied here
+  private SOG.Point ToSpecklePoint(
+    TG.CoordinateSystem coordinateSystem,
+    TG.Vector xAxis,
+    TG.Vector yAxis,
+    double localX,
+    double localY,
+    double conversionFactor
+  )
+  {
+    var origin = coordinateSystem.Origin;
+
+    return new SOG.Point(
+      (origin.X + (localX * xAxis.X) + (localY * yAxis.X)) * conversionFactor,
+      (origin.Y + (localX * xAxis.Y) + (localY * yAxis.Y)) * conversionFactor,
+      (origin.Z + (localX * xAxis.Z) + (localY * yAxis.Z)) * conversionFactor,
+      _settingsStore.Current.SpeckleUnits
+    );
   }
 }


### PR DESCRIPTION
## Description

Tekla reports geometry in the model's current coordinate frame (work plane + current base point). Changing the frame moves every object's coordinates without changing any object, so `ModelObjectChanged` never fires and nothing clears the send cache — publishes keep re-using objects converted in the old frame. The cache is keyed on object id + project, not model card, so a new card doesn't help.

Now we re-read the frame before each send and clear the cache when it moved. Grids were a separate pre-existing bug found while testing: they ignored the frame entirely.

Fixes ENG-8768

## User Value

Publishing after changing true north / the coordinate system sends the objects as they actually are, instead of silently re-publishing the old orientation.

## Changes:

- new `TeklaCoordinateSystemTracker`: fingerprints work plane, north direction and current base point, clears the send cache on change. Unknown or unreadable frame also clears, so it fails safe. This is what Revit and AutoCAD does
- `TeklaSendBinding.Send` calls it before objects are gathered and converted
- grids placed through their own coordinate system so they follow the frame. Also fixes grids whose origin isn't 0,0, and a scale factor taken from `AxisX.X` that shrank with rotation (~1% oversize at -8°) and divided by zero at 90°

## Validation of changes:

- published once, cache cleared
- re-published immediately, cache used as base point hadn't changed
- created a new base point, republished, cache cleared

<img width="1920" height="1044" alt="image" src="https://github.com/user-attachments/assets/4f3eea70-f1c6-4fec-b7d8-415c927f5bba" />