### PR TITLE
fix(revit): further qa/qc fixes

### DIFF
--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Bindings/RevitSendBinding.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Bindings/RevitSendBinding.cs
@@ -306,16 +306,16 @@ internal sealed class RevitSendBinding : RevitBaseBinding, ISendBinding
             document,
             modelCard.SendFilter,
             linkedDoc,
-            transform
+            linkedModel
           );
-          linkedDocumentContexts.Add(new(transform, linkedDoc, linkedElements));
+          linkedDocumentContexts.Add(new(transform, linkedDoc, linkedElements, linkedModel));
         }
         // ⚠️ when disabled, still adds empty contexts to maintain warning generation in RevitRootObjectBuilder
         // this approach (to signal that warnings are needed) relies on empty element lists which smells and is a bit of an implicit mechanism
         // buuuuut, it works (for now 👀).
         else
         {
-          linkedDocumentContexts.Add(new(transform, linkedDoc, new List<Element>()));
+          linkedDocumentContexts.Add(new(transform, linkedDoc, new List<Element>(), linkedModel));
         }
       }
       documentElementContexts.AddRange(linkedDocumentContexts);

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/DocumentToConvert.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/DocumentToConvert.cs
@@ -2,4 +2,12 @@ using Autodesk.Revit.DB;
 
 namespace Speckle.Connectors.Revit.HostApp;
 
-public record DocumentToConvert(Transform? Transform, Document Doc, List<Element> Elements);
+/// <param name="LinkInstance">The <see cref="RevitLinkInstance"/> that places <paramref name="Doc"/> in the host
+/// document, or null for the host document itself. This is the placement's identity — see
+/// <c>LinkedModelHandler.GetPlacementSuffix</c> for why a hash of <paramref name="Transform"/> is not [ENG-9263].</param>
+public record DocumentToConvert(
+  Transform? Transform,
+  Document Doc,
+  List<Element> Elements,
+  RevitLinkInstance? LinkInstance = null
+);

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/LinkedModelHandler.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/LinkedModelHandler.cs
@@ -113,34 +113,22 @@ public class LinkedModelHandler
 
   /// <summary>
   /// The identity of one linked-model placement: the placing <see cref="RevitLinkInstance"/>'s UniqueId, or
-  /// <c>host</c> for the host document. Unique by construction, stable across sessions, traceable back to a
-  /// real Revit element.
+  /// <c>host</c> for the host document.
   /// </summary>
   public string GetIdFromDocumentToConvert(DocumentToConvert documentToConvert) =>
     documentToConvert.LinkInstance?.UniqueId ?? "host";
 
   /// <summary>
   /// The <c>_t{hash}</c> suffix appended to every source UniqueId of a linked-model placement, so occurrences of
-  /// the same linked file under different placements stay distinct identities. Empty for the host document.
+  /// the same linked file under different placements stay distinct. Empty for the host document.
   /// </summary>
   /// <remarks>
-  /// <para>
-  /// Derived from the placing link instance, NOT from the placement transform. The transform hash it replaces
-  /// summarised a 3×3 basis by its three diagonal terms at one decimal place, discarding the off-diagonal terms —
-  /// exactly what separates one rotation from another. Two placements of the same link at a shared origin rotated
-  /// +90° and −90° hashed identically, and both then interned to a single object, silently losing one occurrence.
-  /// </para>
-  /// <para>
-  /// Keyed off <see cref="DocumentToConvert.LinkInstance"/> rather than "has a transform": the HOST document also
-  /// carries a Transform whenever the reference-point setting is Project Base, Survey or Shared Coordinates, so the
-  /// old test suffixed every host element too — which made the parameter editor refuse them as linked
-  /// (<c>ContainsLinkedModelTransformHash</c>) and rewrote every application ID whenever the setting changed.
-  /// </para>
-  /// <para>
-  /// Still a hash, and still <c>_t</c> + lowercase hex, so the <c>_t[a-f0-9]+$</c> probe in
-  /// <c>RevitParametersBinding</c> and the suffix-stripping convention both keep working — a raw UniqueId contains
-  /// hyphens and would break them.
-  /// </para>
+  /// Derived from the placing link instance, not from the placement transform: the transform hash it replaces kept
+  /// only the basis diagonal at 1dp, so +90° and −90° about a shared origin hashed alike and both placements
+  /// interned to one object [ENG-9263]. Keyed off <see cref="DocumentToConvert.LinkInstance"/> rather than "has a
+  /// transform" because the HOST document also has one under Project Base / Survey / Shared Coordinates, which
+  /// suffixed host elements and made the parameter editor refuse them as linked. Still <c>_t</c> + lowercase hex,
+  /// so the <c>_t[a-f0-9]+$</c> probe and the suffix-stripping convention keep working — a raw UniqueId has hyphens.
   /// </remarks>
   public string GetPlacementSuffix(DocumentToConvert documentToConvert)
   {

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/LinkedModelHandler.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/LinkedModelHandler.cs
@@ -120,15 +120,15 @@ public class LinkedModelHandler
 
   /// <summary>
   /// The <c>_t{hash}</c> suffix appended to every source UniqueId of a linked-model placement, so occurrences of
-  /// the same linked file under different placements stay distinct. Empty for the host document.
+  /// the same linked file stay distinct identities. Empty for the host document.
   /// </summary>
   /// <remarks>
-  /// Derived from the placing link instance, not from the placement transform: the transform hash it replaces kept
-  /// only the basis diagonal at 1dp, so +90° and −90° about a shared origin hashed alike and both placements
-  /// interned to one object [ENG-9263]. Keyed off <see cref="DocumentToConvert.LinkInstance"/> rather than "has a
-  /// transform" because the HOST document also has one under Project Base / Survey / Shared Coordinates, which
-  /// suffixed host elements and made the parameter editor refuse them as linked. Still <c>_t</c> + lowercase hex,
-  /// so the <c>_t[a-f0-9]+$</c> probe and the suffix-stripping convention keep working — a raw UniqueId has hyphens.
+  /// Hashes the placing link instance, not the transform: the old hash kept only the basis diagonal at 1dp, so
+  /// +90° and −90° about a shared origin collided into one object [ENG-9263]. Keyed off
+  /// <see cref="DocumentToConvert.LinkInstance"/> rather than "has a transform" because the host document also has
+  /// one under Project Base / Survey / Shared Coordinates, which suffixed host elements and made the parameter
+  /// editor refuse them as linked. Still <c>_t</c> + lowercase hex, so the existing <c>_t[a-f0-9]+$</c> probe and
+  /// suffix-stripping keep working — a raw UniqueId has hyphens.
   /// </remarks>
   public string GetPlacementSuffix(DocumentToConvert documentToConvert)
   {

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/LinkedModelHandler.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/LinkedModelHandler.cs
@@ -4,7 +4,6 @@ using Autodesk.Revit.DB;
 using Speckle.Connectors.DUI.Models.Card.SendFilter;
 using Speckle.Connectors.RevitShared;
 using Speckle.Connectors.RevitShared.Operations.Send.Filters;
-using Speckle.Sdk;
 using Speckle.Sdk.Common;
 
 namespace Speckle.Connectors.Revit.HostApp;
@@ -28,7 +27,7 @@ public class LinkedModelHandler
     Document currentDocument,
     ISendFilter sendFilter,
     Document linkedDocument,
-    Transform? transform
+    RevitLinkInstance linkInstance
   )
   {
     // send mode → Categories
@@ -49,8 +48,6 @@ public class LinkedModelHandler
     // send mode → Views (taken from the legacy code)
     if (sendFilter is RevitViewsFilter viewFilter && viewFilter.GetView(currentDocument) != null)
     {
-      RevitLinkInstance linkInstance = FindLinkInstanceForDocument(linkedDocument.PathName, currentDocument, transform);
-
 #if REVIT2024_OR_GREATER
       // revit 2024 and 2025 we can use the three-parameter constructor to get only visible elements
       using var viewCollector = new FilteredElementCollector(
@@ -114,8 +111,54 @@ public class LinkedModelHandler
     }
   }
 
+  /// <summary>
+  /// The identity of one linked-model placement: the placing <see cref="RevitLinkInstance"/>'s UniqueId, or
+  /// <c>host</c> for the host document. Unique by construction, stable across sessions, traceable back to a
+  /// real Revit element.
+  /// </summary>
   public string GetIdFromDocumentToConvert(DocumentToConvert documentToConvert) =>
-    documentToConvert.Doc.GetHashCode() + "-" + (documentToConvert.Transform?.GetHashCode() ?? 0);
+    documentToConvert.LinkInstance?.UniqueId ?? "host";
+
+  /// <summary>
+  /// The <c>_t{hash}</c> suffix appended to every source UniqueId of a linked-model placement, so occurrences of
+  /// the same linked file under different placements stay distinct identities. Empty for the host document.
+  /// </summary>
+  /// <remarks>
+  /// <para>
+  /// Derived from the placing link instance, NOT from the placement transform. The transform hash it replaces
+  /// summarised a 3×3 basis by its three diagonal terms at one decimal place, discarding the off-diagonal terms —
+  /// exactly what separates one rotation from another. Two placements of the same link at a shared origin rotated
+  /// +90° and −90° hashed identically, and both then interned to a single object, silently losing one occurrence.
+  /// </para>
+  /// <para>
+  /// Keyed off <see cref="DocumentToConvert.LinkInstance"/> rather than "has a transform": the HOST document also
+  /// carries a Transform whenever the reference-point setting is Project Base, Survey or Shared Coordinates, so the
+  /// old test suffixed every host element too — which made the parameter editor refuse them as linked
+  /// (<c>ContainsLinkedModelTransformHash</c>) and rewrote every application ID whenever the setting changed.
+  /// </para>
+  /// <para>
+  /// Still a hash, and still <c>_t</c> + lowercase hex, so the <c>_t[a-f0-9]+$</c> probe in
+  /// <c>RevitParametersBinding</c> and the suffix-stripping convention both keep working — a raw UniqueId contains
+  /// hyphens and would break them.
+  /// </para>
+  /// </remarks>
+  public string GetPlacementSuffix(DocumentToConvert documentToConvert)
+  {
+    if (documentToConvert.LinkInstance is not { } linkInstance)
+    {
+      return string.Empty;
+    }
+
+    byte[] bytes = System.Text.Encoding.UTF8.GetBytes(linkInstance.UniqueId);
+#if NET8_0_OR_GREATER
+    return "_t" + Convert.ToHexString(SHA256.HashData(bytes)).ToLowerInvariant()[..16];
+#else
+    using (var sha256 = SHA256.Create())
+    {
+      return "_t" + BitConverter.ToString(sha256.ComputeHash(bytes)).Replace("-", "").ToLowerInvariant()[..16];
+    }
+#endif
+  }
 
   /// <summary>
   /// Gets elements from a document that belong to the specified categories.
@@ -131,33 +174,6 @@ public class LinkedModelHandler
       .ToList();
   }
 
-  // Helper method to generate a simple hash for a transform
-  // transformedElement.applicationId = ${applicationId}-t{transformHash}
-  public string GetTransformHash(Transform transform)
-  {
-    // create a simplified representation of the transform
-    string json =
-      $@"{{
-      ""origin"": [{transform.Origin.X:F2}, {transform.Origin.Y:F2}, {transform.Origin.Z:F2}],
-      ""basis"": [{transform.BasisX.X:F1}, {transform.BasisY.Y:F1}, {transform.BasisZ.Z:F1}]
-    }}";
-
-    byte[] jsonBytes = System.Text.Encoding.UTF8.GetBytes(json);
-
-#if NET8_0_OR_GREATER
-    byte[] hashBytes = SHA256.HashData(jsonBytes);
-    // keep only the first 8 characters for a short but unique hash
-    return Convert.ToHexString(hashBytes).ToLowerInvariant()[..8];
-#else
-    using (var sha256 = SHA256.Create())
-    {
-      byte[] hashBytes = sha256.ComputeHash(jsonBytes);
-      // keep only the first 8 characters for a short but unique hash
-      return BitConverter.ToString(hashBytes).Replace("-", "").ToLowerInvariant()[..8];
-    }
-#endif
-  }
-
   /// <summary>
   /// Retrieves all elements from the linked document when using selection filters.
   /// When a linked model is selected in the main document, we include all elements
