### PR TITLE
chore: bump Speckle.Sdk to 2026.9.0-alpha.3 (bundle schema_version 1)

### DIFF
--- a/Connectors/Autocad/Speckle.Connectors.Autocad2023/packages.lock.json
+++ b/Connectors/Autocad/Speckle.Connectors.Autocad2023/packages.lock.json
@@ -202,16 +202,16 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "uLLVpEgPV/J1n2DKZVd9Yf6HzKDKsOHsdChdEbNqqY3sidIk6qKPH8Jw8jvCiDCe6H6R82+azkFxusHcQ7+Y7Q==",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "U4y0lPsO3+Dk3ZgER4D2s6wOHPRjA6pJBF1xIJNmFwVvu8NSYOxiuvWTCNobqAgm77EEwkfePFiljuogql2Iyg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.10"
         }
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "zmae3tL4g4sOqmKQyMR6aFMLQb4np62OspIOzhZB3ZmiiCr1zECK7UZWY7BTyBcfjql0yiRR0ddcpIq2e9rT2g=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "kVbdQ9V0RA9KjgYVntZ9BaHlpPqnyGHHZExq2upExe2i2mS0f61t4VRlH4ApHJIDgDtmTdqg1G2bl+hpOq9iyw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -326,7 +326,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "speckle.connectors.dui": {
@@ -355,7 +355,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "Microsoft.Web.WebView2": {
@@ -372,9 +372,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-alpha.2, )",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "agIhQ/tqtWDpw1HSHzvu/EhhoIeRqay6z2SBY+6kgsVOOuQmVaEdRWvujMZrjBI9hTsb+fqv4SrifAbbxraBOw==",
+        "requested": "[2026.9.0-alpha.3, )",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "Sr+Nb/9gcbLCihAyv0B/Aw45jij4sYzhPgI62WFEFctpTOrZm+3hjrhKIC0tCwSFoXR5gGb6B6hpETcU7qwl3A==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -384,8 +384,8 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.2",
-          "Speckle.Sdk.Parquet": "2026.9.0-alpha.2",
+          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.3",
+          "Speckle.Sdk.Parquet": "2026.9.0-alpha.3",
           "System.Memory": "4.5.5",
           "System.Text.Json": "5.0.2"
         }

--- a/Connectors/Autocad/Speckle.Connectors.Autocad2024/packages.lock.json
+++ b/Connectors/Autocad/Speckle.Connectors.Autocad2024/packages.lock.json
@@ -202,16 +202,16 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "uLLVpEgPV/J1n2DKZVd9Yf6HzKDKsOHsdChdEbNqqY3sidIk6qKPH8Jw8jvCiDCe6H6R82+azkFxusHcQ7+Y7Q==",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "U4y0lPsO3+Dk3ZgER4D2s6wOHPRjA6pJBF1xIJNmFwVvu8NSYOxiuvWTCNobqAgm77EEwkfePFiljuogql2Iyg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.10"
         }
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "zmae3tL4g4sOqmKQyMR6aFMLQb4np62OspIOzhZB3ZmiiCr1zECK7UZWY7BTyBcfjql0yiRR0ddcpIq2e9rT2g=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "kVbdQ9V0RA9KjgYVntZ9BaHlpPqnyGHHZExq2upExe2i2mS0f61t4VRlH4ApHJIDgDtmTdqg1G2bl+hpOq9iyw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -326,7 +326,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "speckle.connectors.dui": {
@@ -356,7 +356,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "Microsoft.Web.WebView2": {
@@ -373,9 +373,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-alpha.2, )",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "agIhQ/tqtWDpw1HSHzvu/EhhoIeRqay6z2SBY+6kgsVOOuQmVaEdRWvujMZrjBI9hTsb+fqv4SrifAbbxraBOw==",
+        "requested": "[2026.9.0-alpha.3, )",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "Sr+Nb/9gcbLCihAyv0B/Aw45jij4sYzhPgI62WFEFctpTOrZm+3hjrhKIC0tCwSFoXR5gGb6B6hpETcU7qwl3A==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -385,8 +385,8 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.2",
-          "Speckle.Sdk.Parquet": "2026.9.0-alpha.2",
+          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.3",
+          "Speckle.Sdk.Parquet": "2026.9.0-alpha.3",
           "System.Memory": "4.5.5",
           "System.Text.Json": "5.0.2"
         }

--- a/Connectors/Autocad/Speckle.Connectors.Autocad2025/packages.lock.json
+++ b/Connectors/Autocad/Speckle.Connectors.Autocad2025/packages.lock.json
@@ -139,13 +139,13 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "uLLVpEgPV/J1n2DKZVd9Yf6HzKDKsOHsdChdEbNqqY3sidIk6qKPH8Jw8jvCiDCe6H6R82+azkFxusHcQ7+Y7Q=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "U4y0lPsO3+Dk3ZgER4D2s6wOHPRjA6pJBF1xIJNmFwVvu8NSYOxiuvWTCNobqAgm77EEwkfePFiljuogql2Iyg=="
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "zmae3tL4g4sOqmKQyMR6aFMLQb4np62OspIOzhZB3ZmiiCr1zECK7UZWY7BTyBcfjql0yiRR0ddcpIq2e9rT2g=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "kVbdQ9V0RA9KjgYVntZ9BaHlpPqnyGHHZExq2upExe2i2mS0f61t4VRlH4ApHJIDgDtmTdqg1G2bl+hpOq9iyw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -192,7 +192,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "speckle.connectors.dui": {
@@ -222,7 +222,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "Microsoft.Web.WebView2": {
@@ -239,9 +239,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-alpha.2, )",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "agIhQ/tqtWDpw1HSHzvu/EhhoIeRqay6z2SBY+6kgsVOOuQmVaEdRWvujMZrjBI9hTsb+fqv4SrifAbbxraBOw==",
+        "requested": "[2026.9.0-alpha.3, )",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "Sr+Nb/9gcbLCihAyv0B/Aw45jij4sYzhPgI62WFEFctpTOrZm+3hjrhKIC0tCwSFoXR5gGb6B6hpETcU7qwl3A==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -249,8 +249,8 @@
           "Microsoft.Extensions.ObjectPool": "8.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.2",
-          "Speckle.Sdk.Parquet": "2026.9.0-alpha.2"
+          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.3",
+          "Speckle.Sdk.Parquet": "2026.9.0-alpha.3"
         }
       }
     },

--- a/Connectors/Autocad/Speckle.Connectors.Autocad2026/packages.lock.json
+++ b/Connectors/Autocad/Speckle.Connectors.Autocad2026/packages.lock.json
@@ -139,13 +139,13 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "uLLVpEgPV/J1n2DKZVd9Yf6HzKDKsOHsdChdEbNqqY3sidIk6qKPH8Jw8jvCiDCe6H6R82+azkFxusHcQ7+Y7Q=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "U4y0lPsO3+Dk3ZgER4D2s6wOHPRjA6pJBF1xIJNmFwVvu8NSYOxiuvWTCNobqAgm77EEwkfePFiljuogql2Iyg=="
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "zmae3tL4g4sOqmKQyMR6aFMLQb4np62OspIOzhZB3ZmiiCr1zECK7UZWY7BTyBcfjql0yiRR0ddcpIq2e9rT2g=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "kVbdQ9V0RA9KjgYVntZ9BaHlpPqnyGHHZExq2upExe2i2mS0f61t4VRlH4ApHJIDgDtmTdqg1G2bl+hpOq9iyw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -192,7 +192,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "speckle.connectors.dui": {
@@ -222,7 +222,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "Microsoft.Web.WebView2": {
@@ -239,9 +239,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-alpha.2, )",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "agIhQ/tqtWDpw1HSHzvu/EhhoIeRqay6z2SBY+6kgsVOOuQmVaEdRWvujMZrjBI9hTsb+fqv4SrifAbbxraBOw==",
+        "requested": "[2026.9.0-alpha.3, )",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "Sr+Nb/9gcbLCihAyv0B/Aw45jij4sYzhPgI62WFEFctpTOrZm+3hjrhKIC0tCwSFoXR5gGb6B6hpETcU7qwl3A==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -249,8 +249,8 @@
           "Microsoft.Extensions.ObjectPool": "8.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.2",
-          "Speckle.Sdk.Parquet": "2026.9.0-alpha.2"
+          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.3",
+          "Speckle.Sdk.Parquet": "2026.9.0-alpha.3"
         }
       }
     },

--- a/Connectors/Autocad/Speckle.Connectors.Autocad2027/packages.lock.json
+++ b/Connectors/Autocad/Speckle.Connectors.Autocad2027/packages.lock.json
@@ -140,13 +140,13 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "uLLVpEgPV/J1n2DKZVd9Yf6HzKDKsOHsdChdEbNqqY3sidIk6qKPH8Jw8jvCiDCe6H6R82+azkFxusHcQ7+Y7Q=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "U4y0lPsO3+Dk3ZgER4D2s6wOHPRjA6pJBF1xIJNmFwVvu8NSYOxiuvWTCNobqAgm77EEwkfePFiljuogql2Iyg=="
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "zmae3tL4g4sOqmKQyMR6aFMLQb4np62OspIOzhZB3ZmiiCr1zECK7UZWY7BTyBcfjql0yiRR0ddcpIq2e9rT2g=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "kVbdQ9V0RA9KjgYVntZ9BaHlpPqnyGHHZExq2upExe2i2mS0f61t4VRlH4ApHJIDgDtmTdqg1G2bl+hpOq9iyw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -185,7 +185,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "speckle.connectors.dui": {
@@ -215,7 +215,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "Microsoft.Web.WebView2": {
@@ -232,9 +232,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-alpha.2, )",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "agIhQ/tqtWDpw1HSHzvu/EhhoIeRqay6z2SBY+6kgsVOOuQmVaEdRWvujMZrjBI9hTsb+fqv4SrifAbbxraBOw==",
+        "requested": "[2026.9.0-alpha.3, )",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "Sr+Nb/9gcbLCihAyv0B/Aw45jij4sYzhPgI62WFEFctpTOrZm+3hjrhKIC0tCwSFoXR5gGb6B6hpETcU7qwl3A==",
         "dependencies": {
           "GraphQL.Client": "6.1.0",
           "Microsoft.Data.Sqlite": "10.0.0",
@@ -242,8 +242,8 @@
           "Microsoft.Extensions.ObjectPool": "10.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.2",
-          "Speckle.Sdk.Parquet": "2026.9.0-alpha.2"
+          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.3",
+          "Speckle.Sdk.Parquet": "2026.9.0-alpha.3"
         }
       }
     },

--- a/Connectors/Autocad/Speckle.Connectors.Civil3d2023/packages.lock.json
+++ b/Connectors/Autocad/Speckle.Connectors.Civil3d2023/packages.lock.json
@@ -211,16 +211,16 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "uLLVpEgPV/J1n2DKZVd9Yf6HzKDKsOHsdChdEbNqqY3sidIk6qKPH8Jw8jvCiDCe6H6R82+azkFxusHcQ7+Y7Q==",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "U4y0lPsO3+Dk3ZgER4D2s6wOHPRjA6pJBF1xIJNmFwVvu8NSYOxiuvWTCNobqAgm77EEwkfePFiljuogql2Iyg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.10"
         }
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "zmae3tL4g4sOqmKQyMR6aFMLQb4np62OspIOzhZB3ZmiiCr1zECK7UZWY7BTyBcfjql0yiRR0ddcpIq2e9rT2g=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "kVbdQ9V0RA9KjgYVntZ9BaHlpPqnyGHHZExq2upExe2i2mS0f61t4VRlH4ApHJIDgDtmTdqg1G2bl+hpOq9iyw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -335,7 +335,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "speckle.connectors.dui": {
@@ -365,7 +365,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "Microsoft.Web.WebView2": {
@@ -382,9 +382,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-alpha.2, )",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "agIhQ/tqtWDpw1HSHzvu/EhhoIeRqay6z2SBY+6kgsVOOuQmVaEdRWvujMZrjBI9hTsb+fqv4SrifAbbxraBOw==",
+        "requested": "[2026.9.0-alpha.3, )",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "Sr+Nb/9gcbLCihAyv0B/Aw45jij4sYzhPgI62WFEFctpTOrZm+3hjrhKIC0tCwSFoXR5gGb6B6hpETcU7qwl3A==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -394,8 +394,8 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.2",
-          "Speckle.Sdk.Parquet": "2026.9.0-alpha.2",
+          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.3",
+          "Speckle.Sdk.Parquet": "2026.9.0-alpha.3",
           "System.Memory": "4.5.5",
           "System.Text.Json": "5.0.2"
         }

--- a/Connectors/Autocad/Speckle.Connectors.Civil3d2024/packages.lock.json
+++ b/Connectors/Autocad/Speckle.Connectors.Civil3d2024/packages.lock.json
@@ -211,16 +211,16 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "uLLVpEgPV/J1n2DKZVd9Yf6HzKDKsOHsdChdEbNqqY3sidIk6qKPH8Jw8jvCiDCe6H6R82+azkFxusHcQ7+Y7Q==",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "U4y0lPsO3+Dk3ZgER4D2s6wOHPRjA6pJBF1xIJNmFwVvu8NSYOxiuvWTCNobqAgm77EEwkfePFiljuogql2Iyg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.10"
         }
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "zmae3tL4g4sOqmKQyMR6aFMLQb4np62OspIOzhZB3ZmiiCr1zECK7UZWY7BTyBcfjql0yiRR0ddcpIq2e9rT2g=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "kVbdQ9V0RA9KjgYVntZ9BaHlpPqnyGHHZExq2upExe2i2mS0f61t4VRlH4ApHJIDgDtmTdqg1G2bl+hpOq9iyw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -335,7 +335,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "speckle.connectors.dui": {
@@ -365,7 +365,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "Microsoft.Web.WebView2": {
@@ -382,9 +382,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-alpha.2, )",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "agIhQ/tqtWDpw1HSHzvu/EhhoIeRqay6z2SBY+6kgsVOOuQmVaEdRWvujMZrjBI9hTsb+fqv4SrifAbbxraBOw==",
+        "requested": "[2026.9.0-alpha.3, )",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "Sr+Nb/9gcbLCihAyv0B/Aw45jij4sYzhPgI62WFEFctpTOrZm+3hjrhKIC0tCwSFoXR5gGb6B6hpETcU7qwl3A==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -394,8 +394,8 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.2",
-          "Speckle.Sdk.Parquet": "2026.9.0-alpha.2",
+          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.3",
+          "Speckle.Sdk.Parquet": "2026.9.0-alpha.3",
           "System.Memory": "4.5.5",
           "System.Text.Json": "5.0.2"
         }

--- a/Connectors/Autocad/Speckle.Connectors.Civil3d2025/packages.lock.json
+++ b/Connectors/Autocad/Speckle.Connectors.Civil3d2025/packages.lock.json
@@ -148,13 +148,13 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "uLLVpEgPV/J1n2DKZVd9Yf6HzKDKsOHsdChdEbNqqY3sidIk6qKPH8Jw8jvCiDCe6H6R82+azkFxusHcQ7+Y7Q=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "U4y0lPsO3+Dk3ZgER4D2s6wOHPRjA6pJBF1xIJNmFwVvu8NSYOxiuvWTCNobqAgm77EEwkfePFiljuogql2Iyg=="
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "zmae3tL4g4sOqmKQyMR6aFMLQb4np62OspIOzhZB3ZmiiCr1zECK7UZWY7BTyBcfjql0yiRR0ddcpIq2e9rT2g=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "kVbdQ9V0RA9KjgYVntZ9BaHlpPqnyGHHZExq2upExe2i2mS0f61t4VRlH4ApHJIDgDtmTdqg1G2bl+hpOq9iyw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -201,7 +201,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "speckle.connectors.dui": {
@@ -232,7 +232,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "Microsoft.Web.WebView2": {
@@ -249,9 +249,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-alpha.2, )",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "agIhQ/tqtWDpw1HSHzvu/EhhoIeRqay6z2SBY+6kgsVOOuQmVaEdRWvujMZrjBI9hTsb+fqv4SrifAbbxraBOw==",
+        "requested": "[2026.9.0-alpha.3, )",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "Sr+Nb/9gcbLCihAyv0B/Aw45jij4sYzhPgI62WFEFctpTOrZm+3hjrhKIC0tCwSFoXR5gGb6B6hpETcU7qwl3A==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -259,8 +259,8 @@
           "Microsoft.Extensions.ObjectPool": "8.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.2",
-          "Speckle.Sdk.Parquet": "2026.9.0-alpha.2"
+          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.3",
+          "Speckle.Sdk.Parquet": "2026.9.0-alpha.3"
         }
       }
     },

--- a/Connectors/Autocad/Speckle.Connectors.Civil3d2026/packages.lock.json
+++ b/Connectors/Autocad/Speckle.Connectors.Civil3d2026/packages.lock.json
@@ -148,13 +148,13 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "uLLVpEgPV/J1n2DKZVd9Yf6HzKDKsOHsdChdEbNqqY3sidIk6qKPH8Jw8jvCiDCe6H6R82+azkFxusHcQ7+Y7Q=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "U4y0lPsO3+Dk3ZgER4D2s6wOHPRjA6pJBF1xIJNmFwVvu8NSYOxiuvWTCNobqAgm77EEwkfePFiljuogql2Iyg=="
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "zmae3tL4g4sOqmKQyMR6aFMLQb4np62OspIOzhZB3ZmiiCr1zECK7UZWY7BTyBcfjql0yiRR0ddcpIq2e9rT2g=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "kVbdQ9V0RA9KjgYVntZ9BaHlpPqnyGHHZExq2upExe2i2mS0f61t4VRlH4ApHJIDgDtmTdqg1G2bl+hpOq9iyw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -201,7 +201,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "speckle.connectors.dui": {
@@ -232,7 +232,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "Microsoft.Web.WebView2": {
@@ -249,9 +249,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-alpha.2, )",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "agIhQ/tqtWDpw1HSHzvu/EhhoIeRqay6z2SBY+6kgsVOOuQmVaEdRWvujMZrjBI9hTsb+fqv4SrifAbbxraBOw==",
+        "requested": "[2026.9.0-alpha.3, )",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "Sr+Nb/9gcbLCihAyv0B/Aw45jij4sYzhPgI62WFEFctpTOrZm+3hjrhKIC0tCwSFoXR5gGb6B6hpETcU7qwl3A==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -259,8 +259,8 @@
           "Microsoft.Extensions.ObjectPool": "8.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.2",
-          "Speckle.Sdk.Parquet": "2026.9.0-alpha.2"
+          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.3",
+          "Speckle.Sdk.Parquet": "2026.9.0-alpha.3"
         }
       }
     },

--- a/Connectors/Autocad/Speckle.Connectors.Civil3d2027/packages.lock.json
+++ b/Connectors/Autocad/Speckle.Connectors.Civil3d2027/packages.lock.json
@@ -149,13 +149,13 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "uLLVpEgPV/J1n2DKZVd9Yf6HzKDKsOHsdChdEbNqqY3sidIk6qKPH8Jw8jvCiDCe6H6R82+azkFxusHcQ7+Y7Q=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "U4y0lPsO3+Dk3ZgER4D2s6wOHPRjA6pJBF1xIJNmFwVvu8NSYOxiuvWTCNobqAgm77EEwkfePFiljuogql2Iyg=="
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "zmae3tL4g4sOqmKQyMR6aFMLQb4np62OspIOzhZB3ZmiiCr1zECK7UZWY7BTyBcfjql0yiRR0ddcpIq2e9rT2g=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "kVbdQ9V0RA9KjgYVntZ9BaHlpPqnyGHHZExq2upExe2i2mS0f61t4VRlH4ApHJIDgDtmTdqg1G2bl+hpOq9iyw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -194,7 +194,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "speckle.connectors.dui": {
@@ -225,7 +225,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "Microsoft.Web.WebView2": {
@@ -242,9 +242,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-alpha.2, )",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "agIhQ/tqtWDpw1HSHzvu/EhhoIeRqay6z2SBY+6kgsVOOuQmVaEdRWvujMZrjBI9hTsb+fqv4SrifAbbxraBOw==",
+        "requested": "[2026.9.0-alpha.3, )",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "Sr+Nb/9gcbLCihAyv0B/Aw45jij4sYzhPgI62WFEFctpTOrZm+3hjrhKIC0tCwSFoXR5gGb6B6hpETcU7qwl3A==",
         "dependencies": {
           "GraphQL.Client": "6.1.0",
           "Microsoft.Data.Sqlite": "10.0.0",
@@ -252,8 +252,8 @@
           "Microsoft.Extensions.ObjectPool": "10.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.2",
-          "Speckle.Sdk.Parquet": "2026.9.0-alpha.2"
+          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.3",
+          "Speckle.Sdk.Parquet": "2026.9.0-alpha.3"
         }
       }
     },

--- a/Connectors/Autocad/Speckle.Connectors.Plant3d2026/packages.lock.json
+++ b/Connectors/Autocad/Speckle.Connectors.Plant3d2026/packages.lock.json
@@ -148,13 +148,13 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "uLLVpEgPV/J1n2DKZVd9Yf6HzKDKsOHsdChdEbNqqY3sidIk6qKPH8Jw8jvCiDCe6H6R82+azkFxusHcQ7+Y7Q=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "U4y0lPsO3+Dk3ZgER4D2s6wOHPRjA6pJBF1xIJNmFwVvu8NSYOxiuvWTCNobqAgm77EEwkfePFiljuogql2Iyg=="
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "zmae3tL4g4sOqmKQyMR6aFMLQb4np62OspIOzhZB3ZmiiCr1zECK7UZWY7BTyBcfjql0yiRR0ddcpIq2e9rT2g=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "kVbdQ9V0RA9KjgYVntZ9BaHlpPqnyGHHZExq2upExe2i2mS0f61t4VRlH4ApHJIDgDtmTdqg1G2bl+hpOq9iyw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -201,7 +201,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "speckle.connectors.dui": {
@@ -223,7 +223,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "speckle.converters.plant3d2026": {
@@ -249,9 +249,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-alpha.2, )",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "agIhQ/tqtWDpw1HSHzvu/EhhoIeRqay6z2SBY+6kgsVOOuQmVaEdRWvujMZrjBI9hTsb+fqv4SrifAbbxraBOw==",
+        "requested": "[2026.9.0-alpha.3, )",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "Sr+Nb/9gcbLCihAyv0B/Aw45jij4sYzhPgI62WFEFctpTOrZm+3hjrhKIC0tCwSFoXR5gGb6B6hpETcU7qwl3A==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -259,8 +259,8 @@
           "Microsoft.Extensions.ObjectPool": "8.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.2",
-          "Speckle.Sdk.Parquet": "2026.9.0-alpha.2"
+          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.3",
+          "Speckle.Sdk.Parquet": "2026.9.0-alpha.3"
         }
       }
     },

