### PR TITLE
feat(grasshopper): stop fanning objects out into their geometries

### DIFF
--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Collections/CreateCollection.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Collections/CreateCollection.cs
@@ -83,7 +83,7 @@ public class CreateCollection : VariableParameterComponentBase
     {
       AddRuntimeMessage(
         GH_RuntimeMessageLevel.Error,
-        "Collection contains no valid content. Ensure inputs are Speckle Geometry, Speckle Data Objects, or sub-collections."
+        "Collection contains no valid content. Ensure inputs are Speckle Geometry, Speckle Objects, or sub-collections."
       );
       return;
     }

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Objects/ExploreComponent.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Objects/ExploreComponent.cs
@@ -185,12 +185,13 @@ public class ExploreComponent : GH_Component, IGH_VariableParameterComponent
 
     var values = wrapper switch
     {
-      SpeckleGeometryWrapper { ObjectIndex: { } objK } => ResolveObject(graph, objK),
-      // no object index means it didn't come out of a bundle - don't fall through to the model-scoped branch and
-      // hand back levels for an object the graph doesn't know
-      SpeckleGeometryWrapper => Explain(Constants.EXPLORE_NO_REFERENCE_MESSAGE),
+      // a collection is a container node, never an object - check it before the index
       SpeckleCollectionWrapper => ResolveModel(graph),
-      _ => Explain($"Nothing to explore for a {wrapper.GetType().Name}."),
+      // geometry and Speckle Objects both carry the index; a Speckle Object is the object the graph knows
+      SpeckleWrapper { ObjectIndex: { } objK } => ResolveObject(graph, objK),
+      // no index means it didn't come out of a bundle - don't fall through to the model-scoped branch and hand back
+      // levels for an object the graph doesn't know
+      _ => Explain(Constants.EXPLORE_NO_REFERENCE_MESSAGE),
     };
 
     if (values is { Count: 0 })

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Objects/SpeckleDataObjectPassthrough.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Objects/SpeckleDataObjectPassthrough.cs
@@ -7,12 +7,17 @@ using Speckle.Connectors.GrasshopperShared.Properties;
 
 namespace Speckle.Connectors.GrasshopperShared.Components.Objects;
 
+/// <summary>
+/// One name, one property set, one or more geometries - the container the bundle already models as an object, and
+/// the reason a wall doesn't fan out into its meshes [ENG-9382].
+/// </summary>
 [Guid("5CE8AA40-7706-4893-853D-4C77604548FA")]
 public class SpeckleDataObjectPassthrough()
   : SpecklePassthroughComponentBase(
-    "Speckle Data Object",
-    "SDO",
-    "Create or modify a Speckle Data Object",
+    // display name only - Grasshopper binds by ComponentGuid, so this is cosmetic and safe to change
+    "Speckle Object",
+    "SO",
+    "Create or modify a Speckle Object",
     ComponentCategories.PRIMARY_RIBBON,
     ComponentCategories.OBJECTS
   )
@@ -37,13 +42,7 @@ public class SpeckleDataObjectPassthrough()
 
   public override Guid ComponentGuid => GetType().GUID;
   protected override Bitmap Icon => Resources.speckle_objects_dataobject;
-  public override GH_Exposure Exposure => GH_Exposure.hidden;
-
-  /// <remarks>
-  /// Marks this component as obsolete in the Grasshopper UI (hides it from the ribbon, adds the
-  /// "obsolete" overlay icon on canvas).
-  /// </remarks>
-  public override bool Obsolete => true;
+  public override GH_Exposure Exposure => GH_Exposure.secondary;
 
   protected override int FixedInputCount => 4;
   protected override int FixedOutputCount => 5;
@@ -52,9 +51,9 @@ public class SpeckleDataObjectPassthrough()
   {
     int objIndex = pManager.AddParameter(
       new SpeckleDataObjectParam(),
-      "Speckle Data Object",
-      "SDO",
-      "Input Speckle DataObject. Model Objects are also accepted.",
+      "Speckle Object",
+      "SO",
+      "Input Speckle Object. Model Objects are also accepted.",
       GH_ParamAccess.item
     );
     Params.Input[objIndex].Optional = true;
@@ -63,19 +62,19 @@ public class SpeckleDataObjectPassthrough()
       new SpeckleGeometryWrapperParam(),
       "Geometries",
       "G",
-      "Geometries of the Speckle Data Object. Speckle Geometry and Grasshopper geometry are accepted.",
+      "Geometries of the Speckle Object. Speckle Geometry and Grasshopper geometry are accepted.",
       GH_ParamAccess.list
     );
     Params.Input[geoIndex].Optional = true;
 
