### PR TITLE
fix(revit): addresses eng-9343 by assigning family members to their source layer subcategory

### DIFF
--- a/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/FamilyGeometryBaker.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/FamilyGeometryBaker.cs
@@ -266,23 +266,69 @@ public class FamilyGeometryBaker
     }
   }
 
+  // Looks a subcategory up on the family category and creates it when absent — the same lookup-or-create v1's
+  // ProcessObjectForFamily did. Revit rejects names containing \ : { } [ ] | ; < > ? ` * ~, so the catch is
+  // load-bearing: an unusable layer name logs and bakes without a subcategory rather than failing the definition.
+  private Category? GetOrCreateSubcategory(Document famDoc, string? name, Dictionary<string, Category?> cache)
+  {
+    if (string.IsNullOrWhiteSpace(name))
+    {
+      return null;
+    }
+    if (cache.TryGetValue(name!, out var cached))
+    {
+      return cached;
+    }
+
+    Category? resolved = null;
+    var familyCategory = famDoc.OwnerFamily.FamilyCategory;
+    if (familyCategory != null)
+    {
+      if (familyCategory.SubCategories.Contains(name))
+      {
+        resolved = familyCategory.SubCategories.get_Item(name);
+      }
+      else
+      {
+        try
+        {
+          resolved = famDoc.Settings.Categories.NewSubcategory(familyCategory, name);
+        }
+        catch (Autodesk.Revit.Exceptions.ArgumentException)
+        {
+          _logger.LogWarning("Failed to create Revit subcategory with name: {SubcategoryName}", name);
+        }
+      }
+    }
+    cache[name!] = resolved;
+    return resolved;
+  }
+
   // ENG-9101: bundle-native counterpart of BakeFamilyGeometry above — bakes already-decoded GeometryObjects (the
   // caller resolved these from the artifact bundle via the same DecodeGeometry path DirectShape receive uses)
