### PR TITLE
fix(civil3d): four property-set definition fidelity fixes (ENG-9360/9361/9362/9363)

### DIFF
--- a/Connectors/Autocad/Speckle.Connectors.Civil3dShared/HostApp/PropertySetBaker.cs
+++ b/Connectors/Autocad/Speckle.Connectors.Civil3dShared/HostApp/PropertySetBaker.cs
@@ -1,4 +1,4 @@
-using System.Globalization;
+﻿using System.Globalization;
 using Microsoft.Extensions.Logging;
 using Speckle.Connectors.Common.Operations;
 using Speckle.Converters.Civil3dShared;
@@ -431,15 +431,16 @@ public class PropertySetBaker
   }
 
   /// <summary>The set_key recipe computed over a LIVE definition's fields, for reuse-if-identical. Mirrors
-  /// the send-side capture exactly: DataType.ToString(), unit = UnitType display text (throw → absent, and
-  /// deliberately NOT "(none)"-filtered — the send handler doesn't filter it either).</summary>
+  /// the send-side capture exactly: DataType.ToString(), unit = PropertyHandler.TryGetUnitDisplay (throw and
+  /// "(none)" both → null). Must stay in step with PropertySetDefinitionHandler: filter here without filtering
+  /// there (or vice versa) and every re-receive of an unchanged schema mints a "-{prefix}" copy [ENG-9360].</summary>
   private string ComputeExistingDefinitionKey(string setName, ADB.ObjectId defId, ADB.Transaction tr)
   {
     var setDefinition = (AAECPDB.PropertySetDefinition)tr.GetObject(defId, ADB.OpenMode.ForRead);
     var fields = new List<(string Name, string? DataType, string? Unit)>();
     foreach (AAECPDB.PropertyDefinition propDef in setDefinition.Definitions)
     {
-      _propertyHandler.TryGetValue(() => propDef.UnitType.GetTypeDisplayName(true), out string? unit);
+      string? unit = _propertyHandler.TryGetUnitDisplay(() => propDef.UnitType.GetTypeDisplayName(true));
       fields.Add((propDef.Name, propDef.DataType.ToString(), unit));
     }
     return PropertySetDefinitionLadder.ComputeSetKey(setName, fields);

--- a/Connectors/Autocad/Speckle.Connectors.Civil3dShared/HostApp/PropertySetBaker.cs
+++ b/Connectors/Autocad/Speckle.Connectors.Civil3dShared/HostApp/PropertySetBaker.cs
@@ -446,6 +446,39 @@ public class PropertySetBaker
     return PropertySetDefinitionLadder.ComputeSetKey(setName, fields);
   }
 
