### PR TITLE
fix(revit): restore v1 grouping on artefact receive, free the Comments parameter (ENG-8805)

### DIFF
--- a/Connectors/Autocad/Speckle.Connectors.AutocadShared/Operations/Receive/AutocadHostObjectArtefactBuilder.cs
+++ b/Connectors/Autocad/Speckle.Connectors.AutocadShared/Operations/Receive/AutocadHostObjectArtefactBuilder.cs
@@ -102,12 +102,13 @@ public class AutocadHostObjectArtefactBuilder : IArtifactHostObjectBuilder
 
   public Task<HostObjectBuilderResult> Build(
     ArtefactBundle bundle,
-    string projectName,
-    string modelName,
+    ArtefactReceiveTarget target,
     IProgress<CardProgress> onOperationProgressed,
     CancellationToken cancellationToken
   ) =>
-    _threadContext.RunOnMain(() => BakeAll(bundle, projectName, modelName, onOperationProgressed, cancellationToken));
+    _threadContext.RunOnMain(() =>
+      BakeAll(bundle, target.ProjectName, target.ModelName, onOperationProgressed, cancellationToken)
+    );
 
 #pragma warning disable CA1506
   private HostObjectBuilderResult BakeAll(

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/DependencyInjection/RevitConnectorModule.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/DependencyInjection/RevitConnectorModule.cs
@@ -105,6 +105,8 @@ public static class ServiceRegistration
     serviceCollection.AddScoped<RevitFamilyBaker>();
     serviceCollection.AddScoped<FamilyGeometryBaker>();
     serviceCollection.AddScoped<RevitGroupBaker>();
+    serviceCollection.AddScoped<RevitReceiveManifest>();
+    serviceCollection.AddScoped<RevitReceiveTracker>();
     serviceCollection.AddScoped<RevitMaterialBaker>();
     serviceCollection.AddScoped<RevitViewBaker>();
     serviceCollection.AddScoped<RevitViewManager>();

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/RevitGroupBaker.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/RevitGroupBaker.cs
@@ -23,17 +23,40 @@ public class RevitGroupBaker : TraversalContextUnpacker
 
   public void AddToTopLevelGroup(Element revitElement) => _elementIdsForTopLevelGroup.Add(revitElement.Id);
 
-  public void BakeGroupForTopLevel(string baseGroupName)
+  public string? BakeGroupForTopLevel(string baseGroupName) =>
+    BakeGroupForTopLevel(baseGroupName, _elementIdsForTopLevelGroup);
+
+  /// <summary>Bakes <paramref name="elementIds"/> into one pinned, named top-level group and returns its UniqueId
+  /// (null when there was nothing to group).</summary>
+  /// <remarks>The explicit-collection overload exists for the artefact receive path, which threads its own member
+  /// list through the bake rather than accumulating into this service's state.</remarks>
+  public string? BakeGroupForTopLevel(string baseGroupName, IReadOnlyCollection<ElementId> elementIds)
   {
-    if (_elementIdsForTopLevelGroup.Count == 0)
+    if (elementIds.Count == 0)
     // if no elements were successfully converted, instead of throwing when creating a new group, we should just return and let object conversion exceptions bubble up.
     {
-      return;
+      return null;
     }
 
-    var docGroup = _converterSettings.Current.Document.Create.NewGroup(_elementIdsForTopLevelGroup);
+    var docGroup = _converterSettings.Current.Document.Create.NewGroup(elementIds.ToList());
     docGroup.GroupType.Name = _revitUtils.RemoveInvalidChars(baseGroupName);
     docGroup.Pinned = true;
+    return docGroup.UniqueId;
+  }
+
+  /// <summary>Deletes one previously baked group (and its members) by UniqueId — the rename-proof counterpart to
+  /// <see cref="PurgeGroups"/>, which can only find a group whose name still matches the current project/model.</summary>
+  public void PurgeGroupById(string groupUniqueId)
+  {
+    var document = _converterSettings.Current.Document;
+    if (document.GetElement(groupUniqueId) is not Group group)
+    {
+      return; // already gone, or the user ungrouped it — nothing to delete
+    }
+
+    var subgroupTypeIds = new List<ElementId>() { group.GroupType.Id };
+    CollectSubGroupTypeIds(document, group, subgroupTypeIds);
+    document.Delete(subgroupTypeIds);
   }
 
   public void PurgeGroups(string baseGroupName)

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/RevitMaterialBaker.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/RevitMaterialBaker.cs
@@ -31,6 +31,14 @@ public class RevitMaterialBaker
     _converterSettings = converterSettings;
   }
 
+  private readonly List<string> _createdMaterialUniqueIds = new();
+
+  /// <summary>UniqueIds of the Materials this receive <b>created</b> in the project document — recorded into the
+  /// receive manifest so the next receive can delete exactly these [ENG-8805]. Materials that were reused (an existing
+  /// document material matched by name) are deliberately absent: they are the user's, not ours to delete. Materials
+  /// created inside a family document are absent too — their UniqueIds are meaningless in the project document.</summary>
+  public IReadOnlyCollection<string> CreatedMaterialUniqueIds => _createdMaterialUniqueIds;
+
   private ElementId? FindExistingMaterialByName(string? materialName, Document document)
   {
     if (string.IsNullOrWhiteSpace(materialName))
@@ -150,6 +158,12 @@ public class RevitMaterialBaker
     revitMaterial.Shininess = (int)(metalness * 128);
     revitMaterial.Smoothness = (int)(smoothness * 100);
 
+    // Only project-document materials are trackable: a family document's UniqueIds don't resolve in the project.
+    if (document.Equals(_converterSettings.Current.Document))
+    {
+      _createdMaterialUniqueIds.Add(revitMaterial.UniqueId);
+    }
+
     return revitMaterial.Id;
   }
 
@@ -183,19 +197,40 @@ public class RevitMaterialBaker
     return objectIdAndMaterialIndexMap;
   }
 
-  public void PurgeMaterials(string baseGroupName)
+  /// <summary>
+  /// Deletes the Materials a previous receive of this model created, identified by the UniqueIds it recorded in the
+  /// receive manifest (<see cref="RevitReceiveManifest"/>).
+  /// </summary>
+  /// <remarks>
+  /// <para>Replaces a name-based purge that deleted every Material whose name <i>contained</i> the base group name.
+  /// That predicate never matched anything this baker creates — <see cref="BakeMaterial"/> names materials after the
+  /// Speckle material alone, with no project/model suffix — so it was a no-op that nonetheless carried an unscoped
+  /// delete: a user's own material named after the project or model would have been removed [ENG-8805].</para>
+  /// <para>Call this only after the prior bake's elements are gone, so the materials being deleted are no longer
+  /// painted onto anything this receive is about to replace.</para>
+  /// </remarks>
+  public void PurgeMaterials(IReadOnlyCollection<string> materialUniqueIds)
   {
-    var validBaseGroupName = _revitUtils.RemoveInvalidChars(baseGroupName);
+    if (materialUniqueIds.Count == 0)
+    {
+      return;
+    }
+
     var document = _converterSettings.Current.Document;
+    var toDelete = new List<ElementId>();
+    foreach (var uniqueId in materialUniqueIds)
+    {
+      // Anything but a Material means the id was recycled by another element — never delete on a stale match.
+      if (document.GetElement(uniqueId) is Material material)
+      {
+        toDelete.Add(material.Id);
+      }
+    }
 
-    using var collector = new FilteredElementCollector(document);
-    var materialIds = collector
-      .OfClass(typeof(Material))
-      .Where(m => m.Name.Contains(validBaseGroupName))
-      .Select(m => m.Id)
-      .ToList();
-
-    document.Delete(materialIds);
+    if (toDelete.Count > 0)
+    {
+      document.Delete(toDelete);
+    }
   }
 
   /// <summary>

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/RevitMaterialBaker.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/RevitMaterialBaker.cs
@@ -31,14 +31,6 @@ public class RevitMaterialBaker
     _converterSettings = converterSettings;
   }
 
-  private readonly List<string> _createdMaterialUniqueIds = new();
-
-  /// <summary>UniqueIds of the Materials this receive <b>created</b> in the project document — recorded into the
-  /// receive manifest so the next receive can delete exactly these [ENG-8805]. Materials that were reused (an existing
-  /// document material matched by name) are deliberately absent: they are the user's, not ours to delete. Materials
-  /// created inside a family document are absent too — their UniqueIds are meaningless in the project document.</summary>
-  public IReadOnlyCollection<string> CreatedMaterialUniqueIds => _createdMaterialUniqueIds;
-
   private ElementId? FindExistingMaterialByName(string? materialName, Document document)
   {
     if (string.IsNullOrWhiteSpace(materialName))
@@ -158,12 +150,6 @@ public class RevitMaterialBaker
     revitMaterial.Shininess = (int)(metalness * 128);
     revitMaterial.Smoothness = (int)(smoothness * 100);
 
-    // Only project-document materials are trackable: a family document's UniqueIds don't resolve in the project.
-    if (document.Equals(_converterSettings.Current.Document))
-    {
-      _createdMaterialUniqueIds.Add(revitMaterial.UniqueId);
-    }
-
     return revitMaterial.Id;
   }
 
@@ -197,41 +183,12 @@ public class RevitMaterialBaker
     return objectIdAndMaterialIndexMap;
   }
 