--- a/Connectors/Autocad/Speckle.Connectors.Plant3d2027/packages.lock.json
+++ b/Connectors/Autocad/Speckle.Connectors.Plant3d2027/packages.lock.json
@@ -149,13 +149,13 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "uLLVpEgPV/J1n2DKZVd9Yf6HzKDKsOHsdChdEbNqqY3sidIk6qKPH8Jw8jvCiDCe6H6R82+azkFxusHcQ7+Y7Q=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "U4y0lPsO3+Dk3ZgER4D2s6wOHPRjA6pJBF1xIJNmFwVvu8NSYOxiuvWTCNobqAgm77EEwkfePFiljuogql2Iyg=="
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "zmae3tL4g4sOqmKQyMR6aFMLQb4np62OspIOzhZB3ZmiiCr1zECK7UZWY7BTyBcfjql0yiRR0ddcpIq2e9rT2g=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "kVbdQ9V0RA9KjgYVntZ9BaHlpPqnyGHHZExq2upExe2i2mS0f61t4VRlH4ApHJIDgDtmTdqg1G2bl+hpOq9iyw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -194,7 +194,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "speckle.connectors.dui": {
@@ -216,7 +216,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "speckle.converters.plant3d2027": {
@@ -242,9 +242,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-alpha.2, )",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "agIhQ/tqtWDpw1HSHzvu/EhhoIeRqay6z2SBY+6kgsVOOuQmVaEdRWvujMZrjBI9hTsb+fqv4SrifAbbxraBOw==",
+        "requested": "[2026.9.0-alpha.3, )",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "Sr+Nb/9gcbLCihAyv0B/Aw45jij4sYzhPgI62WFEFctpTOrZm+3hjrhKIC0tCwSFoXR5gGb6B6hpETcU7qwl3A==",
         "dependencies": {
           "GraphQL.Client": "6.1.0",
           "Microsoft.Data.Sqlite": "10.0.0",
@@ -252,8 +252,8 @@
           "Microsoft.Extensions.ObjectPool": "10.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.2",
-          "Speckle.Sdk.Parquet": "2026.9.0-alpha.2"
+          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.3",
+          "Speckle.Sdk.Parquet": "2026.9.0-alpha.3"
         }
       }
     },

--- a/Connectors/CSi/Speckle.Connectors.ETABS21/packages.lock.json
+++ b/Connectors/CSi/Speckle.Connectors.ETABS21/packages.lock.json
@@ -218,16 +218,16 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "uLLVpEgPV/J1n2DKZVd9Yf6HzKDKsOHsdChdEbNqqY3sidIk6qKPH8Jw8jvCiDCe6H6R82+azkFxusHcQ7+Y7Q==",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "U4y0lPsO3+Dk3ZgER4D2s6wOHPRjA6pJBF1xIJNmFwVvu8NSYOxiuvWTCNobqAgm77EEwkfePFiljuogql2Iyg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.10"
         }
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "zmae3tL4g4sOqmKQyMR6aFMLQb4np62OspIOzhZB3ZmiiCr1zECK7UZWY7BTyBcfjql0yiRR0ddcpIq2e9rT2g=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "kVbdQ9V0RA9KjgYVntZ9BaHlpPqnyGHHZExq2upExe2i2mS0f61t4VRlH4ApHJIDgDtmTdqg1G2bl+hpOq9iyw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -343,7 +343,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "speckle.connectors.dui": {
@@ -365,7 +365,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "speckle.converters.etabs21": {
@@ -388,9 +388,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-alpha.2, )",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "agIhQ/tqtWDpw1HSHzvu/EhhoIeRqay6z2SBY+6kgsVOOuQmVaEdRWvujMZrjBI9hTsb+fqv4SrifAbbxraBOw==",
+        "requested": "[2026.9.0-alpha.3, )",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "Sr+Nb/9gcbLCihAyv0B/Aw45jij4sYzhPgI62WFEFctpTOrZm+3hjrhKIC0tCwSFoXR5gGb6B6hpETcU7qwl3A==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -400,8 +400,8 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.2",
-          "Speckle.Sdk.Parquet": "2026.9.0-alpha.2",
+          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.3",
+          "Speckle.Sdk.Parquet": "2026.9.0-alpha.3",
           "System.Memory": "4.5.5",
           "System.Text.Json": "5.0.2"
         }

--- a/Connectors/CSi/Speckle.Connectors.ETABS22/packages.lock.json
+++ b/Connectors/CSi/Speckle.Connectors.ETABS22/packages.lock.json
@@ -139,13 +139,13 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "uLLVpEgPV/J1n2DKZVd9Yf6HzKDKsOHsdChdEbNqqY3sidIk6qKPH8Jw8jvCiDCe6H6R82+azkFxusHcQ7+Y7Q=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "U4y0lPsO3+Dk3ZgER4D2s6wOHPRjA6pJBF1xIJNmFwVvu8NSYOxiuvWTCNobqAgm77EEwkfePFiljuogql2Iyg=="
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "zmae3tL4g4sOqmKQyMR6aFMLQb4np62OspIOzhZB3ZmiiCr1zECK7UZWY7BTyBcfjql0yiRR0ddcpIq2e9rT2g=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "kVbdQ9V0RA9KjgYVntZ9BaHlpPqnyGHHZExq2upExe2i2mS0f61t4VRlH4ApHJIDgDtmTdqg1G2bl+hpOq9iyw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -192,7 +192,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "speckle.connectors.dui": {
@@ -214,7 +214,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "speckle.converters.etabs22": {
@@ -237,9 +237,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-alpha.2, )",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "agIhQ/tqtWDpw1HSHzvu/EhhoIeRqay6z2SBY+6kgsVOOuQmVaEdRWvujMZrjBI9hTsb+fqv4SrifAbbxraBOw==",
+        "requested": "[2026.9.0-alpha.3, )",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "Sr+Nb/9gcbLCihAyv0B/Aw45jij4sYzhPgI62WFEFctpTOrZm+3hjrhKIC0tCwSFoXR5gGb6B6hpETcU7qwl3A==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -247,8 +247,8 @@
           "Microsoft.Extensions.ObjectPool": "8.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.2",
-          "Speckle.Sdk.Parquet": "2026.9.0-alpha.2"
+          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.3",
+          "Speckle.Sdk.Parquet": "2026.9.0-alpha.3"
         }
       }
     }

--- a/Connectors/Navisworks/Speckle.Connectors.Navisworks2020/packages.lock.json
+++ b/Connectors/Navisworks/Speckle.Connectors.Navisworks2020/packages.lock.json
@@ -180,16 +180,16 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "uLLVpEgPV/J1n2DKZVd9Yf6HzKDKsOHsdChdEbNqqY3sidIk6qKPH8Jw8jvCiDCe6H6R82+azkFxusHcQ7+Y7Q==",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "U4y0lPsO3+Dk3ZgER4D2s6wOHPRjA6pJBF1xIJNmFwVvu8NSYOxiuvWTCNobqAgm77EEwkfePFiljuogql2Iyg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.10"
         }
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "zmae3tL4g4sOqmKQyMR6aFMLQb4np62OspIOzhZB3ZmiiCr1zECK7UZWY7BTyBcfjql0yiRR0ddcpIq2e9rT2g=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "kVbdQ9V0RA9KjgYVntZ9BaHlpPqnyGHHZExq2upExe2i2mS0f61t4VRlH4ApHJIDgDtmTdqg1G2bl+hpOq9iyw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -295,7 +295,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "speckle.connectors.dui": {
@@ -317,7 +317,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "speckle.converters.navisworks2020": {
@@ -342,9 +342,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-alpha.2, )",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "agIhQ/tqtWDpw1HSHzvu/EhhoIeRqay6z2SBY+6kgsVOOuQmVaEdRWvujMZrjBI9hTsb+fqv4SrifAbbxraBOw==",
+        "requested": "[2026.9.0-alpha.3, )",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "Sr+Nb/9gcbLCihAyv0B/Aw45jij4sYzhPgI62WFEFctpTOrZm+3hjrhKIC0tCwSFoXR5gGb6B6hpETcU7qwl3A==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -354,8 +354,8 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.2",
-          "Speckle.Sdk.Parquet": "2026.9.0-alpha.2",
+          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.3",
+          "Speckle.Sdk.Parquet": "2026.9.0-alpha.3",
           "System.Memory": "4.5.5",
           "System.Text.Json": "5.0.2"
         }

--- a/Connectors/Navisworks/Speckle.Connectors.Navisworks2021/packages.lock.json
+++ b/Connectors/Navisworks/Speckle.Connectors.Navisworks2021/packages.lock.json
@@ -180,16 +180,16 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "uLLVpEgPV/J1n2DKZVd9Yf6HzKDKsOHsdChdEbNqqY3sidIk6qKPH8Jw8jvCiDCe6H6R82+azkFxusHcQ7+Y7Q==",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "U4y0lPsO3+Dk3ZgER4D2s6wOHPRjA6pJBF1xIJNmFwVvu8NSYOxiuvWTCNobqAgm77EEwkfePFiljuogql2Iyg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.10"
         }
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "zmae3tL4g4sOqmKQyMR6aFMLQb4np62OspIOzhZB3ZmiiCr1zECK7UZWY7BTyBcfjql0yiRR0ddcpIq2e9rT2g=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "kVbdQ9V0RA9KjgYVntZ9BaHlpPqnyGHHZExq2upExe2i2mS0f61t4VRlH4ApHJIDgDtmTdqg1G2bl+hpOq9iyw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -295,7 +295,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "speckle.connectors.dui": {
@@ -317,7 +317,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "speckle.converters.navisworks2021": {
@@ -342,9 +342,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-alpha.2, )",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "agIhQ/tqtWDpw1HSHzvu/EhhoIeRqay6z2SBY+6kgsVOOuQmVaEdRWvujMZrjBI9hTsb+fqv4SrifAbbxraBOw==",
+        "requested": "[2026.9.0-alpha.3, )",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "Sr+Nb/9gcbLCihAyv0B/Aw45jij4sYzhPgI62WFEFctpTOrZm+3hjrhKIC0tCwSFoXR5gGb6B6hpETcU7qwl3A==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -354,8 +354,8 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.2",
-          "Speckle.Sdk.Parquet": "2026.9.0-alpha.2",
+          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.3",
+          "Speckle.Sdk.Parquet": "2026.9.0-alpha.3",
           "System.Memory": "4.5.5",
           "System.Text.Json": "5.0.2"
         }

--- a/Connectors/Navisworks/Speckle.Connectors.Navisworks2022/packages.lock.json
+++ b/Connectors/Navisworks/Speckle.Connectors.Navisworks2022/packages.lock.json
@@ -180,16 +180,16 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "uLLVpEgPV/J1n2DKZVd9Yf6HzKDKsOHsdChdEbNqqY3sidIk6qKPH8Jw8jvCiDCe6H6R82+azkFxusHcQ7+Y7Q==",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "U4y0lPsO3+Dk3ZgER4D2s6wOHPRjA6pJBF1xIJNmFwVvu8NSYOxiuvWTCNobqAgm77EEwkfePFiljuogql2Iyg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.10"
         }
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "zmae3tL4g4sOqmKQyMR6aFMLQb4np62OspIOzhZB3ZmiiCr1zECK7UZWY7BTyBcfjql0yiRR0ddcpIq2e9rT2g=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "kVbdQ9V0RA9KjgYVntZ9BaHlpPqnyGHHZExq2upExe2i2mS0f61t4VRlH4ApHJIDgDtmTdqg1G2bl+hpOq9iyw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -295,7 +295,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "speckle.connectors.dui": {
@@ -317,7 +317,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "speckle.converters.navisworks2022": {
@@ -342,9 +342,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-alpha.2, )",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "agIhQ/tqtWDpw1HSHzvu/EhhoIeRqay6z2SBY+6kgsVOOuQmVaEdRWvujMZrjBI9hTsb+fqv4SrifAbbxraBOw==",
+        "requested": "[2026.9.0-alpha.3, )",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "Sr+Nb/9gcbLCihAyv0B/Aw45jij4sYzhPgI62WFEFctpTOrZm+3hjrhKIC0tCwSFoXR5gGb6B6hpETcU7qwl3A==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -354,8 +354,8 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.2",
-          "Speckle.Sdk.Parquet": "2026.9.0-alpha.2",
+          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.3",
+          "Speckle.Sdk.Parquet": "2026.9.0-alpha.3",
           "System.Memory": "4.5.5",
           "System.Text.Json": "5.0.2"
         }

--- a/Connectors/Navisworks/Speckle.Connectors.Navisworks2023/packages.lock.json
+++ b/Connectors/Navisworks/Speckle.Connectors.Navisworks2023/packages.lock.json
@@ -180,16 +180,16 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "uLLVpEgPV/J1n2DKZVd9Yf6HzKDKsOHsdChdEbNqqY3sidIk6qKPH8Jw8jvCiDCe6H6R82+azkFxusHcQ7+Y7Q==",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "U4y0lPsO3+Dk3ZgER4D2s6wOHPRjA6pJBF1xIJNmFwVvu8NSYOxiuvWTCNobqAgm77EEwkfePFiljuogql2Iyg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.10"
         }
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "zmae3tL4g4sOqmKQyMR6aFMLQb4np62OspIOzhZB3ZmiiCr1zECK7UZWY7BTyBcfjql0yiRR0ddcpIq2e9rT2g=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "kVbdQ9V0RA9KjgYVntZ9BaHlpPqnyGHHZExq2upExe2i2mS0f61t4VRlH4ApHJIDgDtmTdqg1G2bl+hpOq9iyw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -295,7 +295,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "speckle.connectors.dui": {
@@ -317,7 +317,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "speckle.converters.navisworks2023": {
@@ -342,9 +342,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-alpha.2, )",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "agIhQ/tqtWDpw1HSHzvu/EhhoIeRqay6z2SBY+6kgsVOOuQmVaEdRWvujMZrjBI9hTsb+fqv4SrifAbbxraBOw==",
+        "requested": "[2026.9.0-alpha.3, )",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "Sr+Nb/9gcbLCihAyv0B/Aw45jij4sYzhPgI62WFEFctpTOrZm+3hjrhKIC0tCwSFoXR5gGb6B6hpETcU7qwl3A==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -354,8 +354,8 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.2",
-          "Speckle.Sdk.Parquet": "2026.9.0-alpha.2",
+          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.3",
+          "Speckle.Sdk.Parquet": "2026.9.0-alpha.3",
           "System.Memory": "4.5.5",
           "System.Text.Json": "5.0.2"
         }

--- a/Connectors/Navisworks/Speckle.Connectors.Navisworks2024/packages.lock.json
+++ b/Connectors/Navisworks/Speckle.Connectors.Navisworks2024/packages.lock.json
@@ -180,16 +180,16 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "uLLVpEgPV/J1n2DKZVd9Yf6HzKDKsOHsdChdEbNqqY3sidIk6qKPH8Jw8jvCiDCe6H6R82+azkFxusHcQ7+Y7Q==",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "U4y0lPsO3+Dk3ZgER4D2s6wOHPRjA6pJBF1xIJNmFwVvu8NSYOxiuvWTCNobqAgm77EEwkfePFiljuogql2Iyg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.10"
         }
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "zmae3tL4g4sOqmKQyMR6aFMLQb4np62OspIOzhZB3ZmiiCr1zECK7UZWY7BTyBcfjql0yiRR0ddcpIq2e9rT2g=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "kVbdQ9V0RA9KjgYVntZ9BaHlpPqnyGHHZExq2upExe2i2mS0f61t4VRlH4ApHJIDgDtmTdqg1G2bl+hpOq9iyw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -295,7 +295,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "speckle.connectors.dui": {
@@ -317,7 +317,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "speckle.converters.navisworks2024": {
@@ -342,9 +342,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-alpha.2, )",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "agIhQ/tqtWDpw1HSHzvu/EhhoIeRqay6z2SBY+6kgsVOOuQmVaEdRWvujMZrjBI9hTsb+fqv4SrifAbbxraBOw==",
+        "requested": "[2026.9.0-alpha.3, )",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "Sr+Nb/9gcbLCihAyv0B/Aw45jij4sYzhPgI62WFEFctpTOrZm+3hjrhKIC0tCwSFoXR5gGb6B6hpETcU7qwl3A==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -354,8 +354,8 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.2",
-          "Speckle.Sdk.Parquet": "2026.9.0-alpha.2",
+          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.3",
+          "Speckle.Sdk.Parquet": "2026.9.0-alpha.3",
           "System.Memory": "4.5.5",
           "System.Text.Json": "5.0.2"
         }

--- a/Connectors/Navisworks/Speckle.Connectors.Navisworks2025/packages.lock.json
+++ b/Connectors/Navisworks/Speckle.Connectors.Navisworks2025/packages.lock.json
@@ -186,16 +186,16 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "uLLVpEgPV/J1n2DKZVd9Yf6HzKDKsOHsdChdEbNqqY3sidIk6qKPH8Jw8jvCiDCe6H6R82+azkFxusHcQ7+Y7Q==",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "U4y0lPsO3+Dk3ZgER4D2s6wOHPRjA6pJBF1xIJNmFwVvu8NSYOxiuvWTCNobqAgm77EEwkfePFiljuogql2Iyg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.10"
         }
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "zmae3tL4g4sOqmKQyMR6aFMLQb4np62OspIOzhZB3ZmiiCr1zECK7UZWY7BTyBcfjql0yiRR0ddcpIq2e9rT2g=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "kVbdQ9V0RA9KjgYVntZ9BaHlpPqnyGHHZExq2upExe2i2mS0f61t4VRlH4ApHJIDgDtmTdqg1G2bl+hpOq9iyw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -301,7 +301,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "speckle.connectors.dui": {
@@ -323,7 +323,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "speckle.converters.navisworks2025": {
@@ -342,9 +342,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-alpha.2, )",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "agIhQ/tqtWDpw1HSHzvu/EhhoIeRqay6z2SBY+6kgsVOOuQmVaEdRWvujMZrjBI9hTsb+fqv4SrifAbbxraBOw==",
+        "requested": "[2026.9.0-alpha.3, )",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "Sr+Nb/9gcbLCihAyv0B/Aw45jij4sYzhPgI62WFEFctpTOrZm+3hjrhKIC0tCwSFoXR5gGb6B6hpETcU7qwl3A==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -354,8 +354,8 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.2",
-          "Speckle.Sdk.Parquet": "2026.9.0-alpha.2",
+          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.3",
+          "Speckle.Sdk.Parquet": "2026.9.0-alpha.3",
           "System.Memory": "4.5.5",
           "System.Text.Json": "5.0.2"
         }

--- a/Connectors/Navisworks/Speckle.Connectors.Navisworks2026/packages.lock.json
+++ b/Connectors/Navisworks/Speckle.Connectors.Navisworks2026/packages.lock.json
@@ -195,16 +195,16 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "uLLVpEgPV/J1n2DKZVd9Yf6HzKDKsOHsdChdEbNqqY3sidIk6qKPH8Jw8jvCiDCe6H6R82+azkFxusHcQ7+Y7Q==",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "U4y0lPsO3+Dk3ZgER4D2s6wOHPRjA6pJBF1xIJNmFwVvu8NSYOxiuvWTCNobqAgm77EEwkfePFiljuogql2Iyg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.10"
         }
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "zmae3tL4g4sOqmKQyMR6aFMLQb4np62OspIOzhZB3ZmiiCr1zECK7UZWY7BTyBcfjql0yiRR0ddcpIq2e9rT2g=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "kVbdQ9V0RA9KjgYVntZ9BaHlpPqnyGHHZExq2upExe2i2mS0f61t4VRlH4ApHJIDgDtmTdqg1G2bl+hpOq9iyw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -302,7 +302,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "speckle.connectors.dui": {
@@ -324,7 +324,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "speckle.converters.navisworks2026": {
@@ -344,9 +344,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-alpha.2, )",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "agIhQ/tqtWDpw1HSHzvu/EhhoIeRqay6z2SBY+6kgsVOOuQmVaEdRWvujMZrjBI9hTsb+fqv4SrifAbbxraBOw==",
+        "requested": "[2026.9.0-alpha.3, )",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "Sr+Nb/9gcbLCihAyv0B/Aw45jij4sYzhPgI62WFEFctpTOrZm+3hjrhKIC0tCwSFoXR5gGb6B6hpETcU7qwl3A==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -356,8 +356,8 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.2",
-          "Speckle.Sdk.Parquet": "2026.9.0-alpha.2",
+          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.3",
+          "Speckle.Sdk.Parquet": "2026.9.0-alpha.3",
           "System.Memory": "4.5.5",
           "System.Text.Json": "5.0.2"
         }

--- a/Connectors/Navisworks/Speckle.Connectors.Navisworks2027/packages.lock.json
+++ b/Connectors/Navisworks/Speckle.Connectors.Navisworks2027/packages.lock.json
@@ -195,16 +195,16 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "uLLVpEgPV/J1n2DKZVd9Yf6HzKDKsOHsdChdEbNqqY3sidIk6qKPH8Jw8jvCiDCe6H6R82+azkFxusHcQ7+Y7Q==",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "U4y0lPsO3+Dk3ZgER4D2s6wOHPRjA6pJBF1xIJNmFwVvu8NSYOxiuvWTCNobqAgm77EEwkfePFiljuogql2Iyg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.10"
         }
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "zmae3tL4g4sOqmKQyMR6aFMLQb4np62OspIOzhZB3ZmiiCr1zECK7UZWY7BTyBcfjql0yiRR0ddcpIq2e9rT2g=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "kVbdQ9V0RA9KjgYVntZ9BaHlpPqnyGHHZExq2upExe2i2mS0f61t4VRlH4ApHJIDgDtmTdqg1G2bl+hpOq9iyw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -302,7 +302,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "speckle.connectors.dui": {
@@ -324,7 +324,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "speckle.converters.navisworks2027": {
@@ -344,9 +344,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-alpha.2, )",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "agIhQ/tqtWDpw1HSHzvu/EhhoIeRqay6z2SBY+6kgsVOOuQmVaEdRWvujMZrjBI9hTsb+fqv4SrifAbbxraBOw==",
+        "requested": "[2026.9.0-alpha.3, )",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "Sr+Nb/9gcbLCihAyv0B/Aw45jij4sYzhPgI62WFEFctpTOrZm+3hjrhKIC0tCwSFoXR5gGb6B6hpETcU7qwl3A==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -356,8 +356,8 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.2",
-          "Speckle.Sdk.Parquet": "2026.9.0-alpha.2",
+          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.3",
+          "Speckle.Sdk.Parquet": "2026.9.0-alpha.3",
           "System.Memory": "4.5.5",
           "System.Text.Json": "5.0.2"
         }

--- a/Connectors/Revit/Speckle.Connectors.Revit2023/packages.lock.json
+++ b/Connectors/Revit/Speckle.Connectors.Revit2023/packages.lock.json
@@ -225,16 +225,16 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "uLLVpEgPV/J1n2DKZVd9Yf6HzKDKsOHsdChdEbNqqY3sidIk6qKPH8Jw8jvCiDCe6H6R82+azkFxusHcQ7+Y7Q==",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "U4y0lPsO3+Dk3ZgER4D2s6wOHPRjA6pJBF1xIJNmFwVvu8NSYOxiuvWTCNobqAgm77EEwkfePFiljuogql2Iyg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.10"
         }
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "zmae3tL4g4sOqmKQyMR6aFMLQb4np62OspIOzhZB3ZmiiCr1zECK7UZWY7BTyBcfjql0yiRR0ddcpIq2e9rT2g=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "kVbdQ9V0RA9KjgYVntZ9BaHlpPqnyGHHZExq2upExe2i2mS0f61t4VRlH4ApHJIDgDtmTdqg1G2bl+hpOq9iyw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -356,7 +356,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "speckle.connectors.dui": {
@@ -377,7 +377,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "speckle.converters.revit2023": {
@@ -408,9 +408,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-alpha.2, )",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "agIhQ/tqtWDpw1HSHzvu/EhhoIeRqay6z2SBY+6kgsVOOuQmVaEdRWvujMZrjBI9hTsb+fqv4SrifAbbxraBOw==",
+        "requested": "[2026.9.0-alpha.3, )",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "Sr+Nb/9gcbLCihAyv0B/Aw45jij4sYzhPgI62WFEFctpTOrZm+3hjrhKIC0tCwSFoXR5gGb6B6hpETcU7qwl3A==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -420,8 +420,8 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.2",
-          "Speckle.Sdk.Parquet": "2026.9.0-alpha.2",
+          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.3",
+          "Speckle.Sdk.Parquet": "2026.9.0-alpha.3",
           "System.Memory": "4.5.5",
           "System.Text.Json": "5.0.2"
         }