-    int nameIndex = pManager.AddTextParameter("Name", "N", "Name of the Speckle Data Object", GH_ParamAccess.item);
+    int nameIndex = pManager.AddTextParameter("Name", "N", "Name of the Speckle Object", GH_ParamAccess.item);
     Params.Input[nameIndex].Optional = true;
 
     int propIndex = pManager.AddParameter(
       new SpecklePropertyGroupParam(),
       "Properties",
       "P",
-      "The properties of the Speckle Data Object. Speckle Properties and User Content are accepted.",
+      "The properties of the Speckle Object. Speckle Properties and User Content are accepted.",
       GH_ParamAccess.item
     );
     Params.Input[propIndex].Optional = true;
@@ -83,29 +82,23 @@ public class SpeckleDataObjectPassthrough()
 
   protected override void RegisterOutputParams(GH_OutputParamManager pManager)
   {
-    pManager.AddParameter(
-      new SpeckleDataObjectParam(),
-      "Speckle Data Object",
-      "SDO",
-      "Speckle Data Object",
-      GH_ParamAccess.item
-    );
+    pManager.AddParameter(new SpeckleDataObjectParam(), "Speckle Object", "SO", "Speckle Object", GH_ParamAccess.item);
 
     pManager.AddParameter(
       new SpeckleGeometryWrapperParam(),
       "Geometries",
       "G",
-      "Geometries of the Speckle Data Object.",
+      "Geometries of the Speckle Object.",
       GH_ParamAccess.list
     );
 
-    pManager.AddTextParameter("Name", "N", "Name of the Speckle Data Object", GH_ParamAccess.item);
+    pManager.AddTextParameter("Name", "N", "Name of the Speckle Object", GH_ParamAccess.item);
 
     pManager.AddParameter(
       new SpecklePropertyGroupParam(),
       "Properties",
       "P",
-      "The properties of the Speckle Data Object",
+      "The properties of the Speckle Object",
       GH_ParamAccess.item
     );
 
@@ -119,11 +112,6 @@ public class SpeckleDataObjectPassthrough()
 
   protected override void SolveInstance(IGH_DataAccess da)
   {
-    AddRuntimeMessage(
-      GH_RuntimeMessageLevel.Remark,
-      "The 'Speckle Data Object' component is deprecated. We recommend using the 'Speckle Geometry' component(s) instead."
-    );
-
     // process the object
     // deep copy so we don't mutate the object
     SpeckleDataObjectWrapperGoo inputObject = new();
@@ -146,7 +134,7 @@ public class SpeckleDataObjectPassthrough()
 
     if (result == null && !hasGeometries && inputName == null && inputProperties == null && !hasAppId)
     {
-      AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, "Pass in a DataObject or at least one input.");
+      AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, "Pass in a Speckle Object or at least one input.");
       return;
     }
 
@@ -154,7 +142,10 @@ public class SpeckleDataObjectPassthrough()
     {
       if (inputGeo.Value is SpeckleBlockInstanceWrapper)
       {
-        AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "DataObjects cannot contain Block Instances");
+        AddRuntimeMessage(
+          GH_RuntimeMessageLevel.Error,
+          "Speckle Objects cannot contain Block Instances - a Block Instance is already its own object."
+        );
         return;
       }
     }