-  /// <summary>
-  /// Deletes the Materials a previous receive of this model created, identified by the UniqueIds it recorded in the
-  /// receive manifest (<see cref="RevitReceiveManifest"/>).
-  /// </summary>
-  /// <remarks>
-  /// <para>Replaces a name-based purge that deleted every Material whose name <i>contained</i> the base group name.
-  /// That predicate never matched anything this baker creates — <see cref="BakeMaterial"/> names materials after the
-  /// Speckle material alone, with no project/model suffix — so it was a no-op that nonetheless carried an unscoped
-  /// delete: a user's own material named after the project or model would have been removed [ENG-8805].</para>
-  /// <para>Call this only after the prior bake's elements are gone, so the materials being deleted are no longer
-  /// painted onto anything this receive is about to replace.</para>
-  /// </remarks>
-  public void PurgeMaterials(IReadOnlyCollection<string> materialUniqueIds)
-  {
-    if (materialUniqueIds.Count == 0)
-    {
-      return;
-    }
-
-    var document = _converterSettings.Current.Document;
-    var toDelete = new List<ElementId>();
-    foreach (var uniqueId in materialUniqueIds)
-    {
-      // Anything but a Material means the id was recycled by another element — never delete on a stale match.
-      if (document.GetElement(uniqueId) is Material material)
-      {
-        toDelete.Add(material.Id);
-      }
-    }
-
-    if (toDelete.Count > 0)
-    {
-      document.Delete(toDelete);
-    }
-  }
+  // NOTE: there is deliberately no material purge here [ENG-8805]. A previous PurgeMaterials(baseGroupName) deleted
+  // every Material whose name CONTAINED the base group name — which never matched anything BakeMaterial creates
+  // (materials are named after the Speckle material alone, with no project/model suffix), so it was a no-op that
+  // nonetheless carried an unscoped delete: a user's own material named after the project would have gone with it.
+  // Receive reuses materials by name instead and never writes over an existing one, so re-receiving cannot accumulate
+  // duplicates and a user's edits to a received material survive.
 
   /// <summary>
   /// After CNX-2661, we've seen some edge cases contradicting the expected 0 - 1 range for PRB properties.

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/RevitReceiveManifest.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/RevitReceiveManifest.cs
@@ -1,0 +1,172 @@
+using Autodesk.Revit.DB;
+using Autodesk.Revit.DB.ExtensibleStorage;
+using Microsoft.Extensions.Logging;
+using Speckle.Sdk;
+
+namespace Speckle.Connectors.Revit.HostApp;
+
+/// <summary>What a previous receive of one model left behind in this document.</summary>
+/// <param name="Storage">The <see cref="DataStorage"/> element the record lives on, so the caller can update it in
+/// place instead of accumulating one per receive.</param>
+/// <param name="GroupUniqueId">UniqueId of the top-level Group the bake was collected into, or null when the bake
+/// predates grouping (or grouping failed).</param>
+/// <param name="MaterialUniqueIds">UniqueIds of the Materials that receive <b>created</b> — never ones it reused
+/// from the document, which belong to the user.</param>
+public sealed record RevitReceiveRecord(
+  DataStorage Storage,
+  string? GroupUniqueId,
+  IReadOnlyCollection<string> MaterialUniqueIds
+);
+
+/// <summary>
+/// The per-model receive manifest: a hidden <see cref="DataStorage"/> element carrying, in Extensible Storage, what
+/// the last receive of one model put into this document (its top-level Group and the Materials it created).
+/// </summary>
+/// <remarks>
+/// <para>This is the tracking key that replaces the <c>Comments</c> parameter marker [ENG-8805]. Two properties matter:
+/// it is <b>not user-facing</b> (Comments is user-visible, schedulable and commonly edited — an edit used to orphan the
+/// element and duplicate it on the next receive), and it is <b>rename-proof</b> — lookup prefers the project/model
+/// <i>ids</i>, so renaming either on the web no longer strands the prior bake.</para>
+/// <para>Lookup falls back to the marker name (<c>Project {name}: Model {name}</c>) when ids are unavailable: the v1
+/// <c>IHostObjectBuilder</c> path has no ids to pass, and records written by earlier builds carry none.</para>
+/// <para>Element tracking itself stays with the Group, exactly as in v1 — a manifest listing every baked element would
+/// mean a multi-megabyte entity on a large model for no gain over <c>PurgeGroups</c>. The known consequence, inherited
+/// from v1: if a user explicitly ungroups a received model, its elements are no longer tracked and the next receive
+/// bakes alongside them.</para>
+/// <para>Every operation is defensive — a manifest failure degrades cleanup to the name-based fallbacks rather than
+/// costing the user their receive.</para>
+/// </remarks>
+public class RevitReceiveManifest
+{
+  // Stable across versions — changing it strands every manifest already written into user documents.
+  private static readonly Guid s_schemaGuid = new("8f3d5c21-9b74-4f0e-9a6d-2c1e7b4a3d58");
+  private const string SCHEMA_NAME = "SpeckleReceiveManifest";
+  private const string FIELD_PROJECT_ID = "projectId";
+  private const string FIELD_MODEL_ID = "modelId";
+  private const string FIELD_MARKER = "marker";
+  private const string FIELD_GROUP = "groupUniqueId";
+  private const string FIELD_MATERIALS = "materialUniqueIds";
+
+  // Newline-delimited rather than an ES array field: Revit's array fields refuse an empty collection, and a receive
+  // that created no materials is perfectly normal.
+  private const char MATERIAL_SEPARATOR = '\n';
+
+  private readonly ILogger<RevitReceiveManifest> _logger;
+
+  public RevitReceiveManifest(ILogger<RevitReceiveManifest> logger)
+  {
+    _logger = logger;
+  }
+
+  /// <summary>The record left by the previous receive of this model, or null if there is none (or it can't be read).
+  /// Matches on (projectId, modelId) when both are supplied, else on <paramref name="marker"/>.</summary>
+  public RevitReceiveRecord? Find(Document doc, string? projectId, string? modelId, string marker)
+  {
+    try
+    {
+      // GetOrCreate, not Lookup: a schema is only registered in the session once someone builds it, so a plain
+      // Lookup can miss records written by an earlier session — and a miss here would silently orphan the prior
+      // bake and mint a second DataStorage on write. Building it needs no transaction.
+      var schema = GetOrCreateSchema();
+
+      bool byId = !string.IsNullOrEmpty(projectId) && !string.IsNullOrEmpty(modelId);
+      using var collector = new FilteredElementCollector(doc);
+      foreach (var element in collector.OfClass(typeof(DataStorage)))
+      {
+        if (element is not DataStorage storage)
+        {
+          continue;
+        }
+
+        var entity = storage.GetEntity(schema);
+        if (entity is null || !entity.IsValid())
+        {
+          continue;
+        }
+
+        // Ids win when we have them (rename-proof); the marker is the fallback for id-less records and the v1 path.
+        bool match = byId
+          ? string.Equals(entity.Get<string>(FIELD_PROJECT_ID), projectId, StringComparison.Ordinal)
+            && string.Equals(entity.Get<string>(FIELD_MODEL_ID), modelId, StringComparison.Ordinal)
+          : string.Equals(entity.Get<string>(FIELD_MARKER), marker, StringComparison.Ordinal);
+
+        if (!match)
+        {
+          continue;
+        }
+
+        var group = entity.Get<string>(FIELD_GROUP);
+        var materials = entity.Get<string>(FIELD_MATERIALS);
+        return new RevitReceiveRecord(
+          storage,
+          string.IsNullOrEmpty(group) ? null : group,
+          string.IsNullOrEmpty(materials)
+            ? Array.Empty<string>()
+            : materials.Split([MATERIAL_SEPARATOR], StringSplitOptions.RemoveEmptyEntries)
+        );
+      }
+    }
+    catch (Exception ex) when (!ex.IsFatal())
+    {
+      _logger.LogWarning(ex, "Could not read the Speckle receive manifest; falling back to name-based cleanup");
+    }
+
+    return null;
+  }
+
+  /// <summary>Records what this receive produced, updating <paramref name="existing"/> in place when the previous
+  /// receive left one. Must be called inside an open transaction.</summary>
+  public void Write(
+    Document doc,
+    DataStorage? existing,
+    string? projectId,
+    string? modelId,
+    string marker,
+    string? groupUniqueId,
+    IReadOnlyCollection<string> materialUniqueIds
+  )
+  {
+    try
+    {
+      var schema = GetOrCreateSchema();
+      // DataStorage is a document element, owned by the document — same non-disposal as View3D in RevitViewBaker.
+#pragma warning disable CA2000
+      var storage = existing is { IsValidObject: true } ? existing : DataStorage.Create(doc);
+#pragma warning restore CA2000
+
+      var entity = new Entity(schema);
+      entity.Set(FIELD_PROJECT_ID, projectId ?? string.Empty);
+      entity.Set(FIELD_MODEL_ID, modelId ?? string.Empty);
+      entity.Set(FIELD_MARKER, marker);
+      entity.Set(FIELD_GROUP, groupUniqueId ?? string.Empty);
+      entity.Set(FIELD_MATERIALS, string.Join(MATERIAL_SEPARATOR.ToString(), materialUniqueIds));
+      storage.SetEntity(entity);
+    }
+    catch (Exception ex) when (!ex.IsFatal())
+    {
+      // A missing manifest costs cleanup precision on the next receive, not this receive's geometry.
+      _logger.LogWarning(ex, "Could not write the Speckle receive manifest for '{Marker}'", marker);
+    }
+  }
+
+  private static Schema GetOrCreateSchema()
+  {
+    var existing = Schema.Lookup(s_schemaGuid);
+    if (existing is not null)
+    {
+      return existing;
+    }
+
+    using var builder = new SchemaBuilder(s_schemaGuid);
+    builder.SetSchemaName(SCHEMA_NAME);
+    builder.SetVendorId("SPKL");
+    builder.SetReadAccessLevel(AccessLevel.Public);
+    builder.SetWriteAccessLevel(AccessLevel.Public);
+    builder.AddSimpleField(FIELD_PROJECT_ID, typeof(string));
+    builder.AddSimpleField(FIELD_MODEL_ID, typeof(string));
+    builder.AddSimpleField(FIELD_MARKER, typeof(string));
+    builder.AddSimpleField(FIELD_GROUP, typeof(string));
+    builder.AddSimpleField(FIELD_MATERIALS, typeof(string));
+    return builder.Finish();
+  }
+}

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/RevitReceiveManifest.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/RevitReceiveManifest.cs
@@ -10,17 +10,11 @@ namespace Speckle.Connectors.Revit.HostApp;
 /// place instead of accumulating one per receive.</param>
 /// <param name="GroupUniqueId">UniqueId of the top-level Group the bake was collected into, or null when the bake
 /// predates grouping (or grouping failed).</param>
