### PR TITLE
feat(grasshopper): move collection topology onto the collection node

### DIFF
--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Send/SendArtefactAsyncComponent.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Send/SendArtefactAsyncComponent.cs
@@ -7,10 +7,7 @@ namespace Speckle.Connectors.GrasshopperShared.Components.Operations.Send;
 /// <summary>
 /// Asynchronous Publish for Speckle 4.0. Writes an artefact bundle only.
 /// </summary>
-/// <remarks>
-/// No model-wide properties input: the bundle has nowhere to put them, and the sidecar that would have carried them
-/// was rejected. Revisit if a root-properties design lands in the bundle spec.
-/// </remarks>
+/// <remarks>Model-wide properties ride eav.model [ENG-9290].</remarks>
 [Guid("5D0069FF-827E-4D43-8087-6F7F5C70812F")]
 public class SendArtefactAsyncComponent : SendAsyncComponentBase
 {

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Send/SendArtefactComponent.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Send/SendArtefactComponent.cs
@@ -7,10 +7,7 @@ namespace Speckle.Connectors.GrasshopperShared.Components.Operations.Send;
 /// <summary>
 /// Synchronous Publish for Speckle 4.0. Writes an artefact bundle only.
 /// </summary>
-/// <remarks>
-/// No model-wide properties input: the bundle has nowhere to put them, and the sidecar that would have carried them
-/// was rejected. Revisit if a root-properties design lands in the bundle spec.
-/// </remarks>
+/// <remarks>Model-wide properties ride eav.model [ENG-9290].</remarks>
 [Guid("D69E558E-FCD2-45B4-AB34-EE15F58D0B58")]
 public class SendArtefactComponent : SendComponentBase
 {

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Operations/Receive/GrasshopperArtefactObjectBuilder.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Operations/Receive/GrasshopperArtefactObjectBuilder.cs
@@ -116,8 +116,7 @@ internal sealed class GrasshopperArtefactObjectBuilder
       if (geometries.Count == 0 && instCount == 0)
       {
         // A room, level or area carried properties and no geometry in v3, and still counts as an object [ENG-9159].
-        // Only re-emit one when the source really was a DataObject: WasDataObject reads speckle_type, so the
-        // property-carrying sidecars we intern ourselves (__collection_topology_, which have none) stay out.
+        // Only re-emit one when the source really was a DataObject - WasDataObject reads speckle_type.
         if (!groupAsDataObjects || !WasDataObject(props, 0))
         {
           continue;
@@ -1014,37 +1013,17 @@ internal sealed class GrasshopperArtefactObjectBuilder
     return previous;
   }
 
-  // Resolves each CONTAINER node's topology (R4) from its send-side sidecar object (WalkCollection /
-  // CollectionTopologyAppId), via a one-off reverse of ObjectAppIds.
+  // Each CONTAINER node's topology (R4), from nodes.gh_topology.
   private static Dictionary<int, string> CreateCollectionTopologies(ArtefactBundle bundle)
   {
-    var objKByAppId = new Dictionary<string, int>(StringComparer.Ordinal);
-    foreach (var kv in bundle.ObjectAppIds)
-    {
-      objKByAppId[kv.Value] = kv.Key;
-    }
-
     var result = new Dictionary<int, string>();
     foreach (var kv in bundle.Nodes)
     {
-      if (kv.Value.Kind != NodeKind.Container)
+      if (kv.Value.Kind == NodeKind.Container && kv.Value.GhTopology is { Length: > 0 } topology)
       {
-        continue;
-      }
-      if (
-        objKByAppId.TryGetValue(CollectionTopologyAppId(kv.Key), out int topologyObjK)
-        && bundle.Properties.TryGetValue(topologyObjK, out var topologyProps)
-        && topologyProps.TryGetValue("topology", out var topologyVal)
-        && topologyVal is string topologyStr
-      )
-      {
-        result[kv.Key] = topologyStr;
+        result[kv.Key] = topology;
       }
     }
     return result;
   }
-
-  // Mirrors GrasshopperArtifactRootObjectBuilder.CollectionTopologyAppId — must stay byte-identical so the deterministic
-  // key round-trips.
-  private static string CollectionTopologyAppId(int collectionNodeK) => $"__collection_topology_{collectionNodeK}";
 }

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Operations/Send/GrasshopperArtifactRootObjectBuilder.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Operations/Send/GrasshopperArtifactRootObjectBuilder.cs
@@ -188,20 +188,15 @@ public class GrasshopperArtifactRootObjectBuilder(
   {
     ctx.CancellationToken.ThrowIfCancellationRequested();
     collWrapper.ApplicationId ??= collWrapper.GetSpeckleApplicationId();
-    int collK = ctx.Pipeline.AddCollection(collWrapper.ApplicationId, collWrapper.Name, parentCollK, "Collection");
-
-    // GH data-tree topology (R4) has no home on AddCollection's columns, so it rides on a sidecar object keyed off
-    // the collection's own node K (CollectionTopologyAppId) instead of an SDK signature change.
-    if (collWrapper.Topology is { Length: > 0 } topology)
-    {
-      string topologyAppId = CollectionTopologyAppId(collK);
-      ctx.Pipeline.InternObject(topologyAppId);
-      ctx.Pipeline.AddProperties(
-        topologyAppId,
-        s_emptyProps,
-        [new KeyValuePair<string, object?>("topology", topology)]
-      );
-    }
+    // GH data-tree topology rides nodes.gh_topology, the column the spec carves out for it. It used to need a
+    // synthetic object; the objects table is for real objects [ENG-9291].
+    int collK = ctx.Pipeline.AddCollection(
+      collWrapper.ApplicationId,
+      collWrapper.Name,
+      parentCollK,
+      "Collection",
+      ghTopology: collWrapper.Topology is { Length: > 0 } topology ? topology : null
+    );
 
     // collection-level color/material are collected for parity with the v1 walk; they resolve to no geometry K and are
     // therefore not emitted as HAS_* edges (same as Rhino's layer-level materials).
@@ -596,10 +591,6 @@ public class GrasshopperArtifactRootObjectBuilder(
   }
 
   private static readonly Dictionary<string, object?> s_emptyProps = new();
-
-  // Deterministic key for a collection's topology sidecar object (see WalkCollection).
-  // Mirrored in GrasshopperArtefactObjectBuilder.CollectionTopologyAppId — must stay byte-identical.
-  private static string CollectionTopologyAppId(int collectionNodeK) => $"__collection_topology_{collectionNodeK}";
 
   private static IReadOnlyDictionary<string, object?> PropertiesOf(Base @base) =>
     @base["properties"] is IReadOnlyDictionary<string, object?> props ? props : s_emptyProps;


### PR DESCRIPTION
## Description

`nodes.gh_topology` now exists in the spec. A collection node carries its own topology and the fake objects go away.

Needs the SDK branch: https://github.com/specklesystems/speckle-sharp-sdk/pull/542

## User Value

Trees still round trip, without a synthetic object per collection sitting in the objects table.

## Changes:

- Send passes the collection's topology straight to `AddCollection`. The `InternObject` + `AddProperties` sidecar write is gone
- Receive reads it off the node. `CreateCollectionTopologies` is now one loop over container nodes
- Dropped `CollectionTopologyAppId` from both builders. That string had to stay byte-identical across two files with no compiler help, and it's gone
- Dropped the reverse `ObjectAppIds` map receive built on every load just to find the sidecars

## Validation of changes:

By hand, no automated coverage - Grasshopper still has no test project.

- [x] Publish a data tree with several branches. Load it back, same tree, same branch paths
- [x] Nested collections, topology on more than one level
- [x] A flat list (no topology) publishes and loads unchanged - `gh_topology` stays null
- [x] Load a Revit or AutoCAD model. Unchanged, nothing about this touches them

## Checklist:

- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] I have added appropriate tests
- [x] I have updated or added relevant documentation.