--- a/Connectors/Revit/Speckle.Connectors.Revit2024/packages.lock.json
+++ b/Connectors/Revit/Speckle.Connectors.Revit2024/packages.lock.json
@@ -225,16 +225,16 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "uLLVpEgPV/J1n2DKZVd9Yf6HzKDKsOHsdChdEbNqqY3sidIk6qKPH8Jw8jvCiDCe6H6R82+azkFxusHcQ7+Y7Q==",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "U4y0lPsO3+Dk3ZgER4D2s6wOHPRjA6pJBF1xIJNmFwVvu8NSYOxiuvWTCNobqAgm77EEwkfePFiljuogql2Iyg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.10"
         }
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "zmae3tL4g4sOqmKQyMR6aFMLQb4np62OspIOzhZB3ZmiiCr1zECK7UZWY7BTyBcfjql0yiRR0ddcpIq2e9rT2g=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "kVbdQ9V0RA9KjgYVntZ9BaHlpPqnyGHHZExq2upExe2i2mS0f61t4VRlH4ApHJIDgDtmTdqg1G2bl+hpOq9iyw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -356,7 +356,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "speckle.connectors.dui": {
@@ -377,7 +377,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "speckle.converters.revit2024": {
@@ -408,9 +408,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-alpha.2, )",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "agIhQ/tqtWDpw1HSHzvu/EhhoIeRqay6z2SBY+6kgsVOOuQmVaEdRWvujMZrjBI9hTsb+fqv4SrifAbbxraBOw==",
+        "requested": "[2026.9.0-alpha.3, )",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "Sr+Nb/9gcbLCihAyv0B/Aw45jij4sYzhPgI62WFEFctpTOrZm+3hjrhKIC0tCwSFoXR5gGb6B6hpETcU7qwl3A==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -420,8 +420,8 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.2",
-          "Speckle.Sdk.Parquet": "2026.9.0-alpha.2",
+          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.3",
+          "Speckle.Sdk.Parquet": "2026.9.0-alpha.3",
           "System.Memory": "4.5.5",
           "System.Text.Json": "5.0.2"
         }

--- a/Connectors/Revit/Speckle.Connectors.Revit2025/packages.lock.json
+++ b/Connectors/Revit/Speckle.Connectors.Revit2025/packages.lock.json
@@ -155,13 +155,13 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "uLLVpEgPV/J1n2DKZVd9Yf6HzKDKsOHsdChdEbNqqY3sidIk6qKPH8Jw8jvCiDCe6H6R82+azkFxusHcQ7+Y7Q=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "U4y0lPsO3+Dk3ZgER4D2s6wOHPRjA6pJBF1xIJNmFwVvu8NSYOxiuvWTCNobqAgm77EEwkfePFiljuogql2Iyg=="
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "zmae3tL4g4sOqmKQyMR6aFMLQb4np62OspIOzhZB3ZmiiCr1zECK7UZWY7BTyBcfjql0yiRR0ddcpIq2e9rT2g=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "kVbdQ9V0RA9KjgYVntZ9BaHlpPqnyGHHZExq2upExe2i2mS0f61t4VRlH4ApHJIDgDtmTdqg1G2bl+hpOq9iyw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -215,7 +215,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "speckle.connectors.dui": {
@@ -236,7 +236,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "speckle.converters.revit2025": {
@@ -267,9 +267,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-alpha.2, )",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "agIhQ/tqtWDpw1HSHzvu/EhhoIeRqay6z2SBY+6kgsVOOuQmVaEdRWvujMZrjBI9hTsb+fqv4SrifAbbxraBOw==",
+        "requested": "[2026.9.0-alpha.3, )",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "Sr+Nb/9gcbLCihAyv0B/Aw45jij4sYzhPgI62WFEFctpTOrZm+3hjrhKIC0tCwSFoXR5gGb6B6hpETcU7qwl3A==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -277,8 +277,8 @@
           "Microsoft.Extensions.ObjectPool": "8.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.2",
-          "Speckle.Sdk.Parquet": "2026.9.0-alpha.2"
+          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.3",
+          "Speckle.Sdk.Parquet": "2026.9.0-alpha.3"
         }
       }
     },

--- a/Connectors/Revit/Speckle.Connectors.Revit2026/packages.lock.json
+++ b/Connectors/Revit/Speckle.Connectors.Revit2026/packages.lock.json
@@ -140,13 +140,13 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "uLLVpEgPV/J1n2DKZVd9Yf6HzKDKsOHsdChdEbNqqY3sidIk6qKPH8Jw8jvCiDCe6H6R82+azkFxusHcQ7+Y7Q=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "U4y0lPsO3+Dk3ZgER4D2s6wOHPRjA6pJBF1xIJNmFwVvu8NSYOxiuvWTCNobqAgm77EEwkfePFiljuogql2Iyg=="
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "zmae3tL4g4sOqmKQyMR6aFMLQb4np62OspIOzhZB3ZmiiCr1zECK7UZWY7BTyBcfjql0yiRR0ddcpIq2e9rT2g=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "kVbdQ9V0RA9KjgYVntZ9BaHlpPqnyGHHZExq2upExe2i2mS0f61t4VRlH4ApHJIDgDtmTdqg1G2bl+hpOq9iyw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -200,7 +200,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "speckle.connectors.dui": {
@@ -221,7 +221,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "speckle.converters.revit2026": {
@@ -252,9 +252,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-alpha.2, )",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "agIhQ/tqtWDpw1HSHzvu/EhhoIeRqay6z2SBY+6kgsVOOuQmVaEdRWvujMZrjBI9hTsb+fqv4SrifAbbxraBOw==",
+        "requested": "[2026.9.0-alpha.3, )",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "Sr+Nb/9gcbLCihAyv0B/Aw45jij4sYzhPgI62WFEFctpTOrZm+3hjrhKIC0tCwSFoXR5gGb6B6hpETcU7qwl3A==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -262,8 +262,8 @@
           "Microsoft.Extensions.ObjectPool": "8.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.2",
-          "Speckle.Sdk.Parquet": "2026.9.0-alpha.2"
+          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.3",
+          "Speckle.Sdk.Parquet": "2026.9.0-alpha.3"
         }
       }
     },

--- a/Connectors/Revit/Speckle.Connectors.Revit2027/packages.lock.json
+++ b/Connectors/Revit/Speckle.Connectors.Revit2027/packages.lock.json
@@ -140,13 +140,13 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "uLLVpEgPV/J1n2DKZVd9Yf6HzKDKsOHsdChdEbNqqY3sidIk6qKPH8Jw8jvCiDCe6H6R82+azkFxusHcQ7+Y7Q=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "U4y0lPsO3+Dk3ZgER4D2s6wOHPRjA6pJBF1xIJNmFwVvu8NSYOxiuvWTCNobqAgm77EEwkfePFiljuogql2Iyg=="
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "zmae3tL4g4sOqmKQyMR6aFMLQb4np62OspIOzhZB3ZmiiCr1zECK7UZWY7BTyBcfjql0yiRR0ddcpIq2e9rT2g=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "kVbdQ9V0RA9KjgYVntZ9BaHlpPqnyGHHZExq2upExe2i2mS0f61t4VRlH4ApHJIDgDtmTdqg1G2bl+hpOq9iyw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -192,7 +192,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "speckle.connectors.dui": {
@@ -213,7 +213,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "speckle.converters.revit2027": {
@@ -244,9 +244,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-alpha.2, )",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "agIhQ/tqtWDpw1HSHzvu/EhhoIeRqay6z2SBY+6kgsVOOuQmVaEdRWvujMZrjBI9hTsb+fqv4SrifAbbxraBOw==",
+        "requested": "[2026.9.0-alpha.3, )",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "Sr+Nb/9gcbLCihAyv0B/Aw45jij4sYzhPgI62WFEFctpTOrZm+3hjrhKIC0tCwSFoXR5gGb6B6hpETcU7qwl3A==",
         "dependencies": {
           "GraphQL.Client": "6.1.0",
           "Microsoft.Data.Sqlite": "10.0.0",
@@ -254,8 +254,8 @@
           "Microsoft.Extensions.ObjectPool": "10.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.2",
-          "Speckle.Sdk.Parquet": "2026.9.0-alpha.2"
+          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.3",
+          "Speckle.Sdk.Parquet": "2026.9.0-alpha.3"
         }
       }
     },

--- a/Connectors/Rhino/Speckle.Connectors.Grasshopper7/packages.lock.json
+++ b/Connectors/Rhino/Speckle.Connectors.Grasshopper7/packages.lock.json
@@ -235,16 +235,16 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "uLLVpEgPV/J1n2DKZVd9Yf6HzKDKsOHsdChdEbNqqY3sidIk6qKPH8Jw8jvCiDCe6H6R82+azkFxusHcQ7+Y7Q==",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "U4y0lPsO3+Dk3ZgER4D2s6wOHPRjA6pJBF1xIJNmFwVvu8NSYOxiuvWTCNobqAgm77EEwkfePFiljuogql2Iyg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.10"
         }
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "zmae3tL4g4sOqmKQyMR6aFMLQb4np62OspIOzhZB3ZmiiCr1zECK7UZWY7BTyBcfjql0yiRR0ddcpIq2e9rT2g=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "kVbdQ9V0RA9KjgYVntZ9BaHlpPqnyGHHZExq2upExe2i2mS0f61t4VRlH4ApHJIDgDtmTdqg1G2bl+hpOq9iyw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -387,7 +387,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "speckle.connectors.logging": {
@@ -396,7 +396,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "speckle.converters.rhino7": {
@@ -414,9 +414,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-alpha.2, )",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "agIhQ/tqtWDpw1HSHzvu/EhhoIeRqay6z2SBY+6kgsVOOuQmVaEdRWvujMZrjBI9hTsb+fqv4SrifAbbxraBOw==",
+        "requested": "[2026.9.0-alpha.3, )",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "Sr+Nb/9gcbLCihAyv0B/Aw45jij4sYzhPgI62WFEFctpTOrZm+3hjrhKIC0tCwSFoXR5gGb6B6hpETcU7qwl3A==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -426,8 +426,8 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.2",
-          "Speckle.Sdk.Parquet": "2026.9.0-alpha.2",
+          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.3",
+          "Speckle.Sdk.Parquet": "2026.9.0-alpha.3",
           "System.Memory": "4.5.5",
           "System.Text.Json": "5.0.2"
         }

--- a/Connectors/Rhino/Speckle.Connectors.Grasshopper8/packages.lock.json
+++ b/Connectors/Rhino/Speckle.Connectors.Grasshopper8/packages.lock.json
@@ -235,16 +235,16 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "uLLVpEgPV/J1n2DKZVd9Yf6HzKDKsOHsdChdEbNqqY3sidIk6qKPH8Jw8jvCiDCe6H6R82+azkFxusHcQ7+Y7Q==",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "U4y0lPsO3+Dk3ZgER4D2s6wOHPRjA6pJBF1xIJNmFwVvu8NSYOxiuvWTCNobqAgm77EEwkfePFiljuogql2Iyg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.10"
         }
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "zmae3tL4g4sOqmKQyMR6aFMLQb4np62OspIOzhZB3ZmiiCr1zECK7UZWY7BTyBcfjql0yiRR0ddcpIq2e9rT2g=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "kVbdQ9V0RA9KjgYVntZ9BaHlpPqnyGHHZExq2upExe2i2mS0f61t4VRlH4ApHJIDgDtmTdqg1G2bl+hpOq9iyw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -387,7 +387,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "speckle.connectors.logging": {
@@ -396,7 +396,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "speckle.converters.rhino8": {
@@ -413,9 +413,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-alpha.2, )",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "agIhQ/tqtWDpw1HSHzvu/EhhoIeRqay6z2SBY+6kgsVOOuQmVaEdRWvujMZrjBI9hTsb+fqv4SrifAbbxraBOw==",
+        "requested": "[2026.9.0-alpha.3, )",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "Sr+Nb/9gcbLCihAyv0B/Aw45jij4sYzhPgI62WFEFctpTOrZm+3hjrhKIC0tCwSFoXR5gGb6B6hpETcU7qwl3A==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -425,8 +425,8 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.2",
-          "Speckle.Sdk.Parquet": "2026.9.0-alpha.2",
+          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.3",
+          "Speckle.Sdk.Parquet": "2026.9.0-alpha.3",
           "System.Memory": "4.5.5",
           "System.Text.Json": "5.0.2"
         }

--- a/Connectors/Rhino/Speckle.Connectors.Rhino7/packages.lock.json
+++ b/Connectors/Rhino/Speckle.Connectors.Rhino7/packages.lock.json
@@ -194,16 +194,16 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "uLLVpEgPV/J1n2DKZVd9Yf6HzKDKsOHsdChdEbNqqY3sidIk6qKPH8Jw8jvCiDCe6H6R82+azkFxusHcQ7+Y7Q==",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "U4y0lPsO3+Dk3ZgER4D2s6wOHPRjA6pJBF1xIJNmFwVvu8NSYOxiuvWTCNobqAgm77EEwkfePFiljuogql2Iyg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.10"
         }
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "zmae3tL4g4sOqmKQyMR6aFMLQb4np62OspIOzhZB3ZmiiCr1zECK7UZWY7BTyBcfjql0yiRR0ddcpIq2e9rT2g=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "kVbdQ9V0RA9KjgYVntZ9BaHlpPqnyGHHZExq2upExe2i2mS0f61t4VRlH4ApHJIDgDtmTdqg1G2bl+hpOq9iyw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -337,7 +337,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "speckle.connectors.dui": {
@@ -368,7 +368,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "speckle.converters.rhino7": {
@@ -401,9 +401,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-alpha.2, )",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "agIhQ/tqtWDpw1HSHzvu/EhhoIeRqay6z2SBY+6kgsVOOuQmVaEdRWvujMZrjBI9hTsb+fqv4SrifAbbxraBOw==",
+        "requested": "[2026.9.0-alpha.3, )",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "Sr+Nb/9gcbLCihAyv0B/Aw45jij4sYzhPgI62WFEFctpTOrZm+3hjrhKIC0tCwSFoXR5gGb6B6hpETcU7qwl3A==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -413,8 +413,8 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.2",
-          "Speckle.Sdk.Parquet": "2026.9.0-alpha.2",
+          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.3",
+          "Speckle.Sdk.Parquet": "2026.9.0-alpha.3",
           "System.Memory": "4.5.5",
           "System.Text.Json": "5.0.2"
         }

--- a/Connectors/Rhino/Speckle.Connectors.Rhino8/packages.lock.json
+++ b/Connectors/Rhino/Speckle.Connectors.Rhino8/packages.lock.json
@@ -232,16 +232,16 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "uLLVpEgPV/J1n2DKZVd9Yf6HzKDKsOHsdChdEbNqqY3sidIk6qKPH8Jw8jvCiDCe6H6R82+azkFxusHcQ7+Y7Q==",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "U4y0lPsO3+Dk3ZgER4D2s6wOHPRjA6pJBF1xIJNmFwVvu8NSYOxiuvWTCNobqAgm77EEwkfePFiljuogql2Iyg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.10"
         }
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "zmae3tL4g4sOqmKQyMR6aFMLQb4np62OspIOzhZB3ZmiiCr1zECK7UZWY7BTyBcfjql0yiRR0ddcpIq2e9rT2g=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "kVbdQ9V0RA9KjgYVntZ9BaHlpPqnyGHHZExq2upExe2i2mS0f61t4VRlH4ApHJIDgDtmTdqg1G2bl+hpOq9iyw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -385,7 +385,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "speckle.connectors.dui": {
@@ -416,7 +416,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "speckle.converters.rhino8": {
@@ -448,9 +448,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-alpha.2, )",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "agIhQ/tqtWDpw1HSHzvu/EhhoIeRqay6z2SBY+6kgsVOOuQmVaEdRWvujMZrjBI9hTsb+fqv4SrifAbbxraBOw==",
+        "requested": "[2026.9.0-alpha.3, )",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "Sr+Nb/9gcbLCihAyv0B/Aw45jij4sYzhPgI62WFEFctpTOrZm+3hjrhKIC0tCwSFoXR5gGb6B6hpETcU7qwl3A==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -460,8 +460,8 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.2",
-          "Speckle.Sdk.Parquet": "2026.9.0-alpha.2",
+          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.3",
+          "Speckle.Sdk.Parquet": "2026.9.0-alpha.3",
           "System.Memory": "4.5.5",
           "System.Text.Json": "5.0.2"
         }

--- a/Connectors/Rhino/Speckle.Connectors.RhinoHeadless/packages.lock.json
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoHeadless/packages.lock.json
@@ -148,13 +148,13 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "uLLVpEgPV/J1n2DKZVd9Yf6HzKDKsOHsdChdEbNqqY3sidIk6qKPH8Jw8jvCiDCe6H6R82+azkFxusHcQ7+Y7Q=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "U4y0lPsO3+Dk3ZgER4D2s6wOHPRjA6pJBF1xIJNmFwVvu8NSYOxiuvWTCNobqAgm77EEwkfePFiljuogql2Iyg=="
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "zmae3tL4g4sOqmKQyMR6aFMLQb4np62OspIOzhZB3ZmiiCr1zECK7UZWY7BTyBcfjql0yiRR0ddcpIq2e9rT2g=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "kVbdQ9V0RA9KjgYVntZ9BaHlpPqnyGHHZExq2upExe2i2mS0f61t4VRlH4ApHJIDgDtmTdqg1G2bl+hpOq9iyw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -201,7 +201,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "speckle.connectors.logging": {
@@ -210,7 +210,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "speckle.converters.rhino9": {
@@ -238,9 +238,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-alpha.2, )",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "agIhQ/tqtWDpw1HSHzvu/EhhoIeRqay6z2SBY+6kgsVOOuQmVaEdRWvujMZrjBI9hTsb+fqv4SrifAbbxraBOw==",
+        "requested": "[2026.9.0-alpha.3, )",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "Sr+Nb/9gcbLCihAyv0B/Aw45jij4sYzhPgI62WFEFctpTOrZm+3hjrhKIC0tCwSFoXR5gGb6B6hpETcU7qwl3A==",
         "dependencies": {
           "GraphQL.Client": "6.1.0",
           "Microsoft.Data.Sqlite": "10.0.0",
@@ -248,8 +248,8 @@
           "Microsoft.Extensions.ObjectPool": "10.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.2",
-          "Speckle.Sdk.Parquet": "2026.9.0-alpha.2"
+          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.3",
+          "Speckle.Sdk.Parquet": "2026.9.0-alpha.3"
         }
       }
     }

--- a/Connectors/Rhino/Speckle.Connectors.RhinoImporter/packages.lock.json
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoImporter/packages.lock.json
@@ -156,13 +156,13 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "uLLVpEgPV/J1n2DKZVd9Yf6HzKDKsOHsdChdEbNqqY3sidIk6qKPH8Jw8jvCiDCe6H6R82+azkFxusHcQ7+Y7Q=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "U4y0lPsO3+Dk3ZgER4D2s6wOHPRjA6pJBF1xIJNmFwVvu8NSYOxiuvWTCNobqAgm77EEwkfePFiljuogql2Iyg=="
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "zmae3tL4g4sOqmKQyMR6aFMLQb4np62OspIOzhZB3ZmiiCr1zECK7UZWY7BTyBcfjql0yiRR0ddcpIq2e9rT2g=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "kVbdQ9V0RA9KjgYVntZ9BaHlpPqnyGHHZExq2upExe2i2mS0f61t4VRlH4ApHJIDgDtmTdqg1G2bl+hpOq9iyw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -217,7 +217,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "speckle.connectors.dui": {
@@ -239,7 +239,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "speckle.converters.rhino8": {
@@ -262,9 +262,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-alpha.2, )",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "agIhQ/tqtWDpw1HSHzvu/EhhoIeRqay6z2SBY+6kgsVOOuQmVaEdRWvujMZrjBI9hTsb+fqv4SrifAbbxraBOw==",
+        "requested": "[2026.9.0-alpha.3, )",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "Sr+Nb/9gcbLCihAyv0B/Aw45jij4sYzhPgI62WFEFctpTOrZm+3hjrhKIC0tCwSFoXR5gGb6B6hpETcU7qwl3A==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -272,8 +272,8 @@
           "Microsoft.Extensions.ObjectPool": "8.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.2",
-          "Speckle.Sdk.Parquet": "2026.9.0-alpha.2"
+          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.3",
+          "Speckle.Sdk.Parquet": "2026.9.0-alpha.3"
         }
       }
     },

--- a/Connectors/TSD/Speckle.Connectors.TSD2027/packages.lock.json
+++ b/Connectors/TSD/Speckle.Connectors.TSD2027/packages.lock.json
@@ -171,13 +171,13 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "uLLVpEgPV/J1n2DKZVd9Yf6HzKDKsOHsdChdEbNqqY3sidIk6qKPH8Jw8jvCiDCe6H6R82+azkFxusHcQ7+Y7Q=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "U4y0lPsO3+Dk3ZgER4D2s6wOHPRjA6pJBF1xIJNmFwVvu8NSYOxiuvWTCNobqAgm77EEwkfePFiljuogql2Iyg=="
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "zmae3tL4g4sOqmKQyMR6aFMLQb4np62OspIOzhZB3ZmiiCr1zECK7UZWY7BTyBcfjql0yiRR0ddcpIq2e9rT2g=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "kVbdQ9V0RA9KjgYVntZ9BaHlpPqnyGHHZExq2upExe2i2mS0f61t4VRlH4ApHJIDgDtmTdqg1G2bl+hpOq9iyw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -223,7 +223,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "speckle.connectors.dui": {
@@ -245,7 +245,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "speckle.converters.tsd2027": {
@@ -275,9 +275,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-alpha.2, )",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "agIhQ/tqtWDpw1HSHzvu/EhhoIeRqay6z2SBY+6kgsVOOuQmVaEdRWvujMZrjBI9hTsb+fqv4SrifAbbxraBOw==",
+        "requested": "[2026.9.0-alpha.3, )",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "Sr+Nb/9gcbLCihAyv0B/Aw45jij4sYzhPgI62WFEFctpTOrZm+3hjrhKIC0tCwSFoXR5gGb6B6hpETcU7qwl3A==",
         "dependencies": {
           "GraphQL.Client": "6.1.0",
           "Microsoft.Data.Sqlite": "10.0.0",
@@ -285,8 +285,8 @@
           "Microsoft.Extensions.ObjectPool": "10.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.2",
-          "Speckle.Sdk.Parquet": "2026.9.0-alpha.2"
+          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.3",
+          "Speckle.Sdk.Parquet": "2026.9.0-alpha.3"
         }
       }
     }