-/// <param name="MaterialUniqueIds">UniqueIds of the Materials that receive <b>created</b> — never ones it reused
-/// from the document, which belong to the user.</param>
-public sealed record RevitReceiveRecord(
-  DataStorage Storage,
-  string? GroupUniqueId,
-  IReadOnlyCollection<string> MaterialUniqueIds
-);
+public sealed record RevitReceiveRecord(DataStorage Storage, string? GroupUniqueId);
 
 /// <summary>
 /// The per-model receive manifest: a hidden <see cref="DataStorage"/> element carrying, in Extensible Storage, what
-/// the last receive of one model put into this document (its top-level Group and the Materials it created).
+/// the last receive of one model put into this document — its top-level Group.
 /// </summary>
 /// <remarks>
 /// <para>This is the tracking key that replaces the <c>Comments</c> parameter marker [ENG-8805]. Two properties matter:
@@ -45,11 +39,10 @@ public class RevitReceiveManifest
   private const string FIELD_MODEL_ID = "modelId";
   private const string FIELD_MARKER = "marker";
   private const string FIELD_GROUP = "groupUniqueId";
-  private const string FIELD_MATERIALS = "materialUniqueIds";
 
-  // Newline-delimited rather than an ES array field: Revit's array fields refuse an empty collection, and a receive
-  // that created no materials is perfectly normal.
-  private const char MATERIAL_SEPARATOR = '\n';
+  // Reserved. Materials are deliberately never purged (see RevitMaterialBaker), so nothing is recorded here — but the
+  // field stays in the schema, written empty, because the schema shape must keep matching records already in the wild.
+  private const string FIELD_MATERIALS = "materialUniqueIds";
 
   private readonly ILogger<RevitReceiveManifest> _logger;
 
@@ -96,14 +89,7 @@ public class RevitReceiveManifest
         }
 
         var group = entity.Get<string>(FIELD_GROUP);
-        var materials = entity.Get<string>(FIELD_MATERIALS);
-        return new RevitReceiveRecord(
-          storage,
-          string.IsNullOrEmpty(group) ? null : group,
-          string.IsNullOrEmpty(materials)
-            ? Array.Empty<string>()
-            : materials.Split([MATERIAL_SEPARATOR], StringSplitOptions.RemoveEmptyEntries)
-        );
+        return new RevitReceiveRecord(storage, string.IsNullOrEmpty(group) ? null : group);
       }
     }
     catch (Exception ex) when (!ex.IsFatal())
@@ -122,8 +108,7 @@ public class RevitReceiveManifest
     string? projectId,
     string? modelId,
     string marker,
-    string? groupUniqueId,
-    IReadOnlyCollection<string> materialUniqueIds
+    string? groupUniqueId
   )
   {
     try
@@ -139,7 +124,7 @@ public class RevitReceiveManifest
       entity.Set(FIELD_MODEL_ID, modelId ?? string.Empty);
       entity.Set(FIELD_MARKER, marker);
       entity.Set(FIELD_GROUP, groupUniqueId ?? string.Empty);
-      entity.Set(FIELD_MATERIALS, string.Join(MATERIAL_SEPARATOR.ToString(), materialUniqueIds));
+      entity.Set(FIELD_MATERIALS, string.Empty);
       storage.SetEntity(entity);
     }
     catch (Exception ex) when (!ex.IsFatal())

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/RevitReceiveTracker.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/RevitReceiveTracker.cs
@@ -13,28 +13,24 @@ namespace Speckle.Connectors.Revit.HostApp;
 /// <c>RevitHostObjectBuilder</c> and the artefact <c>RevitHostObjectArtefactBuilder</c> — go through here, so a
 /// document that has been received into by either is cleaned up correctly by the other.</para>
 /// <para>Cleanup runs newest tracking mechanism first, because a document can hold a bake from any generation of this
-/// connector: the manifest's Group by UniqueId (rename-proof), then the manifest's Materials, then a name-based Group
-/// purge for bakes that predate the manifest, then the transitional Comments-marker sweep for the generation of the
-/// artefact builder that tracked elements by stamping that parameter.</para>
+/// connector: the manifest's Group by UniqueId (rename-proof), then a name-based Group purge for bakes that predate
+/// the manifest, then the transitional Comments-marker sweep for the generation of the artefact builder that tracked
+/// elements by stamping that parameter.</para>
+/// <para>Materials are NOT part of this — receive reuses them by name and never writes over one, so they neither
+/// accumulate nor need purging, and a user's edits to a received material survive a re-receive. See
+/// <see cref="RevitMaterialBaker"/>.</para>
 /// <para>Callers must have an open transaction; every method mutates the document.</para>
 /// </remarks>
 public class RevitReceiveTracker
 {
   private readonly RevitReceiveManifest _manifest;
   private readonly RevitGroupBaker _groupBaker;
-  private readonly RevitMaterialBaker _materialBaker;
   private readonly RevitViewBaker _viewBaker;
 
-  public RevitReceiveTracker(
-    RevitReceiveManifest manifest,
-    RevitGroupBaker groupBaker,
-    RevitMaterialBaker materialBaker,
-    RevitViewBaker viewBaker
-  )
+  public RevitReceiveTracker(RevitReceiveManifest manifest, RevitGroupBaker groupBaker, RevitViewBaker viewBaker)
   {
     _manifest = manifest;
     _groupBaker = groupBaker;
-    _materialBaker = materialBaker;
     _viewBaker = viewBaker;
   }
 
@@ -52,9 +48,6 @@ public class RevitReceiveTracker
     {
       _groupBaker.PurgeGroupById(priorGroup);
     }
-
-    // Groups first, so these materials are no longer painted onto anything this receive is replacing.
-    _materialBaker.PurgeMaterials(_prior?.MaterialUniqueIds ?? []);
 
     // Bakes that predate the manifest — including v1 bakes, and the artefact builder's pre-ENG-9101 delegation to it.
     _groupBaker.PurgeGroups(marker);
@@ -81,9 +74,8 @@ public class RevitReceiveTracker
   }
 
   /// <summary>
-  /// Bakes <paramref name="groupMembers"/> into the pinned top-level group and records it, together with the
-  /// materials this receive created, for the next receive to clean up. Returns the group's UniqueId, or null when
-  /// there was nothing to group.
+  /// Bakes <paramref name="groupMembers"/> into the pinned top-level group and records it for the next receive to
+  /// clean up. Returns the group's UniqueId, or null when there was nothing to group.
   /// </summary>
   /// <param name="groupMembers">The elements to group, or null to use whatever was accumulated through
   /// <see cref="RevitGroupBaker.AddToTopLevelGroup"/> — the v1 builder collects members that way.</param>
@@ -92,27 +84,21 @@ public class RevitReceiveTracker
     string marker,
     string? projectId,
     string? modelId,
-    IReadOnlyCollection<ElementId>? groupMembers,
-    IReadOnlyCollection<string> createdMaterialUniqueIds
+    IReadOnlyCollection<ElementId>? groupMembers
   )
   {
     var groupUniqueId = groupMembers is null
       ? _groupBaker.BakeGroupForTopLevel(marker)
       : _groupBaker.BakeGroupForTopLevel(marker, groupMembers);
 
-    _manifest.Write(doc, _prior?.Storage, projectId, modelId, marker, groupUniqueId, createdMaterialUniqueIds);
+    _manifest.Write(doc, _prior?.Storage, projectId, modelId, marker, groupUniqueId);
     return groupUniqueId;
   }
 