@@ -167,46 +183,5 @@ public class LinkedModelHandler
   {
     using var collector = new FilteredElementCollector(linkedDoc);
     return collector.WhereElementIsNotElementType().WhereElementIsViewIndependent().ToList();
-  }
-
-  /// <summary>
-  /// Finds a specific RevitLinkInstance that corresponds to a linked document with a matching transform.
-  /// </summary>
-  /// <param name="linkedDocumentPath">The file path of the linked document</param>
-  /// <param name="transform">The transform to match (expected to already be an inverse transform).
-  /// When provided with multiple instances of the same linked document, this is used to find the specific instance.</param>
-  /// <param name="mainDocument">The main Revit document containing the link instances</param>
-  /// <returns>The matching RevitLinkInstance, or the first available instance if no match is found</returns>
-  private RevitLinkInstance FindLinkInstanceForDocument(
-    string linkedDocumentPath,
-    Document mainDocument,
-    Transform? transform
-  )
-  {
-    using var collector = new FilteredElementCollector(mainDocument);
-    var linkInstances = collector
-      .OfClass(typeof(RevitLinkInstance))
-      .Cast<RevitLinkInstance>()
-      .Where(link => link.GetLinkDocument()?.PathName == linkedDocumentPath)
-      .ToList();
-
-    // if no transform or only one instance, just return the first
-    if (transform == null || linkInstances.Count <= 1)
-    {
-      return linkInstances.FirstOrDefault()
-        ?? throw new SpeckleException($"No link instance found for {linkedDocumentPath}");
-    }
-
-    // a match consists of not only the linked document path name but the transformation too (think linked instances)
-    // precompute our target hash once
-    string targetHash = GetTransformHash(transform);
-
-    // directly find the matching instance
-    var matchingInstance = linkInstances.FirstOrDefault(link =>
-      GetTransformHash(link.GetTotalTransform().Inverse) == targetHash
-    );
-
-    // return matching with a fallback to first (main) instance in case something goes funky with the hash
-    return matchingInstance ?? linkInstances.First();
   }
 }

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Receive/RevitHostObjectArtefactBuilder.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Receive/RevitHostObjectArtefactBuilder.cs
@@ -1494,8 +1494,7 @@ public sealed class RevitHostObjectArtefactBuilder : IArtifactHostObjectBuilder
   {
     try
     {
-      // Enum.TryParse also accepts numeric strings, so a foreign producer's value can parse to something
-      // Revit rejects outright rather than merely returning null.
+      // Enum.TryParse also accepts numeric strings, so a bad value can parse to something Revit rejects outright.
       return Category.GetCategory(doc, cat) is { } c && DirectShape.IsValidCategoryId(c.Id, doc);
     }
     catch (Autodesk.Revit.Exceptions.ApplicationException)
@@ -1504,12 +1503,8 @@ public sealed class RevitHostObjectArtefactBuilder : IArtifactHostObjectBuilder
     }
   }
 
-  /// <summary>
-  /// The locale-independent <c>OST_*</c> category identifier. The sender writes it inside the element's
-  /// property tree, so its eav path is <c>properties.builtInCategory</c> and <c>ArtefactBundle.SetNested</c>
-  /// rebuilds it one level down — reading it off the top level, as both resolvers used to, always found
-  /// nothing, leaving the localized display name as the only branch that ever ran [ENG-9337].
-  /// </summary>
+  // The locale-independent OST_* identifier. The sender writes it under `properties`, so SetNested rebuilds it one
+  // level down — reading it off the top level, as both resolvers did, always found nothing [ENG-9337].
   private static string? ReadBuiltInCategory(Dictionary<string, object?>? props) =>
     PropStringNested(props, "properties", "builtInCategory");
 