--- a/Connectors/Tekla/Speckle.Connector.Tekla2023/packages.lock.json
+++ b/Connectors/Tekla/Speckle.Connector.Tekla2023/packages.lock.json
@@ -256,16 +256,16 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "uLLVpEgPV/J1n2DKZVd9Yf6HzKDKsOHsdChdEbNqqY3sidIk6qKPH8Jw8jvCiDCe6H6R82+azkFxusHcQ7+Y7Q==",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "U4y0lPsO3+Dk3ZgER4D2s6wOHPRjA6pJBF1xIJNmFwVvu8NSYOxiuvWTCNobqAgm77EEwkfePFiljuogql2Iyg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.10"
         }
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "zmae3tL4g4sOqmKQyMR6aFMLQb4np62OspIOzhZB3ZmiiCr1zECK7UZWY7BTyBcfjql0yiRR0ddcpIq2e9rT2g=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "kVbdQ9V0RA9KjgYVntZ9BaHlpPqnyGHHZExq2upExe2i2mS0f61t4VRlH4ApHJIDgDtmTdqg1G2bl+hpOq9iyw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -408,7 +408,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "speckle.connectors.dui": {
@@ -439,7 +439,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "LibTessDotNet": {
@@ -462,9 +462,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-alpha.2, )",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "agIhQ/tqtWDpw1HSHzvu/EhhoIeRqay6z2SBY+6kgsVOOuQmVaEdRWvujMZrjBI9hTsb+fqv4SrifAbbxraBOw==",
+        "requested": "[2026.9.0-alpha.3, )",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "Sr+Nb/9gcbLCihAyv0B/Aw45jij4sYzhPgI62WFEFctpTOrZm+3hjrhKIC0tCwSFoXR5gGb6B6hpETcU7qwl3A==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -474,8 +474,8 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.2",
-          "Speckle.Sdk.Parquet": "2026.9.0-alpha.2",
+          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.3",
+          "Speckle.Sdk.Parquet": "2026.9.0-alpha.3",
           "System.Memory": "4.5.5",
           "System.Text.Json": "5.0.2"
         }

--- a/Connectors/Tekla/Speckle.Connector.Tekla2024/packages.lock.json
+++ b/Connectors/Tekla/Speckle.Connector.Tekla2024/packages.lock.json
@@ -275,16 +275,16 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "uLLVpEgPV/J1n2DKZVd9Yf6HzKDKsOHsdChdEbNqqY3sidIk6qKPH8Jw8jvCiDCe6H6R82+azkFxusHcQ7+Y7Q==",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "U4y0lPsO3+Dk3ZgER4D2s6wOHPRjA6pJBF1xIJNmFwVvu8NSYOxiuvWTCNobqAgm77EEwkfePFiljuogql2Iyg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.10"
         }
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "zmae3tL4g4sOqmKQyMR6aFMLQb4np62OspIOzhZB3ZmiiCr1zECK7UZWY7BTyBcfjql0yiRR0ddcpIq2e9rT2g=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "kVbdQ9V0RA9KjgYVntZ9BaHlpPqnyGHHZExq2upExe2i2mS0f61t4VRlH4ApHJIDgDtmTdqg1G2bl+hpOq9iyw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -489,7 +489,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "speckle.connectors.dui": {
@@ -520,7 +520,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "LibTessDotNet": {
@@ -543,9 +543,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-alpha.2, )",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "agIhQ/tqtWDpw1HSHzvu/EhhoIeRqay6z2SBY+6kgsVOOuQmVaEdRWvujMZrjBI9hTsb+fqv4SrifAbbxraBOw==",
+        "requested": "[2026.9.0-alpha.3, )",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "Sr+Nb/9gcbLCihAyv0B/Aw45jij4sYzhPgI62WFEFctpTOrZm+3hjrhKIC0tCwSFoXR5gGb6B6hpETcU7qwl3A==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -555,8 +555,8 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.2",
-          "Speckle.Sdk.Parquet": "2026.9.0-alpha.2",
+          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.3",
+          "Speckle.Sdk.Parquet": "2026.9.0-alpha.3",
           "System.Memory": "4.5.5",
           "System.Text.Json": "5.0.2"
         }

--- a/Connectors/Tekla/Speckle.Connector.Tekla2025/packages.lock.json
+++ b/Connectors/Tekla/Speckle.Connector.Tekla2025/packages.lock.json
@@ -275,16 +275,16 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "uLLVpEgPV/J1n2DKZVd9Yf6HzKDKsOHsdChdEbNqqY3sidIk6qKPH8Jw8jvCiDCe6H6R82+azkFxusHcQ7+Y7Q==",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "U4y0lPsO3+Dk3ZgER4D2s6wOHPRjA6pJBF1xIJNmFwVvu8NSYOxiuvWTCNobqAgm77EEwkfePFiljuogql2Iyg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.10"
         }
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "zmae3tL4g4sOqmKQyMR6aFMLQb4np62OspIOzhZB3ZmiiCr1zECK7UZWY7BTyBcfjql0yiRR0ddcpIq2e9rT2g=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "kVbdQ9V0RA9KjgYVntZ9BaHlpPqnyGHHZExq2upExe2i2mS0f61t4VRlH4ApHJIDgDtmTdqg1G2bl+hpOq9iyw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -489,7 +489,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "speckle.connectors.dui": {
@@ -520,7 +520,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "LibTessDotNet": {
@@ -543,9 +543,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-alpha.2, )",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "agIhQ/tqtWDpw1HSHzvu/EhhoIeRqay6z2SBY+6kgsVOOuQmVaEdRWvujMZrjBI9hTsb+fqv4SrifAbbxraBOw==",
+        "requested": "[2026.9.0-alpha.3, )",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "Sr+Nb/9gcbLCihAyv0B/Aw45jij4sYzhPgI62WFEFctpTOrZm+3hjrhKIC0tCwSFoXR5gGb6B6hpETcU7qwl3A==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -555,8 +555,8 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.2",
-          "Speckle.Sdk.Parquet": "2026.9.0-alpha.2",
+          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.3",
+          "Speckle.Sdk.Parquet": "2026.9.0-alpha.3",
           "System.Memory": "4.5.5",
           "System.Text.Json": "5.0.2"
         }

--- a/Converters/Autocad/Speckle.Converters.Autocad2023/packages.lock.json
+++ b/Converters/Autocad/Speckle.Converters.Autocad2023/packages.lock.json
@@ -180,16 +180,16 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "uLLVpEgPV/J1n2DKZVd9Yf6HzKDKsOHsdChdEbNqqY3sidIk6qKPH8Jw8jvCiDCe6H6R82+azkFxusHcQ7+Y7Q==",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "U4y0lPsO3+Dk3ZgER4D2s6wOHPRjA6pJBF1xIJNmFwVvu8NSYOxiuvWTCNobqAgm77EEwkfePFiljuogql2Iyg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.10"
         }
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "zmae3tL4g4sOqmKQyMR6aFMLQb4np62OspIOzhZB3ZmiiCr1zECK7UZWY7BTyBcfjql0yiRR0ddcpIq2e9rT2g=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "kVbdQ9V0RA9KjgYVntZ9BaHlpPqnyGHHZExq2upExe2i2mS0f61t4VRlH4ApHJIDgDtmTdqg1G2bl+hpOq9iyw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -293,7 +293,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "Speckle.DoubleNumerics": {
@@ -304,9 +304,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-alpha.2, )",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "agIhQ/tqtWDpw1HSHzvu/EhhoIeRqay6z2SBY+6kgsVOOuQmVaEdRWvujMZrjBI9hTsb+fqv4SrifAbbxraBOw==",
+        "requested": "[2026.9.0-alpha.3, )",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "Sr+Nb/9gcbLCihAyv0B/Aw45jij4sYzhPgI62WFEFctpTOrZm+3hjrhKIC0tCwSFoXR5gGb6B6hpETcU7qwl3A==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -316,8 +316,8 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.2",
-          "Speckle.Sdk.Parquet": "2026.9.0-alpha.2",
+          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.3",
+          "Speckle.Sdk.Parquet": "2026.9.0-alpha.3",
           "System.Memory": "4.5.5",
           "System.Text.Json": "5.0.2"
         }

--- a/Converters/Autocad/Speckle.Converters.Autocad2024/packages.lock.json
+++ b/Converters/Autocad/Speckle.Converters.Autocad2024/packages.lock.json
@@ -180,16 +180,16 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "uLLVpEgPV/J1n2DKZVd9Yf6HzKDKsOHsdChdEbNqqY3sidIk6qKPH8Jw8jvCiDCe6H6R82+azkFxusHcQ7+Y7Q==",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "U4y0lPsO3+Dk3ZgER4D2s6wOHPRjA6pJBF1xIJNmFwVvu8NSYOxiuvWTCNobqAgm77EEwkfePFiljuogql2Iyg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.10"
         }
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "zmae3tL4g4sOqmKQyMR6aFMLQb4np62OspIOzhZB3ZmiiCr1zECK7UZWY7BTyBcfjql0yiRR0ddcpIq2e9rT2g=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "kVbdQ9V0RA9KjgYVntZ9BaHlpPqnyGHHZExq2upExe2i2mS0f61t4VRlH4ApHJIDgDtmTdqg1G2bl+hpOq9iyw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -295,7 +295,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "speckle.connectors.dui": {
@@ -317,7 +317,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "Microsoft.Web.WebView2": {
@@ -334,9 +334,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-alpha.2, )",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "agIhQ/tqtWDpw1HSHzvu/EhhoIeRqay6z2SBY+6kgsVOOuQmVaEdRWvujMZrjBI9hTsb+fqv4SrifAbbxraBOw==",
+        "requested": "[2026.9.0-alpha.3, )",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "Sr+Nb/9gcbLCihAyv0B/Aw45jij4sYzhPgI62WFEFctpTOrZm+3hjrhKIC0tCwSFoXR5gGb6B6hpETcU7qwl3A==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -346,8 +346,8 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.2",
-          "Speckle.Sdk.Parquet": "2026.9.0-alpha.2",
+          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.3",
+          "Speckle.Sdk.Parquet": "2026.9.0-alpha.3",
           "System.Memory": "4.5.5",
           "System.Text.Json": "5.0.2"
         }

--- a/Converters/Autocad/Speckle.Converters.Autocad2025/packages.lock.json
+++ b/Converters/Autocad/Speckle.Converters.Autocad2025/packages.lock.json
@@ -139,13 +139,13 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "uLLVpEgPV/J1n2DKZVd9Yf6HzKDKsOHsdChdEbNqqY3sidIk6qKPH8Jw8jvCiDCe6H6R82+azkFxusHcQ7+Y7Q=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "U4y0lPsO3+Dk3ZgER4D2s6wOHPRjA6pJBF1xIJNmFwVvu8NSYOxiuvWTCNobqAgm77EEwkfePFiljuogql2Iyg=="
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "zmae3tL4g4sOqmKQyMR6aFMLQb4np62OspIOzhZB3ZmiiCr1zECK7UZWY7BTyBcfjql0yiRR0ddcpIq2e9rT2g=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "kVbdQ9V0RA9KjgYVntZ9BaHlpPqnyGHHZExq2upExe2i2mS0f61t4VRlH4ApHJIDgDtmTdqg1G2bl+hpOq9iyw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -192,7 +192,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "speckle.connectors.dui": {
@@ -214,7 +214,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "Microsoft.Web.WebView2": {
@@ -231,9 +231,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-alpha.2, )",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "agIhQ/tqtWDpw1HSHzvu/EhhoIeRqay6z2SBY+6kgsVOOuQmVaEdRWvujMZrjBI9hTsb+fqv4SrifAbbxraBOw==",
+        "requested": "[2026.9.0-alpha.3, )",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "Sr+Nb/9gcbLCihAyv0B/Aw45jij4sYzhPgI62WFEFctpTOrZm+3hjrhKIC0tCwSFoXR5gGb6B6hpETcU7qwl3A==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -241,8 +241,8 @@
           "Microsoft.Extensions.ObjectPool": "8.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.2",
-          "Speckle.Sdk.Parquet": "2026.9.0-alpha.2"
+          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.3",
+          "Speckle.Sdk.Parquet": "2026.9.0-alpha.3"
         }
       }
     }

--- a/Converters/Autocad/Speckle.Converters.Autocad2026/packages.lock.json
+++ b/Converters/Autocad/Speckle.Converters.Autocad2026/packages.lock.json
@@ -139,13 +139,13 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "uLLVpEgPV/J1n2DKZVd9Yf6HzKDKsOHsdChdEbNqqY3sidIk6qKPH8Jw8jvCiDCe6H6R82+azkFxusHcQ7+Y7Q=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "U4y0lPsO3+Dk3ZgER4D2s6wOHPRjA6pJBF1xIJNmFwVvu8NSYOxiuvWTCNobqAgm77EEwkfePFiljuogql2Iyg=="
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "zmae3tL4g4sOqmKQyMR6aFMLQb4np62OspIOzhZB3ZmiiCr1zECK7UZWY7BTyBcfjql0yiRR0ddcpIq2e9rT2g=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "kVbdQ9V0RA9KjgYVntZ9BaHlpPqnyGHHZExq2upExe2i2mS0f61t4VRlH4ApHJIDgDtmTdqg1G2bl+hpOq9iyw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -192,7 +192,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "speckle.connectors.dui": {
@@ -214,7 +214,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "Microsoft.Web.WebView2": {
@@ -231,9 +231,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-alpha.2, )",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "agIhQ/tqtWDpw1HSHzvu/EhhoIeRqay6z2SBY+6kgsVOOuQmVaEdRWvujMZrjBI9hTsb+fqv4SrifAbbxraBOw==",
+        "requested": "[2026.9.0-alpha.3, )",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "Sr+Nb/9gcbLCihAyv0B/Aw45jij4sYzhPgI62WFEFctpTOrZm+3hjrhKIC0tCwSFoXR5gGb6B6hpETcU7qwl3A==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -241,8 +241,8 @@
           "Microsoft.Extensions.ObjectPool": "8.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.2",
-          "Speckle.Sdk.Parquet": "2026.9.0-alpha.2"
+          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.3",
+          "Speckle.Sdk.Parquet": "2026.9.0-alpha.3"
         }
       }
     }

--- a/Converters/Autocad/Speckle.Converters.Autocad2027/packages.lock.json
+++ b/Converters/Autocad/Speckle.Converters.Autocad2027/packages.lock.json
@@ -140,13 +140,13 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "uLLVpEgPV/J1n2DKZVd9Yf6HzKDKsOHsdChdEbNqqY3sidIk6qKPH8Jw8jvCiDCe6H6R82+azkFxusHcQ7+Y7Q=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "U4y0lPsO3+Dk3ZgER4D2s6wOHPRjA6pJBF1xIJNmFwVvu8NSYOxiuvWTCNobqAgm77EEwkfePFiljuogql2Iyg=="
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "zmae3tL4g4sOqmKQyMR6aFMLQb4np62OspIOzhZB3ZmiiCr1zECK7UZWY7BTyBcfjql0yiRR0ddcpIq2e9rT2g=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "kVbdQ9V0RA9KjgYVntZ9BaHlpPqnyGHHZExq2upExe2i2mS0f61t4VRlH4ApHJIDgDtmTdqg1G2bl+hpOq9iyw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -185,7 +185,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "speckle.connectors.dui": {
@@ -207,7 +207,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "Microsoft.Web.WebView2": {
@@ -224,9 +224,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-alpha.2, )",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "agIhQ/tqtWDpw1HSHzvu/EhhoIeRqay6z2SBY+6kgsVOOuQmVaEdRWvujMZrjBI9hTsb+fqv4SrifAbbxraBOw==",
+        "requested": "[2026.9.0-alpha.3, )",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "Sr+Nb/9gcbLCihAyv0B/Aw45jij4sYzhPgI62WFEFctpTOrZm+3hjrhKIC0tCwSFoXR5gGb6B6hpETcU7qwl3A==",
         "dependencies": {
           "GraphQL.Client": "6.1.0",
           "Microsoft.Data.Sqlite": "10.0.0",
@@ -234,8 +234,8 @@
           "Microsoft.Extensions.ObjectPool": "10.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.2",
-          "Speckle.Sdk.Parquet": "2026.9.0-alpha.2"
+          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.3",
+          "Speckle.Sdk.Parquet": "2026.9.0-alpha.3"
         }
       }
     }

--- a/Converters/CSi/Speckle.Converters.ETABS21/packages.lock.json
+++ b/Converters/CSi/Speckle.Converters.ETABS21/packages.lock.json
@@ -180,16 +180,16 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "uLLVpEgPV/J1n2DKZVd9Yf6HzKDKsOHsdChdEbNqqY3sidIk6qKPH8Jw8jvCiDCe6H6R82+azkFxusHcQ7+Y7Q==",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "U4y0lPsO3+Dk3ZgER4D2s6wOHPRjA6pJBF1xIJNmFwVvu8NSYOxiuvWTCNobqAgm77EEwkfePFiljuogql2Iyg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.10"
         }
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "zmae3tL4g4sOqmKQyMR6aFMLQb4np62OspIOzhZB3ZmiiCr1zECK7UZWY7BTyBcfjql0yiRR0ddcpIq2e9rT2g=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "kVbdQ9V0RA9KjgYVntZ9BaHlpPqnyGHHZExq2upExe2i2mS0f61t4VRlH4ApHJIDgDtmTdqg1G2bl+hpOq9iyw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -293,7 +293,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "Speckle.DoubleNumerics": {
@@ -304,9 +304,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-alpha.2, )",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "agIhQ/tqtWDpw1HSHzvu/EhhoIeRqay6z2SBY+6kgsVOOuQmVaEdRWvujMZrjBI9hTsb+fqv4SrifAbbxraBOw==",
+        "requested": "[2026.9.0-alpha.3, )",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "Sr+Nb/9gcbLCihAyv0B/Aw45jij4sYzhPgI62WFEFctpTOrZm+3hjrhKIC0tCwSFoXR5gGb6B6hpETcU7qwl3A==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -316,8 +316,8 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.2",
-          "Speckle.Sdk.Parquet": "2026.9.0-alpha.2",
+          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.3",
+          "Speckle.Sdk.Parquet": "2026.9.0-alpha.3",
           "System.Memory": "4.5.5",
           "System.Text.Json": "5.0.2"
         }

--- a/Converters/CSi/Speckle.Converters.ETABS22/packages.lock.json
+++ b/Converters/CSi/Speckle.Converters.ETABS22/packages.lock.json
@@ -139,13 +139,13 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "uLLVpEgPV/J1n2DKZVd9Yf6HzKDKsOHsdChdEbNqqY3sidIk6qKPH8Jw8jvCiDCe6H6R82+azkFxusHcQ7+Y7Q=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "U4y0lPsO3+Dk3ZgER4D2s6wOHPRjA6pJBF1xIJNmFwVvu8NSYOxiuvWTCNobqAgm77EEwkfePFiljuogql2Iyg=="
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "zmae3tL4g4sOqmKQyMR6aFMLQb4np62OspIOzhZB3ZmiiCr1zECK7UZWY7BTyBcfjql0yiRR0ddcpIq2e9rT2g=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "kVbdQ9V0RA9KjgYVntZ9BaHlpPqnyGHHZExq2upExe2i2mS0f61t4VRlH4ApHJIDgDtmTdqg1G2bl+hpOq9iyw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -190,7 +190,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "Speckle.DoubleNumerics": {
@@ -201,9 +201,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-alpha.2, )",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "agIhQ/tqtWDpw1HSHzvu/EhhoIeRqay6z2SBY+6kgsVOOuQmVaEdRWvujMZrjBI9hTsb+fqv4SrifAbbxraBOw==",
+        "requested": "[2026.9.0-alpha.3, )",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "Sr+Nb/9gcbLCihAyv0B/Aw45jij4sYzhPgI62WFEFctpTOrZm+3hjrhKIC0tCwSFoXR5gGb6B6hpETcU7qwl3A==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -211,8 +211,8 @@
           "Microsoft.Extensions.ObjectPool": "8.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.2",
-          "Speckle.Sdk.Parquet": "2026.9.0-alpha.2"
+          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.3",
+          "Speckle.Sdk.Parquet": "2026.9.0-alpha.3"
         }
       }
     }

--- a/Converters/Civil3d/Speckle.Converters.Civil3d2023/packages.lock.json
+++ b/Converters/Civil3d/Speckle.Converters.Civil3d2023/packages.lock.json
@@ -189,16 +189,16 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "uLLVpEgPV/J1n2DKZVd9Yf6HzKDKsOHsdChdEbNqqY3sidIk6qKPH8Jw8jvCiDCe6H6R82+azkFxusHcQ7+Y7Q==",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "U4y0lPsO3+Dk3ZgER4D2s6wOHPRjA6pJBF1xIJNmFwVvu8NSYOxiuvWTCNobqAgm77EEwkfePFiljuogql2Iyg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.10"
         }
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "zmae3tL4g4sOqmKQyMR6aFMLQb4np62OspIOzhZB3ZmiiCr1zECK7UZWY7BTyBcfjql0yiRR0ddcpIq2e9rT2g=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "kVbdQ9V0RA9KjgYVntZ9BaHlpPqnyGHHZExq2upExe2i2mS0f61t4VRlH4ApHJIDgDtmTdqg1G2bl+hpOq9iyw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -302,7 +302,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "Speckle.DoubleNumerics": {
@@ -313,9 +313,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-alpha.2, )",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "agIhQ/tqtWDpw1HSHzvu/EhhoIeRqay6z2SBY+6kgsVOOuQmVaEdRWvujMZrjBI9hTsb+fqv4SrifAbbxraBOw==",
+        "requested": "[2026.9.0-alpha.3, )",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "Sr+Nb/9gcbLCihAyv0B/Aw45jij4sYzhPgI62WFEFctpTOrZm+3hjrhKIC0tCwSFoXR5gGb6B6hpETcU7qwl3A==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -325,8 +325,8 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.2",
-          "Speckle.Sdk.Parquet": "2026.9.0-alpha.2",
+          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.3",
+          "Speckle.Sdk.Parquet": "2026.9.0-alpha.3",
           "System.Memory": "4.5.5",
           "System.Text.Json": "5.0.2"
         }

--- a/Converters/Civil3d/Speckle.Converters.Civil3d2024/packages.lock.json
+++ b/Converters/Civil3d/Speckle.Converters.Civil3d2024/packages.lock.json
@@ -189,16 +189,16 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "uLLVpEgPV/J1n2DKZVd9Yf6HzKDKsOHsdChdEbNqqY3sidIk6qKPH8Jw8jvCiDCe6H6R82+azkFxusHcQ7+Y7Q==",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "U4y0lPsO3+Dk3ZgER4D2s6wOHPRjA6pJBF1xIJNmFwVvu8NSYOxiuvWTCNobqAgm77EEwkfePFiljuogql2Iyg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.10"
         }
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "zmae3tL4g4sOqmKQyMR6aFMLQb4np62OspIOzhZB3ZmiiCr1zECK7UZWY7BTyBcfjql0yiRR0ddcpIq2e9rT2g=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "kVbdQ9V0RA9KjgYVntZ9BaHlpPqnyGHHZExq2upExe2i2mS0f61t4VRlH4ApHJIDgDtmTdqg1G2bl+hpOq9iyw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -302,7 +302,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "Speckle.DoubleNumerics": {
@@ -313,9 +313,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-alpha.2, )",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "agIhQ/tqtWDpw1HSHzvu/EhhoIeRqay6z2SBY+6kgsVOOuQmVaEdRWvujMZrjBI9hTsb+fqv4SrifAbbxraBOw==",
+        "requested": "[2026.9.0-alpha.3, )",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "Sr+Nb/9gcbLCihAyv0B/Aw45jij4sYzhPgI62WFEFctpTOrZm+3hjrhKIC0tCwSFoXR5gGb6B6hpETcU7qwl3A==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -325,8 +325,8 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.2",
-          "Speckle.Sdk.Parquet": "2026.9.0-alpha.2",
+          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.3",
+          "Speckle.Sdk.Parquet": "2026.9.0-alpha.3",
           "System.Memory": "4.5.5",
           "System.Text.Json": "5.0.2"
         }

