### PR TITLE
fix(rhino and gh): emit placement colour as OBJECT_HAS_COLOR instead of HAS_COLOR ord=1

### DIFF
--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Operations/Receive/GrasshopperArtefactObjectBuilder.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Operations/Receive/GrasshopperArtefactObjectBuilder.cs
@@ -383,7 +383,9 @@ internal sealed class GrasshopperArtefactObjectBuilder
         ObjectIndex = objK,
         ApplicationId = totalCount == 1 ? appId : $"{appId}:g{ord++}",
         Color = colorByObject.TryGetValue(appId, out var iArgb) ? System.Drawing.Color.FromArgb(iArgb) : null,
-        // the placement's own material sources the INSTANCE node, so try that before the object-keyed map [ENG-9163]
+        // A placement's own paint arrives object-keyed (OBJECT_HAS_MATERIAL) or, in pre-split bundles, keyed by its
+        // INSTANCE node K (legacy HAS_MATERIAL ord=1) — a bundle carries one vintage or the other, never both, so
+        // either lookup hitting is decisive [ENG-9163, ENG-9368].
         Material =
           materialByInstance.TryGetValue(e.Dst, out var instMat) ? instMat
           : materialByObject.TryGetValue(appId, out var iMat) ? iMat
@@ -490,7 +492,8 @@ internal sealed class GrasshopperArtefactObjectBuilder
   // display-mesh geometry K → material node K) to BOTH a geometry-K lookup (covers standalone DEFINITION/instance
   // geometry, which has no owning object) and an object-appId lookup (covers atomic display objects, resolved via the
   // Display-edges reverse map — robust to whether the object's decoded geometry actually came from its SOLID or
-  // DISPLAY blob, since HAS_MATERIAL only ever targets the display-mesh K). Mirrors
+  // DISPLAY blob, since HAS_MATERIAL only ever targets the display-mesh K). Placement paint arrives separately, on
+  // OBJECT_HAS_MATERIAL (object plane) or the legacy INSTANCE-keyed ord=1 shape — see below. Mirrors
   // RhinoHostObjectArtefactBuilder.CreateMaterials exactly; reuses the same SpeckleMaterialWrapperGoo.CastFrom(RenderMaterial)
   // construction path the v1 GH receive uses (GrasshopperMaterialUnpacker), so a bake/re-send round-trips the same way.
   private static (
@@ -553,8 +556,24 @@ internal sealed class GrasshopperArtefactObjectBuilder
       }
     }
 