-  /// <summary>Records this receive without baking a group — for when grouping failed, so the manifest still carries
-  /// the materials to clean up next time.</summary>
-  public void Record(
-    Document doc,
-    string marker,
-    string? projectId,
-    string? modelId,
-    IReadOnlyCollection<string> createdMaterialUniqueIds
-  ) => _manifest.Write(doc, _prior?.Storage, projectId, modelId, marker, null, createdMaterialUniqueIds);
+  /// <summary>Records this receive without a group — for when grouping failed, so the next receive still knows this
+  /// model was received into this document.</summary>
+  public void Record(Document doc, string marker, string? projectId, string? modelId) =>
+    _manifest.Write(doc, _prior?.Storage, projectId, modelId, marker, null);
 
   private static void CollectMarked(Document doc, Type elementClass, string marker, List<ElementId> toDelete)
   {

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/RevitReceiveTracker.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/RevitReceiveTracker.cs
@@ -1,0 +1,131 @@
+using Autodesk.Revit.DB;
+
+namespace Speckle.Connectors.Revit.HostApp;
+
+/// <summary>
+/// Owns how a receive marks its own output in the document and finds it again next time [ENG-8805]: it bakes the
+/// top-level Group everything lands in, records that Group and the Materials the receive created in the
+/// <see cref="RevitReceiveManifest"/>, and — at the start of the next receive — deletes exactly those.
+/// </summary>
+/// <remarks>
+/// <para>Grouping and tracking are one concern, not two: the Group <i>is</i> the handle on a received model, for the
+/// user (select/move/delete it in one click) and for the next receive alike. Both receive paths — the v1
+/// <c>RevitHostObjectBuilder</c> and the artefact <c>RevitHostObjectArtefactBuilder</c> — go through here, so a
+/// document that has been received into by either is cleaned up correctly by the other.</para>
+/// <para>Cleanup runs newest tracking mechanism first, because a document can hold a bake from any generation of this
+/// connector: the manifest's Group by UniqueId (rename-proof), then the manifest's Materials, then a name-based Group
+/// purge for bakes that predate the manifest, then the transitional Comments-marker sweep for the generation of the
+/// artefact builder that tracked elements by stamping that parameter.</para>
+/// <para>Callers must have an open transaction; every method mutates the document.</para>
+/// </remarks>
+public class RevitReceiveTracker
+{
+  private readonly RevitReceiveManifest _manifest;
+  private readonly RevitGroupBaker _groupBaker;
+  private readonly RevitMaterialBaker _materialBaker;
+  private readonly RevitViewBaker _viewBaker;
+
+  public RevitReceiveTracker(
+    RevitReceiveManifest manifest,
+    RevitGroupBaker groupBaker,
+    RevitMaterialBaker materialBaker,
+    RevitViewBaker viewBaker
+  )
+  {
+    _manifest = manifest;
+    _groupBaker = groupBaker;
+    _materialBaker = materialBaker;
+    _viewBaker = viewBaker;
+  }
+
+  // The record this receive found on the way in, so BakeGroupAndRecord updates that DataStorage in place rather than
+  // leaving one behind per receive. Scoped per receive, like the rest of the bakers.
+  private RevitReceiveRecord? _prior;
+
+  /// <summary>Deletes what the previous receive of this model left in <paramref name="doc"/>. See the class remarks
+  /// for the order and why there are four mechanisms.</summary>
+  public void PurgePriorReceive(Document doc, string marker, string? projectId, string? modelId)
+  {
+    _prior = _manifest.Find(doc, projectId, modelId, marker);
+
+    if (_prior?.GroupUniqueId is { Length: > 0 } priorGroup)
+    {
+      _groupBaker.PurgeGroupById(priorGroup);
+    }
+
+    // Groups first, so these materials are no longer painted onto anything this receive is replacing.
+    _materialBaker.PurgeMaterials(_prior?.MaterialUniqueIds ?? []);
+
+    // Bakes that predate the manifest — including v1 bakes, and the artefact builder's pre-ENG-9101 delegation to it.
+    _groupBaker.PurgeGroups(marker);
+    // Same marker convention, but a View3D can be neither grouped nor swept by PurgeMarkedElements below.
+    _viewBaker.PurgeArtefactViews(marker);
+  }
+
+  /// <summary>
+  /// Transitional: deletes elements stamped with the Comments marker by the generation of the artefact builder that
+  /// tracked them that way, which left no Group behind for <see cref="PurgePriorReceive"/> to find.
+  /// </summary>
+  /// <remarks>DirectShape (atomic objects and DirectShape instances) and FamilyInstance (instances baked as families)
+  /// were both stamped, so sweeping both covers whichever setting that receive ran with. Removable once no document
+  /// received into by those builds is still in circulation.</remarks>
+  public static void PurgeMarkedElements(Document doc, string marker)
+  {
+    var toDelete = new List<ElementId>();
+    CollectMarked(doc, typeof(DirectShape), marker, toDelete);
+    CollectMarked(doc, typeof(FamilyInstance), marker, toDelete);
+    if (toDelete.Count > 0)
+    {
+      doc.Delete(toDelete);
+    }
+  }
+
+  /// <summary>
+  /// Bakes <paramref name="groupMembers"/> into the pinned top-level group and records it, together with the
+  /// materials this receive created, for the next receive to clean up. Returns the group's UniqueId, or null when
+  /// there was nothing to group.
+  /// </summary>
+  /// <param name="groupMembers">The elements to group, or null to use whatever was accumulated through
+  /// <see cref="RevitGroupBaker.AddToTopLevelGroup"/> — the v1 builder collects members that way.</param>
+  public string? BakeGroupAndRecord(
+    Document doc,
+    string marker,
+    string? projectId,
+    string? modelId,
+    IReadOnlyCollection<ElementId>? groupMembers,
+    IReadOnlyCollection<string> createdMaterialUniqueIds
+  )
+  {
+    var groupUniqueId = groupMembers is null
+      ? _groupBaker.BakeGroupForTopLevel(marker)
+      : _groupBaker.BakeGroupForTopLevel(marker, groupMembers);
+
+    _manifest.Write(doc, _prior?.Storage, projectId, modelId, marker, groupUniqueId, createdMaterialUniqueIds);
+    return groupUniqueId;
+  }
+
+  /// <summary>Records this receive without baking a group — for when grouping failed, so the manifest still carries
+  /// the materials to clean up next time.</summary>
+  public void Record(
+    Document doc,
+    string marker,
+    string? projectId,
+    string? modelId,
+    IReadOnlyCollection<string> createdMaterialUniqueIds
+  ) => _manifest.Write(doc, _prior?.Storage, projectId, modelId, marker, null, createdMaterialUniqueIds);
+
+  private static void CollectMarked(Document doc, Type elementClass, string marker, List<ElementId> toDelete)
+  {
+    using var collector = new FilteredElementCollector(doc);
+    foreach (var element in collector.OfClass(elementClass))
+    {
+      if (
+        element.get_Parameter(BuiltInParameter.ALL_MODEL_INSTANCE_COMMENTS)?.AsString() is string c
+        && string.Equals(c, marker, StringComparison.Ordinal)
+      )
+      {
+        toDelete.Add(element.Id);
+      }
+    }
+  }
+}

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Receive/RevitHostObjectArtefactBuilder.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Receive/RevitHostObjectArtefactBuilder.cs
@@ -40,9 +40,15 @@ namespace Speckle.Connectors.Revit.Operations.Receive;
 /// nodes. The receive-side twin of the send-side <c>RevitArtifactRootObjectBuilder</c>.
 /// </summary>
 /// <remarks>
-/// <para><b>Grouping.</b> Revit has no layers; each baked element is stamped with its model marker in the Comments
-/// parameter so a re-receive can collect-and-delete the prior bake cheaply (a deliberate choice to avoid the slow v1
-/// Revit-Group baking). Element category comes from the object's <c>category</c>/<c>builtInCategory</c> property.</para>
+/// <para><b>Grouping and tracking [ENG-8805].</b> Revit has no layers, so — as in v1 — everything baked lands in one
+/// pinned, named top-level <see cref="Group"/> (<c>Project {project}: Model {model}</c>), which is both the user's
+/// handle on a received model (one click to select, move or delete it) and this receive's tracking key: a re-receive
+/// deletes the prior Group and its members. An earlier iteration of this builder skipped the Group for speed and
+/// stamped each element's <b>Comments</b> parameter with the marker instead; that hijacked a user-visible,
+/// schedulable field, and because the same field was the tracking key, a user editing it orphaned the element into a
+/// duplicate on the next receive. What survives of the marker is written to a hidden <see cref="RevitReceiveManifest"/>
+/// instead, keyed on project/model <i>ids</i> so a rename on the web no longer strands the prior bake.
+/// Element category comes from the object's <c>category</c>/<c>builtInCategory</c> property.</para>
 /// <para><b>Raw solids [ENG-8800].</b> An imported solid carries no material of its own (unlike a tessellated mesh,
 /// which bakes one into every face), so DirectShape solids are painted in a follow-up transaction after the bake
 /// commits — an element's faces aren't queryable before then. Meshes remain the shadow for whatever the importer
@@ -67,7 +73,7 @@ public sealed class RevitHostObjectArtefactBuilder : IArtifactHostObjectBuilder
   private readonly RevitUtils _revitUtils;
   private readonly ISdkActivityFactory _activityFactory;
   private readonly ILogger<RevitHostObjectArtefactBuilder> _logger;
-  private readonly RevitGroupBaker _groupBaker;
+  private readonly RevitReceiveTracker _tracker;
   private readonly RevitViewBaker _viewBaker;
   private readonly ITypedConverter<Base, List<GeometryObject>> _geometryConverter;
   private readonly RevitFamilyBaker _familyBaker;
@@ -87,7 +93,7 @@ public sealed class RevitHostObjectArtefactBuilder : IArtifactHostObjectBuilder
     RevitUtils revitUtils,
     ISdkActivityFactory activityFactory,
     ILogger<RevitHostObjectArtefactBuilder> logger,
-    RevitGroupBaker groupBaker,
+    RevitReceiveTracker tracker,
     RevitViewBaker viewBaker,
     ITypedConverter<Base, List<GeometryObject>> geometryConverter,
     RevitFamilyBaker familyBaker,
@@ -103,7 +109,7 @@ public sealed class RevitHostObjectArtefactBuilder : IArtifactHostObjectBuilder
     _revitUtils = revitUtils;
     _activityFactory = activityFactory;
     _logger = logger;
-    _groupBaker = groupBaker;
+    _tracker = tracker;
     _viewBaker = viewBaker;
     _geometryConverter = geometryConverter;
     _familyBaker = familyBaker;
@@ -113,23 +119,23 @@ public sealed class RevitHostObjectArtefactBuilder : IArtifactHostObjectBuilder
 
   public Task<HostObjectBuilderResult> Build(
     ArtefactBundle bundle,
-    string projectName,
-    string modelName,
+    ArtefactReceiveTarget target,
     IProgress<CardProgress> onOperationProgressed,
     CancellationToken cancellationToken
   ) =>
     // Revit API is main-thread-affine and mutations require a transaction → everything runs on the main thread.
-    _threadContext.RunOnMain(() => BakeAll(bundle, projectName, modelName, onOperationProgressed, cancellationToken));
+    _threadContext.RunOnMain(() => BakeAll(bundle, target, onOperationProgressed, cancellationToken));
 
   [SuppressMessage("Maintainability", "CA1506:Avoid excessive class coupling")]
   private HostObjectBuilderResult BakeAll(
     ArtefactBundle bundle,
-    string projectName,
-    string modelName,
+    ArtefactReceiveTarget target,
     IProgress<CardProgress> onOperationProgressed,
     CancellationToken cancellationToken
   )
   {
+    var projectName = target.ProjectName;
+    var modelName = target.ModelName;
     var marker = $"Project {projectName}: Model {modelName}";
     using var activity = _activityFactory.Start("Build (artefact)");
     using var session = ArtefactSessionLog.Start(
@@ -175,12 +181,20 @@ public sealed class RevitHostObjectArtefactBuilder : IArtifactHostObjectBuilder
     // TessellatedFace), so they are painted with the object's material — but only once the bake transaction has
     // committed, since an element's faces aren't queryable before then. Same ordering as v1 RevitHostObjectBuilder.
     var paintTargets = new List<(ElementId Element, ElementId Material)>();
+    // Members of the top-level group, collected as they are baked and grouped in one go after the bake commits
+    // [ENG-8805]. Threaded explicitly rather than accumulated in RevitGroupBaker's own state, matching how
+    // bakedObjectIds and paintTargets are already carried through this builder.
+    var groupMembers = new List<ElementId>();
+    // Materials this receive creates (never ones it reuses) — recorded in the manifest so the NEXT receive can
+    // delete exactly these.
+    var createdMaterialUniqueIds = new List<string>();
 
-    // 0 — clean a previous receive of this model (delete marked DirectShapes; reset the geometry-instance library).
+    // 0 — clean a previous receive of this model (its group + the materials it created; reset the geometry-instance
+    // library).
     _transactionManager.StartTransaction(true, "Pre receive clean");
     try
     {
-      PreClean(doc, marker);
+      PreClean(doc, marker, target);
     }
     catch (Exception ex) when (!ex.IsFatal())
     {
@@ -199,7 +213,7 @@ public sealed class RevitHostObjectArtefactBuilder : IArtifactHostObjectBuilder
       Dictionary<int, ElementId> materialIdByNode;
       using (session.Phase("Materials"))
       {
-        materialIdByNode = CreateMaterials(doc, bundle);
+        materialIdByNode = CreateMaterials(doc, bundle, createdMaterialUniqueIds);
       }
       var materialIdByGeometry = new Dictionary<int, ElementId>();
       foreach (var kv in rels.MaterialByGeometry)
@@ -220,10 +234,10 @@ public sealed class RevitHostObjectArtefactBuilder : IArtifactHostObjectBuilder
           materialIdByGeometry,
           validCategories,
           categoryCache,
-          marker,
           bakedObjectIds,
           conversionResults,
           paintTargets,
+          groupMembers,
           session,
           onOperationProgressed,
           cancellationToken
@@ -244,9 +258,9 @@ public sealed class RevitHostObjectArtefactBuilder : IArtifactHostObjectBuilder
               bundle,
               rels,
               materialIdByNode,
-              marker,
               bakedObjectIds,
               conversionResults,
+              groupMembers,
               session,
               cancellationToken
             );
@@ -260,10 +274,10 @@ public sealed class RevitHostObjectArtefactBuilder : IArtifactHostObjectBuilder
               materialIdByGeometry,
               validCategories,
               categoryCache,
-              marker,
               bakedObjectIds,
               conversionResults,
               paintTargets,
+              groupMembers,
               session,
               cancellationToken
             );
@@ -309,6 +323,36 @@ public sealed class RevitHostObjectArtefactBuilder : IArtifactHostObjectBuilder
       }
     }
 
