### PR TITLE
fix(tsd): key nodal results by construction point instead of solver node

### DIFF
--- a/Converters/TSD/Speckle.Converters.TSDShared/Results/ITsdResultsExtractor.cs
+++ b/Converters/TSD/Speckle.Converters.TSDShared/Results/ITsdResultsExtractor.cs
@@ -4,13 +4,18 @@ namespace Speckle.Converters.TSDShared.Results;
 
 public sealed record TsdLoadingRef(Guid Id, string Name);
 
+/// <summary>
+/// The inputs shared by every results extractor for a single send.
+/// </summary>
+public sealed record TsdResultsContext(
+  IAnalysis3DResults AnalysisResults,
+  IReadOnlyList<TsdLoadingRef> Loadings,
+  TsdNodeIndexMap Nodes
+);
+
 public interface ITsdResultsExtractor
 {
   string ResultsKey { get; }
 
-  Task<Dictionary<string, object?>> GetResultsAsync(
-    IAnalysis3DResults analysisResults,
-    IReadOnlyList<TsdLoadingRef> loadings,
-    CancellationToken cancellationToken
-  );
+  Task<Dictionary<string, object?>> GetResultsAsync(TsdResultsContext context, CancellationToken cancellationToken);
 }

--- a/Converters/TSD/Speckle.Converters.TSDShared/Results/TsdAnalysisResultsExtractor.cs
+++ b/Converters/TSD/Speckle.Converters.TSDShared/Results/TsdAnalysisResultsExtractor.cs
@@ -69,14 +69,17 @@ public sealed class TsdAnalysisResultsExtractor
 
     var loadings = requestedLoadings.Where(loading => solvedIdSet.Contains(loading.Id)).ToList();
 
+    // solver results are keyed by solver node index, which is a different numbering from the construction point
+    // indices the rest of the payload uses, so the extractors need the map to publish them against the right node
+    var nodes = await TsdNodeIndexMap.CreateAsync(model, cancellationToken).ConfigureAwait(false);
+    var context = new TsdResultsContext(analysis3D, loadings, nodes);
+
     var tree = new Dictionary<string, object?>();
     foreach (var resultType in selectedResultTypes)
     {
       cancellationToken.ThrowIfCancellationRequested();
       var extractor = _factory.GetExtractor(resultType);
-      tree[extractor.ResultsKey] = await extractor
-        .GetResultsAsync(analysis3D, loadings, cancellationToken)
-        .ConfigureAwait(false);
+      tree[extractor.ResultsKey] = await extractor.GetResultsAsync(context, cancellationToken).ConfigureAwait(false);
     }
 
     return tree;