@@ -211,7 +202,7 @@ public class SpeckleDataObjectPassthrough()
     }
     else
     {
-      // generate application ID for new data objects. Unlike SpeckleGeometry, DataObject wrappers aren't created
+      // generate application ID for new objects. Unlike SpeckleGeometry, these wrappers aren't created
       // through casting (which auto-generates IDs), so we must explicitly ensure an ID exists here
       result.ApplicationId ??= Guid.NewGuid().ToString();
     }

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Objects/SpeckleDataObjectPassthrough.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Objects/SpeckleDataObjectPassthrough.cs
@@ -171,10 +171,12 @@ public class SpeckleDataObjectPassthrough()
     if (hasGeometries)
     {
       result.Geometries.Clear();
+      bool replacedAttributes = false;
       foreach (var inputGeo in inputGeometry)
       {
         // deep copy so we don't mutate the input geo which may be speckle geometry
         SpeckleGeometryWrapper mutatingGeo = inputGeo.Value.DeepCopy();
+        replacedAttributes |= HasOwnAttributes(mutatingGeo, result);
 
         // assign fields before adding, otherwise they will be out of sync with wrapper
         mutatingGeo.Base[Constants.NAME_PROP] = result.Name;
@@ -183,6 +185,15 @@ public class SpeckleDataObjectPassthrough()
         mutatingGeo.Path = result.Path;
 
         result.Geometries.Add(mutatingGeo);
+      }
+
+      if (replacedAttributes)
+      {
+        AddRuntimeMessage(
+          GH_RuntimeMessageLevel.Warning,
+          "The name or properties on the incoming geometry were replaced by this object's. Name and properties "
+            + "belong to the object, not to its geometry."
+        );
       }
     }
     else if (inputName != null || inputProperties != null)
@@ -226,6 +237,11 @@ public class SpeckleDataObjectPassthrough()
     da.SetData(4, path);
     SetApplicationIdOutput(da, result.ApplicationId);
   }
+
+  /// <summary>Whether the geometry carries a name or properties of its own that this object is about to replace.</summary>
+  private static bool HasOwnAttributes(SpeckleGeometryWrapper geometry, SpeckleDataObjectWrapper owner) =>
+    (!string.IsNullOrEmpty(geometry.Name) && geometry.Name != owner.Name)
+    || (geometry.Properties.Value.Count > 0 && !geometry.Properties.Equals(owner.Properties));
 
   public override void AppendAdditionalMenuItems(ToolStripDropDown menu)
   {

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Objects/SpeckleGeometryPassthrough.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Objects/SpeckleGeometryPassthrough.cs
@@ -145,11 +145,24 @@ public class SpeckleGeometryPassthrough()
             result = mutatingGeo;
           }
 
+          // the base carries the properties, so swapping it below takes the incoming geometry's - the name is
+          // carried across explicitly, the properties are not
+          bool dropsProperties = result.Properties.Value.Count > 0 && !result.Properties.Equals(mutatingGeo.Properties);
+
           // assign before the base, otherwise wrapper name and app id reset
           mutatingGeo.Base[Constants.NAME_PROP] = result.Name;
           mutatingGeo.Base.applicationId = result.ApplicationId;
           result.Base = mutatingGeo.Base;
           result.GeometryBase = mutatingGeo.GeometryBase;
+
+          if (dropsProperties)
+          {
+            AddRuntimeMessage(
+              GH_RuntimeMessageLevel.Warning,
+              "Replacing the geometry dropped its properties. The name was kept. Use a Speckle Object if you need "
+                + "the properties."
+            );
+          }
         }
       }
       else

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Objects/SpeckleGeometryPassthrough.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Objects/SpeckleGeometryPassthrough.cs
@@ -17,7 +17,7 @@ public class SpeckleGeometryPassthrough()
   : SpecklePassthroughComponentBase(
     "Speckle Geometry",
     "SG",
-    "Create or modify a Speckle Geometry",
+    "Create or modify a Speckle Geometry. Name and properties live on the Speckle Object that contains it.",
     ComponentCategories.PRIMARY_RIBBON,
     ComponentCategories.OBJECTS
   )

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Objects/SpeckleGeometryPassthroughLegacy.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Objects/SpeckleGeometryPassthroughLegacy.cs
@@ -9,25 +9,32 @@ using Speckle.Sdk.Common;
 namespace Speckle.Connectors.GrasshopperShared.Components.Objects;
 
 /// <summary>
-/// Geometry, colour and material only. Name and properties belong to a Speckle Object - eav is keyed by object, and
-/// geometry rows are content-hash deduped, so attributes can't live there [ENG-9382].
+/// Deprecated. Kept working, unchanged, for scripts authored before name and properties moved to
+/// <see cref="SpeckleDataObjectPassthrough"/> [ENG-9382].
 /// </summary>