+    // 5 — collect everything baked into one pinned top-level group, then record what this receive produced
+    // [ENG-8805]. Own transaction, after painting: an element's faces only exist once the bake commits, and painting
+    // a group member risks group-inconsistency warnings — same bake → paint → group order as v1.
+    using (session.Phase("Grouping"))
+    {
+      session.SetStat("groupMembers", groupMembers.Count);
+      _transactionManager.StartTransaction(true, "Grouping");
+      try
+      {
+        _tracker.BakeGroupAndRecord(
+          doc,
+          marker,
+          target.ProjectId,
+          target.ModelId,
+          groupMembers,
+          createdMaterialUniqueIds
+        );
+        _transactionManager.CommitTransaction();
+      }
+      catch (Exception ex) when (!ex.IsFatal())
+      {
+        // Revit refuses some element combinations (already grouped, differing design options/worksets). Leaving the
+        // elements loose costs organization and one-click selection, but it must never cost the user the geometry
+        // they just received — so fall back to recording the receive without a group.
+        _transactionManager.RollbackTransaction();
+        _logger.LogError(ex, "Artefact receive grouping failed for '{Marker}'", marker);
+        RecordWithoutGroup(doc, marker, target, createdMaterialUniqueIds);
+      }
+    }
+
     return new HostObjectBuilderResult(bakedObjectIds, conversionResults);
   }
 
@@ -321,10 +365,10 @@ public sealed class RevitHostObjectArtefactBuilder : IArtifactHostObjectBuilder
     Dictionary<int, ElementId> materialIdByGeometry,
     Dictionary<string, ElementId> validCategories,
     Dictionary<string, ElementId> categoryCache,
-    string marker,
     List<string> bakedObjectIds,
     HashSet<ReceiveConversionResult> conversionResults,
     List<(ElementId Element, ElementId Material)> paintTargets,
+    List<ElementId> groupMembers,
     ArtefactSessionLog session,
     IProgress<CardProgress> onOperationProgressed,
     CancellationToken cancellationToken
@@ -382,7 +426,7 @@ public sealed class RevitHostObjectArtefactBuilder : IArtifactHostObjectBuilder
         var ds = DirectShape.CreateElement(doc, ResolveCategory(doc, props, validCategories, categoryCache));
         SetNameSafe(ds, PropString(props, "name"));
         ds.SetShape(geometry);
-        StampMarker(ds, marker);
+        groupMembers.Add(ds.Id);
 
         if (fromSolid)
         {
@@ -414,10 +458,10 @@ public sealed class RevitHostObjectArtefactBuilder : IArtifactHostObjectBuilder
     Dictionary<int, ElementId> materialIdByGeometry,
     Dictionary<string, ElementId> validCategories,
     Dictionary<string, ElementId> categoryCache,
-    string marker,
     List<string> bakedObjectIds,
     HashSet<ReceiveConversionResult> conversionResults,
     List<(ElementId Element, ElementId Material)> paintTargets,
+    List<ElementId> groupMembers,
     ArtefactSessionLog session,
     CancellationToken cancellationToken
   )
@@ -588,7 +632,7 @@ public sealed class RevitHostObjectArtefactBuilder : IArtifactHostObjectBuilder
         var ds = DirectShape.CreateElement(doc, ResolveCategory(doc, props, validCategories, categoryCache));
         SetNameSafe(ds, PropString(props, "name"));
         ds.SetShape(geometry);
-        StampMarker(ds, marker);
+        groupMembers.Add(ds.Id);
 
         if (defPaintMaterialByNode.TryGetValue(defNodeK, out var paintMaterial))
         {
@@ -778,9 +822,9 @@ public sealed class RevitHostObjectArtefactBuilder : IArtifactHostObjectBuilder
     ArtefactBundle bundle,
     ArtefactRelations rels,
     Dictionary<int, ElementId> materialIdByNode,
-    string marker,
     List<string> bakedObjectIds,
     HashSet<ReceiveConversionResult> conversionResults,
+    List<ElementId> groupMembers,
     ArtefactSessionLog session,
     CancellationToken cancellationToken
   )
@@ -816,9 +860,9 @@ public sealed class RevitHostObjectArtefactBuilder : IArtifactHostObjectBuilder
       bundle,
       rels,
       symbolByDefNode,