-  // instead of walking a Base/TraversalContext graph. No subcategory grouping (that's cosmetic, tied to the v1
-  // Collection tree, which the bundle's DEFINES members don't carry) — materials still apply via family parameters.
+  // instead of walking a Base/TraversalContext graph. Members carry their source layer as a subcategory name, which
+  // the caller recovered through the definition-member join [ENG-9343]; materials apply via family parameters.
   public void BakeFamilyGeometryFromArtifact(
     Document famDoc,
-    IReadOnlyList<(GeometryObject geometry, int? materialNodeKey)> members,
+    IReadOnlyList<(GeometryObject geometry, int? materialNodeKey, string? subcategoryName)> members,
     FamilyMaterialManager materialManager
   )
   {
-    foreach (var (geometry, materialNodeKey) in members)
+    // NewSubcategory throws on a name that already exists, and Contains on every member of a large definition is not
+    // free — so resolve each name once per family document.
+    var subcategoryCache = new Dictionary<string, Category?>(StringComparer.Ordinal);
+    foreach (var (geometry, materialNodeKey, subcategoryName) in members)
     {
       try
       {
         if (geometry is Solid solid && !solid.Faces.IsEmpty)
         {
           using var freeFormElement = FreeFormElement.Create(famDoc, solid);
+          // Solid/FreeFormElement only — the DirectShape fallback below never carried a subcategory in v1 either.
+          if (GetOrCreateSubcategory(famDoc, subcategoryName, subcategoryCache) is { } subcategory)
+          {
+            freeFormElement.Subcategory = subcategory;
+          }
           if (
             materialNodeKey is int mk
             && materialManager.FamilyParameters.TryGetValue(mk.ToString(CultureInfo.InvariantCulture), out var famParam)

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/RevitFamilyBaker.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/RevitFamilyBaker.cs
@@ -4,6 +4,7 @@ using Autodesk.Revit.DB;
 using Autodesk.Revit.DB.Structure;
 using Microsoft.Extensions.Logging;
 using Speckle.Connectors.Common.Conversion;
+using Speckle.Connectors.Common.Instances;
 using Speckle.Converters.Common;
 using Speckle.Converters.Common.Objects;
 using Speckle.Converters.RevitShared.Helpers;
@@ -18,6 +19,7 @@ using Speckle.Sdk.Models.Collections;
 using Speckle.Sdk.Models.GraphTraversal;
 using Speckle.Sdk.Models.Instances;
 using Speckle.Sdk.Pipelines.Progress;
+using Speckle.Sdk.Pipelines.Receive.Artifacts;
 using DB = Autodesk.Revit.DB;
 using Document = Autodesk.Revit.DB.Document;
 
@@ -316,6 +318,27 @@ public sealed class RevitFamilyBaker : IDisposable
   }
 
   /// <summary>
+  /// Each definition member's source layer, keyed by the member's geometry K, for use as a Revit subcategory name
+  /// [ENG-9343]. A member carries no <c>DISPLAY</c> edge so <c>ObjectByGeometry()</c> cannot reach its object row —
+  /// and its layer lives on that row — so this goes through the definition-member join [ENG-9110], the same one
+  /// Rhino receive uses. The LEAF container name, not the full path, matching v1's "nearest named Collection".
+  /// </summary>
+  public Dictionary<int, string> BuildMemberSubcategoryNames(ArtefactBundle bundle, ArtefactRelations rels)
+  {
+    var names = new Dictionary<int, string>();
+    var memberIndex = DefinitionMemberIndexes.Build(rels, bundle.Properties);
+    foreach (var kv in memberIndex.ObjectByGeometry)
+    {
+      var segments = SceneViewResolver.Segments(bundle, kv.Value);
+      if (segments.Count > 0 && segments[^1] is { Length: > 0 } leaf)
+      {
+        names[kv.Key] = leaf;
+      }
+    }
+    return names;
+  }
+
+  /// <summary>
   /// Bundle-native counterpart of <see cref="CreateFamilyFromDefinition"/> (ENG-9101): builds/reuses a real Revit
   /// family straight from already-decoded artifact geometry — no Base graph, no <see cref="TraversalContext"/>.
   /// </summary>
@@ -329,7 +352,7 @@ public sealed class RevitFamilyBaker : IDisposable
     string definitionKey,
     string? definitionName,
     string? categoryString,
-    IReadOnlyList<(GeometryObject geometry, int? materialNodeKey)> members,
+    IReadOnlyList<(GeometryObject geometry, int? materialNodeKey, string? subcategoryName)> members,
     IReadOnlyDictionary<int, RenderMaterial> familyMaterialsByNode,
     IReadOnlyDictionary<int, ElementId> projectMaterialIdByNode,
     IReadOnlyList<(string childDefinitionKey, Matrix4x4 transform, string units)> nestedPlacements
@@ -388,7 +411,7 @@ public sealed class RevitFamilyBaker : IDisposable
     string familyName,
     string definitionKey,
     string? categoryString,
-    IReadOnlyList<(GeometryObject geometry, int? materialNodeKey)> members,
+    IReadOnlyList<(GeometryObject geometry, int? materialNodeKey, string? subcategoryName)> members,
     IReadOnlyDictionary<int, RenderMaterial> familyMaterialsByNode,
     IReadOnlyList<(string childDefinitionKey, Matrix4x4 transform, string units)> nestedPlacements
   )

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Receive/RevitHostObjectArtefactBuilder.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Receive/RevitHostObjectArtefactBuilder.cs
@@ -789,6 +789,8 @@ public sealed class RevitHostObjectArtefactBuilder : IArtifactHostObjectBuilder
     // definitions built depth-first (memoized here) so a parent can nest an already-baked child.
     var symbolByDefNode = new Dictionary<int, FamilySymbol>();
     var defBuilding = new HashSet<int>();
+    // Each member's source layer, keyed by its geometry K — the family baker owns the join [ENG-9343].
+    var subcategoryNames = _familyBaker.BuildMemberSubcategoryNames(bundle, rels);
 
     foreach (var kv in bundle.Nodes)
     {
@@ -800,6 +802,7 @@ public sealed class RevitHostObjectArtefactBuilder : IArtifactHostObjectBuilder
           rels,
           materialIdByNode,
           familyMaterialsByNode,
+          subcategoryNames,
           kv.Key,
           symbolByDefNode,
           defBuilding,
@@ -831,6 +834,7 @@ public sealed class RevitHostObjectArtefactBuilder : IArtifactHostObjectBuilder
     ArtefactRelations rels,
     Dictionary<int, ElementId> materialIdByNode,
     Dictionary<int, RenderMaterial> familyMaterialsByNode,
+    IReadOnlyDictionary<int, string> subcategoryNames,
     int defNodeK,
     Dictionary<int, FamilySymbol> symbolByDefNode,
     HashSet<int> defBuilding,
@@ -855,16 +859,17 @@ public sealed class RevitHostObjectArtefactBuilder : IArtifactHostObjectBuilder
 
     // direct geometry members (DEFINES → geometry). Definition/local-space — no reference-point re-basing here;
     // it's applied once, to the outer instance placement, in PlaceFamilyInstances [ENG-9099].
-    var members = new List<(GeometryObject geometry, int? materialNodeKey)>();
+    var members = new List<(GeometryObject geometry, int? materialNodeKey, string? subcategoryName)>();
     _lastDecodeFailure = null;
     if (rels.DefinesByDefinition.TryGetValue(defNodeK, out var geomKs))
     {
       foreach (var geomK in geomKs)
       {
         int? matNodeK = rels.MaterialByGeometry.TryGetValue(geomK, out var mk) ? mk : null;
+        subcategoryNames.TryGetValue(geomK, out var subcategoryName);
         foreach (var geom in DecodeFamilyGeometry(bundle, geomK))
         {
-          members.Add((geom, matNodeK));
+          members.Add((geom, matNodeK, subcategoryName));
         }
       }
     }
@@ -888,6 +893,7 @@ public sealed class RevitHostObjectArtefactBuilder : IArtifactHostObjectBuilder
             rels,
             materialIdByNode,
             familyMaterialsByNode,
+            subcategoryNames,
             childDefNodeK,
             symbolByDefNode,
             defBuilding,

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/Operations/Receive/RhinoHostObjectArtefactBuilder.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/Operations/Receive/RhinoHostObjectArtefactBuilder.cs
@@ -123,7 +123,7 @@ public class RhinoHostObjectArtefactBuilder : IArtifactHostObjectBuilder
     // on the object plane — member↔geometry joins on (definition, member ordinal), immune to the content-hash-dedup
     // collision a geometry-K-keyed inversion cannot distinguish. Bundles predating the vocab (no rel 25) fall back
     // to the @speckle.* member stamps [ENG-9110].
-    var memberIndex = TryBuildMemberIndexFromRels(rels) ?? DefinitionMemberStamps.Read(bundle.Properties);
+    var memberIndex = DefinitionMemberIndexes.Build(rels, bundle.Properties);
     session.SetStat("memberStamps", memberIndex.ObjectByGeometry.Count + memberIndex.ObjectByInstance.Count);
     var bakedObjectIds = new HashSet<string>();
     var conversionResults = new HashSet<ReceiveConversionResult>();
@@ -774,52 +774,6 @@ public class RhinoHostObjectArtefactBuilder : IArtifactHostObjectBuilder
         .ToList();
       yield return solids.Count > 0 ? solids : geoms;
     }
-  }
-
-  // The rel-built member index: DEFINES_MEMBER (25, def → member object, ord = member ordinal) joined against the
-  // definition's DEFINES ords recovers geometry K → member object K; PLACES (24, member object → INSTANCE node)
-  // inverts to INSTANCE K → member object K. Returns null when the bundle predates the vocabulary (no rel 25 rows)
-  // so the caller falls back to the legacy @speckle.* stamps.
-  private static DefinitionMemberIndex? TryBuildMemberIndexFromRels(ArtefactRelations rels)
-  {
-    //   rels.MemberObjectsByDefinition / rels.MemberOrdByDefinition : def K → member object Ks + MEMBER ordinals,
-    //                                                                index-aligned (DEFINES_MEMBER, rel 25)
-    //   rels.PlacesByObject            : member object K → INSTANCE node K (PLACES, rel 24)
-    if (rels.MemberObjectsByDefinition.Count == 0)
-    {
-      return null;
-    }
-    var byGeometry = new Dictionary<int, int>();
-    var byInstance = new Dictionary<int, int>();
-    foreach (var kv in rels.MemberObjectsByDefinition)
-    {
-      // member ordinal → member object K for this definition
-      var objByOrd = new Dictionary<int, int>();
-      var memberOrds = rels.MemberOrdByDefinition[kv.Key];
-      for (int m = 0; m < kv.Value.Count; m++)
-      {
-        objByOrd[memberOrds[m]] = kv.Value[m];
-      }
-      if (
-        !rels.DefinesByDefinition.TryGetValue(kv.Key, out var geomKs)
-        || !rels.DefinesOrdByDefinition.TryGetValue(kv.Key, out var geomOrds)
-      )
-      {
-        continue;
-      }
-      for (int i = 0; i < geomKs.Count; i++)
-      {
-        if (objByOrd.TryGetValue(geomOrds[i], out int memberObjK))
-        {
-          byGeometry[geomKs[i]] = memberObjK;
-        }
-      }
-    }
-    foreach (var kv in rels.PlacesByObject)
-    {
-      byInstance[kv.Value] = kv.Key;
-    }
-    return new DefinitionMemberIndex(byGeometry, byInstance);
   }
 
   // Builds every DEFINITION node into a Rhino InstanceDefinition, returning node K → Rhino defIndex. A DEFINITION owns

--- a/Sdk/Speckle.Connectors.Common/Instances/DefinitionMemberStamps.cs
+++ b/Sdk/Speckle.Connectors.Common/Instances/DefinitionMemberStamps.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using Speckle.Sdk.Pipelines.Receive.Artifacts;
 
 namespace Speckle.Connectors.Common.Instances;
 
@@ -115,3 +116,60 @@ public sealed record DefinitionMemberIndex(
   IReadOnlyDictionary<int, int> ObjectByGeometry,
   IReadOnlyDictionary<int, int> ObjectByInstance
 );
+
+/// <summary>
+/// Builds the <see cref="DefinitionMemberIndex"/> for a bundle, preferring the graph-native join over the eav
+/// stamps. Shared because Rhino, SketchUp and Revit all need the same member → object direction [ENG-9110].
+/// </summary>
+public static class DefinitionMemberIndexes
+{
+  /// <summary>
+  /// The graph-native join (<c>DEFINES_MEMBER</c> 25 / <c>PLACES</c> 24) when the bundle carries it, else the
+  /// <c>@speckle.*</c> stamps. Both invert the same direction; a bundle predating the vocab has only the stamps.
+  /// </summary>
+  public static DefinitionMemberIndex Build(
+    ArtefactRelations rels,
+    IReadOnlyDictionary<int, Dictionary<string, object?>> propertiesByObject
+  ) => TryFromRels(rels) ?? DefinitionMemberStamps.Read(propertiesByObject);
+
+  // Member ↔ geometry joins on (definition, member ordinal), which is immune to the content-hash-dedup collision a
+  // geometry-K-keyed inversion cannot distinguish.
+  private static DefinitionMemberIndex? TryFromRels(ArtefactRelations rels)
+  {
+    if (rels.MemberObjectsByDefinition.Count == 0)
+    {
+      return null;
+    }
+    var byGeometry = new Dictionary<int, int>();
+    var byInstance = new Dictionary<int, int>();
+    foreach (var kv in rels.MemberObjectsByDefinition)
+    {
+      // member ordinal → member object K for this definition
+      var objByOrd = new Dictionary<int, int>();
+      var memberOrds = rels.MemberOrdByDefinition[kv.Key];
+      for (int m = 0; m < kv.Value.Count; m++)
+      {
+        objByOrd[memberOrds[m]] = kv.Value[m];
+      }
+      if (
+        !rels.DefinesByDefinition.TryGetValue(kv.Key, out var geomKs)
+        || !rels.DefinesOrdByDefinition.TryGetValue(kv.Key, out var geomOrds)
+      )
+      {
+        continue;
+      }
+      for (int i = 0; i < geomKs.Count; i++)
+      {
+        if (objByOrd.TryGetValue(geomOrds[i], out int memberObjK))
+        {
+          byGeometry[geomKs[i]] = memberObjK;
+        }
+      }
+    }
+    foreach (var kv in rels.PlacesByObject)
+    {
+      byInstance[kv.Value] = kv.Key;
+    }
+    return new DefinitionMemberIndex(byGeometry, byInstance);
+  }
+}


### PR DESCRIPTION
### Before

See ticket [ENG-9343: Revit: blocks received as families lose their subcategories](https://linear.app/speckle/issue/ENG-9343/revit-blocks-received-as-families-lose-their-subcategories).

### After

<img width="1920" height="1049" alt="image" src="https://github.com/user-attachments/assets/e28891d7-b6b3-467a-8883-ec61f60ed5ee" />