--- a/Converters/Civil3d/Speckle.Converters.Civil3d2025/packages.lock.json
+++ b/Converters/Civil3d/Speckle.Converters.Civil3d2025/packages.lock.json
@@ -148,13 +148,13 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "uLLVpEgPV/J1n2DKZVd9Yf6HzKDKsOHsdChdEbNqqY3sidIk6qKPH8Jw8jvCiDCe6H6R82+azkFxusHcQ7+Y7Q=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "U4y0lPsO3+Dk3ZgER4D2s6wOHPRjA6pJBF1xIJNmFwVvu8NSYOxiuvWTCNobqAgm77EEwkfePFiljuogql2Iyg=="
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "zmae3tL4g4sOqmKQyMR6aFMLQb4np62OspIOzhZB3ZmiiCr1zECK7UZWY7BTyBcfjql0yiRR0ddcpIq2e9rT2g=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "kVbdQ9V0RA9KjgYVntZ9BaHlpPqnyGHHZExq2upExe2i2mS0f61t4VRlH4ApHJIDgDtmTdqg1G2bl+hpOq9iyw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -201,7 +201,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "speckle.connectors.dui": {
@@ -223,7 +223,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "Microsoft.Web.WebView2": {
@@ -240,9 +240,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-alpha.2, )",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "agIhQ/tqtWDpw1HSHzvu/EhhoIeRqay6z2SBY+6kgsVOOuQmVaEdRWvujMZrjBI9hTsb+fqv4SrifAbbxraBOw==",
+        "requested": "[2026.9.0-alpha.3, )",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "Sr+Nb/9gcbLCihAyv0B/Aw45jij4sYzhPgI62WFEFctpTOrZm+3hjrhKIC0tCwSFoXR5gGb6B6hpETcU7qwl3A==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -250,8 +250,8 @@
           "Microsoft.Extensions.ObjectPool": "8.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.2",
-          "Speckle.Sdk.Parquet": "2026.9.0-alpha.2"
+          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.3",
+          "Speckle.Sdk.Parquet": "2026.9.0-alpha.3"
         }
       }
     }

--- a/Converters/Civil3d/Speckle.Converters.Civil3d2026/packages.lock.json
+++ b/Converters/Civil3d/Speckle.Converters.Civil3d2026/packages.lock.json
@@ -148,13 +148,13 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "uLLVpEgPV/J1n2DKZVd9Yf6HzKDKsOHsdChdEbNqqY3sidIk6qKPH8Jw8jvCiDCe6H6R82+azkFxusHcQ7+Y7Q=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "U4y0lPsO3+Dk3ZgER4D2s6wOHPRjA6pJBF1xIJNmFwVvu8NSYOxiuvWTCNobqAgm77EEwkfePFiljuogql2Iyg=="
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "zmae3tL4g4sOqmKQyMR6aFMLQb4np62OspIOzhZB3ZmiiCr1zECK7UZWY7BTyBcfjql0yiRR0ddcpIq2e9rT2g=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "kVbdQ9V0RA9KjgYVntZ9BaHlpPqnyGHHZExq2upExe2i2mS0f61t4VRlH4ApHJIDgDtmTdqg1G2bl+hpOq9iyw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -201,7 +201,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "speckle.connectors.dui": {
@@ -223,7 +223,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "Microsoft.Web.WebView2": {
@@ -240,9 +240,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-alpha.2, )",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "agIhQ/tqtWDpw1HSHzvu/EhhoIeRqay6z2SBY+6kgsVOOuQmVaEdRWvujMZrjBI9hTsb+fqv4SrifAbbxraBOw==",
+        "requested": "[2026.9.0-alpha.3, )",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "Sr+Nb/9gcbLCihAyv0B/Aw45jij4sYzhPgI62WFEFctpTOrZm+3hjrhKIC0tCwSFoXR5gGb6B6hpETcU7qwl3A==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -250,8 +250,8 @@
           "Microsoft.Extensions.ObjectPool": "8.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.2",
-          "Speckle.Sdk.Parquet": "2026.9.0-alpha.2"
+          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.3",
+          "Speckle.Sdk.Parquet": "2026.9.0-alpha.3"
         }
       }
     }

--- a/Converters/Civil3d/Speckle.Converters.Civil3d2027/packages.lock.json
+++ b/Converters/Civil3d/Speckle.Converters.Civil3d2027/packages.lock.json
@@ -149,13 +149,13 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "uLLVpEgPV/J1n2DKZVd9Yf6HzKDKsOHsdChdEbNqqY3sidIk6qKPH8Jw8jvCiDCe6H6R82+azkFxusHcQ7+Y7Q=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "U4y0lPsO3+Dk3ZgER4D2s6wOHPRjA6pJBF1xIJNmFwVvu8NSYOxiuvWTCNobqAgm77EEwkfePFiljuogql2Iyg=="
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "zmae3tL4g4sOqmKQyMR6aFMLQb4np62OspIOzhZB3ZmiiCr1zECK7UZWY7BTyBcfjql0yiRR0ddcpIq2e9rT2g=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "kVbdQ9V0RA9KjgYVntZ9BaHlpPqnyGHHZExq2upExe2i2mS0f61t4VRlH4ApHJIDgDtmTdqg1G2bl+hpOq9iyw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -194,7 +194,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "speckle.connectors.dui": {
@@ -216,7 +216,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "Microsoft.Web.WebView2": {
@@ -233,9 +233,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-alpha.2, )",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "agIhQ/tqtWDpw1HSHzvu/EhhoIeRqay6z2SBY+6kgsVOOuQmVaEdRWvujMZrjBI9hTsb+fqv4SrifAbbxraBOw==",
+        "requested": "[2026.9.0-alpha.3, )",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "Sr+Nb/9gcbLCihAyv0B/Aw45jij4sYzhPgI62WFEFctpTOrZm+3hjrhKIC0tCwSFoXR5gGb6B6hpETcU7qwl3A==",
         "dependencies": {
           "GraphQL.Client": "6.1.0",
           "Microsoft.Data.Sqlite": "10.0.0",
@@ -243,8 +243,8 @@
           "Microsoft.Extensions.ObjectPool": "10.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.2",
-          "Speckle.Sdk.Parquet": "2026.9.0-alpha.2"
+          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.3",
+          "Speckle.Sdk.Parquet": "2026.9.0-alpha.3"
         }
       }
     }

--- a/Converters/Navisworks/Speckle.Converters.Navisworks2020/packages.lock.json
+++ b/Converters/Navisworks/Speckle.Converters.Navisworks2020/packages.lock.json
@@ -180,16 +180,16 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "uLLVpEgPV/J1n2DKZVd9Yf6HzKDKsOHsdChdEbNqqY3sidIk6qKPH8Jw8jvCiDCe6H6R82+azkFxusHcQ7+Y7Q==",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "U4y0lPsO3+Dk3ZgER4D2s6wOHPRjA6pJBF1xIJNmFwVvu8NSYOxiuvWTCNobqAgm77EEwkfePFiljuogql2Iyg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.10"
         }
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "zmae3tL4g4sOqmKQyMR6aFMLQb4np62OspIOzhZB3ZmiiCr1zECK7UZWY7BTyBcfjql0yiRR0ddcpIq2e9rT2g=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "kVbdQ9V0RA9KjgYVntZ9BaHlpPqnyGHHZExq2upExe2i2mS0f61t4VRlH4ApHJIDgDtmTdqg1G2bl+hpOq9iyw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -295,7 +295,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "speckle.connectors.dui": {
@@ -310,7 +310,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "Speckle.DoubleNumerics": {
@@ -321,9 +321,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-alpha.2, )",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "agIhQ/tqtWDpw1HSHzvu/EhhoIeRqay6z2SBY+6kgsVOOuQmVaEdRWvujMZrjBI9hTsb+fqv4SrifAbbxraBOw==",
+        "requested": "[2026.9.0-alpha.3, )",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "Sr+Nb/9gcbLCihAyv0B/Aw45jij4sYzhPgI62WFEFctpTOrZm+3hjrhKIC0tCwSFoXR5gGb6B6hpETcU7qwl3A==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -333,8 +333,8 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.2",
-          "Speckle.Sdk.Parquet": "2026.9.0-alpha.2",
+          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.3",
+          "Speckle.Sdk.Parquet": "2026.9.0-alpha.3",
           "System.Memory": "4.5.5",
           "System.Text.Json": "5.0.2"
         }

--- a/Converters/Navisworks/Speckle.Converters.Navisworks2021/packages.lock.json
+++ b/Converters/Navisworks/Speckle.Converters.Navisworks2021/packages.lock.json
@@ -180,16 +180,16 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "uLLVpEgPV/J1n2DKZVd9Yf6HzKDKsOHsdChdEbNqqY3sidIk6qKPH8Jw8jvCiDCe6H6R82+azkFxusHcQ7+Y7Q==",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "U4y0lPsO3+Dk3ZgER4D2s6wOHPRjA6pJBF1xIJNmFwVvu8NSYOxiuvWTCNobqAgm77EEwkfePFiljuogql2Iyg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.10"
         }
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "zmae3tL4g4sOqmKQyMR6aFMLQb4np62OspIOzhZB3ZmiiCr1zECK7UZWY7BTyBcfjql0yiRR0ddcpIq2e9rT2g=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "kVbdQ9V0RA9KjgYVntZ9BaHlpPqnyGHHZExq2upExe2i2mS0f61t4VRlH4ApHJIDgDtmTdqg1G2bl+hpOq9iyw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -295,7 +295,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "speckle.connectors.dui": {
@@ -310,7 +310,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "Speckle.DoubleNumerics": {
@@ -321,9 +321,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-alpha.2, )",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "agIhQ/tqtWDpw1HSHzvu/EhhoIeRqay6z2SBY+6kgsVOOuQmVaEdRWvujMZrjBI9hTsb+fqv4SrifAbbxraBOw==",
+        "requested": "[2026.9.0-alpha.3, )",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "Sr+Nb/9gcbLCihAyv0B/Aw45jij4sYzhPgI62WFEFctpTOrZm+3hjrhKIC0tCwSFoXR5gGb6B6hpETcU7qwl3A==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -333,8 +333,8 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.2",
-          "Speckle.Sdk.Parquet": "2026.9.0-alpha.2",
+          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.3",
+          "Speckle.Sdk.Parquet": "2026.9.0-alpha.3",
           "System.Memory": "4.5.5",
           "System.Text.Json": "5.0.2"
         }

--- a/Converters/Navisworks/Speckle.Converters.Navisworks2022/packages.lock.json
+++ b/Converters/Navisworks/Speckle.Converters.Navisworks2022/packages.lock.json
@@ -180,16 +180,16 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "uLLVpEgPV/J1n2DKZVd9Yf6HzKDKsOHsdChdEbNqqY3sidIk6qKPH8Jw8jvCiDCe6H6R82+azkFxusHcQ7+Y7Q==",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "U4y0lPsO3+Dk3ZgER4D2s6wOHPRjA6pJBF1xIJNmFwVvu8NSYOxiuvWTCNobqAgm77EEwkfePFiljuogql2Iyg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.10"
         }
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "zmae3tL4g4sOqmKQyMR6aFMLQb4np62OspIOzhZB3ZmiiCr1zECK7UZWY7BTyBcfjql0yiRR0ddcpIq2e9rT2g=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "kVbdQ9V0RA9KjgYVntZ9BaHlpPqnyGHHZExq2upExe2i2mS0f61t4VRlH4ApHJIDgDtmTdqg1G2bl+hpOq9iyw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -295,7 +295,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "speckle.connectors.dui": {
@@ -310,7 +310,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "Speckle.DoubleNumerics": {
@@ -321,9 +321,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-alpha.2, )",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "agIhQ/tqtWDpw1HSHzvu/EhhoIeRqay6z2SBY+6kgsVOOuQmVaEdRWvujMZrjBI9hTsb+fqv4SrifAbbxraBOw==",
+        "requested": "[2026.9.0-alpha.3, )",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "Sr+Nb/9gcbLCihAyv0B/Aw45jij4sYzhPgI62WFEFctpTOrZm+3hjrhKIC0tCwSFoXR5gGb6B6hpETcU7qwl3A==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -333,8 +333,8 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.2",
-          "Speckle.Sdk.Parquet": "2026.9.0-alpha.2",
+          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.3",
+          "Speckle.Sdk.Parquet": "2026.9.0-alpha.3",
           "System.Memory": "4.5.5",
           "System.Text.Json": "5.0.2"
         }

--- a/Converters/Navisworks/Speckle.Converters.Navisworks2023/packages.lock.json
+++ b/Converters/Navisworks/Speckle.Converters.Navisworks2023/packages.lock.json
@@ -180,16 +180,16 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "uLLVpEgPV/J1n2DKZVd9Yf6HzKDKsOHsdChdEbNqqY3sidIk6qKPH8Jw8jvCiDCe6H6R82+azkFxusHcQ7+Y7Q==",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "U4y0lPsO3+Dk3ZgER4D2s6wOHPRjA6pJBF1xIJNmFwVvu8NSYOxiuvWTCNobqAgm77EEwkfePFiljuogql2Iyg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.10"
         }
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "zmae3tL4g4sOqmKQyMR6aFMLQb4np62OspIOzhZB3ZmiiCr1zECK7UZWY7BTyBcfjql0yiRR0ddcpIq2e9rT2g=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "kVbdQ9V0RA9KjgYVntZ9BaHlpPqnyGHHZExq2upExe2i2mS0f61t4VRlH4ApHJIDgDtmTdqg1G2bl+hpOq9iyw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -295,7 +295,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "speckle.connectors.dui": {
@@ -310,7 +310,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "Speckle.DoubleNumerics": {
@@ -321,9 +321,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-alpha.2, )",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "agIhQ/tqtWDpw1HSHzvu/EhhoIeRqay6z2SBY+6kgsVOOuQmVaEdRWvujMZrjBI9hTsb+fqv4SrifAbbxraBOw==",
+        "requested": "[2026.9.0-alpha.3, )",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "Sr+Nb/9gcbLCihAyv0B/Aw45jij4sYzhPgI62WFEFctpTOrZm+3hjrhKIC0tCwSFoXR5gGb6B6hpETcU7qwl3A==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -333,8 +333,8 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.2",
-          "Speckle.Sdk.Parquet": "2026.9.0-alpha.2",
+          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.3",
+          "Speckle.Sdk.Parquet": "2026.9.0-alpha.3",
           "System.Memory": "4.5.5",
           "System.Text.Json": "5.0.2"
         }

--- a/Converters/Navisworks/Speckle.Converters.Navisworks2024/packages.lock.json
+++ b/Converters/Navisworks/Speckle.Converters.Navisworks2024/packages.lock.json
@@ -180,16 +180,16 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "uLLVpEgPV/J1n2DKZVd9Yf6HzKDKsOHsdChdEbNqqY3sidIk6qKPH8Jw8jvCiDCe6H6R82+azkFxusHcQ7+Y7Q==",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "U4y0lPsO3+Dk3ZgER4D2s6wOHPRjA6pJBF1xIJNmFwVvu8NSYOxiuvWTCNobqAgm77EEwkfePFiljuogql2Iyg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.10"
         }
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "zmae3tL4g4sOqmKQyMR6aFMLQb4np62OspIOzhZB3ZmiiCr1zECK7UZWY7BTyBcfjql0yiRR0ddcpIq2e9rT2g=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "kVbdQ9V0RA9KjgYVntZ9BaHlpPqnyGHHZExq2upExe2i2mS0f61t4VRlH4ApHJIDgDtmTdqg1G2bl+hpOq9iyw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -295,7 +295,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "speckle.connectors.dui": {
@@ -310,7 +310,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "Speckle.DoubleNumerics": {
@@ -321,9 +321,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-alpha.2, )",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "agIhQ/tqtWDpw1HSHzvu/EhhoIeRqay6z2SBY+6kgsVOOuQmVaEdRWvujMZrjBI9hTsb+fqv4SrifAbbxraBOw==",
+        "requested": "[2026.9.0-alpha.3, )",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "Sr+Nb/9gcbLCihAyv0B/Aw45jij4sYzhPgI62WFEFctpTOrZm+3hjrhKIC0tCwSFoXR5gGb6B6hpETcU7qwl3A==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -333,8 +333,8 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.2",
-          "Speckle.Sdk.Parquet": "2026.9.0-alpha.2",
+          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.3",
+          "Speckle.Sdk.Parquet": "2026.9.0-alpha.3",
           "System.Memory": "4.5.5",
           "System.Text.Json": "5.0.2"
         }

--- a/Converters/Navisworks/Speckle.Converters.Navisworks2025/packages.lock.json
+++ b/Converters/Navisworks/Speckle.Converters.Navisworks2025/packages.lock.json
@@ -180,16 +180,16 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "uLLVpEgPV/J1n2DKZVd9Yf6HzKDKsOHsdChdEbNqqY3sidIk6qKPH8Jw8jvCiDCe6H6R82+azkFxusHcQ7+Y7Q==",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "U4y0lPsO3+Dk3ZgER4D2s6wOHPRjA6pJBF1xIJNmFwVvu8NSYOxiuvWTCNobqAgm77EEwkfePFiljuogql2Iyg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.10"
         }
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "zmae3tL4g4sOqmKQyMR6aFMLQb4np62OspIOzhZB3ZmiiCr1zECK7UZWY7BTyBcfjql0yiRR0ddcpIq2e9rT2g=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "kVbdQ9V0RA9KjgYVntZ9BaHlpPqnyGHHZExq2upExe2i2mS0f61t4VRlH4ApHJIDgDtmTdqg1G2bl+hpOq9iyw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -295,7 +295,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "speckle.connectors.dui": {
@@ -310,7 +310,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "Speckle.DoubleNumerics": {
@@ -321,9 +321,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-alpha.2, )",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "agIhQ/tqtWDpw1HSHzvu/EhhoIeRqay6z2SBY+6kgsVOOuQmVaEdRWvujMZrjBI9hTsb+fqv4SrifAbbxraBOw==",
+        "requested": "[2026.9.0-alpha.3, )",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "Sr+Nb/9gcbLCihAyv0B/Aw45jij4sYzhPgI62WFEFctpTOrZm+3hjrhKIC0tCwSFoXR5gGb6B6hpETcU7qwl3A==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -333,8 +333,8 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.2",
-          "Speckle.Sdk.Parquet": "2026.9.0-alpha.2",
+          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.3",
+          "Speckle.Sdk.Parquet": "2026.9.0-alpha.3",
           "System.Memory": "4.5.5",
           "System.Text.Json": "5.0.2"
         }

--- a/Converters/Navisworks/Speckle.Converters.Navisworks2026/packages.lock.json
+++ b/Converters/Navisworks/Speckle.Converters.Navisworks2026/packages.lock.json
@@ -189,16 +189,16 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "uLLVpEgPV/J1n2DKZVd9Yf6HzKDKsOHsdChdEbNqqY3sidIk6qKPH8Jw8jvCiDCe6H6R82+azkFxusHcQ7+Y7Q==",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "U4y0lPsO3+Dk3ZgER4D2s6wOHPRjA6pJBF1xIJNmFwVvu8NSYOxiuvWTCNobqAgm77EEwkfePFiljuogql2Iyg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.10"
         }
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "zmae3tL4g4sOqmKQyMR6aFMLQb4np62OspIOzhZB3ZmiiCr1zECK7UZWY7BTyBcfjql0yiRR0ddcpIq2e9rT2g=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "kVbdQ9V0RA9KjgYVntZ9BaHlpPqnyGHHZExq2upExe2i2mS0f61t4VRlH4ApHJIDgDtmTdqg1G2bl+hpOq9iyw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -296,7 +296,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "speckle.connectors.dui": {
@@ -311,7 +311,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "Speckle.DoubleNumerics": {
@@ -322,9 +322,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-alpha.2, )",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "agIhQ/tqtWDpw1HSHzvu/EhhoIeRqay6z2SBY+6kgsVOOuQmVaEdRWvujMZrjBI9hTsb+fqv4SrifAbbxraBOw==",
+        "requested": "[2026.9.0-alpha.3, )",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "Sr+Nb/9gcbLCihAyv0B/Aw45jij4sYzhPgI62WFEFctpTOrZm+3hjrhKIC0tCwSFoXR5gGb6B6hpETcU7qwl3A==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -334,8 +334,8 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.2",
-          "Speckle.Sdk.Parquet": "2026.9.0-alpha.2",
+          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.3",
+          "Speckle.Sdk.Parquet": "2026.9.0-alpha.3",
           "System.Memory": "4.5.5",
           "System.Text.Json": "5.0.2"
         }

--- a/Converters/Navisworks/Speckle.Converters.Navisworks2027/packages.lock.json
+++ b/Converters/Navisworks/Speckle.Converters.Navisworks2027/packages.lock.json
@@ -189,16 +189,16 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "uLLVpEgPV/J1n2DKZVd9Yf6HzKDKsOHsdChdEbNqqY3sidIk6qKPH8Jw8jvCiDCe6H6R82+azkFxusHcQ7+Y7Q==",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "U4y0lPsO3+Dk3ZgER4D2s6wOHPRjA6pJBF1xIJNmFwVvu8NSYOxiuvWTCNobqAgm77EEwkfePFiljuogql2Iyg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.10"
         }
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "zmae3tL4g4sOqmKQyMR6aFMLQb4np62OspIOzhZB3ZmiiCr1zECK7UZWY7BTyBcfjql0yiRR0ddcpIq2e9rT2g=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "kVbdQ9V0RA9KjgYVntZ9BaHlpPqnyGHHZExq2upExe2i2mS0f61t4VRlH4ApHJIDgDtmTdqg1G2bl+hpOq9iyw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -296,7 +296,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "speckle.connectors.dui": {
@@ -311,7 +311,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "Speckle.DoubleNumerics": {
@@ -322,9 +322,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-alpha.2, )",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "agIhQ/tqtWDpw1HSHzvu/EhhoIeRqay6z2SBY+6kgsVOOuQmVaEdRWvujMZrjBI9hTsb+fqv4SrifAbbxraBOw==",
+        "requested": "[2026.9.0-alpha.3, )",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "Sr+Nb/9gcbLCihAyv0B/Aw45jij4sYzhPgI62WFEFctpTOrZm+3hjrhKIC0tCwSFoXR5gGb6B6hpETcU7qwl3A==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -334,8 +334,8 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.2",
-          "Speckle.Sdk.Parquet": "2026.9.0-alpha.2",
+          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.3",
+          "Speckle.Sdk.Parquet": "2026.9.0-alpha.3",
           "System.Memory": "4.5.5",
           "System.Text.Json": "5.0.2"
         }