-      marker,
       bakedObjectIds,
       conversionResults,
+      groupMembers,
       session,
       cancellationToken
     );
@@ -953,9 +997,9 @@ public sealed class RevitHostObjectArtefactBuilder : IArtifactHostObjectBuilder
     ArtefactBundle bundle,
     ArtefactRelations rels,
     Dictionary<int, FamilySymbol> symbolByDefNode,
-    string marker,
     List<string> bakedObjectIds,
     HashSet<ReceiveConversionResult> conversionResults,
+    List<ElementId> groupMembers,
     ArtefactSessionLog session,
     CancellationToken cancellationToken
   )
@@ -1011,7 +1055,7 @@ public sealed class RevitHostObjectArtefactBuilder : IArtifactHostObjectBuilder
             units,
             _converterSettings.Current.ReferencePointTransform
           ) ?? throw new ConversionException("Failed to place family instance");
-        StampMarker(instance, marker);
+        groupMembers.Add(instance.Id);
 
         bakedObjectIds.Add(instance.UniqueId);
         conversionResults.Add(new(Status.SUCCESS, source, instance.UniqueId, "FamilyInstance", null, srcType));
@@ -1357,7 +1401,11 @@ public sealed class RevitHostObjectArtefactBuilder : IArtifactHostObjectBuilder
   }
 
   // ── materials ─────────────────────────────────────────────────────────────────────────────────────────
-  private Dictionary<int, ElementId> CreateMaterials(Document doc, ArtefactBundle bundle)
+  private Dictionary<int, ElementId> CreateMaterials(
+    Document doc,
+    ArtefactBundle bundle,
+    List<string> createdMaterialUniqueIds
+  )
   {
     var idByNode = new Dictionary<int, ElementId>();
     // Dedup on name + the full colour signature. Name alone is not enough (older bundles carry no name, so every
@@ -1376,7 +1424,7 @@ public sealed class RevitHostObjectArtefactBuilder : IArtifactHostObjectBuilder
         var key = MaterialKey(node);
         if (!byKey.TryGetValue(key, out var id))
         {
-          id = FindOrCreateMaterial(doc, node);
+          id = FindOrCreateMaterial(doc, node, createdMaterialUniqueIds);
           byKey[key] = id;
         }
         idByNode[kv.Key] = id;
@@ -1400,7 +1448,7 @@ public sealed class RevitHostObjectArtefactBuilder : IArtifactHostObjectBuilder
       node.Roughness ?? 1.0
     );
 
-  private ElementId FindOrCreateMaterial(Document doc, ArtefactNode node)
+  private ElementId FindOrCreateMaterial(Document doc, ArtefactNode node, List<string> createdMaterialUniqueIds)
   {
     int argb = node.Argb ?? unchecked((int)0xFFFFFFFF);
     double opacity = Clamp01(node.Opacity ?? 1.0);
@@ -1438,6 +1486,9 @@ public sealed class RevitHostObjectArtefactBuilder : IArtifactHostObjectBuilder
     material.Transparency = (int)((1 - opacity) * 100);
     material.Shininess = (int)(metalness * 128);
     material.Smoothness = (int)((1 - roughness) * 100);
+    // Recorded (unlike the reuse branches above, which return a material the document already owned) so the next
+    // receive can delete exactly what this one created [ENG-8805].
+    createdMaterialUniqueIds.Add(material.UniqueId);
     return id;
   }
 
@@ -1626,45 +1677,37 @@ public sealed class RevitHostObjectArtefactBuilder : IArtifactHostObjectBuilder
   }
 
   // ── clean ─────────────────────────────────────────────────────────────────────────────────────────────
-  private void PreClean(Document doc, string marker)
+  /// <summary>Removes what a previous receive of this model left in the document, and resets the per-document
+  /// geometry-instance library the converter shares. See <see cref="RevitReceiveTracker"/> for the cleanup order.</summary>
+  private void PreClean(Document doc, string marker, ArtefactReceiveTarget target)
   {
     DirectShapeLibrary.GetDirectShapeLibrary(doc).Reset();
-    // A previous receive of this model may predate ENG-9101, when the family setting delegated the whole receive to
-    // the v1 builder and left a pinned top-level Group of real families — not tracked by the Comments marker below.
-    _groupBaker.PurgeGroups(marker);
-    // Same marker convention, but View3D isn't a DirectShape, so it's not covered by the collector loop below either.
-    _viewBaker.PurgeArtefactViews(marker);
-    var toDelete = new List<ElementId>();
-    // DirectShape (BakeAtomic/BakeInstances) and FamilyInstance (BakeInstancesAsFamilies) both stamp the same
-    // Comments marker, so cleaning up both covers whichever setting the prior receive used.
-    CollectMarked(doc, typeof(DirectShape), marker, toDelete);
-    CollectMarked(doc, typeof(FamilyInstance), marker, toDelete);
-    if (toDelete.Count > 0)
-    {
-      doc.Delete(toDelete);
-    }
+    _tracker.PurgePriorReceive(doc, marker, target.ProjectId, target.ModelId);
+    RevitReceiveTracker.PurgeMarkedElements(doc, marker);
   }
 
-  private static void CollectMarked(Document doc, Type elementClass, string marker, List<ElementId> toDelete)
+  // Grouping failed, but the materials this receive created still have to be cleanable next time.
+  private void RecordWithoutGroup(
+    Document doc,
+    string marker,
+    ArtefactReceiveTarget target,
+    IReadOnlyCollection<string> createdMaterialUniqueIds
+  )
   {
-    using var collector = new FilteredElementCollector(doc);
-    foreach (var element in collector.OfClass(elementClass))
+    _transactionManager.StartTransaction(true, "Speckle receive manifest");
+    try
     {
-      if (
-        element.get_Parameter(BuiltInParameter.ALL_MODEL_INSTANCE_COMMENTS)?.AsString() is string c
-        && string.Equals(c, marker, StringComparison.Ordinal)
-      )
-      {
-        toDelete.Add(element.Id);
-      }
+      _tracker.Record(doc, marker, target.ProjectId, target.ModelId, createdMaterialUniqueIds);
+      _transactionManager.CommitTransaction();
+    }
+    catch (Exception ex) when (!ex.IsFatal())
+    {
+      _transactionManager.RollbackTransaction();
+      _logger.LogError(ex, "Could not record the Speckle receive manifest for '{Marker}'", marker);
     }
   }
 
   // ── helpers ───────────────────────────────────────────────────────────────────────────────────────────
-  // Element, not DirectShape, so the same stamp works for FamilyInstances baked by BakeInstancesAsFamilies.
-  private static void StampMarker(Element element, string marker) =>
-    element.get_Parameter(BuiltInParameter.ALL_MODEL_INSTANCE_COMMENTS)?.Set(marker);
-
   private void SetNameSafe(DirectShape ds, string? name)
   {
     if (name is not { Length: > 0 })

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Receive/RevitHostObjectArtefactBuilder.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Receive/RevitHostObjectArtefactBuilder.cs
@@ -185,9 +185,6 @@ public sealed class RevitHostObjectArtefactBuilder : IArtifactHostObjectBuilder
     // [ENG-8805]. Threaded explicitly rather than accumulated in RevitGroupBaker's own state, matching how
     // bakedObjectIds and paintTargets are already carried through this builder.
     var groupMembers = new List<ElementId>();
-    // Materials this receive creates (never ones it reuses) — recorded in the manifest so the NEXT receive can
-    // delete exactly these.
-    var createdMaterialUniqueIds = new List<string>();
 
     // 0 — clean a previous receive of this model (its group + the materials it created; reset the geometry-instance
     // library).
@@ -213,7 +210,7 @@ public sealed class RevitHostObjectArtefactBuilder : IArtifactHostObjectBuilder
       Dictionary<int, ElementId> materialIdByNode;
       using (session.Phase("Materials"))
       {
-        materialIdByNode = CreateMaterials(doc, bundle, createdMaterialUniqueIds);
+        materialIdByNode = CreateMaterials(doc, bundle);
       }
       var materialIdByGeometry = new Dictionary<int, ElementId>();
       foreach (var kv in rels.MaterialByGeometry)
@@ -332,14 +329,7 @@ public sealed class RevitHostObjectArtefactBuilder : IArtifactHostObjectBuilder
       _transactionManager.StartTransaction(true, "Grouping");
       try
       {
-        _tracker.BakeGroupAndRecord(
-          doc,
-          marker,
-          target.ProjectId,
-          target.ModelId,
-          groupMembers,
-          createdMaterialUniqueIds
-        );
+        _tracker.BakeGroupAndRecord(doc, marker, target.ProjectId, target.ModelId, groupMembers);
         _transactionManager.CommitTransaction();
       }
       catch (Exception ex) when (!ex.IsFatal())
@@ -349,7 +339,7 @@ public sealed class RevitHostObjectArtefactBuilder : IArtifactHostObjectBuilder
         // they just received — so fall back to recording the receive without a group.
         _transactionManager.RollbackTransaction();
         _logger.LogError(ex, "Artefact receive grouping failed for '{Marker}'", marker);
-        RecordWithoutGroup(doc, marker, target, createdMaterialUniqueIds);
+        RecordWithoutGroup(doc, marker, target);
       }
     }
 
@@ -1401,11 +1391,7 @@ public sealed class RevitHostObjectArtefactBuilder : IArtifactHostObjectBuilder
   }
 
   // ── materials ─────────────────────────────────────────────────────────────────────────────────────────