-    // Instance-sourced: a material painted on a block placement, keyed by its INSTANCE node K. A placement owns no
-    // geometry of its own, so it's invisible to the loop above [ENG-9163]. Mirrors RhinoHostObjectArtefactBuilder.
+    // Placement paint (OBJECT_HAS_MATERIAL, rel 26): a material set directly on a block placement. A placement owns
+    // no geometry, so it's invisible to the geometry loop above — resolve it straight through the object dictionary,
+    // the same appId key the placement's own wrapper joins on [ENG-9368]. FILL semantics (rel 26): a geometry-level
+    // HAS_MATERIAL already recorded above wins, so this only fills where that said nothing.
+    foreach (var kv in bundle.Relations.MaterialByObject)
+    {
+      if (
+        wrapperByMaterialNode.TryGetValue(kv.Value, out var wrapper)
+        && bundle.ObjectAppIds.TryGetValue(kv.Key, out var appId)
+        && !byObject.ContainsKey(appId)
+      )
+      {
+        byObject[appId] = wrapper;
+      }
+    }
+
+    // Legacy fallback: pre-split bundles carried placement paint as HAS_MATERIAL ord=1 keyed by the INSTANCE node K
+    // [ENG-9163]. Kept for bundles published before rel 26 existed. Mirrors RhinoHostObjectArtefactBuilder.
     var byInstance = new Dictionary<int, SpeckleMaterialWrapper>();
     foreach (var kv in bundle.Relations.MaterialByInstance)
     {

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Operations/Send/GrasshopperArtifactRootObjectBuilder.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Operations/Send/GrasshopperArtifactRootObjectBuilder.cs
@@ -397,8 +397,8 @@ public class GrasshopperArtifactRootObjectBuilder(
       ctx.Pipeline.DisplayInstance(objK, instK, 0);
     }
 
-    // A placement's own colour and material are object-sourced, so they carry the ord=1 namespace tag the reader
-    // expects (HAS_COLOR / HAS_MATERIAL on the object, not on a geometry) [ENG-9163].
+    // A placement's own colour and material hang off its OBJECT K, not any geometry — EmitValueNodes turns these
+    // into OBJECT_HAS_COLOR / OBJECT_HAS_MATERIAL [bundle-spec rels 27/26] [ENG-9163].
     ctx.ColorPacker.ProcessColor(appId, instance.Color);
     ctx.MaterialPacker.ProcessMaterial(appId, instance.Material);
 
@@ -554,8 +554,9 @@ public class GrasshopperArtifactRootObjectBuilder(
         }
         else if (instanceObjectKByAppId.TryGetValue(objectId, out var objK))
         {
-          // by-object colour on a placement: the object and geometry namespaces overlap, hence the tag
-          pipeline.HasColor(objK, colorK, srcIsObject: true);
+          // a placement paints its own colour: no geometry of its own, so it lives on the object plane as
+          // OBJECT_HAS_COLOR [bundle-spec rel 27] — the retired HAS_COLOR ord=1 object-src overload is gone.
+          pipeline.ObjectHasColor(objK, colorK);
         }
       }
     }

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/Operations/Receive/RhinoHostObjectArtefactBuilder.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/Operations/Receive/RhinoHostObjectArtefactBuilder.cs
@@ -153,7 +153,8 @@ public class RhinoHostObjectArtefactBuilder : IArtifactHostObjectBuilder
       );
     }
 
-    // By-object display colours (HAS_COLOR → COLOR node), resolved to owning object like materials. appId → argb.
+    // By-object display colours (HAS_COLOR / OBJECT_HAS_COLOR → COLOR node), resolved to owning object like
+    // materials. appId → argb.
     var colorByObject = CreateColors(bundle, objByGeom);
 
     // 3 - atomic geometry (objects with a direct DISPLAY/SOLID). Instances + non-geometric elements handled below.
@@ -713,7 +714,8 @@ public class RhinoHostObjectArtefactBuilder : IArtifactHostObjectBuilder
         atts.RenderMaterial = RenderContent.FromId(doc, materialGuid) as RhinoRenderMaterial;
         atts.MaterialSource = ObjectMaterialSource.MaterialFromObject;
       }
-      // the placement's own colour (object-sourced HAS_COLOR), so a per-instance override survives [ENG-9114]
+      // the placement's own colour (OBJECT_HAS_COLOR, or legacy HAS_COLOR ord=1), so a per-instance override
+      // survives [ENG-9114]
       if (colorByObject.TryGetValue(appId, out int instArgb))
       {
         atts.ObjectColor = Color.FromArgb(instArgb);
@@ -887,8 +889,8 @@ public class RhinoHostObjectArtefactBuilder : IArtifactHostObjectBuilder
           );
           // A nested-block member owns no geometry K, so its whole join — layer, name, user strings, colour — hangs
           // off its INSTANCE node K instead. Its material is placement paint (OBJECT_HAS_MATERIAL re-keyed via