--- a/Converters/TSD/Speckle.Converters.TSDShared/Results/TsdElementForceResultsExtractorBase.cs
+++ b/Converters/TSD/Speckle.Converters.TSDShared/Results/TsdElementForceResultsExtractorBase.cs
@@ -4,7 +4,7 @@ namespace Speckle.Converters.TSDShared.Results;
 
 public abstract class TsdElementForceResultsExtractorBase : TsdLoadingResultsExtractorBase<IElementEndForces>
 {
-  protected override Dictionary<string, object?> Build(IEnumerable<IElementEndForces> items)
+  protected override Dictionary<string, object?> Build(IEnumerable<IElementEndForces> items, TsdResultsContext context)
   {
     var perElement = new Dictionary<string, object?>();
     foreach (var elementForces in items)

--- a/Converters/TSD/Speckle.Converters.TSDShared/Results/TsdLoadingResultsExtractorBase.cs
+++ b/Converters/TSD/Speckle.Converters.TSDShared/Results/TsdLoadingResultsExtractorBase.cs
@@ -12,27 +12,26 @@ public abstract class TsdLoadingResultsExtractorBase<TResult> : ITsdResultsExtra
     CancellationToken cancellationToken
   );
 
-  protected abstract Dictionary<string, object?> Build(IEnumerable<TResult> items);
+  protected abstract Dictionary<string, object?> Build(IEnumerable<TResult> items, TsdResultsContext context);
 
   public async Task<Dictionary<string, object?>> GetResultsAsync(
-    IAnalysis3DResults analysisResults,
-    IReadOnlyList<TsdLoadingRef> loadings,
+    TsdResultsContext context,
     CancellationToken cancellationToken
   )
   {
     var results = new Dictionary<string, object?>();
 
-    foreach (var loading in loadings)
+    foreach (var loading in context.Loadings)
     {
       cancellationToken.ThrowIfCancellationRequested();
 
-      var items = await FetchAsync(analysisResults, loading.Id, cancellationToken).ConfigureAwait(false);
+      var items = await FetchAsync(context.AnalysisResults, loading.Id, cancellationToken).ConfigureAwait(false);
       if (items is null)
       {
         continue;
       }
 
-      var entries = Build(items);
+      var entries = Build(items, context);
       if (entries.Count > 0)
       {
         results[loading.Name] = entries;

--- a/Converters/TSD/Speckle.Converters.TSDShared/Results/TsdNodalDisplacementResultsExtractor.cs
+++ b/Converters/TSD/Speckle.Converters.TSDShared/Results/TsdNodalDisplacementResultsExtractor.cs
@@ -16,14 +16,15 @@ public sealed class TsdNodalDisplacementResultsExtractor : TsdLoadingResultsExtr
       .GetNodalDisplacementsAsync(loadingId, LoadingResultType.Base, null, cancellationToken)
       .ConfigureAwait(false);
 
-  protected override Dictionary<string, object?> Build(IEnumerable<INodalDisplacement> items)
+  protected override Dictionary<string, object?> Build(IEnumerable<INodalDisplacement> items, TsdResultsContext context)
   {
     var perNode = new Dictionary<string, object?>();
     foreach (var nodalDisplacement in items)
     {
-      perNode[nodalDisplacement.NodeIndex.ToString()] = TsdResultValueBuilder.Displacement(
-        nodalDisplacement.Displacement
-      );
+      foreach (var nodeKey in context.Nodes.GetNodeKeys(nodalDisplacement.NodeIndex))
+      {
+        perNode[nodeKey] = TsdResultValueBuilder.Displacement(nodalDisplacement.Displacement);
+      }
     }
 
     return perNode;

--- a/Converters/TSD/Speckle.Converters.TSDShared/Results/TsdNodalForceResultsExtractorBase.cs
+++ b/Converters/TSD/Speckle.Converters.TSDShared/Results/TsdNodalForceResultsExtractorBase.cs
@@ -4,12 +4,15 @@ namespace Speckle.Converters.TSDShared.Results;
 
 public abstract class TsdNodalForceResultsExtractorBase : TsdLoadingResultsExtractorBase<INodalForce>
 {
-  protected override Dictionary<string, object?> Build(IEnumerable<INodalForce> items)
+  protected override Dictionary<string, object?> Build(IEnumerable<INodalForce> items, TsdResultsContext context)
   {
     var perNode = new Dictionary<string, object?>();
     foreach (var nodalForce in items)
     {
-      perNode[nodalForce.NodeIndex.ToString()] = TsdResultValueBuilder.Force(nodalForce.Force);
+      foreach (var nodeKey in context.Nodes.GetNodeKeys(nodalForce.NodeIndex))
+      {
+        perNode[nodeKey] = TsdResultValueBuilder.Force(nodalForce.Force);
+      }
     }
 
     return perNode;

--- a/Converters/TSD/Speckle.Converters.TSDShared/Results/TsdNodeIndexMap.cs
+++ b/Converters/TSD/Speckle.Converters.TSDShared/Results/TsdNodeIndexMap.cs
@@ -1,0 +1,77 @@
+using Speckle.Sdk;
+using TSD.API.Remoting.Structure;
+
+namespace Speckle.Converters.TSDShared.Results;
+
+/// <summary>
+/// Translates solver node indices into the construction point indices that the rest of the published payload uses.
+/// </summary>
+/// <remarks>
+/// TSD numbers solver nodes independently of construction points, so the raw node index carried by a solver result
+/// does not identify the same node as, say, a member's I-End Node. Publishing nodal results under the raw solver index
+/// therefore attaches a valid result to the wrong node. A solver node can back several coincident construction points,
+/// and mesh nodes (for example along a supported slab or wall edge) have no construction point at all - those keep
+/// their solver index behind <see cref="SOLVER_NODE_PREFIX"/> so that the two index spaces cannot collide.
+/// </remarks>
+public sealed class TsdNodeIndexMap
+{
+  /// <summary>
+  /// Marks a key that is still a solver node index because the node has no construction point in the model.
+  /// </summary>
+  public const string SOLVER_NODE_PREFIX = "solverNode:";
+
+  private readonly Dictionary<int, List<string>> _constructionPointKeys;
+
+  private TsdNodeIndexMap(Dictionary<int, List<string>> constructionPointKeys)
+  {
+    _constructionPointKeys = constructionPointKeys;
+  }
+
+  /// <summary>
+  /// Reads the model's construction points and indexes them by the solver node each one resolves to.
+  /// </summary>
+  public static async Task<TsdNodeIndexMap> CreateAsync(IModel model, CancellationToken cancellationToken)
+  {
+    var constructionPoints = await model.GetConstructionPointsAsync(null, cancellationToken).ConfigureAwait(false);
+
+    var constructionPointKeys = new Dictionary<int, List<string>>();
+    foreach (var constructionPoint in constructionPoints ?? Enumerable.Empty<IConstructionPoint>())
+    {
+      if (TryGetSolverNodeIndex(constructionPoint) is not int solverNodeIndex)
+      {
+        continue;
+      }
+
+      if (!constructionPointKeys.TryGetValue(solverNodeIndex, out var keys))
+      {
+        keys = new List<string>(1);
+        constructionPointKeys[solverNodeIndex] = keys;
+      }
+
+      keys.Add(constructionPoint.Index.ToString());
+    }
+
+    return new TsdNodeIndexMap(constructionPointKeys);
+  }
+
+  /// <summary>
+  /// Returns every key a result for <paramref name="solverNodeIndex"/> should be published under.
+  /// </summary>
+  public IReadOnlyList<string> GetNodeKeys(int solverNodeIndex) =>
+    _constructionPointKeys.TryGetValue(solverNodeIndex, out var keys)
+      ? keys
+      : new[] { $"{SOLVER_NODE_PREFIX}{solverNodeIndex}" };
+
+  private static int? TryGetSolverNodeIndex(IConstructionPoint constructionPoint)
+  {
+    try
+    {
+      return constructionPoint.SolverNodeIndex.IsApplicable ? constructionPoint.SolverNodeIndex.Value : null;
+    }
+    catch (Exception ex) when (!ex.IsFatal())
+    {
+      // a construction point that is not part of the solver model simply contributes nothing to the map
+      return null;
+    }
+  }
+}

--- a/Converters/TSD/Speckle.Converters.TSDShared/Results/TsdOffsetDisplacementResultsExtractor.cs
+++ b/Converters/TSD/Speckle.Converters.TSDShared/Results/TsdOffsetDisplacementResultsExtractor.cs
@@ -16,7 +16,10 @@ public sealed class TsdOffsetDisplacementResultsExtractor : TsdLoadingResultsExt
       .GetOffsetDisplacementsAsync(loadingId, LoadingResultType.Base, null, cancellationToken)
       .ConfigureAwait(false);
 
-  protected override Dictionary<string, object?> Build(IEnumerable<IElementOffsetDisplacements> items)
+  protected override Dictionary<string, object?> Build(
+    IEnumerable<IElementOffsetDisplacements> items,
+    TsdResultsContext context
+  )
   {
     var perElement = new Dictionary<string, object?>();
     foreach (var elementDisplacements in items)

--- a/Converters/TSD/Speckle.Converters.TSDShared/Results/TsdResultLineForceResultsExtractor.cs
+++ b/Converters/TSD/Speckle.Converters.TSDShared/Results/TsdResultLineForceResultsExtractor.cs
@@ -16,7 +16,7 @@ public sealed class TsdResultLineForceResultsExtractor : TsdLoadingResultsExtrac
       .GetResultLineForcesAsync(loadingId, LoadingResultType.Base, null, cancellationToken)
       .ConfigureAwait(false);
 
-  protected override Dictionary<string, object?> Build(IEnumerable<IResultLineForces> items)
+  protected override Dictionary<string, object?> Build(IEnumerable<IResultLineForces> items, TsdResultsContext context)
   {
     var perLine = new Dictionary<string, object?>();
     foreach (var line in items)

--- a/Converters/TSD/Speckle.Converters.TSDShared/Results/TsdWallLineForceResultsExtractor.cs
+++ b/Converters/TSD/Speckle.Converters.TSDShared/Results/TsdWallLineForceResultsExtractor.cs
@@ -16,7 +16,7 @@ public sealed class TsdWallLineForceResultsExtractor : TsdLoadingResultsExtracto
       .GetWallLineForcesAsync(loadingId, LoadingResultType.Base, null, cancellationToken)
       .ConfigureAwait(false);
 
-  protected override Dictionary<string, object?> Build(IEnumerable<IWallLineForces> items)
+  protected override Dictionary<string, object?> Build(IEnumerable<IWallLineForces> items, TsdResultsContext context)
   {
     var perWallLine = new Dictionary<string, object?>();
     foreach (var wallLine in items)

--- a/Converters/TSD/Speckle.Converters.TSDShared/Speckle.Converters.TSDShared.projitems
+++ b/Converters/TSD/Speckle.Converters.TSDShared/Speckle.Converters.TSDShared.projitems
@@ -16,6 +16,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)TsdWallPropertyExtractor.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Results\ITsdResultsExtractor.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Results\TsdResultValueBuilder.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Results\TsdNodeIndexMap.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TsdConversionSettings.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Results\TsdResultsKeys.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Results\TsdLoadingResultsExtractorBase.cs" />


### PR DESCRIPTION
## Description

TSD has two node numbering systems: construction point indices (what you see in the model, and what we already publish as a member's I-End/J-End node) and solver node indices (internal to the analysis run). They don't line up.

Nodal results were being keyed by the raw solver index, so joining a member's node to a reaction returned a valid force belonging to a different node. Nothing was lost or corrupted, which is why it looked plausible.

## User Value

Reaction forces now land on the node they actually belong to, so node-level data can be trusted downstream without cross-checking against TSD.

## Changes:

- Adds `TsdNodeIndexMap` — resolves solver node indices to construction point indices via `IConstructionPoint.SolverNodeIndex`, built once per send
- Reactions, slab/wall nodal forces and nodal displacements now key by construction point index
- Coincident points sharing a solver node each get the value; mesh nodes with no construction point (e.g. supported wall base) keep the solver index behind a `solverNode:` prefix so the two index spaces can't collide
- `TsdResultsContext` replaces the loose params on `ITsdResultsExtractor.GetResultsAsync` so extractors can reach shared per-send state

## To-do before merge:

- [x] Verify against problematic Model 

<img width="1919" height="1044" alt="image" src="https://github.com/user-attachments/assets/37aa7fb9-ed43-44c5-b31f-c4c403e9a91b" />

## Checklist:
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [ ] I have added appropriate tests.
- [x] I have updated or added relevant documentation.