### PR TITLE
Include assembly name in TSD extension path

### DIFF
--- a/Connectors/TSD/Speckle.Connectors.TSD2027/Speckle.Connectors.TSD2027.csproj
+++ b/Connectors/TSD/Speckle.Connectors.TSD2027/Speckle.Connectors.TSD2027.csproj
@@ -26,7 +26,7 @@
 
   <Target Name="DeployToTsdExtensions" AfterTargets="Build" Condition="'$(GITHUB_ACTIONS)' != 'true'">
     <PropertyGroup>
-      <TsdExtensionsDir>$(LOCALAPPDATA)\Trimble\Tekla Structural Designer\Extensions\</TsdExtensionsDir>
+      <TsdExtensionsDir>$(LOCALAPPDATA)\Trimble\Tekla Structural Designer\Extensions\$(AssemblyName)\</TsdExtensionsDir>
     </PropertyGroup>
     <ItemGroup>
       <TsdDeployFiles Include="$(OutDir)**\*.*" />


### PR DESCRIPTION
<!---

Provide a short summary in the Title above. Use the following template:

category(project): summary

Categories:

* feat: (new feature for the user, not a new feature for build script)
* fix: (bug fix for the user, not a fix to a build script)
* docs: (changes to the documentation)
* style: (formatting, missing semi colons, etc; no production code change)
* refactor: (refactoring production code, eg. renaming a variable)
* test: (adding missing tests, refactoring tests; no production code change)
* chore: (updating grunt tasks etc; no production code change)

Example:

feat(revit): added category filter to send

-->

## Description
I'm proposing this change on behalf of the TSD team. We need the Speckle TSD connector to be isolated from other potential extensions in the target path.

<!---

Describe your changes, and why you're making them.

Link related github issues here ->
Fixes #85, Fixes #22, Connects #123

-->

## User Value
Separates the connector from other potential extensions. Allows having multiple versions of the connector.

## Changes:
Updated the target dir of the `DeployToTsdExtensions` build target.

## Screenshots:
_Not relevant_

## Validation of changes:
Manually tested connection with a running TSD instance.
