### PR TITLE
fix(plant3d): property-extraction failure no longer discards converted geometry (ENG-8839)

### DIFF
--- a/Converters/Plant3d/Speckle.Converters.Plant3dShared/Plant3dRootToSpeckleConverter.cs
+++ b/Converters/Plant3d/Speckle.Converters.Plant3dShared/Plant3dRootToSpeckleConverter.cs
@@ -1,8 +1,10 @@
 using System.ComponentModel.DataAnnotations;
+using Microsoft.Extensions.Logging;
 using Speckle.Converters.Common;
 using Speckle.Converters.Common.Objects;
 using Speckle.Converters.Common.Registration;
 using Speckle.Objects.Data;
+using Speckle.Sdk;
 using Speckle.Sdk.Models;
 
 namespace Speckle.Converters.Plant3dShared;
@@ -11,7 +13,8 @@ public class Plant3dRootToSpeckleConverter(
   IConverterManager<IToSpeckleTopLevelConverter> toSpeckle,
   IConverterSettingsStore<Plant3dConversionSettings> settingsStore,
   ToSpeckle.PropertiesExtractor propertiesExtractor,
-  ToSpeckle.Plant3dDataExtractor dataExtractor
+  ToSpeckle.Plant3dDataExtractor dataExtractor,
+  ILogger<Plant3dRootToSpeckleConverter> logger
 ) : IRootToSpeckleConverter
 {
   public Base Convert(object target)
@@ -33,11 +36,28 @@ public class Plant3dRootToSpeckleConverter(
 
     if (target is ADB.Entity autocadEntity)
     {
+      // Property extraction is best-effort: a failure here must not discard already-converted geometry.
       // Extract AEC property sets and extension dictionaries
-      var properties = propertiesExtractor.GetProperties(autocadEntity);
+      Dictionary<string, object?> properties = new();
+      try
+      {
+        properties = propertiesExtractor.GetProperties(autocadEntity);
+      }
+      catch (Exception ex) when (!ex.IsFatal())
+      {
+        logger.LogWarning(ex, "Failed to extract AEC properties on object {HandleValue}", autocadEntity.Handle.Value);
+      }
 
       // Extract Plant3D project database properties (Tag, NominalDiameter, etc.)
-      var dataProperties = dataExtractor.GetDataProperties(autocadEntity);
+      Dictionary<string, object?> dataProperties = new();
+      try
+      {
+        dataProperties = dataExtractor.GetDataProperties(autocadEntity);
+      }
+      catch (Exception ex) when (!ex.IsFatal())
+      {
+        logger.LogWarning(ex, "Failed to extract P&ID properties on object {HandleValue}", autocadEntity.Handle.Value);
+      }
 
       if (result is DataObject dataObject)
       {

--- a/Converters/Plant3d/Speckle.Converters.Plant3dShared/ToSpeckle/Properties/Plant3dDataExtractor.cs
+++ b/Converters/Plant3d/Speckle.Converters.Plant3dShared/ToSpeckle/Properties/Plant3dDataExtractor.cs
@@ -1,4 +1,6 @@
+using Microsoft.Extensions.Logging;
 using Speckle.Converters.Common;
+using Speckle.Sdk;
 
 namespace Speckle.Converters.Plant3dShared.ToSpeckle;
 
@@ -10,10 +12,15 @@ namespace Speckle.Converters.Plant3dShared.ToSpeckle;
 public class Plant3dDataExtractor
 {
   private readonly IConverterSettingsStore<Plant3dConversionSettings> _settingsStore;
+  private readonly ILogger<Plant3dDataExtractor> _logger;
 
-  public Plant3dDataExtractor(IConverterSettingsStore<Plant3dConversionSettings> settingsStore)
+  public Plant3dDataExtractor(
+    IConverterSettingsStore<Plant3dConversionSettings> settingsStore,
+    ILogger<Plant3dDataExtractor> logger
+  )
   {
     _settingsStore = settingsStore;
+    _logger = logger;
   }
 
   /// <summary>
@@ -55,9 +62,11 @@ public class Plant3dDataExtractor
         }
       }
     }
-    catch (PPDL.DLException)
+    catch (Exception ex) when (!ex.IsFatal())
     {
-      // DataLinksManager not available or other API failure
+      // DataLinksManager unavailable, entity unlinked/orphaned from the PnP project database,
+      // or any other DataLinks API failure — degrade to no P&ID properties instead of failing the object.
+      _logger.LogWarning(ex, "Failed to read PnP DataLinks properties on object {HandleValue}", entity.Handle.Value);
     }
 
     return result;


### PR DESCRIPTION
Fixes ENG-8839 — https://linear.app/speckle/issue/ENG-8839

On the Plant 3D artefact path, an object whose geometry converted fine was still reported as a per-object ERROR (geometry discarded) when reading its Plant 3D project-database properties threw anything other than `DLException` — e.g. an entity copied between drawings with an orphaned rowId, or a drawing detached from its project DB. If every object hit it, the whole send failed.

- `Plant3dRootToSpeckleConverter.Convert`: both `propertiesExtractor.GetProperties` and `dataExtractor.GetDataProperties` are now best-effort — a failure logs a warning and continues with empty properties, so already-converted geometry is kept.
- `Plant3dDataExtractor.GetDataProperties`: catch broadened past `PPDL.DLException` to match the `CA1031` pragma it already carried.

Rebased onto current `big-truck`; Plant3d2027 builds, csharpier clean. Live verification is matrix test **P2** (the non-`DLException` path was found by code review, not reproduced).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P5y5UfidUk3twgqPFSwdf8