@@ -1669,9 +1664,7 @@ public sealed class RevitHostObjectArtefactBuilder : IArtifactHostObjectBuilder
   private static string? PropString(Dictionary<string, object?>? props, string key) =>
     props is not null && props.TryGetValue(key, out var v) && v is string s && s.Length > 0 ? s : null;
 
-  /// <summary>Reads a string one level down, e.g. <c>props["properties"]["builtInCategory"]</c> — the shape
-  /// <c>ArtefactBundle.SetNested</c> rebuilds from a dotted eav path. Root scalars use
-  /// <see cref="PropString"/>; anything the sender wrote under <c>properties</c> needs this.</summary>
+  /// <summary>Reads a string one level down, e.g. <c>props["properties"]["builtInCategory"]</c>.</summary>
   private static string? PropStringNested(Dictionary<string, object?>? props, string outerKey, string key) =>
     props is not null && props.TryGetValue(outerKey, out var outer) && outer is Dictionary<string, object?> nested
       ? PropString(nested, key)

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Receive/RevitHostObjectArtefactBuilder.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Receive/RevitHostObjectArtefactBuilder.cs
@@ -1505,8 +1505,9 @@ public sealed class RevitHostObjectArtefactBuilder : IArtifactHostObjectBuilder
 
   // The locale-independent OST_* identifier. The sender writes it under `properties`, so SetNested rebuilds it one
   // level down — reading it off the top level, as both resolvers did, always found nothing [ENG-9337].
+  // The top-level fallback keeps a producer that emits builtInCategory as a root scalar working.
   private static string? ReadBuiltInCategory(Dictionary<string, object?>? props) =>
-    PropStringNested(props, "properties", "builtInCategory");
+    PropStringNested(props, "properties", "builtInCategory") ?? PropString(props, "builtInCategory");
 
   // ENG-8947 / ENG-9099: the transform that restores the source model's INTERNAL coordinates from stored
   // geometry, or null when nothing was applied. Read from modelPlacement (the only placement record):

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Receive/RevitHostObjectArtefactBuilder.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Receive/RevitHostObjectArtefactBuilder.cs
@@ -1047,7 +1047,10 @@ public sealed class RevitHostObjectArtefactBuilder : IArtifactHostObjectBuilder
         continue;
       }
       bundle.Properties.TryGetValue(edge.Src, out var props);
-      return PropString(props, "builtInCategory") ?? PropString(props, "category");
+      // Only the OST_* identifier is usable here: FamilyCategoryUtils.SetFamilyCategory feeds it to
+      // Enum.TryParse, so the localized display name could never resolve and every received family
+      // silently defaulted its category [ENG-9337].
+      return ReadBuiltInCategory(props);
     }
     return null;
   }