-          // PLACES, or legacy HAS_MATERIAL ord=1), and its colour is object-sourced (HAS_COLOR ord=1), so no
-          // geometry K goes in [ENG-9213].
+          // PLACES, or legacy HAS_MATERIAL ord=1), and its colour is object-plane (OBJECT_HAS_COLOR, or legacy
+          // HAS_COLOR ord=1), so no geometry K goes in [ENG-9213].
           materialByInstance.TryGetValue(instNodeK, out Guid nestedMaterial);
           var nestedAtts = BuildMemberAttributes(
             doc,
@@ -1039,8 +1041,9 @@ public class RhinoHostObjectArtefactBuilder : IArtifactHostObjectBuilder
   /// <param name="geometryK">The member's geometry K when it has one, else null. Geometry and INSTANCE node Ks
   /// overlap numerically, so this must stay null for a nested member or its colour would be looked up in the wrong
   /// K-space and could hit an unrelated geometry's HAS_COLOR.</param>
-  /// <param name="materialGuid">Resolved by the caller — geometry-sourced (ord=0) for a direct member,
-  /// instance-sourced (ord=1) for a nested placement. <see cref="Guid.Empty"/> leaves the material by-layer.</param>
+  /// <param name="materialGuid">Resolved by the caller — geometry-sourced (HAS_MATERIAL) for a direct member,
+  /// placement paint (OBJECT_HAS_MATERIAL, or legacy HAS_MATERIAL ord=1) for a nested placement.
+  /// <see cref="Guid.Empty"/> leaves the material by-layer.</param>
   private static ObjectAttributes BuildMemberAttributes(
     RhinoDoc doc,
     ArtefactBundle bundle,
@@ -1089,9 +1092,10 @@ public class RhinoHostObjectArtefactBuilder : IArtifactHostObjectBuilder
     return atts;
   }
 
-  // A member's by-object colour: geometry-sourced (HAS_COLOR ord=0) for a direct member, object-sourced (ord=1) for a
-  // nested placement — the same two shapes CreateColors handles, except CreateColors resolves through
-  // ObjectByGeometry, which is built from the DISPLAY edges a member deliberately never has.
+  // A member's by-object colour: geometry-sourced (HAS_COLOR) for a direct member, object-plane (OBJECT_HAS_COLOR,
+  // or legacy HAS_COLOR ord=1 — the reader folds both into ColorByObject) for a nested placement. The same two
+  // shapes CreateColors handles, except CreateColors resolves through ObjectByGeometry, which is built from the
+  // DISPLAY edges a member deliberately never has.
   private static int? MemberColor(ArtefactBundle bundle, int memberObjK, int? geometryK)
   {
     var rels = bundle.Relations;
@@ -1370,8 +1374,9 @@ public class RhinoHostObjectArtefactBuilder : IArtifactHostObjectBuilder
   // comparison would report every material as changed.
   private static bool Near(double a, double b) => Math.Abs(a - b) < 1e-6;
 
-  // By-object display colours: HAS_COLOR (geometry → COLOR node) resolved to the owning object's appId → argb, mirroring
-  // CreateMaterials. Applied as ObjectColor + ColorSource.ColorFromObject on bake.
+  // By-object display colours: HAS_COLOR (geometry → COLOR node) and OBJECT_HAS_COLOR (object → COLOR node) resolved
+  // to the owning object's appId → argb, mirroring CreateMaterials. Applied as ObjectColor +
+  // ColorSource.ColorFromObject on bake.
   private static Dictionary<string, int> CreateColors(ArtefactBundle bundle, Dictionary<int, int> objByGeom)
   {
     var byObject = new Dictionary<string, int>(StringComparer.Ordinal);
@@ -1387,9 +1392,11 @@ public class RhinoHostObjectArtefactBuilder : IArtifactHostObjectBuilder
       }
     }
 
-    // Object-sourced edges (ord=1): a block placement's own colour. A placement owns no geometry, so it never appears
-    // in objByGeom — resolve it straight through the object dictionary [ENG-8822, ENG-9114]. Same shape as the Autocad
-    // artefact builder's MapColors.
+    // Object-plane edges (OBJECT_HAS_COLOR, rel 27 — the reader folds the legacy ord=1-tagged HAS_COLOR object src
+    // into the same map, so pre-split bundles keep resolving): a block placement's own colour. A placement owns no
+    // geometry, so it never appears in objByGeom — resolve it straight through the object dictionary [ENG-8822,
+    // ENG-9114, ENG-9368]. Runs after the geometry loop, so the object colour OVERRIDES the geometry one, which is
+    // rel 27's precedence [spec #16]. Same shape as the Autocad artefact builder's MapColors.
     foreach (var kv in bundle.Relations.ColorByObject)
     {
       if (

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/Operations/Send/RhinoArtifactRootObjectBuilder.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/Operations/Send/RhinoArtifactRootObjectBuilder.cs
@@ -833,8 +833,9 @@ public class RhinoArtifactRootObjectBuilder(
       }
     }
 
-    // 3) by-object display colors → HAS_COLOR (geometry → COLOR node). Same shape as materials: Rhino color proxies
-    // list OBJECT ids, so resolve each to its display-mesh geometry K(s).
+    // 3) by-object display colors → HAS_COLOR (geometry → COLOR node), or OBJECT_HAS_COLOR for a geometry-less
+    // placement. Same shape as materials: Rhino color proxies list OBJECT ids, so resolve each to its
+    // display-mesh geometry K(s).
     foreach (var colorProxy in model.Colors)
     {
       int colorK = pipeline.AddColor(colorProxy.value);
@@ -849,11 +850,12 @@ public class RhinoArtifactRootObjectBuilder(
         }
         else if (instanceKByObjectId.ContainsKey(objectId))
         {
-          // block instance: no geometry of its own — emit the colour OBJECT-sourced (spec HAS_COLOR src is
-          // geometry|object; the viewer looks up both) so per-placement overrides survive [ENG-8825].
-          // srcIsObject: the object and geometry K-spaces overlap numerically, so the edge carries a namespace
-          // tag (ord=1) — without it receive can't tell this from a geometry-sourced colour [ENG-8822].
-          pipeline.HasColor(pipeline.InternObject(objectId), colorK, srcIsObject: true);
+          // A colour set directly on a block placement: it owns no geometry to hang HAS_COLOR on, so it rides the
+          // object plane instead [bundle-spec rel 27 OBJECT_HAS_COLOR] — successor of the tagged HAS_COLOR (rel 6,
+          // ord=1) stopgap from ENG-8822. Rel 27 is object-sourced by definition, so no namespace tag is needed;
+          // receive folds both vintages into ColorByObject, so pre-split bundles keep resolving [ENG-9368].
+          // OVERRIDE semantics: the placement's colour beats the definition geometry's own [ENG-8825].
+          pipeline.ObjectHasColor(pipeline.InternObject(objectId), colorK);
         }
       }
     }


### PR DESCRIPTION
## Description

Rhino and Grasshopper send were still writing a block placement's own display colour as `HAS_COLOR` (rel 6) with an object src tagged `ord=1` — retired in favour of `OBJECT_HAS_COLOR` (rel 27). 

## User Value

Rhino and Grasshopper block-instance colours and materials survive a receive in any 4.0 consumer.

## Changes:

- `RhinoArtifactRootObjectBuilder.cs`: `HasColor(InternObject(objectId), colorK, srcIsObject: true)` → `ObjectHasColor(InternObject(objectId), colorK)`
- `GrasshopperArtifactRootObjectBuilder.cs`: same swap (`instanceObjectKByAppId` already holds the interned object K, so the value passed is unchanged)

## Validation of changes:

Nothing in this repo asserts on emitted `rel` rows, so validation is manual against the ticket's acceptance criteria:

- [x] `MaterialFromObject` instance → `rel = 26` row sourced from the instance's object K, no `rel = 5, ord = 1` rows
- [x] Coloured instance → `rel = 27` row, no `rel = 6, ord = 1` rows
- [x] Rhino → Rhino round trip restores both the material and the colour on the placed instance
- [x] Rhino → Grasshopper round trip restores both the material and the colour on the placed instance
- [x] Grasshopper → Rhino round trip restores both the material and the colour on the placed instance
- [x] Grasshopper → Grasshopper round trip restores both the material and the colour on the placed instance

## Checklist:

- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] I have added appropriate tests.
- [x] I have updated or added relevant documentation.