--- a/Converters/Plant3d/Speckle.Converters.Plant3d2026/packages.lock.json
+++ b/Converters/Plant3d/Speckle.Converters.Plant3d2026/packages.lock.json
@@ -148,13 +148,13 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "uLLVpEgPV/J1n2DKZVd9Yf6HzKDKsOHsdChdEbNqqY3sidIk6qKPH8Jw8jvCiDCe6H6R82+azkFxusHcQ7+Y7Q=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "U4y0lPsO3+Dk3ZgER4D2s6wOHPRjA6pJBF1xIJNmFwVvu8NSYOxiuvWTCNobqAgm77EEwkfePFiljuogql2Iyg=="
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "zmae3tL4g4sOqmKQyMR6aFMLQb4np62OspIOzhZB3ZmiiCr1zECK7UZWY7BTyBcfjql0yiRR0ddcpIq2e9rT2g=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "kVbdQ9V0RA9KjgYVntZ9BaHlpPqnyGHHZExq2upExe2i2mS0f61t4VRlH4ApHJIDgDtmTdqg1G2bl+hpOq9iyw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -201,7 +201,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "speckle.connectors.dui": {
@@ -223,7 +223,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "Microsoft.Web.WebView2": {
@@ -240,9 +240,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-alpha.2, )",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "agIhQ/tqtWDpw1HSHzvu/EhhoIeRqay6z2SBY+6kgsVOOuQmVaEdRWvujMZrjBI9hTsb+fqv4SrifAbbxraBOw==",
+        "requested": "[2026.9.0-alpha.3, )",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "Sr+Nb/9gcbLCihAyv0B/Aw45jij4sYzhPgI62WFEFctpTOrZm+3hjrhKIC0tCwSFoXR5gGb6B6hpETcU7qwl3A==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -250,8 +250,8 @@
           "Microsoft.Extensions.ObjectPool": "8.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.2",
-          "Speckle.Sdk.Parquet": "2026.9.0-alpha.2"
+          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.3",
+          "Speckle.Sdk.Parquet": "2026.9.0-alpha.3"
         }
       }
     }

--- a/Converters/Plant3d/Speckle.Converters.Plant3d2027/packages.lock.json
+++ b/Converters/Plant3d/Speckle.Converters.Plant3d2027/packages.lock.json
@@ -149,13 +149,13 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "uLLVpEgPV/J1n2DKZVd9Yf6HzKDKsOHsdChdEbNqqY3sidIk6qKPH8Jw8jvCiDCe6H6R82+azkFxusHcQ7+Y7Q=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "U4y0lPsO3+Dk3ZgER4D2s6wOHPRjA6pJBF1xIJNmFwVvu8NSYOxiuvWTCNobqAgm77EEwkfePFiljuogql2Iyg=="
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "zmae3tL4g4sOqmKQyMR6aFMLQb4np62OspIOzhZB3ZmiiCr1zECK7UZWY7BTyBcfjql0yiRR0ddcpIq2e9rT2g=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "kVbdQ9V0RA9KjgYVntZ9BaHlpPqnyGHHZExq2upExe2i2mS0f61t4VRlH4ApHJIDgDtmTdqg1G2bl+hpOq9iyw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -194,7 +194,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "speckle.connectors.dui": {
@@ -216,7 +216,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "Microsoft.Web.WebView2": {
@@ -233,9 +233,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-alpha.2, )",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "agIhQ/tqtWDpw1HSHzvu/EhhoIeRqay6z2SBY+6kgsVOOuQmVaEdRWvujMZrjBI9hTsb+fqv4SrifAbbxraBOw==",
+        "requested": "[2026.9.0-alpha.3, )",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "Sr+Nb/9gcbLCihAyv0B/Aw45jij4sYzhPgI62WFEFctpTOrZm+3hjrhKIC0tCwSFoXR5gGb6B6hpETcU7qwl3A==",
         "dependencies": {
           "GraphQL.Client": "6.1.0",
           "Microsoft.Data.Sqlite": "10.0.0",
@@ -243,8 +243,8 @@
           "Microsoft.Extensions.ObjectPool": "10.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.2",
-          "Speckle.Sdk.Parquet": "2026.9.0-alpha.2"
+          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.3",
+          "Speckle.Sdk.Parquet": "2026.9.0-alpha.3"
         }
       }
     }

--- a/Converters/Revit/Speckle.Converters.Revit2023/packages.lock.json
+++ b/Converters/Revit/Speckle.Converters.Revit2023/packages.lock.json
@@ -180,16 +180,16 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "uLLVpEgPV/J1n2DKZVd9Yf6HzKDKsOHsdChdEbNqqY3sidIk6qKPH8Jw8jvCiDCe6H6R82+azkFxusHcQ7+Y7Q==",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "U4y0lPsO3+Dk3ZgER4D2s6wOHPRjA6pJBF1xIJNmFwVvu8NSYOxiuvWTCNobqAgm77EEwkfePFiljuogql2Iyg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.10"
         }
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "zmae3tL4g4sOqmKQyMR6aFMLQb4np62OspIOzhZB3ZmiiCr1zECK7UZWY7BTyBcfjql0yiRR0ddcpIq2e9rT2g=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "kVbdQ9V0RA9KjgYVntZ9BaHlpPqnyGHHZExq2upExe2i2mS0f61t4VRlH4ApHJIDgDtmTdqg1G2bl+hpOq9iyw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -300,7 +300,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "LibTessDotNet": {
@@ -317,9 +317,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-alpha.2, )",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "agIhQ/tqtWDpw1HSHzvu/EhhoIeRqay6z2SBY+6kgsVOOuQmVaEdRWvujMZrjBI9hTsb+fqv4SrifAbbxraBOw==",
+        "requested": "[2026.9.0-alpha.3, )",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "Sr+Nb/9gcbLCihAyv0B/Aw45jij4sYzhPgI62WFEFctpTOrZm+3hjrhKIC0tCwSFoXR5gGb6B6hpETcU7qwl3A==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -329,8 +329,8 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.2",
-          "Speckle.Sdk.Parquet": "2026.9.0-alpha.2",
+          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.3",
+          "Speckle.Sdk.Parquet": "2026.9.0-alpha.3",
           "System.Memory": "4.5.5",
           "System.Text.Json": "5.0.2"
         }

--- a/Converters/Revit/Speckle.Converters.Revit2024/packages.lock.json
+++ b/Converters/Revit/Speckle.Converters.Revit2024/packages.lock.json
@@ -180,16 +180,16 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "uLLVpEgPV/J1n2DKZVd9Yf6HzKDKsOHsdChdEbNqqY3sidIk6qKPH8Jw8jvCiDCe6H6R82+azkFxusHcQ7+Y7Q==",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "U4y0lPsO3+Dk3ZgER4D2s6wOHPRjA6pJBF1xIJNmFwVvu8NSYOxiuvWTCNobqAgm77EEwkfePFiljuogql2Iyg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.10"
         }
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "zmae3tL4g4sOqmKQyMR6aFMLQb4np62OspIOzhZB3ZmiiCr1zECK7UZWY7BTyBcfjql0yiRR0ddcpIq2e9rT2g=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "kVbdQ9V0RA9KjgYVntZ9BaHlpPqnyGHHZExq2upExe2i2mS0f61t4VRlH4ApHJIDgDtmTdqg1G2bl+hpOq9iyw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -300,7 +300,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "LibTessDotNet": {
@@ -317,9 +317,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-alpha.2, )",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "agIhQ/tqtWDpw1HSHzvu/EhhoIeRqay6z2SBY+6kgsVOOuQmVaEdRWvujMZrjBI9hTsb+fqv4SrifAbbxraBOw==",
+        "requested": "[2026.9.0-alpha.3, )",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "Sr+Nb/9gcbLCihAyv0B/Aw45jij4sYzhPgI62WFEFctpTOrZm+3hjrhKIC0tCwSFoXR5gGb6B6hpETcU7qwl3A==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -329,8 +329,8 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.2",
-          "Speckle.Sdk.Parquet": "2026.9.0-alpha.2",
+          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.3",
+          "Speckle.Sdk.Parquet": "2026.9.0-alpha.3",
           "System.Memory": "4.5.5",
           "System.Text.Json": "5.0.2"
         }

--- a/Converters/Revit/Speckle.Converters.Revit2025/packages.lock.json
+++ b/Converters/Revit/Speckle.Converters.Revit2025/packages.lock.json
@@ -139,13 +139,13 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "uLLVpEgPV/J1n2DKZVd9Yf6HzKDKsOHsdChdEbNqqY3sidIk6qKPH8Jw8jvCiDCe6H6R82+azkFxusHcQ7+Y7Q=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "U4y0lPsO3+Dk3ZgER4D2s6wOHPRjA6pJBF1xIJNmFwVvu8NSYOxiuvWTCNobqAgm77EEwkfePFiljuogql2Iyg=="
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "zmae3tL4g4sOqmKQyMR6aFMLQb4np62OspIOzhZB3ZmiiCr1zECK7UZWY7BTyBcfjql0yiRR0ddcpIq2e9rT2g=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "kVbdQ9V0RA9KjgYVntZ9BaHlpPqnyGHHZExq2upExe2i2mS0f61t4VRlH4ApHJIDgDtmTdqg1G2bl+hpOq9iyw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -197,7 +197,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "LibTessDotNet": {
@@ -214,9 +214,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-alpha.2, )",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "agIhQ/tqtWDpw1HSHzvu/EhhoIeRqay6z2SBY+6kgsVOOuQmVaEdRWvujMZrjBI9hTsb+fqv4SrifAbbxraBOw==",
+        "requested": "[2026.9.0-alpha.3, )",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "Sr+Nb/9gcbLCihAyv0B/Aw45jij4sYzhPgI62WFEFctpTOrZm+3hjrhKIC0tCwSFoXR5gGb6B6hpETcU7qwl3A==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -224,8 +224,8 @@
           "Microsoft.Extensions.ObjectPool": "8.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.2",
-          "Speckle.Sdk.Parquet": "2026.9.0-alpha.2"
+          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.3",
+          "Speckle.Sdk.Parquet": "2026.9.0-alpha.3"
         }
       }
     }

--- a/Converters/Revit/Speckle.Converters.Revit2026/packages.lock.json
+++ b/Converters/Revit/Speckle.Converters.Revit2026/packages.lock.json
@@ -139,13 +139,13 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "uLLVpEgPV/J1n2DKZVd9Yf6HzKDKsOHsdChdEbNqqY3sidIk6qKPH8Jw8jvCiDCe6H6R82+azkFxusHcQ7+Y7Q=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "U4y0lPsO3+Dk3ZgER4D2s6wOHPRjA6pJBF1xIJNmFwVvu8NSYOxiuvWTCNobqAgm77EEwkfePFiljuogql2Iyg=="
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "zmae3tL4g4sOqmKQyMR6aFMLQb4np62OspIOzhZB3ZmiiCr1zECK7UZWY7BTyBcfjql0yiRR0ddcpIq2e9rT2g=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "kVbdQ9V0RA9KjgYVntZ9BaHlpPqnyGHHZExq2upExe2i2mS0f61t4VRlH4ApHJIDgDtmTdqg1G2bl+hpOq9iyw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -197,7 +197,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "LibTessDotNet": {
@@ -214,9 +214,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-alpha.2, )",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "agIhQ/tqtWDpw1HSHzvu/EhhoIeRqay6z2SBY+6kgsVOOuQmVaEdRWvujMZrjBI9hTsb+fqv4SrifAbbxraBOw==",
+        "requested": "[2026.9.0-alpha.3, )",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "Sr+Nb/9gcbLCihAyv0B/Aw45jij4sYzhPgI62WFEFctpTOrZm+3hjrhKIC0tCwSFoXR5gGb6B6hpETcU7qwl3A==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -224,8 +224,8 @@
           "Microsoft.Extensions.ObjectPool": "8.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.2",
-          "Speckle.Sdk.Parquet": "2026.9.0-alpha.2"
+          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.3",
+          "Speckle.Sdk.Parquet": "2026.9.0-alpha.3"
         }
       }
     }

--- a/Converters/Revit/Speckle.Converters.Revit2027/packages.lock.json
+++ b/Converters/Revit/Speckle.Converters.Revit2027/packages.lock.json
@@ -140,13 +140,13 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "uLLVpEgPV/J1n2DKZVd9Yf6HzKDKsOHsdChdEbNqqY3sidIk6qKPH8Jw8jvCiDCe6H6R82+azkFxusHcQ7+Y7Q=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "U4y0lPsO3+Dk3ZgER4D2s6wOHPRjA6pJBF1xIJNmFwVvu8NSYOxiuvWTCNobqAgm77EEwkfePFiljuogql2Iyg=="
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "zmae3tL4g4sOqmKQyMR6aFMLQb4np62OspIOzhZB3ZmiiCr1zECK7UZWY7BTyBcfjql0yiRR0ddcpIq2e9rT2g=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "kVbdQ9V0RA9KjgYVntZ9BaHlpPqnyGHHZExq2upExe2i2mS0f61t4VRlH4ApHJIDgDtmTdqg1G2bl+hpOq9iyw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -190,7 +190,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "LibTessDotNet": {
@@ -207,9 +207,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-alpha.2, )",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "agIhQ/tqtWDpw1HSHzvu/EhhoIeRqay6z2SBY+6kgsVOOuQmVaEdRWvujMZrjBI9hTsb+fqv4SrifAbbxraBOw==",
+        "requested": "[2026.9.0-alpha.3, )",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "Sr+Nb/9gcbLCihAyv0B/Aw45jij4sYzhPgI62WFEFctpTOrZm+3hjrhKIC0tCwSFoXR5gGb6B6hpETcU7qwl3A==",
         "dependencies": {
           "GraphQL.Client": "6.1.0",
           "Microsoft.Data.Sqlite": "10.0.0",
@@ -217,8 +217,8 @@
           "Microsoft.Extensions.ObjectPool": "10.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.2",
-          "Speckle.Sdk.Parquet": "2026.9.0-alpha.2"
+          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.3",
+          "Speckle.Sdk.Parquet": "2026.9.0-alpha.3"
         }
       }
     }

--- a/Converters/Rhino/Speckle.Converters.Rhino7/packages.lock.json
+++ b/Converters/Rhino/Speckle.Converters.Rhino7/packages.lock.json
@@ -180,16 +180,16 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "uLLVpEgPV/J1n2DKZVd9Yf6HzKDKsOHsdChdEbNqqY3sidIk6qKPH8Jw8jvCiDCe6H6R82+azkFxusHcQ7+Y7Q==",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "U4y0lPsO3+Dk3ZgER4D2s6wOHPRjA6pJBF1xIJNmFwVvu8NSYOxiuvWTCNobqAgm77EEwkfePFiljuogql2Iyg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.10"
         }
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "zmae3tL4g4sOqmKQyMR6aFMLQb4np62OspIOzhZB3ZmiiCr1zECK7UZWY7BTyBcfjql0yiRR0ddcpIq2e9rT2g=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "kVbdQ9V0RA9KjgYVntZ9BaHlpPqnyGHHZExq2upExe2i2mS0f61t4VRlH4ApHJIDgDtmTdqg1G2bl+hpOq9iyw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -293,7 +293,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "Speckle.DoubleNumerics": {
@@ -304,9 +304,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-alpha.2, )",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "agIhQ/tqtWDpw1HSHzvu/EhhoIeRqay6z2SBY+6kgsVOOuQmVaEdRWvujMZrjBI9hTsb+fqv4SrifAbbxraBOw==",
+        "requested": "[2026.9.0-alpha.3, )",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "Sr+Nb/9gcbLCihAyv0B/Aw45jij4sYzhPgI62WFEFctpTOrZm+3hjrhKIC0tCwSFoXR5gGb6B6hpETcU7qwl3A==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -316,8 +316,8 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.2",
-          "Speckle.Sdk.Parquet": "2026.9.0-alpha.2",
+          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.3",
+          "Speckle.Sdk.Parquet": "2026.9.0-alpha.3",
           "System.Memory": "4.5.5",
           "System.Text.Json": "5.0.2"
         }

--- a/Converters/Rhino/Speckle.Converters.Rhino8/packages.lock.json
+++ b/Converters/Rhino/Speckle.Converters.Rhino8/packages.lock.json
@@ -505,7 +505,10 @@
       "SQLitePCLRaw.core": {
         "type": "Transitive",
         "resolved": "2.1.4",
-        "contentHash": "inBjvSHo9UDKneGNzfUfDjK08JzlcIhn1+SP5Y3m6cgXpCxXKCJDy6Mka7LpgSV+UZmKSnC8rTwB0SQ0xKu5pA=="
+        "contentHash": "inBjvSHo9UDKneGNzfUfDjK08JzlcIhn1+SP5Y3m6cgXpCxXKCJDy6Mka7LpgSV+UZmKSnC8rTwB0SQ0xKu5pA==",
+        "dependencies": {
+          "System.Memory": "4.5.3"
+        }
       },
       "SQLitePCLRaw.lib.e_sqlite3": {
         "type": "Transitive",
@@ -527,6 +530,11 @@
         "dependencies": {
           "Microsoft.Win32.SystemEvents": "7.0.0"
         }
+      },
+      "System.Memory": {
+        "type": "Transitive",
+        "resolved": "4.5.3",
+        "contentHash": "3oDzvc/zzetpTKWMShs1AADwZjQ/36HnsufHRPcOjyRAAMLDlu2iD33MBI2opxnezcVUtXyqDXXjoFMOU9c7SA=="
       },
       "System.Reactive": {
         "type": "Transitive",

--- a/Converters/Rhino/Speckle.Converters.Rhino8/packages.lock.json
+++ b/Converters/Rhino/Speckle.Converters.Rhino8/packages.lock.json
@@ -180,16 +180,16 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "uLLVpEgPV/J1n2DKZVd9Yf6HzKDKsOHsdChdEbNqqY3sidIk6qKPH8Jw8jvCiDCe6H6R82+azkFxusHcQ7+Y7Q==",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "U4y0lPsO3+Dk3ZgER4D2s6wOHPRjA6pJBF1xIJNmFwVvu8NSYOxiuvWTCNobqAgm77EEwkfePFiljuogql2Iyg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.10"
         }
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "zmae3tL4g4sOqmKQyMR6aFMLQb4np62OspIOzhZB3ZmiiCr1zECK7UZWY7BTyBcfjql0yiRR0ddcpIq2e9rT2g=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "kVbdQ9V0RA9KjgYVntZ9BaHlpPqnyGHHZExq2upExe2i2mS0f61t4VRlH4ApHJIDgDtmTdqg1G2bl+hpOq9iyw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -293,7 +293,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "Speckle.DoubleNumerics": {
@@ -304,9 +304,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-alpha.2, )",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "agIhQ/tqtWDpw1HSHzvu/EhhoIeRqay6z2SBY+6kgsVOOuQmVaEdRWvujMZrjBI9hTsb+fqv4SrifAbbxraBOw==",
+        "requested": "[2026.9.0-alpha.3, )",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "Sr+Nb/9gcbLCihAyv0B/Aw45jij4sYzhPgI62WFEFctpTOrZm+3hjrhKIC0tCwSFoXR5gGb6B6hpETcU7qwl3A==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -316,8 +316,8 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.2",
-          "Speckle.Sdk.Parquet": "2026.9.0-alpha.2",
+          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.3",
+          "Speckle.Sdk.Parquet": "2026.9.0-alpha.3",
           "System.Memory": "4.5.5",
           "System.Text.Json": "5.0.2"
         }
@@ -485,13 +485,13 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "uLLVpEgPV/J1n2DKZVd9Yf6HzKDKsOHsdChdEbNqqY3sidIk6qKPH8Jw8jvCiDCe6H6R82+azkFxusHcQ7+Y7Q=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "U4y0lPsO3+Dk3ZgER4D2s6wOHPRjA6pJBF1xIJNmFwVvu8NSYOxiuvWTCNobqAgm77EEwkfePFiljuogql2Iyg=="
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "zmae3tL4g4sOqmKQyMR6aFMLQb4np62OspIOzhZB3ZmiiCr1zECK7UZWY7BTyBcfjql0yiRR0ddcpIq2e9rT2g=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "kVbdQ9V0RA9KjgYVntZ9BaHlpPqnyGHHZExq2upExe2i2mS0f61t4VRlH4ApHJIDgDtmTdqg1G2bl+hpOq9iyw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -505,10 +505,7 @@
       "SQLitePCLRaw.core": {
         "type": "Transitive",
         "resolved": "2.1.4",
-        "contentHash": "inBjvSHo9UDKneGNzfUfDjK08JzlcIhn1+SP5Y3m6cgXpCxXKCJDy6Mka7LpgSV+UZmKSnC8rTwB0SQ0xKu5pA==",
-        "dependencies": {
-          "System.Memory": "4.5.3"
-        }
+        "contentHash": "inBjvSHo9UDKneGNzfUfDjK08JzlcIhn1+SP5Y3m6cgXpCxXKCJDy6Mka7LpgSV+UZmKSnC8rTwB0SQ0xKu5pA=="
       },
       "SQLitePCLRaw.lib.e_sqlite3": {
         "type": "Transitive",
@@ -531,11 +528,6 @@
           "Microsoft.Win32.SystemEvents": "7.0.0"
         }
       },
-      "System.Memory": {
-        "type": "Transitive",
-        "resolved": "4.5.3",
-        "contentHash": "3oDzvc/zzetpTKWMShs1AADwZjQ/36HnsufHRPcOjyRAAMLDlu2iD33MBI2opxnezcVUtXyqDXXjoFMOU9c7SA=="
-      },
       "System.Reactive": {
         "type": "Transitive",
         "resolved": "5.0.0",
@@ -544,7 +536,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "Speckle.DoubleNumerics": {
@@ -555,9 +547,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-alpha.2, )",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "agIhQ/tqtWDpw1HSHzvu/EhhoIeRqay6z2SBY+6kgsVOOuQmVaEdRWvujMZrjBI9hTsb+fqv4SrifAbbxraBOw==",
+        "requested": "[2026.9.0-alpha.3, )",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "Sr+Nb/9gcbLCihAyv0B/Aw45jij4sYzhPgI62WFEFctpTOrZm+3hjrhKIC0tCwSFoXR5gGb6B6hpETcU7qwl3A==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -565,8 +557,8 @@
           "Microsoft.Extensions.ObjectPool": "8.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.2",
-          "Speckle.Sdk.Parquet": "2026.9.0-alpha.2"
+          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.3",
+          "Speckle.Sdk.Parquet": "2026.9.0-alpha.3"
         }
       }
     }

--- a/Converters/Rhino/Speckle.Converters.Rhino9/packages.lock.json
+++ b/Converters/Rhino/Speckle.Converters.Rhino9/packages.lock.json
@@ -167,13 +167,13 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "uLLVpEgPV/J1n2DKZVd9Yf6HzKDKsOHsdChdEbNqqY3sidIk6qKPH8Jw8jvCiDCe6H6R82+azkFxusHcQ7+Y7Q=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "U4y0lPsO3+Dk3ZgER4D2s6wOHPRjA6pJBF1xIJNmFwVvu8NSYOxiuvWTCNobqAgm77EEwkfePFiljuogql2Iyg=="
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "zmae3tL4g4sOqmKQyMR6aFMLQb4np62OspIOzhZB3ZmiiCr1zECK7UZWY7BTyBcfjql0yiRR0ddcpIq2e9rT2g=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "kVbdQ9V0RA9KjgYVntZ9BaHlpPqnyGHHZExq2upExe2i2mS0f61t4VRlH4ApHJIDgDtmTdqg1G2bl+hpOq9iyw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -218,7 +218,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "Speckle.DoubleNumerics": {
@@ -229,9 +229,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-alpha.2, )",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "agIhQ/tqtWDpw1HSHzvu/EhhoIeRqay6z2SBY+6kgsVOOuQmVaEdRWvujMZrjBI9hTsb+fqv4SrifAbbxraBOw==",
+        "requested": "[2026.9.0-alpha.3, )",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "Sr+Nb/9gcbLCihAyv0B/Aw45jij4sYzhPgI62WFEFctpTOrZm+3hjrhKIC0tCwSFoXR5gGb6B6hpETcU7qwl3A==",
         "dependencies": {
           "GraphQL.Client": "6.1.0",
           "Microsoft.Data.Sqlite": "10.0.0",
@@ -239,8 +239,8 @@
           "Microsoft.Extensions.ObjectPool": "10.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.2",
-          "Speckle.Sdk.Parquet": "2026.9.0-alpha.2"
+          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.3",
+          "Speckle.Sdk.Parquet": "2026.9.0-alpha.3"
         }
       }
     }