@@ -1462,22 +1465,21 @@ public sealed class RevitHostObjectArtefactBuilder : IArtifactHostObjectBuilder
     Dictionary<string, ElementId> cache
   )
   {
-    var bic = PropString(props, "builtInCategory");
+    var bic = ReadBuiltInCategory(props);
     var display = PropString(props, "category");
-    var key = bic ?? display ?? "";
+    // Both values in the key: it was `bic ?? display`, which changes meaning the moment bic resolves.
+    var key = $"{bic}|{display}";
     if (cache.TryGetValue(key, out var cached))
     {
       return cached;
     }
 
+    // A ladder, not an either/or: a builtInCategory this document cannot use still gets to try the display
+    // name before defaulting.
     ElementId resolved = new(BuiltInCategory.OST_GenericModel);
-    if (bic is not null && Enum.TryParse(bic, out BuiltInCategory cat))
+    if (bic is not null && Enum.TryParse(bic, out BuiltInCategory cat) && IsValidDirectShapeCategory(doc, cat))
     {
-      var c = Category.GetCategory(doc, cat);
-      if (c is not null && DirectShape.IsValidCategoryId(c.Id, doc))
-      {
-        resolved = new ElementId(cat);
-      }
+      resolved = new ElementId(cat);
     }
     else if (display is not null && validCategories.TryGetValue(display, out var byName))
     {
@@ -1487,6 +1489,29 @@ public sealed class RevitHostObjectArtefactBuilder : IArtifactHostObjectBuilder
     cache[key] = resolved;
     return resolved;
   }
+
+  private static bool IsValidDirectShapeCategory(Document doc, BuiltInCategory cat)
+  {
+    try
+    {
+      // Enum.TryParse also accepts numeric strings, so a foreign producer's value can parse to something
+      // Revit rejects outright rather than merely returning null.
+      return Category.GetCategory(doc, cat) is { } c && DirectShape.IsValidCategoryId(c.Id, doc);
+    }
+    catch (Autodesk.Revit.Exceptions.ApplicationException)
+    {
+      return false;
+    }
+  }
+
+  /// <summary>
+  /// The locale-independent <c>OST_*</c> category identifier. The sender writes it inside the element's
+  /// property tree, so its eav path is <c>properties.builtInCategory</c> and <c>ArtefactBundle.SetNested</c>
+  /// rebuilds it one level down — reading it off the top level, as both resolvers used to, always found
+  /// nothing, leaving the localized display name as the only branch that ever ran [ENG-9337].
+  /// </summary>
+  private static string? ReadBuiltInCategory(Dictionary<string, object?>? props) =>
+    PropStringNested(props, "properties", "builtInCategory");
 
   // ENG-8947 / ENG-9099: the transform that restores the source model's INTERNAL coordinates from stored
   // geometry, or null when nothing was applied. Read from modelPlacement (the only placement record):
@@ -1643,6 +1668,14 @@ public sealed class RevitHostObjectArtefactBuilder : IArtifactHostObjectBuilder
 
   private static string? PropString(Dictionary<string, object?>? props, string key) =>
     props is not null && props.TryGetValue(key, out var v) && v is string s && s.Length > 0 ? s : null;
+
+  /// <summary>Reads a string one level down, e.g. <c>props["properties"]["builtInCategory"]</c> — the shape
+  /// <c>ArtefactBundle.SetNested</c> rebuilds from a dotted eav path. Root scalars use
+  /// <see cref="PropString"/>; anything the sender wrote under <c>properties</c> needs this.</summary>
+  private static string? PropStringNested(Dictionary<string, object?>? props, string outerKey, string key) =>
+    props is not null && props.TryGetValue(outerKey, out var outer) && outer is Dictionary<string, object?> nested
+      ? PropString(nested, key)
+      : null;
 
   // The object's real Speckle type for the conversion report (so it shows e.g. "Objects.Data.RevitObject > Direct
   // Shape" instead of "Base > …" — the report's Base source is only a UI placeholder, not reconstructed data).

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/RevitArtifactRootObjectBuilder.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/RevitArtifactRootObjectBuilder.cs
@@ -230,22 +230,20 @@ public class RevitArtifactRootObjectBuilder(
       int modelK = pipeline.AddContainer(modelKey, modelName, null, "Model");
       modelContainerKeys.Add(modelKey);
 
-      // This placement's own identity map. Keyed per modelKey rather than freshly allocated so two contexts that
-      // DO share a placement key (coincident transforms — see ENG-9263) degrade to merging, exactly as their
-      // interned object Ks already merge, instead of silently splitting the topology of one merged model.
+      // This placement's own identity map. Keyed per modelKey, which now derives from the SAME source as the
+      // application-id suffix below — the placing link instance — so the container tier and the object tier can no
+      // longer disagree about what one placement is [ENG-9263].
       if (!objectKsByPlacement.TryGetValue(modelKey, out var placementIndex))
       {
         placementIndex = new Dictionary<string, int>(StringComparer.Ordinal);
         objectKsByPlacement[modelKey] = placementIndex;
       }
 
-      // Transformed (linked) elements get a transform hash appended so occurrences of the same linked file under
-      // different placements stay distinct — same convention as the v1 builder. Constant per placement, so hash
-      // once here instead of per element, and apply it to children as well as atomic objects [ENG-9212].
+      // Linked elements get a placement hash appended so occurrences of the same linked file under different
+      // placements stay distinct. Constant per placement, so hash once here instead of per element, and apply it
+      // to children as well as atomic objects [ENG-9212].
       var placement = new PlacementContext(
-        documentContext.Transform is { } placementTransform
-          ? $"_t{linkedModelHandler.GetTransformHash(placementTransform)}"
-          : string.Empty,
+        linkedModelHandler.GetPlacementSuffix(documentContext),
         placementIndex,
         new HashSet<string>(documentContext.Elements.Select(e => e.UniqueId), StringComparer.Ordinal)
       );
@@ -469,7 +467,7 @@ public class RevitArtifactRootObjectBuilder(
     pipeline.InModel(objK, modelK, 0);
 
     // Indexer, not Add: ElementUnpacker already dedups by ElementId so one UniqueId maps to one K per placement,
-    // but a coincident-transform placement key (ENG-9263) must degrade quietly rather than throw mid-send.
+    // and a placement key that somehow repeats must degrade quietly rather than throw mid-send.
     placement.ObjectKsByUniqueId[revitElement.UniqueId] = objK;
 
     if (converted is not DataObject dataObject)
@@ -1118,8 +1116,8 @@ public class RevitArtifactRootObjectBuilder(
   /// ONE linked-model placement [ENG-9212]. A linked file placed N times produces N of these over the same source
   /// document, and nothing may leak between them.
   /// </summary>
-  /// <param name="Suffix">Appended to every source UniqueId in this placement: <c>_t{transformHash}</c> for a linked
-  /// document, empty for the host document.</param>
+  /// <param name="Suffix">Appended to every source UniqueId in this placement: <c>_t{placementHash}</c>, derived
+  /// from the placing link instance, for a linked document; empty for the host document.</param>
   /// <param name="ObjectKsByUniqueId">Source UniqueId → interned object K, for THIS placement only. Element→element
   /// relations resolve here, which is what keeps them from crossing placements.</param>
   /// <param name="AtomicUniqueIds">The UniqueIds converted as atomic objects in this placement — a composite child

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/RevitContinuousTraversalBuilder.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/RevitContinuousTraversalBuilder.cs
@@ -14,7 +14,6 @@ using Speckle.Converters.Common;
 using Speckle.Converters.RevitShared.Helpers;
 using Speckle.Converters.RevitShared.Settings;
 using Speckle.Sdk;
-using Speckle.Sdk.Common;
 using Speckle.Sdk.Models;
 using Speckle.Sdk.Models.Collections;
 using Speckle.Sdk.Pipelines.Progress;
@@ -211,14 +210,9 @@ public class RevitContinuousTraversalBuilder(
             // not in cache means we convert
             else
             {
-              // if it has a transform we append transform hash to the applicationId to distinguish the elements from other instances
-              if (hasTransform)
-              {
-                string transformHash = linkedModelHandler.GetTransformHash(
-                  atomicObjectByDocumentAndTransform.Transform.NotNull()
-                );
-                applicationId = $"{applicationId}_t{transformHash}";
-              }
+              // linked elements get a placement hash appended to distinguish them from other placements of the
+              // same linked file [ENG-9263]
+              applicationId += linkedModelHandler.GetPlacementSuffix(atomicObjectByDocumentAndTransform);
               // normal conversions
               converted = converter.Convert(revitElement);
               converted.applicationId = applicationId;

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/RevitRootObjectBuilder.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/RevitRootObjectBuilder.cs
@@ -14,7 +14,6 @@ using Speckle.Converters.Common;
 using Speckle.Converters.RevitShared.Helpers;
 using Speckle.Converters.RevitShared.Settings;
 using Speckle.Sdk;
-using Speckle.Sdk.Common;
 using Speckle.Sdk.Models;
 using Speckle.Sdk.Models.Collections;
 using Speckle.Sdk.Pipelines.Progress;
@@ -206,14 +205,9 @@ public class RevitRootObjectBuilder(
             // not in cache means we convert
             else
             {
-              // if it has a transform we append transform hash to the applicationId to distinguish the elements from other instances
-              if (hasTransform)
-              {
-                string transformHash = linkedModelHandler.GetTransformHash(
-                  atomicObjectByDocumentAndTransform.Transform.NotNull()
-                );
-                applicationId = $"{applicationId}_t{transformHash}";
-              }
+              // linked elements get a placement hash appended to distinguish them from other placements of the
+              // same linked file [ENG-9263]
+              applicationId += linkedModelHandler.GetPlacementSuffix(atomicObjectByDocumentAndTransform);
               // normal conversions
               converted = converter.Convert(revitElement);
               converted.applicationId = applicationId;

--- a/Converters/Revit/Speckle.Converters.RevitShared/ServiceRegistration.cs
+++ b/Converters/Revit/Speckle.Converters.RevitShared/ServiceRegistration.cs
@@ -52,6 +52,7 @@ public static class ServiceRegistration
     serviceCollection.AddScoped<ParameterDefinitionHandler>();
     serviceCollection.AddScoped<ParameterExtractor>();
     serviceCollection.AddScoped<ClassPropertiesExtractor>();
+    serviceCollection.AddScoped<CompoundStructureExtractor>();
     serviceCollection.AddScoped<PropertiesExtractor>();
     serviceCollection.AddScoped<StructuralMaterialAssetExtractor>();
     serviceCollection.AddSingleton<CategoryExtractor>();

--- a/Converters/Revit/Speckle.Converters.RevitShared/Speckle.Converters.RevitShared.projitems
+++ b/Converters/Revit/Speckle.Converters.RevitShared/Speckle.Converters.RevitShared.projitems
@@ -54,6 +54,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)ToHost\Raw\Geometry\VectorConverterToHost.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ToSpeckle\Properties\PropertiesExtractor.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ToSpeckle\Properties\ClassPropertiesExtractor.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)ToSpeckle\Properties\CompoundStructureExtractor.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ToSpeckle\Properties\ParameterDefinitionHandler.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ToSpeckle\Properties\ParameterExtractor.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ToSpeckle\Properties\StructuralMaterialAssetExtractor.cs" />

--- a/Converters/Revit/Speckle.Converters.RevitShared/ToSpeckle/Properties/CompoundStructureExtractor.cs
+++ b/Converters/Revit/Speckle.Converters.RevitShared/ToSpeckle/Properties/CompoundStructureExtractor.cs
@@ -10,21 +10,12 @@ namespace Speckle.Converters.RevitShared.ToSpeckle.Properties;
 /// floors, roofs and ceilings alike. One record per layer: material name, layer function, thickness and units.
 /// </summary>
 /// <remarks>
-/// <para>
-/// Lives beside <c>Material Quantities</c> at the top of <c>properties</c>, NOT inside
+/// Lives beside <c>Material Quantities</c> at the top of <c>properties</c>, not inside
 /// <c>Parameters.Type Parameters</c> where <see cref="ParameterExtractor"/> used to build it [ENG-9338]. A compound
-/// structure is not a Revit parameter and never was — the old home is what routed it into the type-scoped eav
-/// table, where it could only be read back through a join, and what made the property flattener drop it as
-/// something it had no shape for. The extractor it was cohabiting with said as much: "this could be paired up and
-/// merged with material quantities - they're pretty much the same".
-/// </para>
-/// <para>
-/// Layers are keyed by ORDINAL in <c>GetLayers()</c> order, which is exterior → interior. The former
-/// <c>{material} ({layerId})</c> key carried no order at all — and a buildup without its order is not a buildup —
-/// minted one eav path per distinct material name, and broke the dot-delimited property paths whenever a material
-/// name contained a full stop ("Insulation 2.5mm"). A layer with no assigned material keeps its slot with a null
-/// material rather than being dropped, so the list never silently shortens.
-/// </para>
+/// structure is not a Revit parameter; the old home routed it into the type-scoped eav table, readable only through
+/// a join. Layers are keyed by ORDINAL in <c>GetLayers()</c> order (exterior → interior) — the former
+/// <c>{material} ({layerId})</c> key carried no order, minted one eav path per material name, and broke the
+/// dot-delimited paths on a name like "Insulation 2.5mm". A layer with no assigned material keeps its slot.
 /// </remarks>
 public class CompoundStructureExtractor
 {

--- a/Converters/Revit/Speckle.Converters.RevitShared/ToSpeckle/Properties/CompoundStructureExtractor.cs
+++ b/Converters/Revit/Speckle.Converters.RevitShared/ToSpeckle/Properties/CompoundStructureExtractor.cs
@@ -6,19 +6,11 @@ using Speckle.Converters.RevitShared.Settings;
 namespace Speckle.Converters.RevitShared.ToSpeckle.Properties;
 
 /// <summary>
-/// The layer buildup of a compound element type — every <see cref="DB.HostObjAttributes"/> subclass, so walls,
-/// floors, roofs and ceilings alike. One record per layer: material, function and thickness.
+/// The layer buildup of a compound element type — walls, floors, roofs, ceilings [ENG-9338]. Sits beside
+/// <c>Material Quantities</c> at the top of <c>properties</c>, not in <c>Parameters.Type Parameters</c>, which
+/// routed it into the type-scoped eav table where the flattener dropped it. Layers are keyed by ordinal in
+/// <c>GetLayers()</c> order (exterior → interior).
 /// </summary>
-/// <remarks>
-/// Lives beside <c>Material Quantities</c> at the top of <c>properties</c>, not inside
-/// <c>Parameters.Type Parameters</c> where <see cref="ParameterExtractor"/> used to build it [ENG-9338]. The old
-/// home routed it into the type-scoped eav table, readable only through a join, and the property flattener dropped
-/// it there outright. Each layer field is parameter-shaped (<c>{ name, value, units }</c>) — the same shape ODA
-/// publishes and the shape the flatten already collapses to one row per field with the unit on the row — so this
-/// needs no special-casing downstream. Layers are keyed by ORDINAL in <c>GetLayers()</c> order (exterior →
-/// interior); the former <c>{material} ({layerId})</c> key carried no order at all, and a buildup without its order
-/// is not a buildup.
-/// </remarks>
 public class CompoundStructureExtractor
 {
   private readonly IConverterSettingsStore<RevitConversionSettings> _settingsStore;
@@ -85,10 +77,8 @@ public class CompoundStructureExtractor
     return result;
   }
 
-  // The parameter shape the whole pipeline already understands — { name, value, units } — which is also what ODA
-  // publishes for every Revit property. EavExtraction's generic walk collapses it to one row per field with the
-  // unit on the row, so the layer buildup needs no special-casing anywhere downstream. A layer with no assigned
-  // material carries a null value and simply produces no material row.
+  // The parameter shape ODA publishes and the flatten already collapses to one row per field, unit on the row —
+  // so the buildup needs no special-casing downstream. A null value simply produces no row.
   private static Dictionary<string, object?> Field(string name, object? value, string? units = null)
   {
     var field = new Dictionary<string, object?>() { ["name"] = name, ["value"] = value };

--- a/Converters/Revit/Speckle.Converters.RevitShared/ToSpeckle/Properties/CompoundStructureExtractor.cs
+++ b/Converters/Revit/Speckle.Converters.RevitShared/ToSpeckle/Properties/CompoundStructureExtractor.cs
@@ -1,0 +1,86 @@
+using System.Globalization;
+using Speckle.Converters.Common;
+using Speckle.Converters.RevitShared.Services;
+using Speckle.Converters.RevitShared.Settings;
+
+namespace Speckle.Converters.RevitShared.ToSpeckle.Properties;
+
+/// <summary>
+/// The layer buildup of a compound element type — every <see cref="DB.HostObjAttributes"/> subclass, so walls,
+/// floors, roofs and ceilings alike. One record per layer: material name, layer function, thickness and units.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Lives beside <c>Material Quantities</c> at the top of <c>properties</c>, NOT inside
+/// <c>Parameters.Type Parameters</c> where <see cref="ParameterExtractor"/> used to build it [ENG-9338]. A compound
+/// structure is not a Revit parameter and never was — the old home is what routed it into the type-scoped eav
+/// table, where it could only be read back through a join, and what made the property flattener drop it as
+/// something it had no shape for. The extractor it was cohabiting with said as much: "this could be paired up and
+/// merged with material quantities - they're pretty much the same".
+/// </para>
+/// <para>
+/// Layers are keyed by ORDINAL in <c>GetLayers()</c> order, which is exterior → interior. The former
+/// <c>{material} ({layerId})</c> key carried no order at all — and a buildup without its order is not a buildup —
+/// minted one eav path per distinct material name, and broke the dot-delimited property paths whenever a material
+/// name contained a full stop ("Insulation 2.5mm"). A layer with no assigned material keeps its slot with a null
+/// material rather than being dropped, so the list never silently shortens.
+/// </para>
+/// </remarks>
+public class CompoundStructureExtractor
+{
+  private readonly IConverterSettingsStore<RevitConversionSettings> _settingsStore;
+  private readonly ScalingServiceToSpeckle _scalingServiceToSpeckle;
+
+  // Keyed by the type's UniqueId, which is unique across documents — an ElementId is not, and this extractor is
+  // scoped to the whole send operation: host document plus every linked model.
+  private readonly Dictionary<string, Dictionary<string, object?>> _structureCache = new();
+
+  public CompoundStructureExtractor(
+    IConverterSettingsStore<RevitConversionSettings> settingsStore,
+    ScalingServiceToSpeckle scalingServiceToSpeckle
+  )
+  {
+    _settingsStore = settingsStore;
+    _scalingServiceToSpeckle = scalingServiceToSpeckle;
+  }
+
+  /// <summary>
+  /// The layer buildup of <paramref name="element"/>'s type, or null when the type is not a compound element or
+  /// carries no compound structure (a curtain wall, a generic model, an in-place family).
+  /// </summary>
+  public Dictionary<string, object?>? GetCompoundStructure(DB.Element element)
+  {
+    if (_settingsStore.Current.Document.GetElement(element.GetTypeId()) is not DB.HostObjAttributes type)
+    {
+      return null;
+    }
+
+    if (_structureCache.TryGetValue(type.UniqueId, out Dictionary<string, object?>? cached))
+    {
+      return cached;
+    }
+
+    if (type.GetCompoundStructure() is not DB.CompoundStructure structure) // GetCompoundStructure can return null
+    {
+      return null;
+    }
+
+    var factor = _scalingServiceToSpeckle.ScaleLength(1);
+    var layers = structure.GetLayers();
+    var structureDictionary = new Dictionary<string, object?>();
+    for (int i = 0; i < layers.Count; i++)
+    {
+      var layer = layers[i];
+      structureDictionary[i.ToString(CultureInfo.InvariantCulture)] = new Dictionary<string, object?>()
+      {
+        ["material"] = (_settingsStore.Current.Document.GetElement(layer.MaterialId) as DB.Material)?.Name,
+        ["function"] = layer.Function.ToString(),
+        ["thickness"] = layer.Width * factor,
+        ["units"] = _settingsStore.Current.SpeckleUnits,
+      };
+    }
+
+    _structureCache[type.UniqueId] = structureDictionary;
+    return structureDictionary;
+  }
+}

--- a/Converters/Revit/Speckle.Converters.RevitShared/ToSpeckle/Properties/CompoundStructureExtractor.cs
+++ b/Converters/Revit/Speckle.Converters.RevitShared/ToSpeckle/Properties/CompoundStructureExtractor.cs
@@ -7,15 +7,17 @@ namespace Speckle.Converters.RevitShared.ToSpeckle.Properties;
 
 /// <summary>
 /// The layer buildup of a compound element type — every <see cref="DB.HostObjAttributes"/> subclass, so walls,
-/// floors, roofs and ceilings alike. One record per layer: material name, layer function, thickness and units.
+/// floors, roofs and ceilings alike. One record per layer: material, function and thickness.
 /// </summary>
 /// <remarks>
 /// Lives beside <c>Material Quantities</c> at the top of <c>properties</c>, not inside
-/// <c>Parameters.Type Parameters</c> where <see cref="ParameterExtractor"/> used to build it [ENG-9338]. A compound
-/// structure is not a Revit parameter; the old home routed it into the type-scoped eav table, readable only through
-/// a join. Layers are keyed by ORDINAL in <c>GetLayers()</c> order (exterior → interior) — the former
-/// <c>{material} ({layerId})</c> key carried no order, minted one eav path per material name, and broke the
-/// dot-delimited paths on a name like "Insulation 2.5mm". A layer with no assigned material keeps its slot.
+/// <c>Parameters.Type Parameters</c> where <see cref="ParameterExtractor"/> used to build it [ENG-9338]. The old
+/// home routed it into the type-scoped eav table, readable only through a join, and the property flattener dropped
+/// it there outright. Each layer field is parameter-shaped (<c>{ name, value, units }</c>) — the same shape ODA
+/// publishes and the shape the flatten already collapses to one row per field with the unit on the row — so this
+/// needs no special-casing downstream. Layers are keyed by ORDINAL in <c>GetLayers()</c> order (exterior →
+/// interior); the former <c>{material} ({layerId})</c> key carried no order at all, and a buildup without its order
+/// is not a buildup.
 /// </remarks>
 public class CompoundStructureExtractor
 {
@@ -67,16 +69,33 @@ public class CompoundStructureExtractor
       var layer = layers[i];
       structureDictionary[i.ToString(CultureInfo.InvariantCulture)] = new Dictionary<string, object?>()
       {
-        ["material"] = (_settingsStore.Current.Document.GetElement(layer.MaterialId) as DB.Material)?.Name,
-        ["function"] = layer.Function.ToString(),
-        ["thickness"] = layer.Width * factor,
-        ["units"] = _settingsStore.Current.SpeckleUnits,
+        ["material"] = Field(
+          "Material",
+          (_settingsStore.Current.Document.GetElement(layer.MaterialId) as DB.Material)?.Name
+        ),
+        ["function"] = Field("Function", layer.Function.ToString()),
+        ["thickness"] = Field("Thickness", layer.Width * factor, _settingsStore.Current.SpeckleUnits),
       };
     }
 
     // A structure with no layers is not a buildup — don't put an empty dict on the object.
     var result = structureDictionary.Count > 0 ? structureDictionary : null;
     _structureCache[type.UniqueId] = result;
+
     return result;
+  }
+
+  // The parameter shape the whole pipeline already understands — { name, value, units } — which is also what ODA
+  // publishes for every Revit property. EavExtraction's generic walk collapses it to one row per field with the
+  // unit on the row, so the layer buildup needs no special-casing anywhere downstream. A layer with no assigned
+  // material carries a null value and simply produces no material row.
+  private static Dictionary<string, object?> Field(string name, object? value, string? units = null)
+  {
+    var field = new Dictionary<string, object?>() { ["name"] = name, ["value"] = value };
+    if (units is not null)
+    {
+      field["units"] = units;
+    }
+    return field;
   }
 }

--- a/Converters/Revit/Speckle.Converters.RevitShared/ToSpeckle/Properties/CompoundStructureExtractor.cs
+++ b/Converters/Revit/Speckle.Converters.RevitShared/ToSpeckle/Properties/CompoundStructureExtractor.cs
@@ -24,7 +24,7 @@ public class CompoundStructureExtractor
 
   // Keyed by the type's UniqueId, which is unique across documents — an ElementId is not, and this extractor is
   // scoped to the whole send operation: host document plus every linked model.
-  private readonly Dictionary<string, Dictionary<string, object?>> _structureCache = new();
+  private readonly Dictionary<string, Dictionary<string, object?>?> _structureCache = new();
 
   public CompoundStructureExtractor(
     IConverterSettingsStore<RevitConversionSettings> settingsStore,
@@ -51,8 +51,11 @@ public class CompoundStructureExtractor
       return cached;
     }
 
+    // Cache the miss too: a curtain-wall type is a HostObjAttributes with no compound structure, and without a
+    // negative entry every one of its elements pays another GetCompoundStructure call.
     if (type.GetCompoundStructure() is not DB.CompoundStructure structure) // GetCompoundStructure can return null
     {
+      _structureCache[type.UniqueId] = null;
       return null;
     }
 
@@ -71,7 +74,9 @@ public class CompoundStructureExtractor
       };
     }
 
-    _structureCache[type.UniqueId] = structureDictionary;
-    return structureDictionary;
+    // A structure with no layers is not a buildup — don't put an empty dict on the object.
+    var result = structureDictionary.Count > 0 ? structureDictionary : null;
+    _structureCache[type.UniqueId] = result;
+    return result;
   }
 }

--- a/Converters/Revit/Speckle.Converters.RevitShared/ToSpeckle/Properties/ParameterExtractor.cs
+++ b/Converters/Revit/Speckle.Converters.RevitShared/ToSpeckle/Properties/ParameterExtractor.cs
@@ -88,12 +88,10 @@ public class ParameterExtractor
   }
 
   /// <summary>
-  /// Guarantees the Identity Data ▸ Type Name entry that ODA's <c>.rvt</c> reader always publishes, so the two
-  /// producers agree [ENG-8684]. <c>ALL_MODEL_TYPE_NAME</c> is read-only, is not reliably enumerated by
-  /// <c>ElementType.Parameters</c>, and a null <c>AsString()</c> is discarded unless
-  /// <c>SendParameterNullOrEmptyStrings</c> is on — so today it arrives by luck. A real parameter value always wins.
-  /// The group label is resolved the same way its siblings' are, so the entry lands inside "Identitätsdaten" with
-  /// them on a German install rather than stranding a lone English group.
+  /// Guarantees the Identity Data ▸ Type Name entry ODA always publishes, so the two producers agree [ENG-8684].
+  /// <c>ALL_MODEL_TYPE_NAME</c> is read-only and not reliably enumerated, so today it arrives by luck; fill it in
+  /// from <c>ElementType.Name</c>, letting a real parameter value win. The group label is resolved the same way its
+  /// siblings' are, so it lands with them in the host's language rather than in a lone English group.
   /// </summary>
   private void EnsureTypeName(DB.ElementType type, Dictionary<string, Dictionary<string, object?>> typeParameters)
   {

--- a/Converters/Revit/Speckle.Converters.RevitShared/ToSpeckle/Properties/ParameterExtractor.cs
+++ b/Converters/Revit/Speckle.Converters.RevitShared/ToSpeckle/Properties/ParameterExtractor.cs
@@ -31,10 +31,12 @@ public class ParameterExtractor
     _scalingServiceToSpeckle = scalingServiceToSpeckle;
   }
 
-  private readonly Dictionary<DB.ElementId, Dictionary<string, Dictionary<string, object?>>> _typeParameterCache =
-    new();
+  // All three caches are keyed by UniqueId, NOT ElementId. An ElementId is only unique WITHIN a document, and this
+  // extractor is scoped to the whole send operation — host document plus every linked model — so an ElementId key
+  // served a linked type's parameters from whichever document got there first.
+  private readonly Dictionary<string, Dictionary<string, Dictionary<string, object?>>> _typeParameterCache = new();
 
-  private readonly Dictionary<DB.ElementId, Dictionary<string, Dictionary<string, object?>>> _systemTypeParameterCache =
+  private readonly Dictionary<string, Dictionary<string, Dictionary<string, object?>>> _systemTypeParameterCache =
     new();
 
   /// <summary>
@@ -61,9 +63,14 @@ public class ParameterExtractor
       return null;
     }
 
