### PR TITLE
fix(grasshopper): default Speckle Properties mode to Merge

### DIFF
--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Objects/SpecklePropertiesPassthrough.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Objects/SpecklePropertiesPassthrough.cs
@@ -37,7 +37,7 @@ public class SpecklePropertiesPassthrough : SpeckleSolveInstance
     Overwrite, // pre rewording (cnx-3177), keeping for scripts with settings saved
   }
 
-  private PropertyMode _mode = PropertyMode.Update;
+  private PropertyMode _mode = PropertyMode.Merge;
   private PropertyMode Mode
   {
     get => _mode;
@@ -109,7 +109,7 @@ public class SpecklePropertiesPassthrough : SpeckleSolveInstance
     }
 
     // validate that keys and values are of valid length
-    if ((Mode == PropertyMode.Update || Mode == PropertyMode.Overwrite) && inputKeys.Count != inputValues.Count)
+    if ((Mode == PropertyMode.Merge || Mode == PropertyMode.Replace) && inputKeys.Count != inputValues.Count)
     {
       AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, "Keys and values are mismatched in length");
       return;
@@ -177,6 +177,9 @@ public class SpecklePropertiesPassthrough : SpeckleSolveInstance
           case PropertyMode.Remove:
             resultGoo.RemoveValueByPath(key);
             break;
+          default:
+            AddRuntimeMessage(GH_RuntimeMessageLevel.Error, $"Unsupported property mode: {Mode}");
+            return;
         }
       }
     }


### PR DESCRIPTION
## Description

`#1313` renamed the `Speckle Properties` modes `Update`/`Overwrite` back to `Merge`/`Replace`, keeping the old members as legacy values migrated in the `Mode` setter. The backing field initializer was missed and left at `PropertyMode.Update` — a field initializer bypasses the setter, so a freshly placed component sat in a mode the `SolveInstance` switch has no case for, silently dropping all keys and values.

## User Value

Newly placed `Speckle Properties` components apply their key-value pairs again instead of silently passing input through.

## Changes:

- Default `_mode` to `PropertyMode.Merge` so a fresh component starts in a supported mode
- Retarget the keys/values length validation from `Update`/`Overwrite` (unreachable post-migration, so dead for every saved definition) to `Merge`/`Replace` — previously a mismatch skipped the warning and threw `IndexOutOfRangeException`
- Add a `default:` arm raising a runtime error, so a future rename fails loudly rather than silently no-opping

## Checklist:
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.