### PR TITLE
refactor(bundle): modelPlacement.transform is the single placement re…

### DIFF
--- a/Connectors/Autocad/Speckle.Connectors.AutocadShared/Operations/Send/AutocadArtifactRootObjectBuilder.cs
+++ b/Connectors/Autocad/Speckle.Connectors.AutocadShared/Operations/Send/AutocadArtifactRootObjectBuilder.cs
@@ -1014,24 +1014,20 @@ public class AutocadArtifactRootObjectBuilder(
 
   protected virtual void EmitAdditionalNodes(ObjectsArtifactPipeline pipeline) { }
 
+  // modelPlacement.* — same contract as the Revit producer: transform / options.*.transform map WCS (the drawing's
+  // internal frame) → that datum's space and are emitted regardless of baking; appliedToGeometry says whether the
+  // sender already applied `transform` to stored coordinates.
   private static void EmitModelPlacement(ObjectsArtifactPipeline pipeline, CollectedModel model)
   {
     var options = model.ModelPlacementOptions ?? new Dictionary<string, Matrix3d>();
-    Matrix3d bakedWcsToStored = Matrix3d.Identity;
-    if (model.ApplyTransform && options.TryGetValue(model.ModelPlacementSource, out Matrix3d selectedWcsToStored))
-    {
-      bakedWcsToStored = selectedWcsToStored;
-    }
-    Matrix3d storedToWcs = bakedWcsToStored.Inverse();
     Matrix3d defaultPlacement = Matrix3d.Identity;
 
     foreach (var option in options)
     {
-      Matrix3d storedToOption = option.Value.PostMultiplyBy(storedToWcs);
-      pipeline.AddModelProperty($"modelPlacement.options.{option.Key}.transform", MatrixToCsv(storedToOption));
+      pipeline.AddModelProperty($"modelPlacement.options.{option.Key}.transform", MatrixToCsv(option.Value));
       if (option.Key == model.ModelPlacementSource)
       {
-        defaultPlacement = storedToOption;
+        defaultPlacement = option.Value;
       }
     }
 

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Receive/RevitHostObjectArtefactBuilder.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Receive/RevitHostObjectArtefactBuilder.cs
@@ -148,17 +148,15 @@ public sealed class RevitHostObjectArtefactBuilder : IArtifactHostObjectBuilder
     var doc = _converterSettings.Current.Document;
     var rels = bundle.Relations;
 
-    // ENG-8808 / ENG-9099: undo/redo the sender's reference-point re-basing (translation + rotation, e.g. Shared
-    // Coordinates' true-north angle). The send pipeline baked its main-model reference-point transform into
-    // geometry and recorded it in the bundle; compose it with the receiver's own reference-point setting
-    // (Source = no local transform → apply the sender's as-is, restoring the source model's internal coordinates)
-    // and push it so ToInternalPoints/ConvertToInternalCoordinates re-bases every atomic vertex, and
-    // BuildInstanceTransform re-bases every instance placement. Mirrors v1 RevitHostObjectBuilder's composition.
-    // No recorded transform + no local setting = no-op.
-    // BAKED bundles (legacy sends and migrated old models — appliedToGeometry absent or true) are unbaked
-    // UNCONDITIONALLY, regardless of the Apply Transform receive setting: their stored coordinates already carry
-    // the source datum, so skipping the unbake would land them displaced. ReadSourceReferencePointTransform
-    // returns null for un-baked bundles (appliedToGeometry=false), which keep their stored coordinates.
+    // ENG-8808 / ENG-9099: undo the sender's reference-point re-basing (translation + rotation, e.g. Shared
+    // Coordinates' true-north angle). When the sender applied its selected datum to stored geometry
+    // (modelPlacement.appliedToGeometry = true) the inverse of modelPlacement.transform restores the source
+    // model's internal coordinates; compose it with the receiver's own reference-point setting and push it so
+    // ToInternalPoints/ConvertToInternalCoordinates re-bases every atomic vertex and BuildInstanceTransform
+    // re-bases every instance placement. Mirrors v1 RevitHostObjectBuilder's composition. Baked bundles are
+    // unbaked UNCONDITIONALLY, regardless of the Apply Transform receive setting — skipping it would land them
+    // displaced. Un-baked bundles (the default) store internal coordinates already → ReadSourceReferencePointTransform
+    // returns null and only the local setting applies.
     var sourceReferencePoint = ReadSourceReferencePointTransform(bundle);
     using var referencePointScope = _converterSettings.Push(s =>
       s with
@@ -1490,43 +1488,22 @@ public sealed class RevitHostObjectArtefactBuilder : IArtifactHostObjectBuilder
     return resolved;
   }
 
-  // ENG-8947 / ENG-9099: rebuild the sender's reference-point transform from the eav.model record
-  // (referencePoint.transform — the FULL rigid transform as a 16-value row-major CSV, same layout ParseMatrix
-  // already uses for InstanceProxy transforms; referencePoint.units, falling back to the bundle's display
-  // units). Scale the translation to internal feet so the result composes with the receive setting and applies
-  // through ConvertToInternalCoordinates. No record / internalOriginFallback (kind row without a transform) →
-  // no source re-basing. The former meta.reference_point_* columns are removed from the spec and NOT read.
+  // ENG-8947 / ENG-9099: the transform that restores the source model's INTERNAL coordinates from stored
+  // geometry, or null when nothing was applied. Read from modelPlacement (the only placement record):
+  // appliedToGeometry must be true, transform is INTERNAL → selected datum (16-value row-major CSV, same layout
+  // ParseMatrix uses for InstanceProxy transforms) so its inverse is stored → internal; units fall back to the
+  // bundle's display units. The translation is scaled to internal feet so the result composes with the receive
+  // setting and applies through ConvertToInternalCoordinates.
   private Transform? ReadSourceReferencePointTransform(ArtefactBundle bundle)
   {
     if (
-      !bundle.ModelProperties.TryGetValue("referencePoint", out var rpObj)
-      || rpObj is not Dictionary<string, object?> rp
-      || !rp.TryGetValue("transform", out var tObj)
+      !bundle.ModelProperties.TryGetValue("modelPlacement", out var placementObj)
+      || placementObj is not Dictionary<string, object?> placement
+      || !placement.TryGetValue("appliedToGeometry", out var appliedObj)
+      || appliedObj is not true
+      || !placement.TryGetValue("transform", out var tObj)
       || tObj is not string transformCsv
     )
-    {
-      return null;
-    }
-
-    // New bundles store this source-independent state under modelPlacement. Fall back to the temporary
-    // referencePoint location emitted by earlier builds of this branch; absence means a legacy baked bundle.
-    bool? appliedToGeometry = null;
-    if (
-      bundle.ModelProperties.TryGetValue("modelPlacement", out var placementObj)
-      && placementObj is Dictionary<string, object?> placement
-      && placement.TryGetValue("appliedToGeometry", out var placementAppliedObj)
-      && placementAppliedObj is bool placementApplied
-    )
-    {
-      appliedToGeometry = placementApplied;
-    }
-    else if (
-      rp.TryGetValue("appliedToGeometry", out var referenceAppliedObj) && referenceAppliedObj is bool referenceApplied
-    )
-    {
-      appliedToGeometry = referenceApplied;
-    }
-    if (appliedToGeometry is false)
     {
       return null;
     }
@@ -1544,18 +1521,18 @@ public sealed class RevitHostObjectArtefactBuilder : IArtifactHostObjectBuilder
         return null;
       }
     }
-    string units = rp.TryGetValue("units", out var uObj) && uObj is string u && u.Length > 0 ? u : bundle.Units;
+    string units = placement.TryGetValue("units", out var uObj) && uObj is string u && u.Length > 0 ? u : bundle.Units;
     var fTypeId = ResolveForge(units);
-    var full = Transform.Identity;
-    full.BasisX = new XYZ(d[0], d[4], d[8]);
-    full.BasisY = new XYZ(d[1], d[5], d[9]);
-    full.BasisZ = new XYZ(d[2], d[6], d[10]);
-    full.Origin = new XYZ(
+    var internalToDatum = Transform.Identity;
+    internalToDatum.BasisX = new XYZ(d[0], d[4], d[8]);
+    internalToDatum.BasisY = new XYZ(d[1], d[5], d[9]);
+    internalToDatum.BasisZ = new XYZ(d[2], d[6], d[10]);
+    internalToDatum.Origin = new XYZ(
       _scalingService.ScaleToNative(d[3], fTypeId),
       _scalingService.ScaleToNative(d[7], fTypeId),
       _scalingService.ScaleToNative(d[11], fTypeId)
     );
-    return full;
+    return internalToDatum.Inverse;
   }
 
   // ── transforms ────────────────────────────────────────────────────────────────────────────────────────

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/RevitArtifactRootObjectBuilder.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/RevitArtifactRootObjectBuilder.cs
@@ -542,56 +542,42 @@ public class RevitArtifactRootObjectBuilder(
     // ActiveProjectLocation and GetProjectPosition are both nullable — a document without a resolvable project
     // position must not fail the whole publish; the angle row is simply omitted.
     double? trueNorthAngle = documentContext.Doc.ActiveProjectLocation?.GetProjectPosition(XYZ.Zero)?.Angle;
-    EmitReferencePointModelRows(
-      pipeline,
-      referencePointKind,
-      requestedKind,
-      referencePointTransform,
-      placementData,
-      trueNorthAngle
-    );
+    EmitReferencePointModelRows(pipeline, referencePointKind, requestedKind, placementData, trueNorthAngle);
   }
 
-  // referencePoint.transform retains Revit's selected source datum for round-tripping. Every
-  // modelPlacement.options.*.transform is viewer-ready and maps STORED geometry into that option's coordinate
-  // space. This remains true for legacy baked sends: the selected source transform first restores internal
-  // coordinates, then the option's inverse datum transform places them in the requested space.
+  // modelPlacement.* is the single source of truth for where the model sits [ENG-9099]:
+  //   transform          — the datum the user selected on the producer, as Revit INTERNAL → that datum's space.
+  //                        Always emitted, whether or not it was applied to stored geometry.
+  //   appliedToGeometry  — true when the sender already applied `transform` to stored coordinates (Apply
+  //                        Transform on). Consumers then place the geometry as-is; a Revit receive inverts
+  //                        `transform` to land back in internal coordinates. False → stored coordinates ARE
+  //                        internal, consumers apply `transform`, a Revit receive applies nothing.
+  //   options.*.transform — every available datum, same INTERNAL → datum convention, for switching.
+  //   default / source   — the selected datum kind (source keeps the internalOriginFallback marker).
   private void EmitReferencePointModelRows(
     ObjectsArtifactPipeline pipeline,
     string referencePointKind,
     string requestedKind,
-    Transform? selectedSourceTransform,
     RevitModelPlacementData placementData,
     double? trueNorthAngle
   )
   {
-    pipeline.AddModelProperty("referencePoint.kind", referencePointKind);
-    if (selectedSourceTransform is { } t)
-    {
-      pipeline.AddModelProperty("referencePoint.transform", FormatReferencePointTransform(t));
-      pipeline.AddModelProperty("referencePoint.units", converterSettings.Current.SpeckleUnits);
-    }
-
     string effectiveDefault = referencePointKind == "internalOriginFallback" ? "internalOrigin" : requestedKind;
     Transform defaultPlacement = Transform.Identity;
     foreach (string optionKind in new[] { "internalOrigin", "projectBasePoint", "surveyPoint", "sharedCoordinates" })
     {
-      Transform? storedToOption = placementData.GetStoredToOptionTransform(
-        optionKind,
-        converterSettings.Current.ApplyTransform,
-        selectedSourceTransform
-      );
-      if (storedToOption is null)
+      Transform? internalToOption = placementData.GetInternalToOptionTransform(optionKind);
+      if (internalToOption is null)
       {
         continue;
       }
       pipeline.AddModelProperty(
         $"modelPlacement.options.{optionKind}.transform",
-        FormatReferencePointTransform(storedToOption)
+        FormatReferencePointTransform(internalToOption)
       );
       if (optionKind == effectiveDefault)
       {
-        defaultPlacement = storedToOption;
+        defaultPlacement = internalToOption;
       }
     }
 
@@ -666,9 +652,9 @@ public class RevitArtifactRootObjectBuilder(
     }
   }
 
-  // ENG-9099 referencePoint.transform: the full rigid transform subtracted from
-  // world-space output, as 16 row-major doubles — same layout Flatten/BuildInstanceTransform already use for
-  // InstanceProxy transforms (basis columns unscaled/unit vectors, translation column in display units).
+  // ENG-9099 modelPlacement.*.transform: a full rigid transform as 16 row-major doubles — same layout
+  // Flatten/BuildInstanceTransform already use for InstanceProxy transforms (basis columns unscaled/unit vectors,
+  // translation column in display units).
   private string FormatReferencePointTransform(Transform transform)
   {
     var scaled = Transform.Identity;

--- a/Converters/Revit/Speckle.Converters.RevitShared/Helpers/ReferencePointHelper.cs
+++ b/Converters/Revit/Speckle.Converters.RevitShared/Helpers/ReferencePointHelper.cs
@@ -245,15 +245,9 @@ public sealed class RevitModelPlacementData(
 
   public void SetSourceTransform(string kind, Transform transform) => sourceTransforms[kind] = transform;
 
-  public Transform? GetStoredToOptionTransform(string kind, bool appliedToGeometry, Transform? selectedSourceTransform)
-  {
-    if (!sourceTransforms.TryGetValue(kind, out Transform? sourceTransform))
-    {
-      return null;
-    }
-
-    Transform storedToInternal =
-      appliedToGeometry && selectedSourceTransform is not null ? selectedSourceTransform : Transform.Identity;
-    return sourceTransform.Inverse.Multiply(storedToInternal);
-  }
+  /// <summary>Revit INTERNAL coordinates → the datum's coordinate space (the inverse of the datum's source
+  /// transform). Independent of whether the sender baked anything into stored geometry — that is what
+  /// <c>modelPlacement.appliedToGeometry</c> records.</summary>
+  public Transform? GetInternalToOptionTransform(string kind) =>
+    sourceTransforms.TryGetValue(kind, out Transform? sourceTransform) ? sourceTransform.Inverse : null;
 }


### PR DESCRIPTION
…cord; drop referencePoint.* rows (ENG-9099)

modelPlacement.transform now always carries the producer-selected datum as INTERNAL → datum, regardless of whether it was applied to stored geometry; modelPlacement.appliedToGeometry says whether it was. Revit receive inverts it when applied and does nothing otherwise, so the duplicate referencePoint.kind / .transform / .units rows and the receive-side fallback branches are removed. options.*.transform follow the same internal → datum convention. AutoCAD producer aligned; AutoCAD receive unchanged (only consumes unbaked bundles)