-[Guid("6B4E1D07-9A83-4F2C-B5D1-7E0C3A9F4128")]
-public class SpeckleGeometryPassthrough()
+/// <remarks>
+/// Its Name and Properties inputs were always dropped when the geometry went into an object - EmitDataObject reads
+/// shape, colour and material and nothing else - so nothing changes for an existing script.
+/// </remarks>
+[Guid("F9418610-ACAE-4417-B010-19EBEA6A121F")]
+public class SpeckleGeometryPassthroughLegacy()
   : SpecklePassthroughComponentBase(
-    "Speckle Geometry",
+    // display name only - Grasshopper binds by ComponentGuid, so this is cosmetic and safe to change
+    "Speckle Geometry (legacy)",
     "SG",
-    "Create or modify a Speckle Geometry",
+    "Create or modify a Speckle Geometry. Deprecated - use the new Speckle Geometry component.",
     ComponentCategories.PRIMARY_RIBBON,
     ComponentCategories.OBJECTS
   )
 {
   public override Guid ComponentGuid => GetType().GUID;
   protected override Bitmap Icon => Resources.speckle_objects_geometry;
-  public override GH_Exposure Exposure => GH_Exposure.secondary;
+  public override GH_Exposure Exposure => GH_Exposure.hidden;
 
-  protected override int FixedInputCount => 4;
-  protected override int FixedOutputCount => 5;
+  public override bool Obsolete => true;
+
+  protected override int FixedInputCount => 6;
+  protected override int FixedOutputCount => 7;
 
   protected override void RegisterInputParams(GH_InputParamManager pManager)
   {
@@ -47,6 +54,18 @@ public class SpeckleGeometryPassthrough()
     );
     Params.Input[geoIndex].Optional = true;
 
+    int nameIndex = pManager.AddTextParameter("Name", "N", "Name of the Speckle Geometry", GH_ParamAccess.item);
+    Params.Input[nameIndex].Optional = true;
+
+    int propIndex = pManager.AddParameter(
+      new SpecklePropertyGroupParam(),
+      "Properties",
+      "P",
+      "The properties of the Speckle Geometry. Speckle Properties and User Content are accepted.",
+      GH_ParamAccess.item
+    );
+    Params.Input[propIndex].Optional = true;
+
     int colorIndex = pManager.AddColourParameter(
       "Color",
       "c",
@@ -63,6 +82,16 @@ public class SpeckleGeometryPassthrough()
       GH_ParamAccess.item
     );
     Params.Input[matIndex].Optional = true;
+
+    /* POC: disable for now as we are doing anything with this
+    pManager.AddTextParameter(
+      "Path",
+      "p",
+      "The Collection Path of the Speckle Object. Should be delimited with `:`",
+      GH_ParamAccess.item
+    );
+    Params.Input[6].Optional = true;
+    */
   }
 
   protected override void RegisterOutputParams(GH_OutputParamManager pManager)
@@ -70,6 +99,16 @@ public class SpeckleGeometryPassthrough()
     pManager.AddGenericParameter("Speckle Geometry", "SG", "Speckle Geometry", GH_ParamAccess.item);
 
     pManager.AddGeometryParameter("Geometry", "G", "Geometry of the Speckle Geometry.", GH_ParamAccess.item);
+
+    pManager.AddTextParameter("Name", "N", "Name of the Speckle Geometry", GH_ParamAccess.item);
+
+    pManager.AddParameter(
+      new SpecklePropertyGroupParam(),
+      "Properties",
+      "P",
+      "The properties of the Speckle Geometry",
+      GH_ParamAccess.item
+    );
 
     pManager.AddColourParameter("Color", "c", "The color of the Speckle Geometry", GH_ParamAccess.item);
 
@@ -91,7 +130,8 @@ public class SpeckleGeometryPassthrough()
 
   protected override void SolveInstance(IGH_DataAccess da)
   {
-    // deep copy so we don't mutate the input
+    // process the object
+    // deep copy so we don't mutate the object
     IGH_Goo? inputObject = null;
     SpeckleGeometryWrapper? result = null;
     if (da.GetData(0, ref inputObject))
@@ -116,12 +156,20 @@ public class SpeckleGeometryPassthrough()
       return;
     }
 
+    string? inputName = null;
+    da.GetData(2, ref inputName);
+
+    SpecklePropertyGroupGoo? inputProperties = null;
+    da.GetData(3, ref inputProperties);
+
     Color? inputColor = null;