+    if (_settingsStore.Current.Document.GetElement(typeId) is not DB.ElementType type)
+    {
+      return null;
+    }
+
     if (
       _typeParameterCache.TryGetValue(
-        typeId,
+        type.UniqueId,
         out Dictionary<string, Dictionary<string, object?>>? typeParameterDictionary
       )
     )
@@ -71,17 +78,12 @@ public class ParameterExtractor
       return typeParameterDictionary;
     }
 
-    if (_settingsStore.Current.Document.GetElement(typeId) is not DB.ElementType type)
-    {
-      return null;
-    }
-
     // NOTE: compound structure used to be grafted on here as a pseudo type parameter. It now lives at the top of
     // `properties` beside Material Quantities — see CompoundStructureExtractor [ENG-9338].
     typeParameterDictionary = ParseParameterSet(type.Parameters); // NOTE: type parameters should be ideally proxied out for a better data layout.
     EnsureTypeName(type, typeParameterDictionary);
 
-    _typeParameterCache[typeId] = typeParameterDictionary;
+    _typeParameterCache[type.UniqueId] = typeParameterDictionary;
     return typeParameterDictionary;
   }
 
@@ -142,11 +144,11 @@ public class ParameterExtractor
 
     if (system != null)
     {
-      DB.ElementId systemTypeId = system.GetTypeId();
+      DB.Element systemType = _settingsStore.Current.Document.GetElement(system.GetTypeId());
 
       if (
         _systemTypeParameterCache.TryGetValue(
-          systemTypeId,
+          systemType.UniqueId,
           out Dictionary<string, Dictionary<string, object?>>? systemTypeParameterDictionary
         )
       )
@@ -154,9 +156,8 @@ public class ParameterExtractor
         return systemTypeParameterDictionary;
       }
 