--- a/Converters/TSD/Speckle.Converters.TSD2027/packages.lock.json
+++ b/Converters/TSD/Speckle.Converters.TSD2027/packages.lock.json
@@ -171,13 +171,13 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "uLLVpEgPV/J1n2DKZVd9Yf6HzKDKsOHsdChdEbNqqY3sidIk6qKPH8Jw8jvCiDCe6H6R82+azkFxusHcQ7+Y7Q=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "U4y0lPsO3+Dk3ZgER4D2s6wOHPRjA6pJBF1xIJNmFwVvu8NSYOxiuvWTCNobqAgm77EEwkfePFiljuogql2Iyg=="
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "zmae3tL4g4sOqmKQyMR6aFMLQb4np62OspIOzhZB3ZmiiCr1zECK7UZWY7BTyBcfjql0yiRR0ddcpIq2e9rT2g=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "kVbdQ9V0RA9KjgYVntZ9BaHlpPqnyGHHZExq2upExe2i2mS0f61t4VRlH4ApHJIDgDtmTdqg1G2bl+hpOq9iyw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -221,7 +221,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "LibTessDotNet": {
@@ -238,9 +238,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-alpha.2, )",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "agIhQ/tqtWDpw1HSHzvu/EhhoIeRqay6z2SBY+6kgsVOOuQmVaEdRWvujMZrjBI9hTsb+fqv4SrifAbbxraBOw==",
+        "requested": "[2026.9.0-alpha.3, )",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "Sr+Nb/9gcbLCihAyv0B/Aw45jij4sYzhPgI62WFEFctpTOrZm+3hjrhKIC0tCwSFoXR5gGb6B6hpETcU7qwl3A==",
         "dependencies": {
           "GraphQL.Client": "6.1.0",
           "Microsoft.Data.Sqlite": "10.0.0",
@@ -248,8 +248,8 @@
           "Microsoft.Extensions.ObjectPool": "10.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.2",
-          "Speckle.Sdk.Parquet": "2026.9.0-alpha.2"
+          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.3",
+          "Speckle.Sdk.Parquet": "2026.9.0-alpha.3"
         }
       }
     }

--- a/Converters/Tekla/Speckle.Converter.Tekla2023/packages.lock.json
+++ b/Converters/Tekla/Speckle.Converter.Tekla2023/packages.lock.json
@@ -197,16 +197,16 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "uLLVpEgPV/J1n2DKZVd9Yf6HzKDKsOHsdChdEbNqqY3sidIk6qKPH8Jw8jvCiDCe6H6R82+azkFxusHcQ7+Y7Q==",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "U4y0lPsO3+Dk3ZgER4D2s6wOHPRjA6pJBF1xIJNmFwVvu8NSYOxiuvWTCNobqAgm77EEwkfePFiljuogql2Iyg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.10"
         }
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "zmae3tL4g4sOqmKQyMR6aFMLQb4np62OspIOzhZB3ZmiiCr1zECK7UZWY7BTyBcfjql0yiRR0ddcpIq2e9rT2g=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "kVbdQ9V0RA9KjgYVntZ9BaHlpPqnyGHHZExq2upExe2i2mS0f61t4VRlH4ApHJIDgDtmTdqg1G2bl+hpOq9iyw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -337,7 +337,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "LibTessDotNet": {
@@ -354,9 +354,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-alpha.2, )",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "agIhQ/tqtWDpw1HSHzvu/EhhoIeRqay6z2SBY+6kgsVOOuQmVaEdRWvujMZrjBI9hTsb+fqv4SrifAbbxraBOw==",
+        "requested": "[2026.9.0-alpha.3, )",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "Sr+Nb/9gcbLCihAyv0B/Aw45jij4sYzhPgI62WFEFctpTOrZm+3hjrhKIC0tCwSFoXR5gGb6B6hpETcU7qwl3A==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -366,8 +366,8 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.2",
-          "Speckle.Sdk.Parquet": "2026.9.0-alpha.2",
+          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.3",
+          "Speckle.Sdk.Parquet": "2026.9.0-alpha.3",
           "System.Memory": "4.5.5",
           "System.Text.Json": "5.0.2"
         }

--- a/Converters/Tekla/Speckle.Converter.Tekla2024/packages.lock.json
+++ b/Converters/Tekla/Speckle.Converter.Tekla2024/packages.lock.json
@@ -207,16 +207,16 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "uLLVpEgPV/J1n2DKZVd9Yf6HzKDKsOHsdChdEbNqqY3sidIk6qKPH8Jw8jvCiDCe6H6R82+azkFxusHcQ7+Y7Q==",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "U4y0lPsO3+Dk3ZgER4D2s6wOHPRjA6pJBF1xIJNmFwVvu8NSYOxiuvWTCNobqAgm77EEwkfePFiljuogql2Iyg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.10"
         }
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "zmae3tL4g4sOqmKQyMR6aFMLQb4np62OspIOzhZB3ZmiiCr1zECK7UZWY7BTyBcfjql0yiRR0ddcpIq2e9rT2g=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "kVbdQ9V0RA9KjgYVntZ9BaHlpPqnyGHHZExq2upExe2i2mS0f61t4VRlH4ApHJIDgDtmTdqg1G2bl+hpOq9iyw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -378,7 +378,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "LibTessDotNet": {
@@ -395,9 +395,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-alpha.2, )",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "agIhQ/tqtWDpw1HSHzvu/EhhoIeRqay6z2SBY+6kgsVOOuQmVaEdRWvujMZrjBI9hTsb+fqv4SrifAbbxraBOw==",
+        "requested": "[2026.9.0-alpha.3, )",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "Sr+Nb/9gcbLCihAyv0B/Aw45jij4sYzhPgI62WFEFctpTOrZm+3hjrhKIC0tCwSFoXR5gGb6B6hpETcU7qwl3A==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -407,8 +407,8 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.2",
-          "Speckle.Sdk.Parquet": "2026.9.0-alpha.2",
+          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.3",
+          "Speckle.Sdk.Parquet": "2026.9.0-alpha.3",
           "System.Memory": "4.5.5",
           "System.Text.Json": "5.0.2"
         }

--- a/Converters/Tekla/Speckle.Converter.Tekla2025/packages.lock.json
+++ b/Converters/Tekla/Speckle.Converter.Tekla2025/packages.lock.json
@@ -207,16 +207,16 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "uLLVpEgPV/J1n2DKZVd9Yf6HzKDKsOHsdChdEbNqqY3sidIk6qKPH8Jw8jvCiDCe6H6R82+azkFxusHcQ7+Y7Q==",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "U4y0lPsO3+Dk3ZgER4D2s6wOHPRjA6pJBF1xIJNmFwVvu8NSYOxiuvWTCNobqAgm77EEwkfePFiljuogql2Iyg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.10"
         }
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "zmae3tL4g4sOqmKQyMR6aFMLQb4np62OspIOzhZB3ZmiiCr1zECK7UZWY7BTyBcfjql0yiRR0ddcpIq2e9rT2g=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "kVbdQ9V0RA9KjgYVntZ9BaHlpPqnyGHHZExq2upExe2i2mS0f61t4VRlH4ApHJIDgDtmTdqg1G2bl+hpOq9iyw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -378,7 +378,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "LibTessDotNet": {
@@ -395,9 +395,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-alpha.2, )",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "agIhQ/tqtWDpw1HSHzvu/EhhoIeRqay6z2SBY+6kgsVOOuQmVaEdRWvujMZrjBI9hTsb+fqv4SrifAbbxraBOw==",
+        "requested": "[2026.9.0-alpha.3, )",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "Sr+Nb/9gcbLCihAyv0B/Aw45jij4sYzhPgI62WFEFctpTOrZm+3hjrhKIC0tCwSFoXR5gGb6B6hpETcU7qwl3A==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -407,8 +407,8 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.2",
-          "Speckle.Sdk.Parquet": "2026.9.0-alpha.2",
+          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.3",
+          "Speckle.Sdk.Parquet": "2026.9.0-alpha.3",
           "System.Memory": "4.5.5",
           "System.Text.Json": "5.0.2"
         }

--- a/DUI3/Speckle.Connectors.DUI.Tests/packages.lock.json
+++ b/DUI3/Speckle.Connectors.DUI.Tests/packages.lock.json
@@ -271,13 +271,13 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "uLLVpEgPV/J1n2DKZVd9Yf6HzKDKsOHsdChdEbNqqY3sidIk6qKPH8Jw8jvCiDCe6H6R82+azkFxusHcQ7+Y7Q=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "U4y0lPsO3+Dk3ZgER4D2s6wOHPRjA6pJBF1xIJNmFwVvu8NSYOxiuvWTCNobqAgm77EEwkfePFiljuogql2Iyg=="
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "zmae3tL4g4sOqmKQyMR6aFMLQb4np62OspIOzhZB3ZmiiCr1zECK7UZWY7BTyBcfjql0yiRR0ddcpIq2e9rT2g=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "kVbdQ9V0RA9KjgYVntZ9BaHlpPqnyGHHZExq2upExe2i2mS0f61t4VRlH4ApHJIDgDtmTdqg1G2bl+hpOq9iyw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -321,7 +321,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "speckle.connectors.dui": {
@@ -336,7 +336,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "speckle.testing": {
@@ -344,7 +344,7 @@
         "dependencies": {
           "Moq": "[4.20.70, )",
           "NUnit": "[4.5.1, )",
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "Speckle.DoubleNumerics": {
@@ -355,9 +355,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-alpha.2, )",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "agIhQ/tqtWDpw1HSHzvu/EhhoIeRqay6z2SBY+6kgsVOOuQmVaEdRWvujMZrjBI9hTsb+fqv4SrifAbbxraBOw==",
+        "requested": "[2026.9.0-alpha.3, )",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "Sr+Nb/9gcbLCihAyv0B/Aw45jij4sYzhPgI62WFEFctpTOrZm+3hjrhKIC0tCwSFoXR5gGb6B6hpETcU7qwl3A==",
         "dependencies": {
           "GraphQL.Client": "6.1.0",
           "Microsoft.Data.Sqlite": "10.0.0",
@@ -365,8 +365,8 @@
           "Microsoft.Extensions.ObjectPool": "10.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.2",
-          "Speckle.Sdk.Parquet": "2026.9.0-alpha.2"
+          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.3",
+          "Speckle.Sdk.Parquet": "2026.9.0-alpha.3"
         }
       }
     }

--- a/DUI3/Speckle.Connectors.DUI.WebView/packages.lock.json
+++ b/DUI3/Speckle.Connectors.DUI.WebView/packages.lock.json
@@ -180,16 +180,16 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "uLLVpEgPV/J1n2DKZVd9Yf6HzKDKsOHsdChdEbNqqY3sidIk6qKPH8Jw8jvCiDCe6H6R82+azkFxusHcQ7+Y7Q==",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "U4y0lPsO3+Dk3ZgER4D2s6wOHPRjA6pJBF1xIJNmFwVvu8NSYOxiuvWTCNobqAgm77EEwkfePFiljuogql2Iyg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.10"
         }
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "zmae3tL4g4sOqmKQyMR6aFMLQb4np62OspIOzhZB3ZmiiCr1zECK7UZWY7BTyBcfjql0yiRR0ddcpIq2e9rT2g=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "kVbdQ9V0RA9KjgYVntZ9BaHlpPqnyGHHZExq2upExe2i2mS0f61t4VRlH4ApHJIDgDtmTdqg1G2bl+hpOq9iyw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -295,7 +295,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "speckle.connectors.dui": {
@@ -310,7 +310,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "Speckle.DoubleNumerics": {
@@ -321,9 +321,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-alpha.2, )",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "agIhQ/tqtWDpw1HSHzvu/EhhoIeRqay6z2SBY+6kgsVOOuQmVaEdRWvujMZrjBI9hTsb+fqv4SrifAbbxraBOw==",
+        "requested": "[2026.9.0-alpha.3, )",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "Sr+Nb/9gcbLCihAyv0B/Aw45jij4sYzhPgI62WFEFctpTOrZm+3hjrhKIC0tCwSFoXR5gGb6B6hpETcU7qwl3A==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -333,8 +333,8 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.2",
-          "Speckle.Sdk.Parquet": "2026.9.0-alpha.2",
+          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.3",
+          "Speckle.Sdk.Parquet": "2026.9.0-alpha.3",
           "System.Memory": "4.5.5",
           "System.Text.Json": "5.0.2"
         }
@@ -495,13 +495,13 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "uLLVpEgPV/J1n2DKZVd9Yf6HzKDKsOHsdChdEbNqqY3sidIk6qKPH8Jw8jvCiDCe6H6R82+azkFxusHcQ7+Y7Q=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "U4y0lPsO3+Dk3ZgER4D2s6wOHPRjA6pJBF1xIJNmFwVvu8NSYOxiuvWTCNobqAgm77EEwkfePFiljuogql2Iyg=="
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "zmae3tL4g4sOqmKQyMR6aFMLQb4np62OspIOzhZB3ZmiiCr1zECK7UZWY7BTyBcfjql0yiRR0ddcpIq2e9rT2g=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "kVbdQ9V0RA9KjgYVntZ9BaHlpPqnyGHHZExq2upExe2i2mS0f61t4VRlH4ApHJIDgDtmTdqg1G2bl+hpOq9iyw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -540,7 +540,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "speckle.connectors.dui": {
@@ -555,7 +555,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "Speckle.DoubleNumerics": {
@@ -566,9 +566,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-alpha.2, )",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "agIhQ/tqtWDpw1HSHzvu/EhhoIeRqay6z2SBY+6kgsVOOuQmVaEdRWvujMZrjBI9hTsb+fqv4SrifAbbxraBOw==",
+        "requested": "[2026.9.0-alpha.3, )",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "Sr+Nb/9gcbLCihAyv0B/Aw45jij4sYzhPgI62WFEFctpTOrZm+3hjrhKIC0tCwSFoXR5gGb6B6hpETcU7qwl3A==",
         "dependencies": {
           "GraphQL.Client": "6.1.0",
           "Microsoft.Data.Sqlite": "10.0.0",
@@ -576,8 +576,8 @@
           "Microsoft.Extensions.ObjectPool": "10.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.2",
-          "Speckle.Sdk.Parquet": "2026.9.0-alpha.2"
+          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.3",
+          "Speckle.Sdk.Parquet": "2026.9.0-alpha.3"
         }
       }
     },
@@ -719,13 +719,13 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "uLLVpEgPV/J1n2DKZVd9Yf6HzKDKsOHsdChdEbNqqY3sidIk6qKPH8Jw8jvCiDCe6H6R82+azkFxusHcQ7+Y7Q=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "U4y0lPsO3+Dk3ZgER4D2s6wOHPRjA6pJBF1xIJNmFwVvu8NSYOxiuvWTCNobqAgm77EEwkfePFiljuogql2Iyg=="
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "zmae3tL4g4sOqmKQyMR6aFMLQb4np62OspIOzhZB3ZmiiCr1zECK7UZWY7BTyBcfjql0yiRR0ddcpIq2e9rT2g=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "kVbdQ9V0RA9KjgYVntZ9BaHlpPqnyGHHZExq2upExe2i2mS0f61t4VRlH4ApHJIDgDtmTdqg1G2bl+hpOq9iyw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -764,7 +764,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "speckle.connectors.dui": {
@@ -779,7 +779,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "Speckle.DoubleNumerics": {
@@ -790,9 +790,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-alpha.2, )",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "agIhQ/tqtWDpw1HSHzvu/EhhoIeRqay6z2SBY+6kgsVOOuQmVaEdRWvujMZrjBI9hTsb+fqv4SrifAbbxraBOw==",
+        "requested": "[2026.9.0-alpha.3, )",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "Sr+Nb/9gcbLCihAyv0B/Aw45jij4sYzhPgI62WFEFctpTOrZm+3hjrhKIC0tCwSFoXR5gGb6B6hpETcU7qwl3A==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -800,8 +800,8 @@
           "Microsoft.Extensions.ObjectPool": "8.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.2",
-          "Speckle.Sdk.Parquet": "2026.9.0-alpha.2"
+          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.3",
+          "Speckle.Sdk.Parquet": "2026.9.0-alpha.3"
         }
       }
     }

--- a/DUI3/Speckle.Connectors.DUI/packages.lock.json
+++ b/DUI3/Speckle.Connectors.DUI/packages.lock.json
@@ -174,16 +174,16 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "uLLVpEgPV/J1n2DKZVd9Yf6HzKDKsOHsdChdEbNqqY3sidIk6qKPH8Jw8jvCiDCe6H6R82+azkFxusHcQ7+Y7Q==",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "U4y0lPsO3+Dk3ZgER4D2s6wOHPRjA6pJBF1xIJNmFwVvu8NSYOxiuvWTCNobqAgm77EEwkfePFiljuogql2Iyg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.10"
         }
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "zmae3tL4g4sOqmKQyMR6aFMLQb4np62OspIOzhZB3ZmiiCr1zECK7UZWY7BTyBcfjql0yiRR0ddcpIq2e9rT2g=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "kVbdQ9V0RA9KjgYVntZ9BaHlpPqnyGHHZExq2upExe2i2mS0f61t4VRlH4ApHJIDgDtmTdqg1G2bl+hpOq9iyw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -289,7 +289,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "speckle.connectors.logging": {
@@ -298,7 +298,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "Speckle.DoubleNumerics": {
@@ -309,9 +309,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-alpha.2, )",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "agIhQ/tqtWDpw1HSHzvu/EhhoIeRqay6z2SBY+6kgsVOOuQmVaEdRWvujMZrjBI9hTsb+fqv4SrifAbbxraBOw==",
+        "requested": "[2026.9.0-alpha.3, )",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "Sr+Nb/9gcbLCihAyv0B/Aw45jij4sYzhPgI62WFEFctpTOrZm+3hjrhKIC0tCwSFoXR5gGb6B6hpETcU7qwl3A==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -321,8 +321,8 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.2",
-          "Speckle.Sdk.Parquet": "2026.9.0-alpha.2",
+          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.3",
+          "Speckle.Sdk.Parquet": "2026.9.0-alpha.3",
           "System.Memory": "4.5.5",
           "System.Text.Json": "5.0.2"
         }
@@ -477,13 +477,13 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "uLLVpEgPV/J1n2DKZVd9Yf6HzKDKsOHsdChdEbNqqY3sidIk6qKPH8Jw8jvCiDCe6H6R82+azkFxusHcQ7+Y7Q=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "U4y0lPsO3+Dk3ZgER4D2s6wOHPRjA6pJBF1xIJNmFwVvu8NSYOxiuvWTCNobqAgm77EEwkfePFiljuogql2Iyg=="
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "zmae3tL4g4sOqmKQyMR6aFMLQb4np62OspIOzhZB3ZmiiCr1zECK7UZWY7BTyBcfjql0yiRR0ddcpIq2e9rT2g=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "kVbdQ9V0RA9KjgYVntZ9BaHlpPqnyGHHZExq2upExe2i2mS0f61t4VRlH4ApHJIDgDtmTdqg1G2bl+hpOq9iyw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -522,7 +522,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "speckle.connectors.logging": {
@@ -531,7 +531,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "Speckle.DoubleNumerics": {
@@ -542,9 +542,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-alpha.2, )",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "agIhQ/tqtWDpw1HSHzvu/EhhoIeRqay6z2SBY+6kgsVOOuQmVaEdRWvujMZrjBI9hTsb+fqv4SrifAbbxraBOw==",
+        "requested": "[2026.9.0-alpha.3, )",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "Sr+Nb/9gcbLCihAyv0B/Aw45jij4sYzhPgI62WFEFctpTOrZm+3hjrhKIC0tCwSFoXR5gGb6B6hpETcU7qwl3A==",
         "dependencies": {
           "GraphQL.Client": "6.1.0",
           "Microsoft.Data.Sqlite": "10.0.0",
@@ -552,8 +552,8 @@
           "Microsoft.Extensions.ObjectPool": "10.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.2",
-          "Speckle.Sdk.Parquet": "2026.9.0-alpha.2"
+          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.3",
+          "Speckle.Sdk.Parquet": "2026.9.0-alpha.3"
         }
       }
     },
@@ -689,13 +689,13 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "uLLVpEgPV/J1n2DKZVd9Yf6HzKDKsOHsdChdEbNqqY3sidIk6qKPH8Jw8jvCiDCe6H6R82+azkFxusHcQ7+Y7Q=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "U4y0lPsO3+Dk3ZgER4D2s6wOHPRjA6pJBF1xIJNmFwVvu8NSYOxiuvWTCNobqAgm77EEwkfePFiljuogql2Iyg=="
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "zmae3tL4g4sOqmKQyMR6aFMLQb4np62OspIOzhZB3ZmiiCr1zECK7UZWY7BTyBcfjql0yiRR0ddcpIq2e9rT2g=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "kVbdQ9V0RA9KjgYVntZ9BaHlpPqnyGHHZExq2upExe2i2mS0f61t4VRlH4ApHJIDgDtmTdqg1G2bl+hpOq9iyw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -734,7 +734,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "speckle.connectors.logging": {
@@ -743,7 +743,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "Speckle.DoubleNumerics": {
@@ -754,9 +754,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-alpha.2, )",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "agIhQ/tqtWDpw1HSHzvu/EhhoIeRqay6z2SBY+6kgsVOOuQmVaEdRWvujMZrjBI9hTsb+fqv4SrifAbbxraBOw==",
+        "requested": "[2026.9.0-alpha.3, )",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "Sr+Nb/9gcbLCihAyv0B/Aw45jij4sYzhPgI62WFEFctpTOrZm+3hjrhKIC0tCwSFoXR5gGb6B6hpETcU7qwl3A==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -764,8 +764,8 @@
           "Microsoft.Extensions.ObjectPool": "8.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.2",
-          "Speckle.Sdk.Parquet": "2026.9.0-alpha.2"
+          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.3",
+          "Speckle.Sdk.Parquet": "2026.9.0-alpha.3"
         }
       }
     }

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -53,7 +53,7 @@
     <PackageVersion Include="Speckle.Civil3D.API" Version="2022.0.2" />
     <PackageVersion Include="Speckle.Revit.API" Version="2023.0.0" />
     <PackageVersion Include="Speckle.Navisworks.API" Version="2024.0.0" />
-    <PackageVersion Include="Speckle.Sdk" Version="2026.9.0-alpha.2" />
+    <PackageVersion Include="Speckle.Sdk" Version="2026.9.0-alpha.3" />
     <PackageVersion Include="SimpleExec" Version="12.0.0" />
     <GlobalPackageReference Include="PolySharp" Version="1.15.0" />
     <GlobalPackageReference Include="Speckle.InterfaceGenerator" Version="0.9.6" />