-    da.GetData(2, ref inputColor);
+    da.GetData(4, ref inputColor);
 
     SpeckleMaterialWrapperGoo? inputMaterial = null;
-    da.GetData(3, ref inputMaterial);
+    da.GetData(5, ref inputMaterial);
 
+    // process geometry
+    // deep copy so we don't mutate the input geo which may be speckle objects
     if (inputGeometry != null)
     {
       if (inputGeometry.ToSpeckleGeometryWrapper() is SpeckleGeometryWrapper geoWrapper)
@@ -133,7 +181,7 @@ public class SpeckleGeometryPassthrough()
         }
         else
         {
-          // switch to the incoming geo's wrapper type if this is a mutation on the object
+          // we need to switch to the actual object wrapper type of the incoming geo if this is a mutation on the object
           if (mutatingGeo is SpeckleBlockInstanceWrapper mutatingInstance && result is not SpeckleBlockInstanceWrapper)
           {
             MatchNonGeometryProps(mutatingInstance, result);
@@ -145,9 +193,8 @@ public class SpeckleGeometryPassthrough()
             result = mutatingGeo;
           }
 
-          // assign before the base, otherwise wrapper name and app id reset
-          mutatingGeo.Base[Constants.NAME_PROP] = result.Name;
-          mutatingGeo.Base.applicationId = result.ApplicationId;
+          mutatingGeo.Base[Constants.NAME_PROP] = result.Name; // assign these before assigning base since otherwise wrapper name and app will reset
+          mutatingGeo.Base.applicationId = result.ApplicationId; // assign these before assigning base since otherwise wrapper name and app will reset
           result.Base = mutatingGeo.Base;
           result.GeometryBase = mutatingGeo.GeometryBase;
         }
@@ -163,34 +210,52 @@ public class SpeckleGeometryPassthrough()
     }
 
     result.NotNull();
+    // process name
+    if (inputName != null)
+    {
+      result.Name = inputName;
+    }
 
+    // process properties
+    if (inputProperties != null)
+    {
+      result.Properties = inputProperties;
+    }
+
+    // process color (no mutation)
     if (inputColor != null)
     {
       result.Color = inputColor;
     }
 
+    // process material (no mutation)
     if (inputMaterial != null)
     {
       result.Material = inputMaterial.Value;
     }
 
+    // process application id (only if user provided one, otherwise preserve existing)
     if (TryGetApplicationIdInput(da, out string? inputAppId))
     {
       result.ApplicationId = inputAppId;
     }
 
+    // get the path
     string? path =
       result.Path.Count > 1 ? string.Join(Constants.LAYER_PATH_DELIMITER, result.Path) : result.Path.FirstOrDefault();
 
+    // set all the data
     da.SetData(0, result.CreateGoo());
     da.SetData(1, result.GeometryBase);
-    da.SetData(2, result.Color);
-    da.SetData(3, result.Material);
-    da.SetData(4, path);
+    da.SetData(2, result.Name);
+    da.SetData(3, result.Properties);
+    da.SetData(4, result.Color);
+    da.SetData(5, result.Material);
+    da.SetData(6, path);
     SetApplicationIdOutput(da, result.ApplicationId);
   }
 