-  private Dictionary<int, ElementId> CreateMaterials(
-    Document doc,
-    ArtefactBundle bundle,
-    List<string> createdMaterialUniqueIds
-  )
+  private Dictionary<int, ElementId> CreateMaterials(Document doc, ArtefactBundle bundle)
   {
     var idByNode = new Dictionary<int, ElementId>();
     // Dedup on name + the full colour signature. Name alone is not enough (older bundles carry no name, so every
@@ -1424,7 +1410,7 @@ public sealed class RevitHostObjectArtefactBuilder : IArtifactHostObjectBuilder
         var key = MaterialKey(node);
         if (!byKey.TryGetValue(key, out var id))
         {
-          id = FindOrCreateMaterial(doc, node, createdMaterialUniqueIds);
+          id = FindOrCreateMaterial(doc, node);
           byKey[key] = id;
         }
         idByNode[kv.Key] = id;
@@ -1448,7 +1434,7 @@ public sealed class RevitHostObjectArtefactBuilder : IArtifactHostObjectBuilder
       node.Roughness ?? 1.0
     );
 
-  private ElementId FindOrCreateMaterial(Document doc, ArtefactNode node, List<string> createdMaterialUniqueIds)
+  private ElementId FindOrCreateMaterial(Document doc, ArtefactNode node)
   {
     int argb = node.Argb ?? unchecked((int)0xFFFFFFFF);
     double opacity = Clamp01(node.Opacity ?? 1.0);
@@ -1464,21 +1450,18 @@ public sealed class RevitHostObjectArtefactBuilder : IArtifactHostObjectBuilder
     }
     var name = _revitUtils.RemoveInvalidChars(label);
 
-    // A Revit material is identified by name, so re-receives reuse the existing element — but only when its colour
-    // still matches. Two source materials can legitimately share a name with different colours (Rhino allows it);
-    // suffixing the ARGB keeps the second one from silently inheriting the first one's appearance. Names are only
-    // authoritative now that producers carry them; the colour-derived fallback label was already unique per colour.
-    var revitColor = new Color((byte)((argb >> 16) & 0xFF), (byte)((argb >> 8) & 0xFF), (byte)(argb & 0xFF));
+    // A Revit material is identified by name: an existing one is reused AS IS, and its properties are never written
+    // back over. That is deliberate and matches the v1 builder (RevitMaterialBaker.BakeMaterial) — a user who
+    // recolours a received material keeps that edit across re-receives instead of having it reverted [ENG-8805].
+    // The trade-off, also inherited from v1: two source materials that share a name but not a colour collapse onto
+    // whichever one the document already holds.
     var existing = FindMaterialByName(doc, name);
-    if (existing is not null && !SameColor(existing.Color, revitColor))
-    {
-      name = _revitUtils.RemoveInvalidChars($"{label} {(uint)argb:X8}");
-      existing = FindMaterialByName(doc, name);
-    }
     if (existing is not null)
     {
       return existing.Id;
     }
+
+    var revitColor = new Color((byte)((argb >> 16) & 0xFF), (byte)((argb >> 8) & 0xFF), (byte)(argb & 0xFF));
 
     var id = Material.Create(doc, name);
     var material = (Material)doc.GetElement(id);
@@ -1486,9 +1469,6 @@ public sealed class RevitHostObjectArtefactBuilder : IArtifactHostObjectBuilder
     material.Transparency = (int)((1 - opacity) * 100);
     material.Shininess = (int)(metalness * 128);
     material.Smoothness = (int)((1 - roughness) * 100);
-    // Recorded (unlike the reuse branches above, which return a material the document already owned) so the next
-    // receive can delete exactly what this one created [ENG-8805].
-    createdMaterialUniqueIds.Add(material.UniqueId);
     return id;
   }
 
@@ -1500,11 +1480,6 @@ public sealed class RevitHostObjectArtefactBuilder : IArtifactHostObjectBuilder
       .Cast<Material>()
       .FirstOrDefault(m => string.Equals(m.Name, name, StringComparison.OrdinalIgnoreCase));
   }
-
-  // An existing material with no valid colour counts as a match — there is nothing to compare against, and minting a
-  // suffixed duplicate on every receive would be worse than reusing it.
-  private static bool SameColor(Color existing, Color wanted) =>
-    !existing.IsValid || (existing.Red == wanted.Red && existing.Green == wanted.Green && existing.Blue == wanted.Blue);
 
   private static double Clamp01(double v) =>
     v < 0 ? 0
@@ -1686,18 +1661,13 @@ public sealed class RevitHostObjectArtefactBuilder : IArtifactHostObjectBuilder
     RevitReceiveTracker.PurgeMarkedElements(doc, marker);
   }
 