+  /// <summary>Scopes the definition to the entity types the sender captured in applies_to; a NULL/empty column
+  /// means apply-to-all — the sender either had an apply-to-all set, or is a producer that cannot enumerate the
+  /// filter (dwgextract) [ENG-9362]. Object-based only: the sender never publishes style filters, so byStyle is
+  /// false. A class name the receiving Civil 3D release does not know makes SetAppliesToFilter throw — that
+  /// degrades to apply-to-all rather than losing the definition.</summary>
+  private void ApplyAppliesTo(AAECPDB.PropertySetDefinition propSetDef, PropertySetSchema schema)
+  {
+    string[] classNames = schema.AppliesTo?.Split(',').Select(n => n.Trim()).Where(n => n.Length > 0).ToArray() ?? [];
+    if (classNames.Length == 0)
+    {
+      propSetDef.AppliesToAll = true;
+      return;
+    }
+
+    try
+    {
+      System.Collections.Specialized.StringCollection filter = new();
+      filter.AddRange(classNames);
+      propSetDef.SetAppliesToFilter(filter, false);
+      propSetDef.AppliesToAll = false;
+    }
+    catch (Exception ex) when (!ex.IsFatal())
+    {
+      _logger.LogWarning(
+        ex,
+        "Could not scope property set definition {SetName} to {AppliesTo}; it applies to all object types",
+        schema.SetName,
+        schema.AppliesTo
+      );
+      propSetDef.AppliesToAll = true;
+    }
+  }
+
   private ADB.ObjectId CreatePropertySetDefinitionFromSchema(
     PropertySetSchema schema,
     string recordName,
@@ -462,9 +495,7 @@ public class PropertySetBaker
     {
       propSetDef.Description = schema.SetDescription;
     }
-    // schema.AppliesTo is shipped but not applied: only AppliesToAll has repo-confirmed API surface
-    // (expected filter member: PropertySetDefinition.AppliesToFilter — wire when confirmed on Windows).
-    propSetDef.AppliesToAll = true;
+    ApplyAppliesTo(propSetDef, schema);
 
     foreach (var field in schema.Fields)
     {
@@ -611,6 +642,8 @@ public class PropertySetBaker
     propSetDef.SetToStandard(db);
     propSetDef.SubSetDatabaseDefaults(db);
     //propSetDef.Description = "Property Set Definition added by Speckle"; // POC: should use the description that was published. can this back in if needed
+    // The tier-2 carrier never shipped an entity-type filter, so apply-to-all is all this path can honour;
+    // tier-1 schemas go through ApplyAppliesTo instead [ENG-9362].
     propSetDef.AppliesToAll = true;
 
     foreach (var propertyDefinition in propertyDefinitions)

--- a/Connectors/Autocad/Speckle.Connectors.Civil3dShared/HostApp/PropertySetBaker.cs
+++ b/Connectors/Autocad/Speckle.Connectors.Civil3dShared/HostApp/PropertySetBaker.cs
@@ -1,4 +1,4 @@
-﻿using System.Globalization;
+using System.Globalization;
 using Microsoft.Extensions.Logging;
 using Speckle.Connectors.Common.Operations;
 using Speckle.Converters.Civil3dShared;
@@ -24,14 +24,20 @@ public class PropertySetBaker
   private readonly ILogger<PropertySetBaker> _logger;
   private readonly PropertyHandler _propertyHandler;
 
-  /// <summary>
-  /// Map of property set definition name to its ObjectId. Populated during ParsePropertySetDefinitions.
-  /// </summary>
-  private readonly Dictionary<string, ADB.ObjectId> _propertySetDefinitionMap = new();
+  /// <summary>Map of property set definition name to every definition baked under that name, in schema order.
+  /// A LIST because Civil 3D allows two same-named definitions and the bundle keeps them apart by set_key; the
+  /// value paths carry only the name, so which one an object's values belong to is decided per object by
+  /// <see cref="SelectDefinition"/> [ENG-9363]. Populated during ParsePropertySetDefinitions / BakeSchemas.</summary>
+  private readonly Dictionary<string, List<BakedDefinition>> _propertySetDefinitionMap = new();
 
-  /// <summary>set name → (FieldBucketId → field name), from tier-1/3 schemas — the rebind's join index.
-  /// Empty for carrier-built definitions (tier 2), which never shipped bucket ids.</summary>
-  private readonly Dictionary<string, Dictionary<string, string>> _bucketToFieldNameBySet = new();
+  /// <summary>One definition baked this run: its ObjectId, its (FieldBucketId → field name) rebind index, and
+  /// its field names. The latter two are what tell same-named definitions apart. Both are empty for
+  /// carrier-built definitions (tier 2), which never shipped bucket ids.</summary>
+  private sealed record BakedDefinition(
+    ADB.ObjectId DefId,
+    Dictionary<string, string> BucketToFieldName,
+    HashSet<string> FieldNames
+  );
 
   public PropertySetBaker(
     IConverterSettingsStore<Civil3dConversionSettings> settingsStore,
@@ -94,7 +100,6 @@ public class PropertySetBaker
   public void ParseAndBakePropertySetDefinitions(Dictionary<string, object?> definitions, string namePrefix)
   {
     _propertySetDefinitionMap.Clear();
-    _bucketToFieldNameBySet.Clear();
     ResetRunCounters();
 
     if (definitions.Count == 0)
@@ -134,7 +139,7 @@ public class PropertySetBaker
         ADB.ObjectId defId = CreatePropertySetDefinition(setName, propertyDefinitions, namePrefix, tr);
         if (!defId.IsNull)
         {
-          _propertySetDefinitionMap[setName] = defId;
+          Register(setName, defId, new Dictionary<string, string>(), new HashSet<string>(propertyDefinitions.Keys));
         }
       }
       catch (Exception ex) when (!ex.IsFatal())
@@ -152,7 +157,6 @@ public class PropertySetBaker
   public void BakeSchemas(IReadOnlyList<PropertySetSchema> schemas, string namePrefix)
   {
     _propertySetDefinitionMap.Clear();
-    _bucketToFieldNameBySet.Clear();
     ResetRunCounters();
     if (schemas.Count == 0)
     {
@@ -162,14 +166,9 @@ public class PropertySetBaker
     using var tr = _settingsStore.Current.Document.Database.TransactionManager.StartTransaction();
     foreach (var schema in schemas)
     {
-      if (_propertySetDefinitionMap.ContainsKey(schema.SetName))
-      {
-        // Two same-named sets (distinct set_key). The name-keyed map — and the value paths, which only
-        // carry the name — cannot address both: first wins, matching send's first-wins Definitions dict.
-        _logger.LogWarning("Duplicate property set name {SetName}; keeping the first definition", schema.SetName);
-        continue;
-      }
-
+      // Two same-named schemas (distinct set_key) are BOTH baked — the second lands under "{name}-{prefix}",
+      // because the reuse check below compares set_key and cannot match it to the first. Which one an object's
+      // values attach to is decided per object by SelectDefinition [ENG-9363].
       // Naming/collision policy [user feedback: no blanket project-name prefixing]:
       //   (a) an existing def with the ORIGINAL name that is schema-identical (same set_key recipe over its
       //       live fields) is REUSED — no create, no prefix; re-receives of unchanged schemas converge here,
@@ -190,8 +189,7 @@ public class PropertySetBaker
             TryReadSetKeyStamp(existingId, tr) ?? ComputeExistingDefinitionKey(schema.SetName, existingId, tr);
           if (string.Equals(incomingKey, existingKey, StringComparison.OrdinalIgnoreCase))
           {
-            _propertySetDefinitionMap[schema.SetName] = existingId;
-            AddBucketMap(schema);
+            Register(schema, existingId);
             DefinitionsReused++;
             CleanupRetryCopies(schema.SetName, incomingKey, existingId, tr);
             continue;
@@ -211,8 +209,7 @@ public class PropertySetBaker
         {
           continue;
         }
-        _propertySetDefinitionMap[schema.SetName] = defId;
-        AddBucketMap(schema);
+        Register(schema, defId);
         CleanupRetryCopies(schema.SetName, PropertySetDefinitionLadder.EffectiveSetKey(schema), defId, tr);
       }
       catch (Exception ex) when (!ex.IsFatal())
@@ -296,7 +293,7 @@ public class PropertySetBaker
   public int DefinitionsCreated { get; private set; }
   public int DefinitionsReused { get; private set; }
 
-  public int DefinitionCount => _propertySetDefinitionMap.Count;
+  public int DefinitionCount => _propertySetDefinitionMap.Values.Sum(baked => baked.Count);
 
   private void ResetRunCounters()
   {
@@ -304,20 +301,83 @@ public class PropertySetBaker
     DefinitionsReused = 0;
   }
 
-  private void AddBucketMap(PropertySetSchema schema)
+  private void Register(PropertySetSchema schema, ADB.ObjectId defId)
   {
     var bucketMap = new Dictionary<string, string>();
+    var fieldNames = new HashSet<string>(StringComparer.Ordinal);
     foreach (var field in schema.Fields)
     {
+      fieldNames.Add(field.Name);
       if (field.BucketId is not null)
       {
         bucketMap[field.BucketId] = field.Name;
       }
     }
-    if (bucketMap.Count > 0)
+    Register(schema.SetName, defId, bucketMap, fieldNames);
+  }
+
+  private void Register(
+    string setName,
+    ADB.ObjectId defId,
+    Dictionary<string, string> bucketMap,
+    HashSet<string> fieldNames
+  )
+  {
+    if (!_propertySetDefinitionMap.TryGetValue(setName, out var baked))
     {
-      _bucketToFieldNameBySet[schema.SetName] = bucketMap;
+      baked = new List<BakedDefinition>();
+      _propertySetDefinitionMap[setName] = baked;
     }
+    if (baked.Count > 0)
+    {
+      _logger.LogInformation(
+        "Property set name {SetName} now has {Count} definitions; values are matched to one by field_bucket_id",
+        setName,
+        baked.Count + 1
+      );
+    }
+    baked.Add(new BakedDefinition(defId, bucketMap, fieldNames));
+  }
+
+  /// <summary>Picks which of several same-named definitions THIS object's values belong to. The value paths
+  /// carry only the set name, so the discriminator is field_bucket_id membership — the rule the spec names for
+  /// exactly this case — with field-name overlap as the tiebreak for producers that ship no bucket ids. The
+  /// single-candidate case (every ordinary drawing) short-circuits and behaves as before [ENG-9363].</summary>
+  private static BakedDefinition SelectDefinition(List<BakedDefinition> candidates, Dictionary<string, object?> setData)
+  {
+    if (candidates.Count == 1)
+    {
+      return candidates[0];
+    }
+
+    BakedDefinition best = candidates[0];
+    int bestScore = -1;
+    foreach (var candidate in candidates)
+    {
+      int score = 0;
+      foreach (var entry in setData)
+      {
+        string? bucketId =
+          entry.Value is Dictionary<string, object?> leaf && leaf.TryGetValue("internalDefinitionName", out var idn)
+            ? idn as string
+            : null;
+        // A bucket-id hit is hard evidence; a field-name hit is weaker (same-named sets often share names).
+        if (bucketId is { Length: > 0 } && candidate.BucketToFieldName.ContainsKey(bucketId))
+        {
+          score += 2;
+        }
+        else if (candidate.FieldNames.Contains(entry.Key))
+        {
+          score += 1;
+        }
+      }
+      if (score > bestScore)
+      {
+        bestScore = score;
+        best = candidate;
+      }
+    }
+    return best;
   }
 
   private const string SET_KEY_XRECORD = "SPECKLE_SET_KEY";
@@ -606,18 +666,19 @@ public class PropertySetBaker
   {
     try
     {
-      if (!_propertySetDefinitionMap.TryGetValue(setName, out ADB.ObjectId propertySetDefId))
+      if (!_propertySetDefinitionMap.TryGetValue(setName, out var candidates) || candidates.Count == 0)
       {
         _logger.LogWarning("Property set definition {SetName} not found in definition map", setName);
         return false;
       }
 
-      if (propertySetDefId.IsNull)
+      BakedDefinition baked = SelectDefinition(candidates, setData);
+      if (baked.DefId.IsNull)
       {
         return false;
       }
 
-      return AddPropertySetToEntity(entity, setName, propertySetDefId, setData, tr);
+      return AddPropertySetToEntity(entity, setName, baked, setData, tr);
     }
     catch (Exception ex) when (!ex.IsFatal())
     {
@@ -734,11 +795,12 @@ public class PropertySetBaker
   private bool AddPropertySetToEntity(
     ADB.Entity entity,
     string setName,
-    ADB.ObjectId propertySetDefId,
+    BakedDefinition baked,
     Dictionary<string, object?> setData,
     ADB.Transaction tr
   )
   {
+    ADB.ObjectId propertySetDefId = baked.DefId;
     try
     {
       if (!entity.IsWriteEnabled)
@@ -753,23 +815,23 @@ public class PropertySetBaker
         AAECPDB.PropertyDataServices.AddPropertySet(entity, propertySetDefId);
       }
 
-      return TrySetPropertyValues(entity, setName, propertySetDefId, setData, tr);
+      return TrySetPropertyValues(entity, baked, setData, tr);
     }
     catch (Exception ex) when (!ex.IsFatal())
     {
-      _logger.LogWarning(ex, "Failed to add property set to entity");
+      _logger.LogWarning(ex, "Failed to add property set {SetName} to entity", setName);
       return false;
     }
   }
 
   private bool TrySetPropertyValues(
     ADB.Entity entity,
-    string setName,
-    ADB.ObjectId propertySetDefId,
+    BakedDefinition baked,
     Dictionary<string, object?> setData,
     ADB.Transaction tr
   )
   {
+    ADB.ObjectId propertySetDefId = baked.DefId;
     try
     {
       ADB.ObjectId propertySetId = AAECPDB.PropertyDataServices.GetPropertySet(entity, propertySetDefId);
@@ -783,7 +845,7 @@ public class PropertySetBaker
         propertyNameToDef[propDef.Name] = (propDef.Id, propDef.DataType);
       }
 
-      _bucketToFieldNameBySet.TryGetValue(setName, out var bucketMap);
+      var bucketMap = baked.BucketToFieldName;
       foreach (var propertyEntry in setData)
       {
         // Bucket-id-first field matching: internalDefinitionName is the FieldBucketId the producer shipped;

--- a/Connectors/Autocad/Speckle.Connectors.Civil3dShared/HostApp/PropertySetDefinitionLadder.cs
+++ b/Connectors/Autocad/Speckle.Connectors.Civil3dShared/HostApp/PropertySetDefinitionLadder.cs
@@ -1,4 +1,4 @@
-﻿using Speckle.Sdk.Pipelines.Receive.Artifacts;
+using Speckle.Sdk.Pipelines.Receive.Artifacts;
 
 namespace Speckle.Connectors.Civil3dShared.HostApp;
 

--- a/Connectors/Autocad/Speckle.Connectors.Civil3dShared/HostApp/PropertySetDefinitionLadder.cs
+++ b/Connectors/Autocad/Speckle.Connectors.Civil3dShared/HostApp/PropertySetDefinitionLadder.cs
@@ -1,4 +1,4 @@
-using Speckle.Sdk.Pipelines.Receive.Artifacts;
+﻿using Speckle.Sdk.Pipelines.Receive.Artifacts;
 
 namespace Speckle.Connectors.Civil3dShared.HostApp;
 
@@ -155,8 +155,9 @@ public static class PropertySetDefinitionLadder
   /// <summary>THE set_key recipe — the single implementation both send (emission) and receive (existing-def
   /// comparison) use, so the two sides can never drift. Cross-producer, byte-exact (keep in sync with
   /// dwgextract): sha256_hex_uppercase( utf8( set_name + "\n" + join("\n", for each field in AUTHORED
-  /// order: field_name + "|" + data_type + "|" + (unit ?? "")) ) ). Unit is the raw captured display text —
-  /// deliberately NOT "(none)"-filtered, mirroring PropertySetDefinitionHandler's capture.</summary>
+  /// order: field_name + "|" + data_type + "|" + (unit ?? "")) ) ). Unit is the FILTERED display text
+  /// (PropertyHandler.TryGetUnitDisplay: throw and "(none)" both → null), so a unitless field hashes the empty
+  /// string — which is what dwgextract hashes for one too [ENG-9360].</summary>
   public static string ComputeSetKey(string setName, IEnumerable<(string Name, string? DataType, string? Unit)> fields)
   {
     var parts = new List<string> { setName };

--- a/Connectors/Autocad/Speckle.Connectors.Civil3dShared/Operations/Send/Civil3dArtifactRootObjectBuilder.cs
+++ b/Connectors/Autocad/Speckle.Connectors.Civil3dShared/Operations/Send/Civil3dArtifactRootObjectBuilder.cs
@@ -90,6 +90,9 @@ public class Civil3dArtifactRootObjectBuilder : AutocadArtifactRootObjectBuilder
       string setKey = PropertySetDefinitionLadder.ComputeSetKey(setName, keyFields);
 
       _propertySetDefinitionHandler.SetDescriptions.TryGetValue(setName, out string? setDescription);
+      // Absent = apply-to-all, which is what a NULL applies_to means. Deliberately NOT part of set_key: the
+      // recipe is shared with dwgextract, which cannot enumerate the filter at all [ENG-9362].
+      _propertySetDefinitionHandler.SetAppliesTo.TryGetValue(setName, out string? appliesTo);
       _propertySetDefinitionHandler.DefinitionFieldBucketIds.TryGetValue(setName, out var bucketByFieldFromDefinition);
       _propertySetDefinitionHandler.FieldBucketIds.TryGetValue(setName, out var bucketByFieldObserved);
 
@@ -128,7 +131,7 @@ public class Civil3dArtifactRootObjectBuilder : AutocadArtifactRootObjectBuilder
           Field(fd, "units") as string,
           Field(fd, PropertySetDefinitionHandler.PROP_DEF_DESCRIPTION_KEY) as string,
           setDescription,
-          appliesTo: null // only AppliesToAll is repo-confirmed; expected member: PropertySetDefinition.AppliesToFilter
+          appliesTo
         );
       }
     }

--- a/Connectors/Autocad/Speckle.Connectors.Civil3dShared/Operations/Send/Civil3dArtifactRootObjectBuilder.cs
+++ b/Connectors/Autocad/Speckle.Connectors.Civil3dShared/Operations/Send/Civil3dArtifactRootObjectBuilder.cs
@@ -1,4 +1,4 @@
-using Microsoft.Extensions.Logging;
+﻿using Microsoft.Extensions.Logging;
 using Speckle.Connectors.Autocad.HostApp;
 using Speckle.Connectors.Autocad.Operations.Send;
 using Speckle.Connectors.Civil3dShared.HostApp;
@@ -90,7 +90,8 @@ public class Civil3dArtifactRootObjectBuilder : AutocadArtifactRootObjectBuilder
       string setKey = PropertySetDefinitionLadder.ComputeSetKey(setName, keyFields);
 
       _propertySetDefinitionHandler.SetDescriptions.TryGetValue(setName, out string? setDescription);
-      _propertySetDefinitionHandler.FieldBucketIds.TryGetValue(setName, out var bucketByField);
+      _propertySetDefinitionHandler.DefinitionFieldBucketIds.TryGetValue(setName, out var bucketByFieldFromDefinition);
+      _propertySetDefinitionHandler.FieldBucketIds.TryGetValue(setName, out var bucketByFieldObserved);
 
       foreach (var fieldName in fieldOrder)
       {
@@ -108,13 +109,18 @@ public class Civil3dArtifactRootObjectBuilder : AutocadArtifactRootObjectBuilder
             : null;
         string? defaultString =
           defaultBoolean is null && defaultDouble is null && defaultValue?.ToString() is { Length: > 0 } dv ? dv : null;
+        // The definition's own FieldBucketId covers every authored field; the ids observed on instance values
+        // are the fallback for a throwing getter [ENG-9361].
         string? bucketId = null;
-        bucketByField?.TryGetValue(fieldName, out bucketId);
+        if (bucketByFieldFromDefinition?.TryGetValue(fieldName, out bucketId) != true)
+        {
+          bucketByFieldObserved?.TryGetValue(fieldName, out bucketId);
+        }
         pipeline.AddPropertySetDefinition(
           setName,
           setKey,
           fieldName,
-          bucketId, // null when the definition was never attached to a sent object — receive matches by name
+          bucketId, // null only if BOTH the definition getter threw and no instance value was seen
           Field(fd, PropertySetDefinitionHandler.PROP_DEF_TYPE_KEY) as string,
           defaultString,
           defaultDouble,

--- a/Connectors/Autocad/Speckle.Connectors.Civil3dShared/Operations/Send/Civil3dArtifactRootObjectBuilder.cs
+++ b/Connectors/Autocad/Speckle.Connectors.Civil3dShared/Operations/Send/Civil3dArtifactRootObjectBuilder.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging;
 using Speckle.Connectors.Autocad.HostApp;
 using Speckle.Connectors.Autocad.Operations.Send;
 using Speckle.Connectors.Civil3dShared.HostApp;
@@ -45,7 +45,7 @@ public class Civil3dArtifactRootObjectBuilder : AutocadArtifactRootObjectBuilder
 
   protected override void EmitAdditionalNodes(ObjectsArtifactPipeline pipeline)
   {
-    if (_propertySetDefinitionHandler.Definitions.Count == 0)
+    if (_propertySetDefinitionHandler.DefinitionsByHandle.Count == 0)
     {
       return;
     }
@@ -58,25 +58,19 @@ public class Civil3dArtifactRootObjectBuilder : AutocadArtifactRootObjectBuilder
 
   private void EmitPropertySetDefinitionRows(ObjectsArtifactPipeline pipeline)
   {
-    // Rows are emitted in AUTHORED field order (the file's row-order-is-field-order contract).
-    foreach (var setEntry in _propertySetDefinitionHandler.Definitions)
+    // Handle-addressed, so two same-named definitions both reach the file [ENG-9363]. Rows are emitted in
+    // AUTHORED field order (the file's row-order-is-field-order contract).
+    var emittedSetKeys = new HashSet<string>(StringComparer.Ordinal);
+    foreach (var record in _propertySetDefinitionHandler.DefinitionsByHandle.Values)
     {
-      string setName = setEntry.Key;
-      if (
-        !setEntry.Value.TryGetValue(PropertySetDefinitionHandler.PROP_SET_PROP_DEFS_KEY, out object? defsObj)
-        || defsObj is not Dictionary<string, object?> fieldDefs
-        || !_propertySetDefinitionHandler.FieldOrders.TryGetValue(setName, out var fieldOrder)
-      )
-      {
-        continue;
-      }
+      string setName = record.Name;
 
       // set_key: the shared recipe in PropertySetDefinitionLadder.ComputeSetKey — receive compares
       // existing in-document definitions with the same code, so reuse-if-identical cannot drift.
       var keyFields = new List<(string Name, string? DataType, string? Unit)>();
-      foreach (var fieldName in fieldOrder)
+      foreach (var fieldName in record.FieldOrder)
       {
-        if (Field(fieldDefs, fieldName) is Dictionary<string, object?> fdk)
+        if (Field(record.Fields, fieldName) is Dictionary<string, object?> fdk)
         {
           keyFields.Add(
             (
@@ -89,16 +83,24 @@ public class Civil3dArtifactRootObjectBuilder : AutocadArtifactRootObjectBuilder
       }
       string setKey = PropertySetDefinitionLadder.ComputeSetKey(setName, keyFields);
 
-      _propertySetDefinitionHandler.SetDescriptions.TryGetValue(setName, out string? setDescription);
+      // Same name, different fields → two sets, told apart by set_key. Two definitions that hash the same ARE
+      // the same schema, so they collapse to one set of rows — the spec's dedupe-identical-schemas promise.
+      if (!emittedSetKeys.Add(setKey))
+      {
+        continue;
+      }
+
       // Absent = apply-to-all, which is what a NULL applies_to means. Deliberately NOT part of set_key: the
       // recipe is shared with dwgextract, which cannot enumerate the filter at all [ENG-9362].
-      _propertySetDefinitionHandler.SetAppliesTo.TryGetValue(setName, out string? appliesTo);
-      _propertySetDefinitionHandler.DefinitionFieldBucketIds.TryGetValue(setName, out var bucketByFieldFromDefinition);
+      string? setDescription = record.Description;
+      string? appliesTo = record.AppliesTo;
+      // Observed-on-instance ids are name-keyed, so they can only serve as the fallback for the FIRST
+      // definition of a given name; the per-record ids read off the definition cover all of them [ENG-9361].
       _propertySetDefinitionHandler.FieldBucketIds.TryGetValue(setName, out var bucketByFieldObserved);
 
-      foreach (var fieldName in fieldOrder)
+      foreach (var fieldName in record.FieldOrder)
       {
-        if (Field(fieldDefs, fieldName) is not Dictionary<string, object?> fd)
+        if (Field(record.Fields, fieldName) is not Dictionary<string, object?> fd)
         {
           continue;
         }
@@ -114,8 +116,7 @@ public class Civil3dArtifactRootObjectBuilder : AutocadArtifactRootObjectBuilder
           defaultBoolean is null && defaultDouble is null && defaultValue?.ToString() is { Length: > 0 } dv ? dv : null;
         // The definition's own FieldBucketId covers every authored field; the ids observed on instance values
         // are the fallback for a throwing getter [ENG-9361].
-        string? bucketId = null;
-        if (bucketByFieldFromDefinition?.TryGetValue(fieldName, out bucketId) != true)
+        if (!record.FieldBucketIds.TryGetValue(fieldName, out string? bucketId))
         {
           bucketByFieldObserved?.TryGetValue(fieldName, out bucketId);
         }

--- a/Converters/Civil3d/Speckle.Converters.Civil3dShared/Helpers/PropertyHandler.cs
+++ b/Converters/Civil3d/Speckle.Converters.Civil3dShared/Helpers/PropertyHandler.cs
@@ -1,4 +1,4 @@
-namespace Speckle.Converters.Civil3dShared.Helpers;
+﻿namespace Speckle.Converters.Civil3dShared.Helpers;
 
 /// <summary>
 /// Used to help with properties on classes that may throw exceptions when accessed
@@ -39,4 +39,20 @@ public sealed class PropertyHandler
 
     return false;
   }
+
+  /// <summary>Autodesk's literal DISPLAY text for "this definition has no unit" — UI text, never a unit.</summary>
+  public const string NO_UNIT_DISPLAY = "(none)";
+
+  /// <summary>The genuine unit display text behind a throwing <c>UnitType</c> getter, or null when there is
+  /// none. Two distinct "no unit" signals collapse to null here: the getter throwing (units not applicable to
+  /// the definition) and <see cref="NO_UNIT_DISPLAY"/>. The bundle's `unit` columns — definition rows AND value
+  /// rows — plus the set_key recipe all contract on real-unit-or-absent, so every capture site must agree
+  /// [ENG-9360].</summary>
+  public string? TryGetUnitDisplay(Func<string> getDisplayName) =>
+    TryGetValue(getDisplayName, out string? display) ? NormalizeUnitDisplay(display) : null;
+
+  /// <summary>The <see cref="TryGetUnitDisplay"/> filter for a unit display string already in hand (no
+  /// throwing getter to guard) — same sentinel, one definition of it.</summary>
+  public static string? NormalizeUnitDisplay(string? display) =>
+    display is { Length: > 0 } && display != NO_UNIT_DISPLAY ? display : null;
 }

--- a/Converters/Civil3d/Speckle.Converters.Civil3dShared/Helpers/PropertyHandler.cs
+++ b/Converters/Civil3d/Speckle.Converters.Civil3dShared/Helpers/PropertyHandler.cs
@@ -1,4 +1,4 @@
-﻿namespace Speckle.Converters.Civil3dShared.Helpers;
+namespace Speckle.Converters.Civil3dShared.Helpers;
 
 /// <summary>
 /// Used to help with properties on classes that may throw exceptions when accessed

--- a/Converters/Civil3d/Speckle.Converters.Civil3dShared/ToSpeckle/Properties/PartDataExtractor.cs
+++ b/Converters/Civil3d/Speckle.Converters.Civil3dShared/ToSpeckle/Properties/PartDataExtractor.cs
@@ -1,4 +1,4 @@
-﻿using Speckle.Converters.Civil3dShared.Helpers;
+using Speckle.Converters.Civil3dShared.Helpers;
 
 namespace Speckle.Converters.Civil3dShared.ToSpeckle;
 

--- a/Converters/Civil3d/Speckle.Converters.Civil3dShared/ToSpeckle/Properties/PartDataExtractor.cs
+++ b/Converters/Civil3d/Speckle.Converters.Civil3dShared/ToSpeckle/Properties/PartDataExtractor.cs
@@ -1,3 +1,5 @@
+﻿using Speckle.Converters.Civil3dShared.Helpers;
+
 namespace Speckle.Converters.Civil3dShared.ToSpeckle;
 
 /// <summary>
@@ -64,7 +66,7 @@ public class PartDataExtractor
         ["context"] = fieldName,
       };
       // eav `unit` contract is real-unit-or-absent — skip empty / "(none)" placeholder units.
-      if (field.Units is { Length: > 0 } fieldUnits && fieldUnits != "(none)")
+      if (PropertyHandler.NormalizeUnitDisplay(field.Units) is { } fieldUnits)
       {
         fieldDictionary["units"] = fieldUnits;
       }

--- a/Converters/Civil3d/Speckle.Converters.Civil3dShared/ToSpeckle/Properties/PropertySetDefinitionHandler.cs
+++ b/Converters/Civil3d/Speckle.Converters.Civil3dShared/ToSpeckle/Properties/PropertySetDefinitionHandler.cs
@@ -1,4 +1,5 @@
-﻿using Speckle.Converters.Civil3dShared.Helpers;
+﻿using Microsoft.Extensions.Logging;
+using Speckle.Converters.Civil3dShared.Helpers;
 
 namespace Speckle.Converters.Civil3dShared.ToSpeckle;
 
@@ -7,6 +8,13 @@ namespace Speckle.Converters.Civil3dShared.ToSpeckle;
 /// </summary>
 public class PropertySetDefinitionHandler
 {
+  private readonly ILogger<PropertySetDefinitionHandler> _logger;
+
+  public PropertySetDefinitionHandler(ILogger<PropertySetDefinitionHandler> logger)
+  {
+    _logger = logger;
+  }
+
   /// <summary>
   /// Keeps track of all property set definitions used in the current send operation. This should be added to the properties dict on the root commit object post conversion.
   /// </summary>
@@ -22,18 +30,41 @@ public class PropertySetDefinitionHandler
   /// bundle's property_set_definitions file promises ROW ORDER = FIELD ORDER — this list is that promise.</summary>
   public Dictionary<string, List<string>> FieldOrders { get; } = new();
 
-  /// <summary>(set name → field name → FieldBucketId), fed back from PropertySetExtractor while it parses
-  /// instance VALUES: the definition API exposes no bucket id, but PropertySetData does. A definition that is
-  /// never attached to a sent object simply has no entries — the bundle ships NULL and receive falls back to
-  /// field-name matching.</summary>
+  /// <summary>(set name → field name → FieldBucketId) read straight off the DEFINITION
+  /// (PropertyDefinition.FieldBucketId). This is the authoritative source: it covers every authored field,
+  /// including ones no sent entity carried a value row for, so the bundle's field_bucket_id — the rebind join
+  /// key — is no longer NULL for them [ENG-9361]. Kept OUT of <see cref="Definitions"/> alongside
+  /// <see cref="SetDescriptions"/> so the carrier-object shape stays byte-compatible.</summary>
+  public Dictionary<string, Dictionary<string, string>> DefinitionFieldBucketIds { get; } = new();
+
+  /// <summary>(set name → field name → FieldBucketId) as OBSERVED on instance values by PropertySetExtractor.
+  /// Now only a fallback behind <see cref="DefinitionFieldBucketIds"/>, kept for the case where the definition
+  /// getter throws, and as the cross-check that warns when the two disagree.</summary>
   public Dictionary<string, Dictionary<string, string>> FieldBucketIds { get; } = new();
 
-  /// <summary>Records one field's FieldBucketId observed on an instance (see <see cref="FieldBucketIds"/>).</summary>
+  /// <summary>Records one field's FieldBucketId observed on an instance (see <see cref="FieldBucketIds"/>), and
+  /// warns when it contradicts what the definition reported — the two are documented identically ("the field
+  /// code Id"), and a mismatch would mean the rebind join key is being read off the wrong member.</summary>
   public void RecordFieldBucketId(string setName, string fieldName, string bucketId)
   {
     if (string.IsNullOrEmpty(bucketId))
     {
       return;
+    }
+    if (
+      DefinitionFieldBucketIds.TryGetValue(setName, out var fromDefinition)
+      && fromDefinition.TryGetValue(fieldName, out string? definitionBucketId)
+      && !string.Equals(definitionBucketId, bucketId, StringComparison.Ordinal)
+      && _warnedBucketIdMismatch.Add((setName, fieldName))
+    )
+    {
+      _logger.LogWarning(
+        "FieldBucketId mismatch on {SetName}.{FieldName}: definition reports {DefinitionBucketId}, instance value reports {InstanceBucketId}; publishing the definition's",
+        setName,
+        fieldName,
+        definitionBucketId,
+        bucketId
+      );
     }
     if (!FieldBucketIds.TryGetValue(setName, out var byField))
     {
@@ -42,6 +73,10 @@ public class PropertySetDefinitionHandler
     }
     byField[fieldName] = bucketId;
   }
+
+  /// <summary>One mismatch warning per (set, field) — these are per-instance callbacks, so an unguarded warning
+  /// would fire once per entity.</summary>
+  private readonly HashSet<(string SetName, string FieldName)> _warnedBucketIdMismatch = new();
 
   // Keys used for the dictionary representing a single property set definition
   public const string PROP_SET_DEF_NAME_KEY = "name"; // name of the property set definition
@@ -64,6 +99,8 @@ public class PropertySetDefinitionHandler
     Dictionary<string, object?> propertyDefinitionsDict = new(); // this is used to store on the property set definition
     Dictionary<int, string> propertyDefinitionNames = new(); // this is used to pass to the instance for property value retrieval
     List<string> fieldOrder = new(); // authored order — the bundle file's row order contract
+    Dictionary<string, string> fieldBucketIdsByField = new();
+    PropertyHandler propHandlerForField = new();
     foreach (AAECPDB.PropertyDefinition propertyDefinition in setDefinition.Definitions)
     {
       string propertyName = propertyDefinition.Name;
@@ -78,11 +115,30 @@ public class PropertySetDefinitionHandler
         [PROP_DEF_DEFAULT_VALUE_KEY] = propertyDefinition.DefaultData,
       };
 
+      // FieldBucketId ("the field code Id") is the eav.internal_definition_name the value rows ship, so this is
+      // the rebind join key — read it off the definition rather than waiting to observe it on an instance
+      // [ENG-9361]. Guarded like UnitType: these getters can throw for definitions they don't apply to.
+      propHandlerForField.TryGetValue(() => propertyDefinition.FieldBucketId, out string? fieldBucketId);
+      if (fieldBucketId is { Length: > 0 })
+      {
+        fieldBucketIdsByField[propertyName] = fieldBucketId;
+      }
+      propHandlerForField.TryGetValue(() => propertyDefinition.GlobalName, out string? globalName);
+      // dwgextract ships GetIndex() (== managed Id) as its bucket id and has an open question whether that
+      // matches Autodesk's FieldBucketId; this line is the evidence a single test publish needs [ENG-9361].
+      _logger.LogDebug(
+        "Property set field {SetName}.{FieldName}: FieldBucketId={FieldBucketId} Id={FieldId} GlobalName={GlobalName}",
+        setDefinition.Name,
+        propertyName,
+        fieldBucketId,
+        propertyDefinition.Id,
+        globalName
+      );
+
       // Accessing unit type can throw when it's not applicable to the definition, and a unitless definition
       // reports Autodesk's "(none)" placeholder — TryGetUnitDisplay collapses both to null so the definition
       // rows, the value rows and set_key all agree on real-unit-or-absent [ENG-9360].
-      PropertyHandler propHandler = new();
-      if (propHandler.TryGetUnitDisplay(() => propertyDefinition.UnitType.GetTypeDisplayName(true)) is { } unit)
+      if (propHandlerForField.TryGetUnitDisplay(() => propertyDefinition.UnitType.GetTypeDisplayName(true)) is { } unit)
       {
         propertyDict["units"] = unit;
       }
@@ -103,6 +159,7 @@ public class PropertySetDefinitionHandler
       [PROP_SET_PROP_DEFS_KEY] = propertyDefinitionsDict,
     };
     FieldOrders[name] = fieldOrder;
+    DefinitionFieldBucketIds[name] = fieldBucketIdsByField;
     // Set-level description (member confirmed: PropertySetBaker once wrote propSetDef.Description).
     // applies_to is NOT captured: only AppliesToAll has repo evidence; the expected filter member is
     // AAECPDB.PropertySetDefinition.AppliesToFilter — wire it here once confirmed on the real API.

--- a/Converters/Civil3d/Speckle.Converters.Civil3dShared/ToSpeckle/Properties/PropertySetDefinitionHandler.cs
+++ b/Converters/Civil3d/Speckle.Converters.Civil3dShared/ToSpeckle/Properties/PropertySetDefinitionHandler.cs
@@ -1,7 +1,20 @@
-﻿using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging;
 using Speckle.Converters.Civil3dShared.Helpers;
 
 namespace Speckle.Converters.Civil3dShared.ToSpeckle;
+
+/// <summary>One captured property-set definition, addressed by its own handle rather than by name. Civil 3D
+/// allows two same-named definitions in one drawing (separate dictionaries, xrefs, style imports); the
+/// name-keyed <see cref="PropertySetDefinitionHandler.Definitions"/> can only hold the first, so publishing
+/// from these records is what keeps the second one from being dropped [ENG-9363].</summary>
+public sealed record PropertySetDefinitionRecord(
+  string Name,
+  List<string> FieldOrder,
+  Dictionary<string, object?> Fields,
+  Dictionary<string, string> FieldBucketIds,
+  string? Description,
+  string? AppliesTo
+);
 
 /// <summary>
 /// Keeps track during a send conversion operation of the property set definitions used.
@@ -19,8 +32,16 @@ public class PropertySetDefinitionHandler
   /// Keeps track of all property set definitions used in the current send operation. This should be added to the properties dict on the root commit object post conversion.
   /// </summary>
   /// POC: Note that we're abusing dictionaries in here because we've yet to have a simple way to serialize non-base derived classes (or structs?)
-  /// POC: We're storing these by property set def name atm. There is a decent change different property sets can have the same name, need to validate this.
+  /// Stored by property set def NAME, first-wins. Two definitions really can share a name (validated:
+  /// ENG-9363) — that case is served by <see cref="DefinitionsByHandle"/>; this view stays name-keyed
+  /// because the carrier's serialized shape is.
   public Dictionary<string, Dictionary<string, object?>> Definitions { get; } = new();
+
+  /// <summary>Every distinct definition met this send, keyed by its ObjectId handle — the identity Civil 3D
+  /// actually gives a definition, where the name is not unique. This is what the bundle's
+  /// property_set_definitions file is emitted from; <see cref="Definitions"/> above stays name-keyed and
+  /// first-wins because the tier-2 carrier's serialized shape is by name [ENG-9363].</summary>
+  public Dictionary<string, PropertySetDefinitionRecord> DefinitionsByHandle { get; } = new();
 
   /// <summary>Set-level authored description per set name (PropertySetDefinition.Description); absent = none.
   /// Kept OUT of <see cref="Definitions"/> so the carrier-object shape stays byte-compatible.</summary>
@@ -109,6 +130,12 @@ public class PropertySetDefinitionHandler
     List<string> fieldOrder = new(); // authored order — the bundle file's row order contract
     Dictionary<string, string> fieldBucketIdsByField = new();
     PropertyHandler propHandlerForField = new();
+
+    // HandleDefinition runs once per ATTACHED INSTANCE, so anything that only depends on the definition —
+    // logging, the set-level getters — is guarded on first sight of this handle.
+    string handleKey = setDefinition.ObjectId.Handle.ToString();
+    bool firstSightOfDefinition = !DefinitionsByHandle.ContainsKey(handleKey);
+
     foreach (AAECPDB.PropertyDefinition propertyDefinition in setDefinition.Definitions)
     {
       string propertyName = propertyDefinition.Name;
@@ -131,17 +158,21 @@ public class PropertySetDefinitionHandler
       {
         fieldBucketIdsByField[propertyName] = fieldBucketId;
       }
-      propHandlerForField.TryGetValue(() => propertyDefinition.GlobalName, out string? globalName);
-      // dwgextract ships GetIndex() (== managed Id) as its bucket id and has an open question whether that
-      // matches Autodesk's FieldBucketId; this line is the evidence a single test publish needs [ENG-9361].
-      _logger.LogDebug(
-        "Property set field {SetName}.{FieldName}: FieldBucketId={FieldBucketId} Id={FieldId} GlobalName={GlobalName}",
-        setDefinition.Name,
-        propertyName,
-        fieldBucketId,
-        propertyDefinition.Id,
-        globalName
-      );
+
+      if (firstSightOfDefinition)
+      {
+        propHandlerForField.TryGetValue(() => propertyDefinition.GlobalName, out string? globalName);
+        // dwgextract ships GetIndex() (== managed Id) as its bucket id and has an open question whether that
+        // matches Autodesk's FieldBucketId; this line is the evidence a single test publish needs [ENG-9361].
+        _logger.LogDebug(
+          "Property set field {SetName}.{FieldName}: FieldBucketId={FieldBucketId} Id={FieldId} GlobalName={GlobalName}",
+          setDefinition.Name,
+          propertyName,
+          fieldBucketId,
+          propertyDefinition.Id,
+          globalName
+        );
+      }
 
       // Accessing unit type can throw when it's not applicable to the definition, and a unitless definition
       // reports Autodesk's "(none)" placeholder — TryGetUnitDisplay collapses both to null so the definition
@@ -156,44 +187,61 @@ public class PropertySetDefinitionHandler
 
     var name = setDefinition.Name;
 
-    if (Definitions.ContainsKey(name))
+    if (firstSightOfDefinition)
     {
-      return propertyDefinitionNames;
-    }
+      // Set-level description (member confirmed: PropertySetBaker once wrote propSetDef.Description).
+      PropertyHandler setPropHandler = new();
+      setPropHandler.TryGetValue(() => setDefinition.Description, out string? setDescription);
+      string? appliesTo = GetAppliesTo(setDefinition, name, setPropHandler);
 
-    Definitions[name] = new Dictionary<string, object?>()
-    {
-      [PROP_SET_DEF_NAME_KEY] = name,
-      [PROP_SET_PROP_DEFS_KEY] = propertyDefinitionsDict,
-    };
-    FieldOrders[name] = fieldOrder;
-    DefinitionFieldBucketIds[name] = fieldBucketIdsByField;
-    // Set-level description (member confirmed: PropertySetBaker once wrote propSetDef.Description).
-    PropertyHandler setPropHandler = new();
-    if (
-      setPropHandler.TryGetValue(() => setDefinition.Description, out string? setDescription)
-      && !string.IsNullOrEmpty(setDescription)
-    )
-    {
-      SetDescriptions[name] = setDescription!;
-    }
+      DefinitionsByHandle[handleKey] = new PropertySetDefinitionRecord(
+        name,
+        fieldOrder,
+        propertyDefinitionsDict,
+        fieldBucketIdsByField,
+        string.IsNullOrEmpty(setDescription) ? null : setDescription,
+        appliesTo
+      );
 
-    CaptureAppliesTo(setDefinition, name, setPropHandler);
+      // The name-keyed views below feed the legacy carrier and the observed-bucket-id cross-check. They stay
+      // first-wins: a second same-named definition is published from DefinitionsByHandle, not from these.
+      if (!Definitions.ContainsKey(name))
+      {
+        Definitions[name] = new Dictionary<string, object?>()
+        {
+          [PROP_SET_DEF_NAME_KEY] = name,
+          [PROP_SET_PROP_DEFS_KEY] = propertyDefinitionsDict,
+        };
+        FieldOrders[name] = fieldOrder;
+        DefinitionFieldBucketIds[name] = fieldBucketIdsByField;
+        if (!string.IsNullOrEmpty(setDescription))
+        {
+          SetDescriptions[name] = setDescription!;
+        }
+        if (appliesTo is not null)
+        {
+          SetAppliesTo[name] = appliesTo;
+        }
+      }
+      else
+      {
+        _logger.LogInformation(
+          "A second property set definition named {SetName} is present; both are published, distinguished by set_key",
+          name
+        );
+      }
+    }
 
     return propertyDefinitionNames;
   }
 
-  /// <summary>Records the set's entity-type filter for the bundle's applies_to column (see
-  /// <see cref="SetAppliesTo"/>). Apply-to-all sets record nothing — that is what NULL means.</summary>
-  private void CaptureAppliesTo(
-    AAECPDB.PropertySetDefinition setDefinition,
-    string name,
-    PropertyHandler setPropHandler
-  )
+  /// <summary>The set's entity-type filter as the csv the bundle's applies_to column wants, or null for
+  /// apply-to-all — which is what a NULL applies_to means (see <see cref="SetAppliesTo"/>).</summary>
+  private string? GetAppliesTo(AAECPDB.PropertySetDefinition setDefinition, string name, PropertyHandler setPropHandler)
   {
     if (!setPropHandler.TryGetValue(() => setDefinition.AppliesToAll, out bool appliesToAll) || appliesToAll)
     {
-      return;
+      return null;
     }
 
     setPropHandler.TryGetValue(() => setDefinition.IsStyleBased, out bool isStyleBased);
@@ -203,7 +251,7 @@ public class PropertySetDefinitionHandler
         "Property set definition {SetName} filters by STYLE; applies_to carries object-type names only, so it publishes as apply-to-all",
         name
       );
-      return;
+      return null;
     }
 
     if (
@@ -213,7 +261,7 @@ public class PropertySetDefinitionHandler
       ) || filter is null
     )
     {
-      return;
+      return null;
     }
 
     List<string> classNames = new();
@@ -225,9 +273,6 @@ public class PropertySetDefinitionHandler
       }
     }
 
-    if (classNames.Count > 0)
-    {
-      SetAppliesTo[name] = string.Join(",", classNames);
-    }
+    return classNames.Count > 0 ? string.Join(",", classNames) : null;
   }
 }

--- a/Converters/Civil3d/Speckle.Converters.Civil3dShared/ToSpeckle/Properties/PropertySetDefinitionHandler.cs
+++ b/Converters/Civil3d/Speckle.Converters.Civil3dShared/ToSpeckle/Properties/PropertySetDefinitionHandler.cs
@@ -1,4 +1,4 @@
-using Speckle.Converters.Civil3dShared.Helpers;
+﻿using Speckle.Converters.Civil3dShared.Helpers;
 
 namespace Speckle.Converters.Civil3dShared.ToSpeckle;
 
@@ -78,9 +78,14 @@ public class PropertySetDefinitionHandler
         [PROP_DEF_DEFAULT_VALUE_KEY] = propertyDefinition.DefaultData,
       };
 
-      // accessing unit type prop can be expected to throw if it's not applicable to the definition
+      // Accessing unit type can throw when it's not applicable to the definition, and a unitless definition
+      // reports Autodesk's "(none)" placeholder — TryGetUnitDisplay collapses both to null so the definition
+      // rows, the value rows and set_key all agree on real-unit-or-absent [ENG-9360].
       PropertyHandler propHandler = new();
-      propHandler.TryAddToDictionary(propertyDict, "units", () => propertyDefinition.UnitType.GetTypeDisplayName(true));
+      if (propHandler.TryGetUnitDisplay(() => propertyDefinition.UnitType.GetTypeDisplayName(true)) is { } unit)
+      {
+        propertyDict["units"] = unit;
+      }
 
       propertyDefinitionsDict[propertyName] = propertyDict;
     }

--- a/Converters/Civil3d/Speckle.Converters.Civil3dShared/ToSpeckle/Properties/PropertySetDefinitionHandler.cs
+++ b/Converters/Civil3d/Speckle.Converters.Civil3dShared/ToSpeckle/Properties/PropertySetDefinitionHandler.cs
@@ -26,6 +26,14 @@ public class PropertySetDefinitionHandler
   /// Kept OUT of <see cref="Definitions"/> so the carrier-object shape stays byte-compatible.</summary>
   public Dictionary<string, string> SetDescriptions { get; } = new();
 
+  /// <summary>Csv of the host entity-type filters a set applies to, per set name; absent = apply-to-all, which
+  /// is what the bundle's NULL applies_to means [ENG-9362]. STYLE-based filters are deliberately not captured:
+  /// PropertySetDefinition's filter carries an object-vs-style dimension (SetAppliesToFilter's byStyle param,
+  /// IsStyleBased getter) that the spec's flat csv column has nowhere to put, and publishing a style filter as
+  /// an object filter would scope the received set to the wrong things. Those sets stay apply-to-all, as they
+  /// are today, and warn.</summary>
+  public Dictionary<string, string> SetAppliesTo { get; } = new();
+
   /// <summary>Authored field order per set name. Dictionary enumeration order is not contractual, and the
   /// bundle's property_set_definitions file promises ROW ORDER = FIELD ORDER — this list is that promise.</summary>
   public Dictionary<string, List<string>> FieldOrders { get; } = new();
@@ -161,8 +169,6 @@ public class PropertySetDefinitionHandler
     FieldOrders[name] = fieldOrder;
     DefinitionFieldBucketIds[name] = fieldBucketIdsByField;
     // Set-level description (member confirmed: PropertySetBaker once wrote propSetDef.Description).
-    // applies_to is NOT captured: only AppliesToAll has repo evidence; the expected filter member is
-    // AAECPDB.PropertySetDefinition.AppliesToFilter — wire it here once confirmed on the real API.
     PropertyHandler setPropHandler = new();
     if (
       setPropHandler.TryGetValue(() => setDefinition.Description, out string? setDescription)
@@ -172,6 +178,56 @@ public class PropertySetDefinitionHandler
       SetDescriptions[name] = setDescription!;
     }
 
+    CaptureAppliesTo(setDefinition, name, setPropHandler);
+
     return propertyDefinitionNames;
+  }
+
+  /// <summary>Records the set's entity-type filter for the bundle's applies_to column (see
+  /// <see cref="SetAppliesTo"/>). Apply-to-all sets record nothing — that is what NULL means.</summary>
+  private void CaptureAppliesTo(
+    AAECPDB.PropertySetDefinition setDefinition,
+    string name,
+    PropertyHandler setPropHandler
+  )
+  {
+    if (!setPropHandler.TryGetValue(() => setDefinition.AppliesToAll, out bool appliesToAll) || appliesToAll)
+    {
+      return;
+    }
+
+    setPropHandler.TryGetValue(() => setDefinition.IsStyleBased, out bool isStyleBased);
+    if (isStyleBased)
+    {
+      _logger.LogWarning(
+        "Property set definition {SetName} filters by STYLE; applies_to carries object-type names only, so it publishes as apply-to-all",
+        name
+      );
+      return;
+    }
+
+    if (
+      !setPropHandler.TryGetValue(
+        () => setDefinition.AppliesToFilter,
+        out System.Collections.Specialized.StringCollection? filter
+      ) || filter is null
+    )
+    {
+      return;
+    }
+
+    List<string> classNames = new();
+    foreach (string? className in filter)
+    {
+      if (className is { Length: > 0 })
+      {
+        classNames.Add(className);
+      }
+    }
+
+    if (classNames.Count > 0)
+    {
+      SetAppliesTo[name] = string.Join(",", classNames);
+    }
   }
 }

--- a/Converters/Civil3d/Speckle.Converters.Civil3dShared/ToSpeckle/Properties/PropertySetExtractor.cs
+++ b/Converters/Civil3d/Speckle.Converters.Civil3dShared/ToSpeckle/Properties/PropertySetExtractor.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging;
 using Speckle.Converters.Civil3dShared.Helpers;
 using Speckle.Converters.Common;
 using Speckle.Sdk;

--- a/Converters/Civil3d/Speckle.Converters.Civil3dShared/ToSpeckle/Properties/PropertySetExtractor.cs
+++ b/Converters/Civil3d/Speckle.Converters.Civil3dShared/ToSpeckle/Properties/PropertySetExtractor.cs
@@ -1,4 +1,4 @@
-using Microsoft.Extensions.Logging;
+﻿using Microsoft.Extensions.Logging;
 using Speckle.Converters.Civil3dShared.Helpers;
 using Speckle.Converters.Common;
 using Speckle.Sdk;
@@ -103,15 +103,10 @@ public class PropertySetExtractor
         // Definition-level API exposes no bucket id — observe it here so the property_set_definitions
         // file can ship field_bucket_id (the eav.internal_definition_name join key).
         _propertySetDefinitionHandler.RecordFieldBucketId(name, dataName, data.FieldBucketId);
+        // The eav `unit` column contract is real-unit-or-absent; TryGetUnitDisplay is the one filter shared
+        // with the definition rows and the set_key recipe [ENG-9360].
         PropertyHandler propHandler = new();
-        // Units aren't always applicable to a def (the getter throws — swallowed by TryGetValue), and a unitless
-        // def reports Autodesk's literal display name "(none)" — UI text, not a unit. The eav `unit` column
-        // contract is real-unit-or-absent, so add `units` only when a genuine unit comes back.
-        if (
-          propHandler.TryGetValue(() => data.UnitType.GetTypeDisplayName(true), out string? unitDisplay)
-          && unitDisplay is { Length: > 0 }
-          && unitDisplay != "(none)"
-        )
+        if (propHandler.TryGetUnitDisplay(() => data.UnitType.GetTypeDisplayName(true)) is { } unitDisplay)
         {
           propertyValueDict["units"] = unitDisplay;
         }


### PR DESCRIPTION
Four Civil 3D property-set fixes, one commit each, in dependency order. All four were blocked in code by comments saying the AEC API surface was unconfirmed — it is confirmed, see below.

| Ticket | What was wrong |
|---|---|
| ENG-9360 | `"(none)"` — Autodesk's UI text for "no unit" — shipped into the bundle's `unit` column as if it were a unit |
| ENG-9361 | `field_bucket_id` was NULL for any field no published entity carried a value row for |
| ENG-9362 | The sender's "applies to" filter was never published; received definitions applied to every object type |
| ENG-9363 | Two same-named definitions published as one; the second was silently dropped |

## API confirmation

Every member these fixes need is present in **all built API versions (2023–2027)** — verified by reflection on the 2022/2023/2024 packages and from the 2027 XML docs:

```
PropertySetDefinition.AppliesToFilter   : StringCollection  get=True  set=False
PropertySetDefinition.SetAppliesToFilter(StringCollection, Boolean)   <- the write path
PropertySetDefinition.IsStyleBased      : Boolean  get=True
PropertyDefinition.FieldBucketId        : String   get=True
```

The getter is get-only, which answers the open question in ENG-9362: the filter is written through `SetAppliesToFilter`, not by mutating the returned collection.

## Notes for review

**ENG-9360 touches four sites at once, deliberately.** The send capture, the value capture, the receive-side `ComputeExistingDefinitionKey`, and the `ComputeSetKey` doc comment that stated the non-filtering as contract. Filtering on send without filtering in the receive comparison would make every re-receive of an unchanged schema mint a `-{prefix}` copy — ENG-9328 territory. `PropertyHandler.TryGetUnitDisplay` is now the single filter.

One consequence: bundles **already published from `big-truck`** carry `set_key`s hashed with `"(none)"`, so receiving one into a drawing whose definition was created post-fix will see a mismatch and create a duplicate definition. Pre-release branch, so this is called out rather than worked around.

**ENG-9361's ticket repro is wrong** — a Graphic-type field does still get a bucket id recorded (`PropertySetExtractor` nulls the *value*, not the row). The genuine NULL case is narrower: a field with no `PropertySetData` row on any sent entity. The fix is worth it anyway, and it is a prerequisite for ENG-9363.

The observed-on-instance capture is kept as a fallback and now doubles as a cross-check — the two members are documented identically ("the field code Id"), and a disagreement means the join key is being read off the wrong member, so it warns once per (set, field). A `Debug` line per field records `FieldBucketId`/`Id`/`GlobalName`, which is the evidence dwgextract needs to settle whether its `GetIndex()` bucket id matches Autodesk's.

**ENG-9362 leaves style-based filters on the table.** The API filter carries an object-vs-style dimension (`SetAppliesToFilter`'s `byStyle`) that the spec's flat csv column has nowhere to record, and publishing a style filter as an object filter would scope the received set to the wrong things. Those sets stay apply-to-all — what they do today, so no regression — and now warn instead of failing silently. Fixing it properly wants an `applies_to_is_style` spec column, which is a bundle-spec + SDK change, not a connector one.

**ENG-9363 was sized wrong in the ticket.** Two constraints the "key by ObjectId" suggestion misses:

1. `Definitions` is not private to the artefact path — it is serialized wholesale as `ProxyKeys.PROPERTYSET_DEFINITIONS` and read back as tier 2. So it stays name-keyed and first-wins, and a new handle-keyed record store is what the bundle file is emitted from.
2. Receive needed more than "keep every schema": both the attach lookup and the bucket-id index were name-keyed and are now name → list, with a per-object pick.

Selection is by `field_bucket_id` membership (the rule the spec names for this case), with field-name overlap as the tiebreak for producers that ship no bucket ids. **Single-candidate sets — every ordinary drawing — short-circuit and behave exactly as before.**

Two remaining limits, neither a regression: an entity carrying *both* same-named sets at once still cannot be expressed (the value paths have one slot per set name), and re-receiving a duplicate-name bundle re-creates the second definition rather than reusing it, because the existing-definition lookup is by name.

## Testing

Builds clean in `Local` across Civil3D 2023/2024/2025/2026/2027; CSharpier clean. **Nothing here is verified against a running Civil 3D** — I have no host session. Worth exercising on the ENG-9360 drawing:

- [ ] Unitless field publishes `unit` = NULL, no `"(none)"` anywhere in `property_set_definitions`
- [ ] Publish → receive into the same drawing still *reuses* the definition (no `-{prefix}` copy) — the ENG-9360 regression risk
- [ ] Every definition row has a non-NULL `field_bucket_id`; check the `Debug` log for any FieldBucketId mismatch warning
- [ ] A definition scoped to Pipe publishes `applies_to` and receives scoped to Pipe only (and confirms the class names are RX names as assumed)
- [ ] A dwgextract bundle (NULL `applies_to`) still receives, apply-to-all
- [ ] Two same-named definitions publish as two sets with distinct `set_key`, and values land on the right fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)