-      DB.Element systemType = _settingsStore.Current.Document.GetElement(systemTypeId);
       systemTypeParameterDictionary = ParseParameterSet(systemType.Parameters);
-      _systemTypeParameterCache[systemTypeId] = systemTypeParameterDictionary;
+      _systemTypeParameterCache[systemType.UniqueId] = systemTypeParameterDictionary;
       return systemTypeParameterDictionary;
     }
 
@@ -270,7 +271,7 @@ public class ParameterExtractor
     return dict;
   }
 
-  private readonly Dictionary<DB.ElementId, object?> _elementNameCache = new();
+  private readonly Dictionary<string, object?> _elementNameCache = new();
 
   private object? GetValue(DB.Parameter parameter)
   {
@@ -297,12 +298,17 @@ public class ParameterExtractor
           return null;
         }
 
-        if (_elementNameCache.TryGetValue(elId, out object? value))
+        var docElement = _settingsStore.Current.Document.GetElement(elId);
+        if (docElement is null)
+        {
+          return null;
+        }
+
+        if (_elementNameCache.TryGetValue(docElement.UniqueId, out object? value))
         {
           return value;
         }
 
-        var docElement = _settingsStore.Current.Document.GetElement(elId);
         object? docElementName;
 
         // Note: for element types, different params point at the same element. We're getting the right value out in the parent function