-  /// <summary>Keeps geometry and wrapped base, assigns everything else from the input wrapper.</summary>
+  // keeps the geometry and wrapped base the same while assigning all other props from the inut wrapper
   private void MatchNonGeometryProps(SpeckleGeometryWrapper wrapper, SpeckleGeometryWrapper wrapperToMatch)
   {
     wrapper.Name = wrapperToMatch.Name;

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Receive/ReceiveAsyncComponentBase.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Receive/ReceiveAsyncComponentBase.cs
@@ -605,9 +605,7 @@ public sealed class ReceiveComponentWorker : WorkerInstance<ReceiveAsyncComponen
         new GrasshopperArtefactObjectBuilder().Build(
           bundle,
           receiveInfo.ModelName,
-          new SpeckleModelContext(receiveInfo.ProjectId, receiveInfo.SelectedVersionId),
-          // only the deprecated variant reaches here as a fallback, and its scripts expect DataObjects
-          groupAsDataObjects: !Parent.PreferArtefacts
+          new SpeckleModelContext(receiveInfo.ProjectId, receiveInfo.SelectedVersionId)
         );
 
       foreach (var warning in buildWarnings)

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Receive/ReceiveComponentBase.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Operations/Receive/ReceiveComponentBase.cs
@@ -332,9 +332,7 @@ public abstract class ReceiveComponentBase(
         new GrasshopperArtefactObjectBuilder().Build(
           bundle,
           receiveInfo.ModelName,
-          new SpeckleModelContext(receiveInfo.ProjectId, receiveInfo.SelectedVersionId),
-          // only the deprecated variant reaches here as a fallback, and its scripts expect DataObjects
-          groupAsDataObjects: !PreferArtefacts
+          new SpeckleModelContext(receiveInfo.ProjectId, receiveInfo.SelectedVersionId)
         );
 
       foreach (var warning in buildWarnings)

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Operations/Receive/GrasshopperArtefactObjectBuilder.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Operations/Receive/GrasshopperArtefactObjectBuilder.cs
@@ -151,7 +151,7 @@ internal sealed class GrasshopperArtefactObjectBuilder
         && (geometryWrappers.Count > 0 || instCount == 0)
       )
       {
-        collection.Elements.Add(BuildDataObject(appId, name, props, geometryWrappers, collection));
+        collection.Elements.Add(BuildDataObject(objK, appId, name, props, geometryWrappers, collection));
       }
       else
       {
@@ -307,6 +307,7 @@ internal sealed class GrasshopperArtefactObjectBuilder
   /// same as the v1 receive path does.
   /// </summary>
   private static SpeckleDataObjectWrapper BuildDataObject(
+    int objK,
     string appId,
     string? name,
     Dictionary<string, object?>? props,
@@ -332,6 +333,7 @@ internal sealed class GrasshopperArtefactObjectBuilder
       Name = dataObject.name,
       Properties = new SpecklePropertyGroupGoo(properties),
       ApplicationId = appId,
+      ObjectIndex = objK,
     };
   }
 

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Operations/Receive/GrasshopperArtefactObjectBuilder.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Operations/Receive/GrasshopperArtefactObjectBuilder.cs
@@ -34,16 +34,10 @@ internal sealed class GrasshopperArtefactObjectBuilder
 {
   // (root, per-fragment decode/convert warnings) — the caller (ReceiveComponent/ReceiveAsyncComponent) surfaces these
   // as GH runtime messages so an undecodable fragment is visible instead of a silent skip.
-  /// <param name="groupAsDataObjects">
-  /// Regroups an object's geometry into a single <see cref="SpeckleDataObjectWrapper"/> instead of emitting one
-  /// wrapper per geometry. The deprecated Load components pass true so a script that was written against v3 sees the
-  /// object counts and shapes it already expects; the 4.0 components pass false and get the flat geometry.
-  /// </param>
   public (SpeckleCollectionWrapper Root, IReadOnlyList<string> Warnings) Build(
     ArtefactBundle bundle,
     string rootName,
-    SpeckleModelContext context,
-    bool groupAsDataObjects
+    SpeckleModelContext context
   )
   {
     var warnings = new List<string>();
@@ -117,7 +111,7 @@ internal sealed class GrasshopperArtefactObjectBuilder
       {
         // A room, level or area carried properties and no geometry in v3, and still counts as an object [ENG-9159].
         // Only re-emit one when the source really was a DataObject - WasDataObject reads speckle_type.
-        if (!groupAsDataObjects || !WasDataObject(props, 0))
+        if (!WasDataObject(props, 0))
         {
           continue;
         }
@@ -148,11 +142,12 @@ internal sealed class GrasshopperArtefactObjectBuilder
         materialByGeometry
       );
 
-      // An empty DataObject is only right for a genuinely property-only object: one placed as a block already comes
-      // through as its instance wrapper, and adding an empty one beside it would double the count.
+      // Never fan one object out into several wrappers: name and properties would be copied onto each, and a sum over
+      // them double-counts [ENG-9382]. An empty object is only right for a genuinely property-only source - one
+      // placed as a block already comes through as its instance wrapper, and adding an empty one beside it would
+      // double the count.
       if (
-        groupAsDataObjects
-        && WasDataObject(props, geometryWrappers.Count)
+        (WasDataObject(props, geometryWrappers.Count) || geometryWrappers.Count > 1)
         && (geometryWrappers.Count > 0 || instCount == 0)
       )
       {

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Operations/Send/GrasshopperArtifactRootObjectBuilder.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Operations/Send/GrasshopperArtifactRootObjectBuilder.cs
@@ -453,11 +453,14 @@ public class GrasshopperArtifactRootObjectBuilder(
       }
     }
 
+    // One geometry can be walked twice - bare in a collection and again as a member of an object - and both objects
+    // genuinely display it. The DISPLAY edges below are per-object so both are right, but the K must be listed once:
+    // EmitValueNodes multiplies this list by the packer's object ids, so a repeat squares the appearance [ENG-9382].
     var gKs = ctx.GeometryKsByAppId.TryGetValue(geometryAppId, out var existing)
       ? existing
       : ctx.GeometryKsByAppId[geometryAppId] = new List<int>();
 
-    if (memberSolidK is int msk)
+    if (memberSolidK is int msk && !gKs.Contains(msk))
     {
       gKs.Add(msk);
     }
@@ -471,7 +474,10 @@ public class GrasshopperArtifactRootObjectBuilder(
       {
         ctx.Pipeline.Display(objK, gK, displayOrd++); // members render only via DEFINES through a placed instance's transform
       }
-      gKs.Add(gK);
+      if (!gKs.Contains(gK))
+      {
+        gKs.Add(gK);
+      }
     }
   }
 
@@ -522,7 +528,8 @@ public class GrasshopperArtifactRootObjectBuilder(
         value.emissive,
         value["ior"] as double? // dynamic prop (v1 unpacker convention); null when the host has no IOR [ENG-8791]
       );
-      foreach (var objectId in materialProxy.objects)
+      // Distinct: the packer appends per walk, so geometry reached twice lists its id twice
+      foreach (var objectId in materialProxy.objects.Distinct())
       {
         if (geometryKsByAppId.TryGetValue(objectId, out var gKs))
         {
@@ -543,7 +550,7 @@ public class GrasshopperArtifactRootObjectBuilder(
     foreach (var colorProxy in colorPacker.ColorProxies.Values)
     {
       int colorK = pipeline.AddColor(colorProxy.value);
-      foreach (var objectId in colorProxy.objects)
+      foreach (var objectId in colorProxy.objects.Distinct())
       {
         if (geometryKsByAppId.TryGetValue(objectId, out var gKs))
         {

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/Wrappers/SpeckleDataObjectWrapper.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/Wrappers/SpeckleDataObjectWrapper.cs
@@ -103,7 +103,7 @@ public class SpeckleDataObjectWrapper : SpeckleWrapper, ISpeckleCollectionObject
   public override IGH_Goo CreateGoo() => new SpeckleDataObjectWrapperGoo(this);
 
   public override string ToString() =>
-    $"Speckle Data Object : {(string.IsNullOrWhiteSpace(Name) ? Base.speckle_type : Name)}";
+    $"Speckle Object : {(string.IsNullOrWhiteSpace(Name) ? Base.speckle_type : Name)}";
 
   /// <summary>
   /// Draws preview for all geometries contained in this data object.

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/Wrappers/SpeckleDataObjectWrapper.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/Wrappers/SpeckleDataObjectWrapper.cs
@@ -212,6 +212,7 @@ public class SpeckleDataObjectWrapper : SpeckleWrapper, ISpeckleCollectionObject
       Name = Name,
       Path = [.. Path],
       Parent = Parent,
+      ObjectIndex = ObjectIndex,
       ModelContext = ModelContext,
     };
 

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/Wrappers/SpeckleDataObjectWrapperGoo.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/Wrappers/SpeckleDataObjectWrapperGoo.cs
@@ -36,13 +36,13 @@ public partial class SpeckleDataObjectWrapperGoo : GH_Goo<SpeckleDataObjectWrapp
   }
 
   public override bool IsValid => Value?.DataObject is not null && Value.ApplicationId is not null;
-  public override string TypeName => "Speckle Data Object";
+  public override string TypeName => "Speckle Object";
   public override string TypeDescription => "Represents a Speckle data object";
 
   public override IGH_Goo Duplicate() => new SpeckleDataObjectWrapperGoo(Value.DeepCopy());
 
   public override string ToString() =>
-    $"Speckle Data Object : {(string.IsNullOrWhiteSpace(Value.Name) ? Value.Base.speckle_type : Value.Name)}";
+    $"Speckle Object : {(string.IsNullOrWhiteSpace(Value.Name) ? Value.Base.speckle_type : Value.Name)}";
 
   /// <summary>
   /// Handles casting from other types to DataObject wrapper.

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/Wrappers/SpeckleDataObjectWrapperParam.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/Wrappers/SpeckleDataObjectWrapperParam.cs
@@ -20,9 +20,10 @@ public class SpeckleDataObjectParam : GH_Param<SpeckleDataObjectWrapperGoo>, IGH
 
   public SpeckleDataObjectParam(GH_ParamAccess access)
     : base(
-      "Speckle Data Object",
-      "SDO",
-      "A Speckle data object with structured properties and display geometries",
+      // display name only - Grasshopper binds by ComponentGuid, so this is cosmetic and safe to change
+      "Speckle Object",
+      "SO",
+      "A Speckle object with structured properties and one or more geometries",
       ComponentCategories.PRIMARY_RIBBON,
       ComponentCategories.PARAMETERS,
       access
@@ -30,22 +31,7 @@ public class SpeckleDataObjectParam : GH_Param<SpeckleDataObjectWrapperGoo>, IGH
 
   public override Guid ComponentGuid => new("47B930F9-587B-4A88-8CEB-19986E60BA61");
   protected override Bitmap Icon => Resources.speckle_param_dataobject;
-  public override GH_Exposure Exposure => GH_Exposure.hidden;
-
-  /// <remarks>
-  /// Marks this param as obsolete in the Grasshopper UI (hides it from the ribbon, adds the
-  /// "obsolete" overlay icon on canvas).
-  /// </remarks>
-  public override bool Obsolete => true;
-
-  public override void AddedToDocument(GH_Document document)
-  {
-    base.AddedToDocument(document);
-    AddRuntimeMessage(
-      GH_RuntimeMessageLevel.Remark,
-      "The 'Speckle Data Object' parameter is deprecated. We recommend using the 'Speckle Geometry' parameter/component(s) instead."
-    );
-  }
+  public override GH_Exposure Exposure => GH_Exposure.secondary;
 
   bool IGH_BakeAwareObject.IsBakeCapable => !VolatileData.IsEmpty;
 

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/Wrappers/SpeckleGeometryWrapper.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/Wrappers/SpeckleGeometryWrapper.cs
@@ -58,12 +58,6 @@ public class SpeckleGeometryWrapper : SpeckleWrapper, ISpeckleCollectionObject
   /// </summary>
   public SpeckleMaterialWrapper? Material { get; set; }
 
-  /// <summary>
-  /// Dense index in the source bundle's <c>eav.objects</c>, or null when it didn't come from one (canvas-authored, or
-  /// legacy receive). With <see cref="SpeckleWrapper.ModelContext"/>, enough to resolve this object in the graph.
-  /// </summary>
-  public int? ObjectIndex { get; set; }
-
   public override string ToString() =>
     $"Speckle Geometry : {(string.IsNullOrWhiteSpace(Name) ? Base.speckle_type : Name)}";
 

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/Wrappers/SpeckleWrapper.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/Wrappers/SpeckleWrapper.cs
@@ -22,6 +22,13 @@ public abstract class SpeckleWrapper
   }
 
   /// <summary>
+  /// Dense index in the source bundle's <c>eav.objects</c>, or null when it didn't come from one (canvas-authored, or
+  /// legacy receive). With <see cref="ModelContext"/>, enough to resolve this object in the graph. Null on a
+  /// collection - those are container nodes, not objects.
+  /// </summary>
+  public int? ObjectIndex { get; set; }
+
+  /// <summary>
   /// The wrapped <see cref="Base"/>
   /// </summary>
   public abstract Base Base { get; set; }


### PR DESCRIPTION
## Validation of changes:

### Check on no regression

- [x] ENG-9159 working as before
- [x] ENG-9161working as before
- [x] ENG-9163 working as before

### Object count on old scripts

<img width="1025" height="895" alt="image" src="https://github.com/user-attachments/assets/3ef516c0-7647-48c5-84c4-a329be645861" />

### Revit wall loads as one `Speckle Object`

<img width="1025" height="803" alt="image" src="https://github.com/user-attachments/assets/907fe76a-abaa-4a24-a96b-5827276d76a3" />