### PR TITLE
build: add tsd project group so release zips the TSD connector

### DIFF
--- a/Build/Consts.cs
+++ b/Build/Consts.cs
@@ -78,6 +78,7 @@ internal static class Consts
         new("Connectors/CSi/Speckle.Connectors.ETABS22", "net8.0-windows"),
       ]
     ),
+    new("tsd", [new("Connectors/TSD/Speckle.Connectors.TSD2027", "net10.0-windows")]),
     new("rhino-importer", [new("Importers/Rhino/Speckle.Importers.JobProcessor", "net8.0-windows")]),
   };
 }


### PR DESCRIPTION
## Summary
Adds the `tsd` installer slug (`Connectors/TSD/Speckle.Connectors.TSD2027`, `net10.0-windows`) to `Build/Consts.cs` so `build.ps1 zip` emits `output/tsd.zip` for the installer pipeline.

Pairs with specklesystems/connector-installers PR adding `iss/tsd.iss` (installs flat into `%LOCALAPPDATA%\Trimble\Tekla Structural Designer\Extensions\`, as confirmed by the TSD developer team).

## Verification
- `dotnet build -c Release` of the TSD project succeeds (59 files).
- The resulting folder was staged as `outputs/tsd/Speckle.Connectors.TSD2027/` and `tsd.iss` compiled clean with Inno Setup 6.
- csharpier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KSzZY15XWuBT48xQAjsizj