--- a/Importers/Rhino/Speckle.Importers.JobProcessor/packages.lock.json
+++ b/Importers/Rhino/Speckle.Importers.JobProcessor/packages.lock.json
@@ -425,13 +425,13 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "uLLVpEgPV/J1n2DKZVd9Yf6HzKDKsOHsdChdEbNqqY3sidIk6qKPH8Jw8jvCiDCe6H6R82+azkFxusHcQ7+Y7Q=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "U4y0lPsO3+Dk3ZgER4D2s6wOHPRjA6pJBF1xIJNmFwVvu8NSYOxiuvWTCNobqAgm77EEwkfePFiljuogql2Iyg=="
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "zmae3tL4g4sOqmKQyMR6aFMLQb4np62OspIOzhZB3ZmiiCr1zECK7UZWY7BTyBcfjql0yiRR0ddcpIq2e9rT2g=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "kVbdQ9V0RA9KjgYVntZ9BaHlpPqnyGHHZExq2upExe2i2mS0f61t4VRlH4ApHJIDgDtmTdqg1G2bl+hpOq9iyw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -506,7 +506,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "speckle.connectors.dui": {
@@ -536,7 +536,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "speckle.converters.rhino8": {
@@ -583,9 +583,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-alpha.2, )",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "agIhQ/tqtWDpw1HSHzvu/EhhoIeRqay6z2SBY+6kgsVOOuQmVaEdRWvujMZrjBI9hTsb+fqv4SrifAbbxraBOw==",
+        "requested": "[2026.9.0-alpha.3, )",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "Sr+Nb/9gcbLCihAyv0B/Aw45jij4sYzhPgI62WFEFctpTOrZm+3hjrhKIC0tCwSFoXR5gGb6B6hpETcU7qwl3A==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -593,8 +593,8 @@
           "Microsoft.Extensions.ObjectPool": "8.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.2",
-          "Speckle.Sdk.Parquet": "2026.9.0-alpha.2"
+          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.3",
+          "Speckle.Sdk.Parquet": "2026.9.0-alpha.3"
         }
       },
       "System.Text.Json": {

--- a/Importers/Rhino/Speckle.Importers.Rhino/packages.lock.json
+++ b/Importers/Rhino/Speckle.Importers.Rhino/packages.lock.json
@@ -175,13 +175,13 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "uLLVpEgPV/J1n2DKZVd9Yf6HzKDKsOHsdChdEbNqqY3sidIk6qKPH8Jw8jvCiDCe6H6R82+azkFxusHcQ7+Y7Q=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "U4y0lPsO3+Dk3ZgER4D2s6wOHPRjA6pJBF1xIJNmFwVvu8NSYOxiuvWTCNobqAgm77EEwkfePFiljuogql2Iyg=="
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "zmae3tL4g4sOqmKQyMR6aFMLQb4np62OspIOzhZB3ZmiiCr1zECK7UZWY7BTyBcfjql0yiRR0ddcpIq2e9rT2g=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "kVbdQ9V0RA9KjgYVntZ9BaHlpPqnyGHHZExq2upExe2i2mS0f61t4VRlH4ApHJIDgDtmTdqg1G2bl+hpOq9iyw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -236,7 +236,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "speckle.connectors.dui": {
@@ -266,7 +266,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "speckle.converters.rhino8": {
@@ -289,9 +289,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-alpha.2, )",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "agIhQ/tqtWDpw1HSHzvu/EhhoIeRqay6z2SBY+6kgsVOOuQmVaEdRWvujMZrjBI9hTsb+fqv4SrifAbbxraBOw==",
+        "requested": "[2026.9.0-alpha.3, )",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "Sr+Nb/9gcbLCihAyv0B/Aw45jij4sYzhPgI62WFEFctpTOrZm+3hjrhKIC0tCwSFoXR5gGb6B6hpETcU7qwl3A==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -299,8 +299,8 @@
           "Microsoft.Extensions.ObjectPool": "8.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.2",
-          "Speckle.Sdk.Parquet": "2026.9.0-alpha.2"
+          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.3",
+          "Speckle.Sdk.Parquet": "2026.9.0-alpha.3"
         }
       }
     }

--- a/Sdk/Speckle.Connectors.Common.Tests/packages.lock.json
+++ b/Sdk/Speckle.Connectors.Common.Tests/packages.lock.json
@@ -256,13 +256,13 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "uLLVpEgPV/J1n2DKZVd9Yf6HzKDKsOHsdChdEbNqqY3sidIk6qKPH8Jw8jvCiDCe6H6R82+azkFxusHcQ7+Y7Q=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "U4y0lPsO3+Dk3ZgER4D2s6wOHPRjA6pJBF1xIJNmFwVvu8NSYOxiuvWTCNobqAgm77EEwkfePFiljuogql2Iyg=="
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "zmae3tL4g4sOqmKQyMR6aFMLQb4np62OspIOzhZB3ZmiiCr1zECK7UZWY7BTyBcfjql0yiRR0ddcpIq2e9rT2g=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "kVbdQ9V0RA9KjgYVntZ9BaHlpPqnyGHHZExq2upExe2i2mS0f61t4VRlH4ApHJIDgDtmTdqg1G2bl+hpOq9iyw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -306,7 +306,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "speckle.connectors.logging": {
@@ -315,7 +315,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "speckle.testing": {
@@ -323,7 +323,7 @@
         "dependencies": {
           "Moq": "[4.20.70, )",
           "NUnit": "[4.5.1, )",
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "Moq": {
@@ -349,9 +349,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-alpha.2, )",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "agIhQ/tqtWDpw1HSHzvu/EhhoIeRqay6z2SBY+6kgsVOOuQmVaEdRWvujMZrjBI9hTsb+fqv4SrifAbbxraBOw==",
+        "requested": "[2026.9.0-alpha.3, )",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "Sr+Nb/9gcbLCihAyv0B/Aw45jij4sYzhPgI62WFEFctpTOrZm+3hjrhKIC0tCwSFoXR5gGb6B6hpETcU7qwl3A==",
         "dependencies": {
           "GraphQL.Client": "6.1.0",
           "Microsoft.Data.Sqlite": "10.0.0",
@@ -359,8 +359,8 @@
           "Microsoft.Extensions.ObjectPool": "10.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.2",
-          "Speckle.Sdk.Parquet": "2026.9.0-alpha.2"
+          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.3",
+          "Speckle.Sdk.Parquet": "2026.9.0-alpha.3"
         }
       }
     }

--- a/Sdk/Speckle.Connectors.Common/packages.lock.json
+++ b/Sdk/Speckle.Connectors.Common/packages.lock.json
@@ -25,9 +25,9 @@
       },
       "Speckle.Sdk": {
         "type": "Direct",
-        "requested": "[2026.9.0-alpha.2, )",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "agIhQ/tqtWDpw1HSHzvu/EhhoIeRqay6z2SBY+6kgsVOOuQmVaEdRWvujMZrjBI9hTsb+fqv4SrifAbbxraBOw==",
+        "requested": "[2026.9.0-alpha.3, )",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "Sr+Nb/9gcbLCihAyv0B/Aw45jij4sYzhPgI62WFEFctpTOrZm+3hjrhKIC0tCwSFoXR5gGb6B6hpETcU7qwl3A==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -37,8 +37,8 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.2",
-          "Speckle.Sdk.Parquet": "2026.9.0-alpha.2",
+          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.3",
+          "Speckle.Sdk.Parquet": "2026.9.0-alpha.3",
           "System.Memory": "4.5.5",
           "System.Text.Json": "5.0.2"
         }
@@ -194,16 +194,16 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "uLLVpEgPV/J1n2DKZVd9Yf6HzKDKsOHsdChdEbNqqY3sidIk6qKPH8Jw8jvCiDCe6H6R82+azkFxusHcQ7+Y7Q==",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "U4y0lPsO3+Dk3ZgER4D2s6wOHPRjA6pJBF1xIJNmFwVvu8NSYOxiuvWTCNobqAgm77EEwkfePFiljuogql2Iyg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.10"
         }
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "zmae3tL4g4sOqmKQyMR6aFMLQb4np62OspIOzhZB3ZmiiCr1zECK7UZWY7BTyBcfjql0yiRR0ddcpIq2e9rT2g=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "kVbdQ9V0RA9KjgYVntZ9BaHlpPqnyGHHZExq2upExe2i2mS0f61t4VRlH4ApHJIDgDtmTdqg1G2bl+hpOq9iyw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -310,7 +310,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "Speckle.DoubleNumerics": {
@@ -360,9 +360,9 @@
       },
       "Speckle.Sdk": {
         "type": "Direct",
-        "requested": "[2026.9.0-alpha.2, )",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "agIhQ/tqtWDpw1HSHzvu/EhhoIeRqay6z2SBY+6kgsVOOuQmVaEdRWvujMZrjBI9hTsb+fqv4SrifAbbxraBOw==",
+        "requested": "[2026.9.0-alpha.3, )",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "Sr+Nb/9gcbLCihAyv0B/Aw45jij4sYzhPgI62WFEFctpTOrZm+3hjrhKIC0tCwSFoXR5gGb6B6hpETcU7qwl3A==",
         "dependencies": {
           "GraphQL.Client": "6.1.0",
           "Microsoft.Data.Sqlite": "10.0.0",
@@ -370,8 +370,8 @@
           "Microsoft.Extensions.ObjectPool": "10.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.2",
-          "Speckle.Sdk.Parquet": "2026.9.0-alpha.2"
+          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.3",
+          "Speckle.Sdk.Parquet": "2026.9.0-alpha.3"
         }
       },
       "GraphQL.Client": {
@@ -485,13 +485,13 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "uLLVpEgPV/J1n2DKZVd9Yf6HzKDKsOHsdChdEbNqqY3sidIk6qKPH8Jw8jvCiDCe6H6R82+azkFxusHcQ7+Y7Q=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "U4y0lPsO3+Dk3ZgER4D2s6wOHPRjA6pJBF1xIJNmFwVvu8NSYOxiuvWTCNobqAgm77EEwkfePFiljuogql2Iyg=="
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "zmae3tL4g4sOqmKQyMR6aFMLQb4np62OspIOzhZB3ZmiiCr1zECK7UZWY7BTyBcfjql0yiRR0ddcpIq2e9rT2g=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "kVbdQ9V0RA9KjgYVntZ9BaHlpPqnyGHHZExq2upExe2i2mS0f61t4VRlH4ApHJIDgDtmTdqg1G2bl+hpOq9iyw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -531,7 +531,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "Speckle.DoubleNumerics": {
@@ -565,9 +565,9 @@
       },
       "Speckle.Sdk": {
         "type": "Direct",
-        "requested": "[2026.9.0-alpha.2, )",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "agIhQ/tqtWDpw1HSHzvu/EhhoIeRqay6z2SBY+6kgsVOOuQmVaEdRWvujMZrjBI9hTsb+fqv4SrifAbbxraBOw==",
+        "requested": "[2026.9.0-alpha.3, )",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "Sr+Nb/9gcbLCihAyv0B/Aw45jij4sYzhPgI62WFEFctpTOrZm+3hjrhKIC0tCwSFoXR5gGb6B6hpETcU7qwl3A==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -575,8 +575,8 @@
           "Microsoft.Extensions.ObjectPool": "8.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.2",
-          "Speckle.Sdk.Parquet": "2026.9.0-alpha.2"
+          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.3",
+          "Speckle.Sdk.Parquet": "2026.9.0-alpha.3"
         }
       },
       "GraphQL.Client": {
@@ -689,13 +689,13 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "uLLVpEgPV/J1n2DKZVd9Yf6HzKDKsOHsdChdEbNqqY3sidIk6qKPH8Jw8jvCiDCe6H6R82+azkFxusHcQ7+Y7Q=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "U4y0lPsO3+Dk3ZgER4D2s6wOHPRjA6pJBF1xIJNmFwVvu8NSYOxiuvWTCNobqAgm77EEwkfePFiljuogql2Iyg=="
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "zmae3tL4g4sOqmKQyMR6aFMLQb4np62OspIOzhZB3ZmiiCr1zECK7UZWY7BTyBcfjql0yiRR0ddcpIq2e9rT2g=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "kVbdQ9V0RA9KjgYVntZ9BaHlpPqnyGHHZExq2upExe2i2mS0f61t4VRlH4ApHJIDgDtmTdqg1G2bl+hpOq9iyw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -735,7 +735,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "Speckle.DoubleNumerics": {

--- a/Sdk/Speckle.Converters.Common.Tests/packages.lock.json
+++ b/Sdk/Speckle.Converters.Common.Tests/packages.lock.json
@@ -271,13 +271,13 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "uLLVpEgPV/J1n2DKZVd9Yf6HzKDKsOHsdChdEbNqqY3sidIk6qKPH8Jw8jvCiDCe6H6R82+azkFxusHcQ7+Y7Q=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "U4y0lPsO3+Dk3ZgER4D2s6wOHPRjA6pJBF1xIJNmFwVvu8NSYOxiuvWTCNobqAgm77EEwkfePFiljuogql2Iyg=="
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "zmae3tL4g4sOqmKQyMR6aFMLQb4np62OspIOzhZB3ZmiiCr1zECK7UZWY7BTyBcfjql0yiRR0ddcpIq2e9rT2g=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "kVbdQ9V0RA9KjgYVntZ9BaHlpPqnyGHHZExq2upExe2i2mS0f61t4VRlH4ApHJIDgDtmTdqg1G2bl+hpOq9iyw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -319,7 +319,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "speckle.testing": {
@@ -327,7 +327,7 @@
         "dependencies": {
           "Moq": "[4.20.70, )",
           "NUnit": "[4.5.1, )",
-          "Speckle.Sdk": "[2026.9.0-alpha.2, )"
+          "Speckle.Sdk": "[2026.9.0-alpha.3, )"
         }
       },
       "Speckle.DoubleNumerics": {
@@ -338,9 +338,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-alpha.2, )",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "agIhQ/tqtWDpw1HSHzvu/EhhoIeRqay6z2SBY+6kgsVOOuQmVaEdRWvujMZrjBI9hTsb+fqv4SrifAbbxraBOw==",
+        "requested": "[2026.9.0-alpha.3, )",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "Sr+Nb/9gcbLCihAyv0B/Aw45jij4sYzhPgI62WFEFctpTOrZm+3hjrhKIC0tCwSFoXR5gGb6B6hpETcU7qwl3A==",
         "dependencies": {
           "GraphQL.Client": "6.1.0",
           "Microsoft.Data.Sqlite": "10.0.0",
@@ -348,8 +348,8 @@
           "Microsoft.Extensions.ObjectPool": "10.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.2",
-          "Speckle.Sdk.Parquet": "2026.9.0-alpha.2"
+          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.3",
+          "Speckle.Sdk.Parquet": "2026.9.0-alpha.3"
         }
       }
     }

--- a/Sdk/Speckle.Converters.Common/packages.lock.json
+++ b/Sdk/Speckle.Converters.Common/packages.lock.json
@@ -25,9 +25,9 @@
       },
       "Speckle.Sdk": {
         "type": "Direct",
-        "requested": "[2026.9.0-alpha.2, )",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "agIhQ/tqtWDpw1HSHzvu/EhhoIeRqay6z2SBY+6kgsVOOuQmVaEdRWvujMZrjBI9hTsb+fqv4SrifAbbxraBOw==",
+        "requested": "[2026.9.0-alpha.3, )",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "Sr+Nb/9gcbLCihAyv0B/Aw45jij4sYzhPgI62WFEFctpTOrZm+3hjrhKIC0tCwSFoXR5gGb6B6hpETcU7qwl3A==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -37,8 +37,8 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.2",
-          "Speckle.Sdk.Parquet": "2026.9.0-alpha.2",
+          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.3",
+          "Speckle.Sdk.Parquet": "2026.9.0-alpha.3",
           "System.Memory": "4.5.5",
           "System.Text.Json": "5.0.2"
         }
@@ -194,16 +194,16 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "uLLVpEgPV/J1n2DKZVd9Yf6HzKDKsOHsdChdEbNqqY3sidIk6qKPH8Jw8jvCiDCe6H6R82+azkFxusHcQ7+Y7Q==",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "U4y0lPsO3+Dk3ZgER4D2s6wOHPRjA6pJBF1xIJNmFwVvu8NSYOxiuvWTCNobqAgm77EEwkfePFiljuogql2Iyg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.10"
         }
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "zmae3tL4g4sOqmKQyMR6aFMLQb4np62OspIOzhZB3ZmiiCr1zECK7UZWY7BTyBcfjql0yiRR0ddcpIq2e9rT2g=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "kVbdQ9V0RA9KjgYVntZ9BaHlpPqnyGHHZExq2upExe2i2mS0f61t4VRlH4ApHJIDgDtmTdqg1G2bl+hpOq9iyw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -351,9 +351,9 @@
       },
       "Speckle.Sdk": {
         "type": "Direct",
-        "requested": "[2026.9.0-alpha.2, )",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "agIhQ/tqtWDpw1HSHzvu/EhhoIeRqay6z2SBY+6kgsVOOuQmVaEdRWvujMZrjBI9hTsb+fqv4SrifAbbxraBOw==",
+        "requested": "[2026.9.0-alpha.3, )",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "Sr+Nb/9gcbLCihAyv0B/Aw45jij4sYzhPgI62WFEFctpTOrZm+3hjrhKIC0tCwSFoXR5gGb6B6hpETcU7qwl3A==",
         "dependencies": {
           "GraphQL.Client": "6.1.0",
           "Microsoft.Data.Sqlite": "10.0.0",
@@ -361,8 +361,8 @@
           "Microsoft.Extensions.ObjectPool": "10.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.2",
-          "Speckle.Sdk.Parquet": "2026.9.0-alpha.2"
+          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.3",
+          "Speckle.Sdk.Parquet": "2026.9.0-alpha.3"
         }
       },
       "GraphQL.Client": {
@@ -476,13 +476,13 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "uLLVpEgPV/J1n2DKZVd9Yf6HzKDKsOHsdChdEbNqqY3sidIk6qKPH8Jw8jvCiDCe6H6R82+azkFxusHcQ7+Y7Q=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "U4y0lPsO3+Dk3ZgER4D2s6wOHPRjA6pJBF1xIJNmFwVvu8NSYOxiuvWTCNobqAgm77EEwkfePFiljuogql2Iyg=="
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "zmae3tL4g4sOqmKQyMR6aFMLQb4np62OspIOzhZB3ZmiiCr1zECK7UZWY7BTyBcfjql0yiRR0ddcpIq2e9rT2g=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "kVbdQ9V0RA9KjgYVntZ9BaHlpPqnyGHHZExq2upExe2i2mS0f61t4VRlH4ApHJIDgDtmTdqg1G2bl+hpOq9iyw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -547,9 +547,9 @@
       },
       "Speckle.Sdk": {
         "type": "Direct",
-        "requested": "[2026.9.0-alpha.2, )",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "agIhQ/tqtWDpw1HSHzvu/EhhoIeRqay6z2SBY+6kgsVOOuQmVaEdRWvujMZrjBI9hTsb+fqv4SrifAbbxraBOw==",
+        "requested": "[2026.9.0-alpha.3, )",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "Sr+Nb/9gcbLCihAyv0B/Aw45jij4sYzhPgI62WFEFctpTOrZm+3hjrhKIC0tCwSFoXR5gGb6B6hpETcU7qwl3A==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -557,8 +557,8 @@
           "Microsoft.Extensions.ObjectPool": "8.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.2",
-          "Speckle.Sdk.Parquet": "2026.9.0-alpha.2"
+          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.3",
+          "Speckle.Sdk.Parquet": "2026.9.0-alpha.3"
         }
       },
       "GraphQL.Client": {
@@ -671,13 +671,13 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "uLLVpEgPV/J1n2DKZVd9Yf6HzKDKsOHsdChdEbNqqY3sidIk6qKPH8Jw8jvCiDCe6H6R82+azkFxusHcQ7+Y7Q=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "U4y0lPsO3+Dk3ZgER4D2s6wOHPRjA6pJBF1xIJNmFwVvu8NSYOxiuvWTCNobqAgm77EEwkfePFiljuogql2Iyg=="
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "zmae3tL4g4sOqmKQyMR6aFMLQb4np62OspIOzhZB3ZmiiCr1zECK7UZWY7BTyBcfjql0yiRR0ddcpIq2e9rT2g=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "kVbdQ9V0RA9KjgYVntZ9BaHlpPqnyGHHZExq2upExe2i2mS0f61t4VRlH4ApHJIDgDtmTdqg1G2bl+hpOq9iyw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",

--- a/Sdk/Speckle.Testing/packages.lock.json
+++ b/Sdk/Speckle.Testing/packages.lock.json
@@ -40,9 +40,9 @@
       },
       "Speckle.Sdk": {
         "type": "Direct",
-        "requested": "[2026.9.0-alpha.2, )",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "agIhQ/tqtWDpw1HSHzvu/EhhoIeRqay6z2SBY+6kgsVOOuQmVaEdRWvujMZrjBI9hTsb+fqv4SrifAbbxraBOw==",
+        "requested": "[2026.9.0-alpha.3, )",
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "Sr+Nb/9gcbLCihAyv0B/Aw45jij4sYzhPgI62WFEFctpTOrZm+3hjrhKIC0tCwSFoXR5gGb6B6hpETcU7qwl3A==",
         "dependencies": {
           "GraphQL.Client": "6.1.0",
           "Microsoft.Data.Sqlite": "10.0.0",
@@ -50,8 +50,8 @@
           "Microsoft.Extensions.ObjectPool": "10.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.2",
-          "Speckle.Sdk.Parquet": "2026.9.0-alpha.2"
+          "Speckle.Sdk.Dependencies": "2026.9.0-alpha.3",
+          "Speckle.Sdk.Parquet": "2026.9.0-alpha.3"
         }
       },
       "Castle.Core": {
@@ -173,13 +173,13 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "uLLVpEgPV/J1n2DKZVd9Yf6HzKDKsOHsdChdEbNqqY3sidIk6qKPH8Jw8jvCiDCe6H6R82+azkFxusHcQ7+Y7Q=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "U4y0lPsO3+Dk3ZgER4D2s6wOHPRjA6pJBF1xIJNmFwVvu8NSYOxiuvWTCNobqAgm77EEwkfePFiljuogql2Iyg=="
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-alpha.2",
-        "contentHash": "zmae3tL4g4sOqmKQyMR6aFMLQb4np62OspIOzhZB3ZmiiCr1zECK7UZWY7BTyBcfjql0yiRR0ddcpIq2e9rT2g=="
+        "resolved": "2026.9.0-alpha.3",
+        "contentHash": "kVbdQ9V0RA9KjgYVntZ9BaHlpPqnyGHHZExq2upExe2i2mS0f61t4VRlH4ApHJIDgDtmTdqg1G2bl+hpOq9iyw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",


### PR DESCRIPTION
Picks up [speckle-sharp-sdk#551](https://github.com/specklesystems/speckle-sharp-sdk/pull/551) via the `2026.9.0-alpha.3` NuGet: `EnvelopeWriter` now stamps **schema_version 1** (bundle-spec 1.0.0, [speckle-bundle-spec#22](https://github.com/specklesystems/speckle-bundle-spec/pull/22)). Every connector built from `alpha.2` still writes 5 — the value is baked into the SDK assembly at build time.

Last leg of the renumber: spec#22, sdk#551, specklepy#513, converters#102, sketchup#460.

One-line change in `Directory.Packages.props`; `dotnet restore` resolves the package from nuget.org.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018petCQq4mhdr4dzbqfhLdi