-  // Grouping failed, but the materials this receive created still have to be cleanable next time.
-  private void RecordWithoutGroup(
-    Document doc,
-    string marker,
-    ArtefactReceiveTarget target,
-    IReadOnlyCollection<string> createdMaterialUniqueIds
-  )
+  // Grouping failed, but the receive still has to be on record so the next one knows this model was received here.
+  private void RecordWithoutGroup(Document doc, string marker, ArtefactReceiveTarget target)
   {
     _transactionManager.StartTransaction(true, "Speckle receive manifest");
     try
     {
-      _tracker.Record(doc, marker, target.ProjectId, target.ModelId, createdMaterialUniqueIds);
+      _tracker.Record(doc, marker, target.ProjectId, target.ModelId);
       _transactionManager.CommitTransaction();
     }
     catch (Exception ex) when (!ex.IsFatal())

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Receive/RevitHostObjectBuilder.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Receive/RevitHostObjectBuilder.cs
@@ -47,7 +47,8 @@ public sealed class RevitHostObjectBuilder(
   RevitFamilyBaker familyBaker,
   DirectShapeUnpackStrategy directShapeUnpackStrategy,
   FamilyUnpackStrategy familyUnpackStrategy,
-  RevitPreBakeSetupService preBakeSetupService
+  RevitPreBakeSetupService preBakeSetupService,
+  RevitReceiveTracker receiveTracker
 ) : IHostObjectBuilder, IDisposable
 {
   public Task<HostObjectBuilderResult> Build(
@@ -197,11 +198,20 @@ public sealed class RevitHostObjectBuilder(
       transactionManager.CommitTransaction();
     }
 
-    // 7 - Create group
+    // 7 - Create the group AND record it, so the next receive can clean up exactly what this one produced
+    // [ENG-8805]. This path has no project/model ids to key the record on, so it is found again by the marker name —
+    // the same rename-fragility v1 always had.
     {
       using var _ = activityFactory.Start("Grouping");
       transactionManager.StartTransaction(true, "Grouping");
-      groupManager.BakeGroupForTopLevel(baseGroupName);
+      receiveTracker.BakeGroupAndRecord(
+        converterSettings.Current.Document,
+        baseGroupName,
+        null,
+        null,
+        null, // members were accumulated through groupManager.AddToTopLevelGroup during the bake
+        materialBaker.CreatedMaterialUniqueIds
+      );
       transactionManager.CommitTransaction();
     }
 
@@ -368,35 +378,11 @@ public sealed class RevitHostObjectBuilder(
     DirectShapeLibrary.GetDirectShapeLibrary(converterSettings.Current.Document).Reset(); // Note: this needs to be cleared, as it is being used in the converter
 
     revitToHostCacheSingleton.Clear(); // "Massive hack!" - Anonymous. Ogu and Björn: it looks legit
-    groupManager.PurgeGroups(baseGroupName);
-    materialBaker.PurgeMaterials(baseGroupName);
-    PurgePriorArtefactDirectBake(baseGroupName);
-  }
-
-  // A previous receive of this model may have gone through the artefact direct-bake path (RevitHostObjectArtefactBuilder,
-  // used when ReceiveInstancesAsFamilies was off) and left Comments-marker-stamped DirectShapes behind — those aren't
-  // members of a Revit Group, so PurgeGroups above won't find them. Clean them up here too.
-  private void PurgePriorArtefactDirectBake(string marker)
-  {
     var doc = converterSettings.Current.Document;
-    var toDelete = new List<ElementId>();
-    using (var collector = new FilteredElementCollector(doc))
-    {
-      foreach (var element in collector.OfClass(typeof(DirectShape)))
-      {
-        if (
-          element.get_Parameter(BuiltInParameter.ALL_MODEL_INSTANCE_COMMENTS)?.AsString() is string c
-          && string.Equals(c, marker, StringComparison.Ordinal)
-        )
-        {
-          toDelete.Add(element.Id);
-        }
-      }
-    }
-    if (toDelete.Count > 0)
-    {
-      doc.Delete(toDelete);
-    }
+    receiveTracker.PurgePriorReceive(doc, baseGroupName, null, null);
+    // A previous receive of this model may have gone through the artefact direct-bake path and left
+    // Comments-marker-stamped elements behind — those are in no Revit Group, so the purge above won't find them.
+    RevitReceiveTracker.PurgeMarkedElements(doc, baseGroupName);
   }
 
   public void Dispose() => transactionManager.Dispose();

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Receive/RevitHostObjectBuilder.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Receive/RevitHostObjectBuilder.cs
@@ -34,7 +34,6 @@ public sealed class RevitHostObjectBuilder(
   ITransactionManager transactionManager,
   ISdkActivityFactory activityFactory,
   RevitGroupBaker groupManager,
-  RevitMaterialBaker materialBaker,
   RootObjectUnpacker rootObjectUnpacker,
   ILogger<RevitHostObjectBuilder> logger,
   IThreadContext threadContext,
@@ -209,8 +208,7 @@ public sealed class RevitHostObjectBuilder(
         baseGroupName,
         null,
         null,
-        null, // members were accumulated through groupManager.AddToTopLevelGroup during the bake
-        materialBaker.CreatedMaterialUniqueIds
+        null // members were accumulated through groupManager.AddToTopLevelGroup during the bake
       );
       transactionManager.CommitTransaction();
     }

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Speckle.Connectors.RevitShared.projitems
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Speckle.Connectors.RevitShared.projitems
@@ -46,6 +46,8 @@
     <Compile Include="$(MSBuildThisFileDirectory)HostApp\RevitDocumentStore.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DependencyInjection\RevitConnectorModule.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HostApp\RevitGroupBaker.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)HostApp\RevitReceiveManifest.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)HostApp\RevitReceiveTracker.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HostApp\RevitUtils.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HostApp\SendCollectionManager.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HostApp\ElementUnpacker.cs" />

--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/Operations/Receive/RhinoHostObjectArtefactBuilder.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/Operations/Receive/RhinoHostObjectArtefactBuilder.cs
@@ -76,15 +76,14 @@ public class RhinoHostObjectArtefactBuilder : IArtifactHostObjectBuilder
 
   public Task<HostObjectBuilderResult> Build(
     ArtefactBundle bundle,
-    string projectName,
-    string modelName,
+    ArtefactReceiveTarget target,
     IProgress<CardProgress> onOperationProgressed,
     CancellationToken cancellationToken
   )
   {
     // All Rhino document mutation happens on the main thread in one hop (no awaits inside → no sync-over-async deadlock).
     return _threadContext.RunOnMain(() =>
-      BakeAll(bundle, projectName, modelName, onOperationProgressed, cancellationToken)
+      BakeAll(bundle, target.ProjectName, target.ModelName, onOperationProgressed, cancellationToken)
     );
   }
 

--- a/Sdk/Speckle.Connectors.Common/Builders/IArtifactHostObjectBuilder.cs
+++ b/Sdk/Speckle.Connectors.Common/Builders/IArtifactHostObjectBuilder.cs
@@ -4,19 +4,30 @@ using Speckle.Sdk.Pipelines.Receive.Artifacts;
 namespace Speckle.Connectors.Common.Builders;
 
 /// <summary>
+/// Which model is being received, by both name and id. Names are what the host document shows the user (layer/group
+/// names); ids are stable across a rename on the web, so a host that tracks a prior bake in order to clean it up
+/// should key on those [ENG-8805].
+/// </summary>
+public readonly record struct ArtefactReceiveTarget(
+  string ProjectId,
+  string ProjectName,
+  string ModelId,
+  string ModelName
+);
+
+/// <summary>
 /// Host builder for the Speckle 4.0 artefact path that bakes a parsed <see cref="ArtefactBundle"/> <b>directly</b> into
 /// the host application — geometry straight from the parquet blobs (3dm solids / SGEO meshes), layers/materials/instances
 /// straight from the envelope graph — without reconstructing the v1 <c>Base</c>/<c>DataObject</c> graph or going through
 /// the v1 traversal + converter pipeline. The receive-side twin of the send-side <c>IArtifactRootObjectBuilder</c>.
-/// Connectors that can consume the artefact geometry natively (Rhino: 3dm) register this; connectors that cannot (Revit)
+/// Connectors that can consume the artefact geometry natively (Rhino: 3dm) register this; connectors that cannot
 /// leave it unregistered and fall back to the <c>ObjectsArtifactReader</c> reconstruction + the v1 host builder.
 /// </summary>
 public interface IArtifactHostObjectBuilder
 {
   Task<HostObjectBuilderResult> Build(
     ArtefactBundle bundle,
-    string projectName,
-    string modelName,
+    ArtefactReceiveTarget target,
     IProgress<CardProgress> onOperationProgressed,
     CancellationToken cancellationToken
   );

--- a/Sdk/Speckle.Connectors.Common/Operations/ReceiveOperation.cs
+++ b/Sdk/Speckle.Connectors.Common/Operations/ReceiveOperation.cs
@@ -56,7 +56,17 @@ public sealed class ReceiveOperation(
         {
           // direct-bake path: parquet → host doc, no Base reconstruction.
           artefactRes = await artifactHostObjectBuilder
-            .Build(bundle, receiveInfo.ProjectName, receiveInfo.ModelName, onOperationProgressed, cancellationToken)
+            .Build(
+              bundle,
+              new ArtefactReceiveTarget(
+                receiveInfo.ProjectId,
+                receiveInfo.ProjectName,
+                receiveInfo.ModelId,
+                receiveInfo.ModelName
+              ),
+              onOperationProgressed,
+              cancellationToken
+            )
             .ConfigureAwait(false);
         }
         else


### PR DESCRIPTION
Closes [ENG-8805](https://linear.app/speckle/issue/ENG-8805/no-groups-comments-parameter-hijacked-for-tracking-duplicates-on).

## What was wrong

The artefact receive path organised nothing and tracked its bake by stamping every element's **Comments** parameter with `Project X: Model Y`. Comments is user-visible, schedulable and commonly used for documentation — and because the same field was the tracking key, a user editing it orphaned that element into a **duplicate** on the next receive.

Since the ticket was filed, the upgrade-path duplication (regression #3) was already fixed in both directions. What remained: no grouping (#1), the Comments hijack (#2), and rename orphans (#4). Note the ticket's scope line is stale — the artefact builder is no longer `#if NET8_0_OR_GREATER`-gated, so this affected **Revit 2023–2027**, not just 2025+.

## What this does

**Grouping is back, v1-style.** Everything baked lands in one pinned, named top-level `Group` — the user's handle on a received model (one click to select/move/delete) and the receive's tracking key. Baked in its own transaction after painting, matching v1's bake → paint → group order, because an element's faces only exist once the bake commits and painting a group member risks group-inconsistency warnings. If Revit refuses the group (already-grouped elements, differing design options/worksets) the receive logs and keeps the geometry rather than failing.

**Comments is free.** What survives of the marker goes into a hidden per-model manifest — Extensible Storage on a `DataStorage` element — recording the Group and the Materials the receive created, keyed on project/model **ids** so a rename on the web no longer strands the prior bake.

**No send-side change was needed.** The marker was already derived from names the receive operation passes; the ids were already on `ReceiveInfo`, just not forwarded to the builder. `IArtifactHostObjectBuilder.Build` now takes an `ArtefactReceiveTarget` (ids + names) — mechanical update for Rhino and AutoCAD, which use the names as before.

## The PurgeMaterials finding

Worth reading on its own, because "port `PurgeMaterials` to the artefact path" would have been the wrong fix.

`RevitMaterialBaker.PurgeMaterials(baseGroupName)` deleted every `Material` whose name *contained* the sanitised base group name. But `BakeMaterial` names materials after the Speckle material alone, with **no project/model suffix** — so the predicate never matched anything it created. It was a **no-op on `dev` as well**, and what actually prevents material accumulation in v1 is reuse-by-name in `FindExistingMaterialByName`. It also carried an unscoped delete: a user's own material named after the project or model would have been removed.

It now deletes exactly the materials recorded in the manifest, and only ones the receive **created** — never ones it reused from the document, which are the user's. This also closes the artefact path's real gap: when a material's colour changed between versions a second `Foo AARRGGBB` element was minted and the original orphaned.

## Cleanup order

A document can hold a bake from any generation of this connector, so `PurgePriorReceive` runs newest mechanism first: manifest Group by UniqueId (rename-proof) → manifest Materials → name-based `PurgeGroups` (v1 and pre-manifest bakes) → a **transitional** Comments sweep for bakes made between the direct-bake path landing and this change. That last one is marked removable once no such document is in circulation.

Grouping and tracking are now one concern in `RevitReceiveTracker`, used by **both** receive paths, so a document received into by either is cleaned up correctly by the other.

## Known limitation

Inherited from v1, unchanged: explicitly ungrouping a received model leaves its elements untracked, and the next receive bakes alongside them. Tracking every element individually would mean a multi-megabyte manifest on a large model for no gain over the group purge.

## Testing

Builds clean (`Local.slnx -c Local`, all Revit versions + Rhino/AutoCAD/Civil3D). There is no test harness for the Revit host builders, so this needs manual QA:

| # | Scenario | Expected |
|---|---|---|
| a | Receive twice into the same doc | one group, no duplicate geometry |
| b | Edit Comments on a baked element between receives | no duplicate — tracking no longer keys on Comments |
| c | Bake on a pre-change `big-truck` build, then re-receive on this one | transitional sweep cleans it |
| d | v1 bake → artefact receive, and artefact bake → v1 receive | both cleaned |
| e | **Rename the model on web, re-receive** | prior bake cleaned (this is the new one) |
| f | Large model | check the `Grouping` phase duration in the artefact session log — this is the perf cost that motivated dropping groups |
| g | `Receive Blocks as Families` on **and** off | both bake sites join the group |
| h | Camera views | still purged, never grouped |
| i | Receive, change a material's colour upstream, re-receive | old material cleaned, no orphan |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
