### PR TITLE
feat(grasshopper): model-wide properties on the 4.0 Publish and Load

### DIFF
--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Receive/ReceiveArtefactAsyncComponent.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Receive/ReceiveArtefactAsyncComponent.cs
@@ -26,7 +26,8 @@ public class ReceiveArtefactAsyncComponent : ReceiveAsyncComponentBase
     : base("Load", "L", "Load a model from Speckle", ComponentCategories.PRIMARY_RIBBON, ComponentCategories.OPERATIONS)
   { }
 
-  protected override void RegisterOutputParams(GH_OutputParamManager pManager) =>
+  protected override void RegisterOutputParams(GH_OutputParamManager pManager)
+  {
     pManager.AddParameter(
       new SpeckleCollectionParam(GH_ParamAccess.item),
       "Collection",
@@ -35,6 +36,18 @@ public class ReceiveArtefactAsyncComponent : ReceiveAsyncComponentBase
       GH_ParamAccess.item
     );
 
-  public override void WriteOutputs(IGH_DataAccess da, ReceiveComponentOutput result) =>
+    pManager.AddParameter(
+      new SpecklePropertyGroupParam(),
+      "Properties",
+      "properties",
+      "Model-wide properties of the loaded version",
+      GH_ParamAccess.item
+    );
+  }
+
+  public override void WriteOutputs(IGH_DataAccess da, ReceiveComponentOutput result)
+  {
     da.SetData(0, result.RootObject);
+    da.SetData(1, result.RootProperties);
+  }
 }

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Receive/ReceiveArtefactComponent.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Receive/ReceiveArtefactComponent.cs
@@ -31,7 +31,8 @@ public class ReceiveArtefactComponent : ReceiveComponentBase
       ComponentCategories.DEVELOPER
     ) { }
 
-  protected override void RegisterOutputParams(GH_OutputParamManager pManager) =>
+  protected override void RegisterOutputParams(GH_OutputParamManager pManager)
+  {
     pManager.AddParameter(
       new SpeckleCollectionParam(GH_ParamAccess.item),
       "Collection",
@@ -39,6 +40,15 @@ public class ReceiveArtefactComponent : ReceiveComponentBase
       "The model collection of the loaded version",
       GH_ParamAccess.item
     );
+
+    pManager.AddParameter(
+      new SpecklePropertyGroupParam(),
+      "Properties",
+      "properties",
+      "Model-wide properties of the loaded version",
+      GH_ParamAccess.item
+    );
+  }
 
   protected override void SetOutput(IGH_DataAccess da, ReceiveComponentOutput result)
   {
@@ -49,6 +59,7 @@ public class ReceiveArtefactComponent : ReceiveComponentBase
     }
 
     da.SetData(0, result.RootObject);
+    da.SetData(1, result.RootProperties);
     SetStatusMessage(true);
   }
 }

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Receive/ReceiveAsyncComponentBase.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Receive/ReceiveAsyncComponentBase.cs
@@ -632,7 +632,15 @@ public sealed class ReceiveComponentWorker : WorkerInstance<ReceiveAsyncComponen
         );
       }
 
-      Output = new ReceiveComponentOutput { RootObject = new SpeckleCollectionWrapperGoo(rootWrapper) };
+      Output = new ReceiveComponentOutput
+      {
+        RootObject = new SpeckleCollectionWrapperGoo(rootWrapper),
+        // eav.model - an absent file reads as empty, so nothing rather than an empty group
+        RootProperties =
+          bundle.ModelProperties.Count > 0
+            ? new SpecklePropertyGroupGoo(bundle.ModelProperties.ToDictionary(kv => kv.Key, kv => kv.Value))
+            : null,
+      };
       return true;
     }
     catch (Exception ex) when (!ex.IsFatal())

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Receive/ReceiveComponentBase.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Receive/ReceiveComponentBase.cs
@@ -357,7 +357,15 @@ public abstract class ReceiveComponentBase(
         AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, $"Could not mark the version as received ({ex.Message}).");
       }
 