@@ -313,10 +319,10 @@ public class ParameterExtractor
         }
         else
         {
-          docElementName = docElement?.Name ?? null;
+          docElementName = docElement.Name;
         }
 
-        _elementNameCache[parameter.AsElementId()] = docElementName;
+        _elementNameCache[docElement.UniqueId] = docElementName;
         return docElementName;
       case DB.StorageType.String:
       default:

--- a/Converters/Revit/Speckle.Converters.RevitShared/ToSpeckle/Properties/ParameterExtractor.cs
+++ b/Converters/Revit/Speckle.Converters.RevitShared/ToSpeckle/Properties/ParameterExtractor.cs
@@ -76,32 +76,9 @@ public class ParameterExtractor
       return null;
     }
 
+    // NOTE: compound structure used to be grafted on here as a pseudo type parameter. It now lives at the top of
+    // `properties` beside Material Quantities — see CompoundStructureExtractor [ENG-9338].
     typeParameterDictionary = ParseParameterSet(type.Parameters); // NOTE: type parameters should be ideally proxied out for a better data layout.
-    if (type is DB.HostObjAttributes hostObjectAttr)
-    {
-      // NOTE: this could be paired up and merged with material quantities - they're pretty much the same :/
-      var factor = _scalingServiceToSpeckle.ScaleLength(1);
-      if (hostObjectAttr.GetCompoundStructure() is DB.CompoundStructure structure) // GetCompoundStructure can return null
-      {
-        Dictionary<string, object?> structureDictionary = new();
-        foreach (var layer in structure.GetLayers())
-        {
-          if (_settingsStore.Current.Document.GetElement(layer.MaterialId) is DB.Material material)
-          {
-            var uniqueLayerName = $"{material.Name} ({layer.LayerId})";
-            structureDictionary[uniqueLayerName] = new Dictionary<string, object>()
-            {
-              ["material"] = material.Name,
-              ["function"] = layer.Function.ToString(),
-              ["thickness"] = layer.Width * factor,
-              ["units"] = _settingsStore.Current.SpeckleUnits,
-            };
-          }
-        }
-
-        typeParameterDictionary["Structure"] = structureDictionary;
-      }
-    }
 
     _typeParameterCache[typeId] = typeParameterDictionary;
     return typeParameterDictionary;

--- a/Converters/Revit/Speckle.Converters.RevitShared/ToSpeckle/Properties/ParameterExtractor.cs
+++ b/Converters/Revit/Speckle.Converters.RevitShared/ToSpeckle/Properties/ParameterExtractor.cs
@@ -89,15 +89,12 @@ public class ParameterExtractor
 
   /// <summary>
   /// Guarantees the Identity Data ▸ Type Name entry that ODA's <c>.rvt</c> reader always publishes, so the two
-  /// producers agree about it [ENG-8684]. <c>ALL_MODEL_TYPE_NAME</c> is read-only: it is not reliably enumerated by
-  /// <c>ElementType.Parameters</c>, <c>AsString()</c> can come back null, and a null value is then discarded unless
-  /// <c>SendParameterNullOrEmptyStrings</c> is on — so the type's own name reaches the bundle by luck rather than by
-  /// contract. Fill it in from <c>ElementType.Name</c>; a real parameter that already produced a value always wins.
-  /// </summary>
-  /// <remarks>
+  /// producers agree [ENG-8684]. <c>ALL_MODEL_TYPE_NAME</c> is read-only, is not reliably enumerated by
+  /// <c>ElementType.Parameters</c>, and a null <c>AsString()</c> is discarded unless
+  /// <c>SendParameterNullOrEmptyStrings</c> is on — so today it arrives by luck. A real parameter value always wins.
   /// The group label is resolved the same way its siblings' are, so the entry lands inside "Identitätsdaten" with
