### PR TITLE
fix(tekla): publish tekla's object type instead of the api class

### DIFF
--- a/Connectors/Tekla/Speckle.Connector.TeklaShared/Bindings/TeklaSelectionBinding.cs
+++ b/Connectors/Tekla/Speckle.Connector.TeklaShared/Bindings/TeklaSelectionBinding.cs
@@ -1,5 +1,6 @@
 using Speckle.Connectors.DUI.Bindings;
 using Speckle.Connectors.DUI.Bridge;
+using Speckle.Converters.TeklaShared.Extensions;
 using Tekla.Structures;
 using Tekla.Structures.Model;
 
@@ -70,7 +71,7 @@ public class TeklaSelectionBinding : ISelectionBinding
 
       string globalId = modelObject.Identifier.GUID.ToString();
       objectIds.Add(globalId);
-      objectTypes.Add(modelObject.GetType().Name);
+      objectTypes.Add(modelObject.GetSpeckleType());
     }
 
     // Filter out the objects that Tekla API ignores (e.g. Construction objects with "000000.." GUID)

--- a/Connectors/Tekla/Speckle.Connector.TeklaShared/HostApp/SendCollectionManager.cs
+++ b/Connectors/Tekla/Speckle.Connector.TeklaShared/HostApp/SendCollectionManager.cs
@@ -1,3 +1,4 @@
+using Speckle.Converters.TeklaShared.Extensions;
 using Speckle.Sdk.Models.Collections;
 
 namespace Speckle.Connectors.TeklaShared.HostApp;
@@ -11,7 +12,7 @@ public class SendCollectionManager
     // Tekla Data Structure: rootObject > objectType > name
     // Very high-level, would be good to have sub-groups in future releases
     // TODO: Refine further according to section types (for beams), constituent elements (for components) etc. at later stage
-    var path = teklaObject.GetType().ToString().Split('.').Last();
+    var path = teklaObject.GetSpeckleType();
 
     // NOTE: First pass at seeing if a collection key already exists
     if (_collectionCache.TryGetValue(path, out Collection? value))

--- a/Converters/Tekla/Speckle.Converters.TeklaShared/Extensions/SpeckleTypeExtensions.cs
+++ b/Converters/Tekla/Speckle.Converters.TeklaShared/Extensions/SpeckleTypeExtensions.cs
@@ -1,0 +1,34 @@
+namespace Speckle.Converters.TeklaShared.Extensions;
+
+public static class SpeckleTypeExtensions
+{
+  /// <summary>
+  /// Gets the object type Tekla itself reports, falling back to the API class name.
+  /// </summary>
+  /// <remarks>
+  /// Tekla's classes are coarser than its object types: beams, columns, panels and footings are all
+  /// <see cref="TSM.Beam"/>, plates and slabs are all <see cref="TSM.ContourPlate"/>. Publishing the class name
+  /// alone therefore labelled most of a model "Beam". Objects without a type of their own (bolts, rebar, grids)
+  /// keep the class name, which is already specific.
+  /// </remarks>
+  public static string GetSpeckleType(this TSM.ModelObject modelObject) =>
+    modelObject switch
+    {
+      TSM.Beam beam => ToPascalCase(beam.Type.ToString()),
+      TSM.PolyBeam polyBeam => ToPascalCase(polyBeam.Type.ToString()),
+      // NOTE: the plate type is derived from the material and can come back unknown, which tells us less than the class
+      TSM.ContourPlate plate when plate.Type != TSM.ContourPlate.ContourPlateTypeEnum.UNKNOWN => ToPascalCase(
+        plate.Type.ToString()
+      ),
+      _ => modelObject.GetType().Name,
+    };
+
+  // tekla reports its types as PAD_FOOTING, we publish them as PadFooting
+  private static string ToPascalCase(string teklaType) =>
+    string.Concat(
+      teklaType
+        .Split('_')
+        .Where(word => word.Length > 0)
+        .Select(word => char.ToUpperInvariant(word[0]) + word[1..].ToLowerInvariant())
+    );
+}

--- a/Converters/Tekla/Speckle.Converters.TeklaShared/ToSpeckle/Helpers/ClassPropertyExtractor.cs
+++ b/Converters/Tekla/Speckle.Converters.TeklaShared/ToSpeckle/Helpers/ClassPropertyExtractor.cs
@@ -8,6 +8,10 @@ public class ClassPropertyExtractor
   {
     Dictionary<string, object?> properties = new();
 
+    // the api class is coarser than the type we publish (a column and a pad footing are both Beam), so we
+    // keep it here rather than lose it
+    properties["apiClass"] = modelObject.GetType().Name;
+
     switch (modelObject)
     {
       // includes beams and contour plates

--- a/Converters/Tekla/Speckle.Converters.TeklaShared/ToSpeckle/TopLevel/ModelObjectToSpeckleConverter.cs
+++ b/Converters/Tekla/Speckle.Converters.TeklaShared/ToSpeckle/TopLevel/ModelObjectToSpeckleConverter.cs
@@ -29,7 +29,7 @@ public class ModelObjectToSpeckleConverter : IToSpeckleTopLevelConverter
 
   private TeklaObject Convert(TSM.ModelObject target)
   {
-    string type = target.GetType().ToString().Split('.').Last();
+    string type = target.GetSpeckleType();
 
     // get children
     // POC: This logic should be same in the material unpacker in connector


### PR DESCRIPTION
## Description

We published the .NET class name as `type`, and Tekla's classes are much coarser than its object types — beams, columns, panels and both footing kinds are all `Beam`, plates and slabs are all `ContourPlate`. So most of a model came through labelled "Beam".

Now we publish the type Tekla itself reports (`Beam.Type`, `PolyBeam.Type`, `ContourPlate.Type`), normalised to PascalCase, and fall back to the class name for objects that don't carry one (bolts, rebar, grids).

Normalising keeps real beams on `"Beam"`, so only the objects that were mislabelled change value. Plates and slabs do move off `"ContourPlate"` — worth a release note for anyone filtering on `type` downstream.

## User Value

Better differentiation as to what objects are. Not perfect, but better. Constrained by API.

## Changes:

- new `GetSpeckleType()` in the converter, used by the `type` field, the collection tree and the selection filter summary, so the three can't drift apart
- `ContourPlate` reporting `UNKNOWN` keeps the class name rather than publishing "Unknown"
- API class kept in properties as `apiClass`, so a `PolyBeam` publishing as `"Beam"` is still identifiable. Not named `class` to avoid colliding with Tekla's numeric CLASS report property

## Validation of changes:

### Before

<img width="1920" height="1044" alt="image" src="https://github.com/user-attachments/assets/aa9cc914-f1ca-486f-bc4e-d77c04bd49af" />


### After

<img width="1920" height="1044" alt="image" src="https://github.com/user-attachments/assets/2b10cdf8-f167-40b3-822c-7e11d226093d" />