-      return new ReceiveComponentOutput { RootObject = new SpeckleCollectionWrapperGoo(rootWrapper) };
+      return new ReceiveComponentOutput
+      {
+        RootObject = new SpeckleCollectionWrapperGoo(rootWrapper),
+        // eav.model - an absent file reads as empty, so nothing rather than an empty group
+        RootProperties =
+          bundle.ModelProperties.Count > 0
+            ? new SpecklePropertyGroupGoo(bundle.ModelProperties.ToDictionary(kv => kv.Key, kv => kv.Value))
+            : null,
+      };
     }
     catch (Exception ex) when (!ex.IsFatal())
     {

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Send/SendArtefactAsyncComponent.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Send/SendArtefactAsyncComponent.cs
@@ -23,7 +23,7 @@ public class SendArtefactAsyncComponent : SendAsyncComponentBase
   public override GH_Exposure Exposure => GH_Exposure.secondary;
 
   public override bool UseArtifacts => true;
-  protected override bool HasModelPropertiesInput => false;
+  protected override bool HasModelPropertiesInput => true;
 
   public SendArtefactAsyncComponent()
     : base(

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Send/SendArtefactComponent.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Send/SendArtefactComponent.cs
@@ -23,7 +23,7 @@ public class SendArtefactComponent : SendComponentBase
   public override GH_Exposure Exposure => GH_Exposure.primary;
 
   protected override bool UseArtifacts => true;
-  protected override bool HasModelPropertiesInput => false;
+  protected override bool HasModelPropertiesInput => true;
 
   public SendArtefactComponent()
     : base(

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Operations/Send/GrasshopperArtifactRootObjectBuilder.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Operations/Send/GrasshopperArtifactRootObjectBuilder.cs
@@ -145,6 +145,12 @@ public class GrasshopperArtifactRootObjectBuilder(
       onOperationProgressed,
       cancellationToken
     );
+    // Model-wide properties ride eav.model - object-less rows, so no synthetic object needed.
+    if (root is SpeckleRootCollectionWrapper { Properties: { Count: > 0 } modelProps })
+    {
+      EmitModelProperties(pipeline, session, modelProps, null);
+    }
+
     WalkCollection(ctx, root, null);
 
     EmitValueNodes(
@@ -555,6 +561,36 @@ public class GrasshopperArtifactRootObjectBuilder(
           // by-object colour on a placement: the object and geometry namespaces overlap, hence the tag
           pipeline.HasColor(objK, colorK, srcIsObject: true);
         }
+      }
+    }
+  }
+
+  /// <summary>
+  /// Flattens the nested dict into the dotted paths eav.model expects, one row per leaf. Same delimiter as
+  /// SpecklePropertyGroupGoo, so the reader nests it straight back.
+  /// </summary>
+  private static void EmitModelProperties(
+    ObjectsArtifactPipeline pipeline,
+    ArtefactSessionLog session,
+    IReadOnlyDictionary<string, object?> props,
+    string? prefix
+  )
+  {
+    foreach (var kv in props)
+    {
+      string path = prefix is null ? kv.Key : $"{prefix}{Constants.PROPERTY_PATH_DELIMITER}{kv.Key}";
+      switch (kv.Value)
+      {
+        case IReadOnlyDictionary<string, object?> nested:
+          EmitModelProperties(pipeline, session, nested, path);
+          break;
+        // a converted Plane or Vector is the one leaf eav.model can't hold - stringifying it stores a type name
+        case Base:
+          session.Increment("modelPropertiesSkipped");
+          break;
+        default:
+          pipeline.AddModelProperty(path, kv.Value); // drops nulls and non-finite numerics itself
+          break;
       }
     }
   }


### PR DESCRIPTION
## Description

`eav.model` now exists in the bundle - object-less rows, so no fake object needed. 

## User Value

Model-wide properties round trip on the new Publish and Load, so the feature doesn't disappear when the deprecated components go.

## Changes:

- Model Properties input back on both 4.0 Publish components, same position the deprecated ones had
- Properties output back on both 4.0 Load components
- Send flattens the nested property group into the dotted paths `eav.model` expects, one row per leaf. Same delimiter Grasshopper already uses, so the reader nests it straight back
- Load reads `bundle.ModelProperties`. No file means no output, not an empty group
- Non-scalar leaves (a converted Plane or Vector) are skipped and counted. `eav.model` holds scalars, and stringifying a Base stores a type name. Same rule the per-object eav already applies

## Validation of changes:

- v3 commit with model properties, loaded with the new component. Props come through (artefact returns nothing, falls back to the v3 graph)
- Round trip with the new Publish and Load
- Nested groups stay nested, not flattened into one dotted key
- Strings, numbers and booleans come back as their own types
- Publish with no properties. Empty output, no error, no `eav.model.parquet` in the bundle
- New publish loaded with the deprecated component. Props come through via the artefact fallback - they were null before this

<img width="799" height="861" alt="image" src="https://github.com/user-attachments/assets/0f6578ab-a4b5-4f39-a176-159f98923cda" />

## Checklist:

- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] I have added appropriate tests. *No Grasshopper test project exists - worth raising separately.*
- [x] I have updated or added relevant documentation.