-  /// the rest of the identity parameters on a German install instead of stranding a lone English group beside them.
-  /// </remarks>
+  /// them on a German install rather than stranding a lone English group.
+  /// </summary>
   private void EnsureTypeName(DB.ElementType type, Dictionary<string, Dictionary<string, object?>> typeParameters)
   {
     string humanReadableName = "Type Name";

--- a/Converters/Revit/Speckle.Converters.RevitShared/ToSpeckle/Properties/ParameterExtractor.cs
+++ b/Converters/Revit/Speckle.Converters.RevitShared/ToSpeckle/Properties/ParameterExtractor.cs
@@ -79,9 +79,61 @@ public class ParameterExtractor
     // NOTE: compound structure used to be grafted on here as a pseudo type parameter. It now lives at the top of
     // `properties` beside Material Quantities — see CompoundStructureExtractor [ENG-9338].
     typeParameterDictionary = ParseParameterSet(type.Parameters); // NOTE: type parameters should be ideally proxied out for a better data layout.
+    EnsureTypeName(type, typeParameterDictionary);
 
     _typeParameterCache[typeId] = typeParameterDictionary;
     return typeParameterDictionary;
+  }
+
+  /// <summary>
+  /// Guarantees the Identity Data ▸ Type Name entry that ODA's <c>.rvt</c> reader always publishes, so the two
+  /// producers agree about it [ENG-8684]. <c>ALL_MODEL_TYPE_NAME</c> is read-only: it is not reliably enumerated by
+  /// <c>ElementType.Parameters</c>, <c>AsString()</c> can come back null, and a null value is then discarded unless
+  /// <c>SendParameterNullOrEmptyStrings</c> is on — so the type's own name reaches the bundle by luck rather than by
+  /// contract. Fill it in from <c>ElementType.Name</c>; a real parameter that already produced a value always wins.
+  /// </summary>
+  /// <remarks>
+  /// The group label is resolved the same way its siblings' are, so the entry lands inside "Identitätsdaten" with
+  /// the rest of the identity parameters on a German install instead of stranding a lone English group beside them.
+  /// </remarks>
+  private void EnsureTypeName(DB.ElementType type, Dictionary<string, Dictionary<string, object?>> typeParameters)
+  {
+    string humanReadableName = "Type Name";
+    string groupName;
+
+    if (type.get_Parameter(DB.BuiltInParameter.ALL_MODEL_TYPE_NAME) is DB.Parameter parameter)
+    {
+      (_, humanReadableName, groupName, _) = _parameterDefinitionHandler.HandleDefinition(parameter);
+    }
+    else
+    {
+      groupName = DB.LabelUtils.GetLabelForGroup(DB.GroupTypeId.IdentityData);
+    }
+
+    if (!typeParameters.TryGetValue(groupName, out Dictionary<string, object?>? group))
+    {
+      group = new Dictionary<string, object?>();
+      typeParameters[groupName] = group;
+    }
+
+    // ParseParameterSet already got a real value out of Revit — leave it exactly as it found it.
+    if (
+      group.TryGetValue(humanReadableName, out var existing)
+      && existing is Dictionary<string, object?> record
+      && record.TryGetValue("value", out var existingValue)
+      && existingValue is string existingName
+      && !string.IsNullOrEmpty(existingName)
+    )
+    {
+      return;
+    }
+
+    group[humanReadableName] = new Dictionary<string, object?>()
+    {
+      ["value"] = type.Name,
+      ["name"] = humanReadableName,
+      ["internalDefinitionName"] = "ALL_MODEL_TYPE_NAME",
+    };
   }
 
   private Dictionary<string, Dictionary<string, object?>>? GetSystemTypeParameterDictionary(DB.Element element)

--- a/Converters/Revit/Speckle.Converters.RevitShared/ToSpeckle/Properties/PropertiesExtractor.cs
+++ b/Converters/Revit/Speckle.Converters.RevitShared/ToSpeckle/Properties/PropertiesExtractor.cs
@@ -6,16 +6,19 @@ public class PropertiesExtractor
 {
   private readonly ClassPropertiesExtractor _classPropertiesExtractor;
   private readonly ParameterExtractor _parameterExtractor;
+  private readonly CompoundStructureExtractor _compoundStructureExtractor;
   private readonly ITypedConverter<DB.Element, Dictionary<string, object>> _materialQuantityConverter;
 
   public PropertiesExtractor(
     ClassPropertiesExtractor classPropertiesExtractor,
     ParameterExtractor parameterExtractor,
+    CompoundStructureExtractor compoundStructureExtractor,
     ITypedConverter<DB.Element, Dictionary<string, object>> materialQuantityConverter
   )
   {
     _classPropertiesExtractor = classPropertiesExtractor;
     _parameterExtractor = parameterExtractor;
+    _compoundStructureExtractor = compoundStructureExtractor;
     _materialQuantityConverter = materialQuantityConverter;
   }
 
@@ -29,6 +32,12 @@ public class PropertiesExtractor
     if (matQuantities.Count > 0)
     {
       properties.Add("Material Quantities", matQuantities);
+    }
+
+    // add the compound element layer buildup, if this element's type has one
+    if (_compoundStructureExtractor.GetCompoundStructure(element) is Dictionary<string, object?> structure)
+    {
+      properties.Add("Structure", structure);
     }
 
     // add parameters

--- a/Converters/Revit/Speckle.Converters.RevitShared/ToSpeckle/Properties/PropertiesExtractor.cs
+++ b/Converters/Revit/Speckle.Converters.RevitShared/ToSpeckle/Properties/PropertiesExtractor.cs
@@ -37,7 +37,7 @@ public class PropertiesExtractor
     // add the compound element layer buildup, if this element's type has one
     if (_compoundStructureExtractor.GetCompoundStructure(element) is Dictionary<string, object?> structure)
     {
-      properties.Add("Compound Structure", structure);
+      properties.Add("Structure", structure);
     }
 
     // add parameters

--- a/Converters/Revit/Speckle.Converters.RevitShared/ToSpeckle/Properties/PropertiesExtractor.cs
+++ b/Converters/Revit/Speckle.Converters.RevitShared/ToSpeckle/Properties/PropertiesExtractor.cs
@@ -37,7 +37,7 @@ public class PropertiesExtractor
     // add the compound element layer buildup, if this element's type has one
     if (_compoundStructureExtractor.GetCompoundStructure(element) is Dictionary<string, object?> structure)
     {
-      properties.Add("Structure", structure);
+      properties.Add("Compound Structure", structure);
     }
 
     // add parameters


### PR DESCRIPTION
## Description

Four Revit regressions on `big-truck`.
- [ENG-9338: Revit: wall, floor and roof layer structure is missing from published data](https://linear.app/speckle/issue/ENG-9338/revit-wall-floor-and-roof-layer-structure-is-missing-from-published)
- [ENG-9337: Revit: received elements land in the wrong category when host and source Revit languages differ](https://linear.app/speckle/issue/ENG-9337/revit-received-elements-land-in-the-wrong-category-when-host-and)
- [ENG-8684: Type Name eav prop for revit files seems to have slipped post normalisation](https://linear.app/speckle/issue/ENG-8684/type-name-eav-prop-for-revit-files-seems-to-have-slipped-post)
- [ENG-9263: Revit: linked-model transform hash is lossy — coincident-origin placements collide into one identity](https://linear.app/speckle/issue/ENG-9263/revit-linked-model-transform-hash-is-lossy-coincident-origin)

## Changes:

- `CompoundStructureExtractor`: layer buildup at `properties.Structure`, ordinal-keyed, material-less layers kept
- `RevitHostObjectArtefactBuilder`: read nested `builtInCategory`; identifier → display name → Generic Models as a real ladder; cache key from both values
- `LinkedModelHandler`: placement identity from `RevitLinkInstance.UniqueId`, for the container key and the app-id suffix alike, on the 4.0 and legacy paths. `GetTransformHash` and `FindLinkInstanceForDocument` deleted
- `ParameterExtractor`: `Type Name` guaranteed; caches keyed by UniqueId rather than `ElementId` (unique only *within* a document, while the extractor spans host + every link)

## Validation of changes:

### ENG-9338
Model with a multi-layer wall, floor, roof, ceiling; one layer with no material; one curtain wall:
- [x] `Structure` keyed `0,1,2…`, each with `material` / `function` / `thickness` + unit
- [x] Order matches Revit's Edit Assembly dialog (exterior → interior)
- [x] Thickness in document display units

<img width="960" height="1044" alt="image" src="https://github.com/user-attachments/assets/66e8ade0-c20d-4846-a264-c04ccdb67ca9" />


### ENG-9337
Model with walls, doors, windows, families:
- [x] Load into German Revit → source categories, not Generic Models
- [x] Both with "receive instances as families" ON and OFF

<img width="1267" height="858" alt="image" src="https://github.com/user-attachments/assets/160117a4-198a-4ebd-9914-2de0c3199ff6" />

### ENG-9263
Same RVT linked twice at the same origin, +90°/−90°:
- [x] Two separate Model nodes; both placements' geometry present
- [x] Rotational array → one occurrence per placement

Host-model:
- [x] Reference point set to Survey / Shared Coordinates → editing a **host** wall parameter succeeds (no "Cannot modify elements from a linked model")

### ENG-8684
- [x] `Type Name` under Type Parameters → Identity Data = the type's actual name

## Checklist:

- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] I have added appropriate tests.
- [x] I have updated or added relevant documentation.