### PR TITLE
feat(revit,grasshopper): CENTERLINE rel for MEP systems

### DIFF
--- a/Connectors/Autocad/Speckle.Connectors.Autocad2023/packages.lock.json
+++ b/Connectors/Autocad/Speckle.Connectors.Autocad2023/packages.lock.json
@@ -202,16 +202,16 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "o+u1sRKl+KUmxvGHoNhBu+JJtGseDDxevu0khtPrZ6A15AMQ8+jRK7n9C2HkOXlNexVUwKiC8WnAa6/LUo6JHQ==",
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "yM8ZPViRCYZyVoyB2aRXAnQ8HuLA7E9pAjQSk01Rys5EUSBHHQCVMOeOY/maZRUeXVVfqu+/DyV8ST4kjZyYBg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.10"
         }
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "l2Oa6SC8hq8f48mdWIXfnVbaUTlhKlrRVsGVUJSOnB77qPuwmj3CyZXoWFH/Gs9kcaEuC2wkbLRHndLpA77zcg=="
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "XpO62cnn84vGZUubF1CJ4GrsxUujwwdrv26T9uqsLLhzSWnxujNclrunZXcmJGGykufUWNT5SaDhd3UiMH17hw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -326,7 +326,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "speckle.connectors.dui": {
@@ -355,7 +355,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "Microsoft.Web.WebView2": {
@@ -372,9 +372,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-beta.4, )",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "qdHMddzoXCFv8dFe6FrwnLlSzlZNvZ1cv1842zO6HArROE1NOHK50zT8OtrPJJCwZSbBCaogyVxQTXWffDPl4A==",
+        "requested": "[2026.9.0-beta.5, )",
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "24tOTnFe3D8q0SWVCRGdhmDSuvZSicPK0RhzzjQBuT2MfR8goQxsKFcT7ogLWxFGsim5CTqKRidKhf13Wx+vjg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -384,8 +384,8 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-beta.4",
-          "Speckle.Sdk.Parquet": "2026.9.0-beta.4",
+          "Speckle.Sdk.Dependencies": "2026.9.0-beta.5",
+          "Speckle.Sdk.Parquet": "2026.9.0-beta.5",
           "System.Memory": "4.5.5",
           "System.Text.Json": "5.0.2"
         }

--- a/Connectors/Autocad/Speckle.Connectors.Autocad2024/packages.lock.json
+++ b/Connectors/Autocad/Speckle.Connectors.Autocad2024/packages.lock.json
@@ -202,16 +202,16 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "o+u1sRKl+KUmxvGHoNhBu+JJtGseDDxevu0khtPrZ6A15AMQ8+jRK7n9C2HkOXlNexVUwKiC8WnAa6/LUo6JHQ==",
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "yM8ZPViRCYZyVoyB2aRXAnQ8HuLA7E9pAjQSk01Rys5EUSBHHQCVMOeOY/maZRUeXVVfqu+/DyV8ST4kjZyYBg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.10"
         }
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "l2Oa6SC8hq8f48mdWIXfnVbaUTlhKlrRVsGVUJSOnB77qPuwmj3CyZXoWFH/Gs9kcaEuC2wkbLRHndLpA77zcg=="
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "XpO62cnn84vGZUubF1CJ4GrsxUujwwdrv26T9uqsLLhzSWnxujNclrunZXcmJGGykufUWNT5SaDhd3UiMH17hw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -326,7 +326,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "speckle.connectors.dui": {
@@ -356,7 +356,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "Microsoft.Web.WebView2": {
@@ -373,9 +373,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-beta.4, )",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "qdHMddzoXCFv8dFe6FrwnLlSzlZNvZ1cv1842zO6HArROE1NOHK50zT8OtrPJJCwZSbBCaogyVxQTXWffDPl4A==",
+        "requested": "[2026.9.0-beta.5, )",
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "24tOTnFe3D8q0SWVCRGdhmDSuvZSicPK0RhzzjQBuT2MfR8goQxsKFcT7ogLWxFGsim5CTqKRidKhf13Wx+vjg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -385,8 +385,8 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-beta.4",
-          "Speckle.Sdk.Parquet": "2026.9.0-beta.4",
+          "Speckle.Sdk.Dependencies": "2026.9.0-beta.5",
+          "Speckle.Sdk.Parquet": "2026.9.0-beta.5",
           "System.Memory": "4.5.5",
           "System.Text.Json": "5.0.2"
         }

--- a/Connectors/Autocad/Speckle.Connectors.Autocad2025/packages.lock.json
+++ b/Connectors/Autocad/Speckle.Connectors.Autocad2025/packages.lock.json
@@ -139,13 +139,13 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "o+u1sRKl+KUmxvGHoNhBu+JJtGseDDxevu0khtPrZ6A15AMQ8+jRK7n9C2HkOXlNexVUwKiC8WnAa6/LUo6JHQ=="
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "yM8ZPViRCYZyVoyB2aRXAnQ8HuLA7E9pAjQSk01Rys5EUSBHHQCVMOeOY/maZRUeXVVfqu+/DyV8ST4kjZyYBg=="
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "l2Oa6SC8hq8f48mdWIXfnVbaUTlhKlrRVsGVUJSOnB77qPuwmj3CyZXoWFH/Gs9kcaEuC2wkbLRHndLpA77zcg=="
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "XpO62cnn84vGZUubF1CJ4GrsxUujwwdrv26T9uqsLLhzSWnxujNclrunZXcmJGGykufUWNT5SaDhd3UiMH17hw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -192,7 +192,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "speckle.connectors.dui": {
@@ -222,7 +222,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "Microsoft.Web.WebView2": {
@@ -239,9 +239,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-beta.4, )",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "qdHMddzoXCFv8dFe6FrwnLlSzlZNvZ1cv1842zO6HArROE1NOHK50zT8OtrPJJCwZSbBCaogyVxQTXWffDPl4A==",
+        "requested": "[2026.9.0-beta.5, )",
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "24tOTnFe3D8q0SWVCRGdhmDSuvZSicPK0RhzzjQBuT2MfR8goQxsKFcT7ogLWxFGsim5CTqKRidKhf13Wx+vjg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -249,8 +249,8 @@
           "Microsoft.Extensions.ObjectPool": "8.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-beta.4",
-          "Speckle.Sdk.Parquet": "2026.9.0-beta.4"
+          "Speckle.Sdk.Dependencies": "2026.9.0-beta.5",
+          "Speckle.Sdk.Parquet": "2026.9.0-beta.5"
         }
       }
     },

--- a/Connectors/Autocad/Speckle.Connectors.Autocad2026/packages.lock.json
+++ b/Connectors/Autocad/Speckle.Connectors.Autocad2026/packages.lock.json
@@ -139,13 +139,13 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "o+u1sRKl+KUmxvGHoNhBu+JJtGseDDxevu0khtPrZ6A15AMQ8+jRK7n9C2HkOXlNexVUwKiC8WnAa6/LUo6JHQ=="
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "yM8ZPViRCYZyVoyB2aRXAnQ8HuLA7E9pAjQSk01Rys5EUSBHHQCVMOeOY/maZRUeXVVfqu+/DyV8ST4kjZyYBg=="
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "l2Oa6SC8hq8f48mdWIXfnVbaUTlhKlrRVsGVUJSOnB77qPuwmj3CyZXoWFH/Gs9kcaEuC2wkbLRHndLpA77zcg=="
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "XpO62cnn84vGZUubF1CJ4GrsxUujwwdrv26T9uqsLLhzSWnxujNclrunZXcmJGGykufUWNT5SaDhd3UiMH17hw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -192,7 +192,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "speckle.connectors.dui": {
@@ -222,7 +222,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "Microsoft.Web.WebView2": {
@@ -239,9 +239,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-beta.4, )",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "qdHMddzoXCFv8dFe6FrwnLlSzlZNvZ1cv1842zO6HArROE1NOHK50zT8OtrPJJCwZSbBCaogyVxQTXWffDPl4A==",
+        "requested": "[2026.9.0-beta.5, )",
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "24tOTnFe3D8q0SWVCRGdhmDSuvZSicPK0RhzzjQBuT2MfR8goQxsKFcT7ogLWxFGsim5CTqKRidKhf13Wx+vjg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -249,8 +249,8 @@
           "Microsoft.Extensions.ObjectPool": "8.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-beta.4",
-          "Speckle.Sdk.Parquet": "2026.9.0-beta.4"
+          "Speckle.Sdk.Dependencies": "2026.9.0-beta.5",
+          "Speckle.Sdk.Parquet": "2026.9.0-beta.5"
         }
       }
     },

--- a/Connectors/Autocad/Speckle.Connectors.Autocad2027/packages.lock.json
+++ b/Connectors/Autocad/Speckle.Connectors.Autocad2027/packages.lock.json
@@ -140,13 +140,13 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "o+u1sRKl+KUmxvGHoNhBu+JJtGseDDxevu0khtPrZ6A15AMQ8+jRK7n9C2HkOXlNexVUwKiC8WnAa6/LUo6JHQ=="
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "yM8ZPViRCYZyVoyB2aRXAnQ8HuLA7E9pAjQSk01Rys5EUSBHHQCVMOeOY/maZRUeXVVfqu+/DyV8ST4kjZyYBg=="
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "l2Oa6SC8hq8f48mdWIXfnVbaUTlhKlrRVsGVUJSOnB77qPuwmj3CyZXoWFH/Gs9kcaEuC2wkbLRHndLpA77zcg=="
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "XpO62cnn84vGZUubF1CJ4GrsxUujwwdrv26T9uqsLLhzSWnxujNclrunZXcmJGGykufUWNT5SaDhd3UiMH17hw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -185,7 +185,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "speckle.connectors.dui": {
@@ -215,7 +215,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "Microsoft.Web.WebView2": {
@@ -232,9 +232,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-beta.4, )",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "qdHMddzoXCFv8dFe6FrwnLlSzlZNvZ1cv1842zO6HArROE1NOHK50zT8OtrPJJCwZSbBCaogyVxQTXWffDPl4A==",
+        "requested": "[2026.9.0-beta.5, )",
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "24tOTnFe3D8q0SWVCRGdhmDSuvZSicPK0RhzzjQBuT2MfR8goQxsKFcT7ogLWxFGsim5CTqKRidKhf13Wx+vjg==",
         "dependencies": {
           "GraphQL.Client": "6.1.0",
           "Microsoft.Data.Sqlite": "10.0.0",
@@ -242,8 +242,8 @@
           "Microsoft.Extensions.ObjectPool": "10.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-beta.4",
-          "Speckle.Sdk.Parquet": "2026.9.0-beta.4"
+          "Speckle.Sdk.Dependencies": "2026.9.0-beta.5",
+          "Speckle.Sdk.Parquet": "2026.9.0-beta.5"
         }
       }
     },

--- a/Connectors/Autocad/Speckle.Connectors.Civil3d2023/packages.lock.json
+++ b/Connectors/Autocad/Speckle.Connectors.Civil3d2023/packages.lock.json
@@ -211,16 +211,16 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "o+u1sRKl+KUmxvGHoNhBu+JJtGseDDxevu0khtPrZ6A15AMQ8+jRK7n9C2HkOXlNexVUwKiC8WnAa6/LUo6JHQ==",
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "yM8ZPViRCYZyVoyB2aRXAnQ8HuLA7E9pAjQSk01Rys5EUSBHHQCVMOeOY/maZRUeXVVfqu+/DyV8ST4kjZyYBg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.10"
         }
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "l2Oa6SC8hq8f48mdWIXfnVbaUTlhKlrRVsGVUJSOnB77qPuwmj3CyZXoWFH/Gs9kcaEuC2wkbLRHndLpA77zcg=="
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "XpO62cnn84vGZUubF1CJ4GrsxUujwwdrv26T9uqsLLhzSWnxujNclrunZXcmJGGykufUWNT5SaDhd3UiMH17hw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -335,7 +335,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "speckle.connectors.dui": {
@@ -365,7 +365,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "Microsoft.Web.WebView2": {
@@ -382,9 +382,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-beta.4, )",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "qdHMddzoXCFv8dFe6FrwnLlSzlZNvZ1cv1842zO6HArROE1NOHK50zT8OtrPJJCwZSbBCaogyVxQTXWffDPl4A==",
+        "requested": "[2026.9.0-beta.5, )",
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "24tOTnFe3D8q0SWVCRGdhmDSuvZSicPK0RhzzjQBuT2MfR8goQxsKFcT7ogLWxFGsim5CTqKRidKhf13Wx+vjg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -394,8 +394,8 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-beta.4",
-          "Speckle.Sdk.Parquet": "2026.9.0-beta.4",
+          "Speckle.Sdk.Dependencies": "2026.9.0-beta.5",
+          "Speckle.Sdk.Parquet": "2026.9.0-beta.5",
           "System.Memory": "4.5.5",
           "System.Text.Json": "5.0.2"
         }

--- a/Connectors/Autocad/Speckle.Connectors.Civil3d2024/packages.lock.json
+++ b/Connectors/Autocad/Speckle.Connectors.Civil3d2024/packages.lock.json
@@ -211,16 +211,16 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "o+u1sRKl+KUmxvGHoNhBu+JJtGseDDxevu0khtPrZ6A15AMQ8+jRK7n9C2HkOXlNexVUwKiC8WnAa6/LUo6JHQ==",
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "yM8ZPViRCYZyVoyB2aRXAnQ8HuLA7E9pAjQSk01Rys5EUSBHHQCVMOeOY/maZRUeXVVfqu+/DyV8ST4kjZyYBg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.10"
         }
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "l2Oa6SC8hq8f48mdWIXfnVbaUTlhKlrRVsGVUJSOnB77qPuwmj3CyZXoWFH/Gs9kcaEuC2wkbLRHndLpA77zcg=="
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "XpO62cnn84vGZUubF1CJ4GrsxUujwwdrv26T9uqsLLhzSWnxujNclrunZXcmJGGykufUWNT5SaDhd3UiMH17hw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -335,7 +335,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "speckle.connectors.dui": {
@@ -365,7 +365,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "Microsoft.Web.WebView2": {
@@ -382,9 +382,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-beta.4, )",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "qdHMddzoXCFv8dFe6FrwnLlSzlZNvZ1cv1842zO6HArROE1NOHK50zT8OtrPJJCwZSbBCaogyVxQTXWffDPl4A==",
+        "requested": "[2026.9.0-beta.5, )",
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "24tOTnFe3D8q0SWVCRGdhmDSuvZSicPK0RhzzjQBuT2MfR8goQxsKFcT7ogLWxFGsim5CTqKRidKhf13Wx+vjg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -394,8 +394,8 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-beta.4",
-          "Speckle.Sdk.Parquet": "2026.9.0-beta.4",
+          "Speckle.Sdk.Dependencies": "2026.9.0-beta.5",
+          "Speckle.Sdk.Parquet": "2026.9.0-beta.5",
           "System.Memory": "4.5.5",
           "System.Text.Json": "5.0.2"
         }

--- a/Connectors/Autocad/Speckle.Connectors.Civil3d2025/packages.lock.json
+++ b/Connectors/Autocad/Speckle.Connectors.Civil3d2025/packages.lock.json
@@ -148,13 +148,13 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "o+u1sRKl+KUmxvGHoNhBu+JJtGseDDxevu0khtPrZ6A15AMQ8+jRK7n9C2HkOXlNexVUwKiC8WnAa6/LUo6JHQ=="
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "yM8ZPViRCYZyVoyB2aRXAnQ8HuLA7E9pAjQSk01Rys5EUSBHHQCVMOeOY/maZRUeXVVfqu+/DyV8ST4kjZyYBg=="
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "l2Oa6SC8hq8f48mdWIXfnVbaUTlhKlrRVsGVUJSOnB77qPuwmj3CyZXoWFH/Gs9kcaEuC2wkbLRHndLpA77zcg=="
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "XpO62cnn84vGZUubF1CJ4GrsxUujwwdrv26T9uqsLLhzSWnxujNclrunZXcmJGGykufUWNT5SaDhd3UiMH17hw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -201,7 +201,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "speckle.connectors.dui": {
@@ -232,7 +232,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "Microsoft.Web.WebView2": {
@@ -249,9 +249,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-beta.4, )",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "qdHMddzoXCFv8dFe6FrwnLlSzlZNvZ1cv1842zO6HArROE1NOHK50zT8OtrPJJCwZSbBCaogyVxQTXWffDPl4A==",
+        "requested": "[2026.9.0-beta.5, )",
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "24tOTnFe3D8q0SWVCRGdhmDSuvZSicPK0RhzzjQBuT2MfR8goQxsKFcT7ogLWxFGsim5CTqKRidKhf13Wx+vjg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -259,8 +259,8 @@
           "Microsoft.Extensions.ObjectPool": "8.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-beta.4",
-          "Speckle.Sdk.Parquet": "2026.9.0-beta.4"
+          "Speckle.Sdk.Dependencies": "2026.9.0-beta.5",
+          "Speckle.Sdk.Parquet": "2026.9.0-beta.5"
         }
       }
     },

--- a/Connectors/Autocad/Speckle.Connectors.Civil3d2026/packages.lock.json
+++ b/Connectors/Autocad/Speckle.Connectors.Civil3d2026/packages.lock.json
@@ -148,13 +148,13 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "o+u1sRKl+KUmxvGHoNhBu+JJtGseDDxevu0khtPrZ6A15AMQ8+jRK7n9C2HkOXlNexVUwKiC8WnAa6/LUo6JHQ=="
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "yM8ZPViRCYZyVoyB2aRXAnQ8HuLA7E9pAjQSk01Rys5EUSBHHQCVMOeOY/maZRUeXVVfqu+/DyV8ST4kjZyYBg=="
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "l2Oa6SC8hq8f48mdWIXfnVbaUTlhKlrRVsGVUJSOnB77qPuwmj3CyZXoWFH/Gs9kcaEuC2wkbLRHndLpA77zcg=="
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "XpO62cnn84vGZUubF1CJ4GrsxUujwwdrv26T9uqsLLhzSWnxujNclrunZXcmJGGykufUWNT5SaDhd3UiMH17hw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -201,7 +201,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "speckle.connectors.dui": {
@@ -232,7 +232,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "Microsoft.Web.WebView2": {
@@ -249,9 +249,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-beta.4, )",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "qdHMddzoXCFv8dFe6FrwnLlSzlZNvZ1cv1842zO6HArROE1NOHK50zT8OtrPJJCwZSbBCaogyVxQTXWffDPl4A==",
+        "requested": "[2026.9.0-beta.5, )",
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "24tOTnFe3D8q0SWVCRGdhmDSuvZSicPK0RhzzjQBuT2MfR8goQxsKFcT7ogLWxFGsim5CTqKRidKhf13Wx+vjg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -259,8 +259,8 @@
           "Microsoft.Extensions.ObjectPool": "8.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-beta.4",
-          "Speckle.Sdk.Parquet": "2026.9.0-beta.4"
+          "Speckle.Sdk.Dependencies": "2026.9.0-beta.5",
+          "Speckle.Sdk.Parquet": "2026.9.0-beta.5"
         }
       }
     },

--- a/Connectors/Autocad/Speckle.Connectors.Civil3d2027/packages.lock.json
+++ b/Connectors/Autocad/Speckle.Connectors.Civil3d2027/packages.lock.json
@@ -149,13 +149,13 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "o+u1sRKl+KUmxvGHoNhBu+JJtGseDDxevu0khtPrZ6A15AMQ8+jRK7n9C2HkOXlNexVUwKiC8WnAa6/LUo6JHQ=="
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "yM8ZPViRCYZyVoyB2aRXAnQ8HuLA7E9pAjQSk01Rys5EUSBHHQCVMOeOY/maZRUeXVVfqu+/DyV8ST4kjZyYBg=="
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "l2Oa6SC8hq8f48mdWIXfnVbaUTlhKlrRVsGVUJSOnB77qPuwmj3CyZXoWFH/Gs9kcaEuC2wkbLRHndLpA77zcg=="
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "XpO62cnn84vGZUubF1CJ4GrsxUujwwdrv26T9uqsLLhzSWnxujNclrunZXcmJGGykufUWNT5SaDhd3UiMH17hw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -194,7 +194,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "speckle.connectors.dui": {
@@ -225,7 +225,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "Microsoft.Web.WebView2": {
@@ -242,9 +242,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-beta.4, )",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "qdHMddzoXCFv8dFe6FrwnLlSzlZNvZ1cv1842zO6HArROE1NOHK50zT8OtrPJJCwZSbBCaogyVxQTXWffDPl4A==",
+        "requested": "[2026.9.0-beta.5, )",
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "24tOTnFe3D8q0SWVCRGdhmDSuvZSicPK0RhzzjQBuT2MfR8goQxsKFcT7ogLWxFGsim5CTqKRidKhf13Wx+vjg==",
         "dependencies": {
           "GraphQL.Client": "6.1.0",
           "Microsoft.Data.Sqlite": "10.0.0",
@@ -252,8 +252,8 @@
           "Microsoft.Extensions.ObjectPool": "10.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-beta.4",
-          "Speckle.Sdk.Parquet": "2026.9.0-beta.4"
+          "Speckle.Sdk.Dependencies": "2026.9.0-beta.5",
+          "Speckle.Sdk.Parquet": "2026.9.0-beta.5"
         }
       }
     },

--- a/Connectors/Autocad/Speckle.Connectors.Plant3d2026/packages.lock.json
+++ b/Connectors/Autocad/Speckle.Connectors.Plant3d2026/packages.lock.json
@@ -148,13 +148,13 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "o+u1sRKl+KUmxvGHoNhBu+JJtGseDDxevu0khtPrZ6A15AMQ8+jRK7n9C2HkOXlNexVUwKiC8WnAa6/LUo6JHQ=="
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "yM8ZPViRCYZyVoyB2aRXAnQ8HuLA7E9pAjQSk01Rys5EUSBHHQCVMOeOY/maZRUeXVVfqu+/DyV8ST4kjZyYBg=="
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "l2Oa6SC8hq8f48mdWIXfnVbaUTlhKlrRVsGVUJSOnB77qPuwmj3CyZXoWFH/Gs9kcaEuC2wkbLRHndLpA77zcg=="
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "XpO62cnn84vGZUubF1CJ4GrsxUujwwdrv26T9uqsLLhzSWnxujNclrunZXcmJGGykufUWNT5SaDhd3UiMH17hw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -201,7 +201,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "speckle.connectors.dui": {
@@ -223,7 +223,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "speckle.converters.plant3d2026": {
@@ -249,9 +249,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-beta.4, )",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "qdHMddzoXCFv8dFe6FrwnLlSzlZNvZ1cv1842zO6HArROE1NOHK50zT8OtrPJJCwZSbBCaogyVxQTXWffDPl4A==",
+        "requested": "[2026.9.0-beta.5, )",
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "24tOTnFe3D8q0SWVCRGdhmDSuvZSicPK0RhzzjQBuT2MfR8goQxsKFcT7ogLWxFGsim5CTqKRidKhf13Wx+vjg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -259,8 +259,8 @@
           "Microsoft.Extensions.ObjectPool": "8.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-beta.4",
-          "Speckle.Sdk.Parquet": "2026.9.0-beta.4"
+          "Speckle.Sdk.Dependencies": "2026.9.0-beta.5",
+          "Speckle.Sdk.Parquet": "2026.9.0-beta.5"
         }
       }
     },

--- a/Connectors/Autocad/Speckle.Connectors.Plant3d2027/packages.lock.json
+++ b/Connectors/Autocad/Speckle.Connectors.Plant3d2027/packages.lock.json
@@ -149,13 +149,13 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "o+u1sRKl+KUmxvGHoNhBu+JJtGseDDxevu0khtPrZ6A15AMQ8+jRK7n9C2HkOXlNexVUwKiC8WnAa6/LUo6JHQ=="
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "yM8ZPViRCYZyVoyB2aRXAnQ8HuLA7E9pAjQSk01Rys5EUSBHHQCVMOeOY/maZRUeXVVfqu+/DyV8ST4kjZyYBg=="
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "l2Oa6SC8hq8f48mdWIXfnVbaUTlhKlrRVsGVUJSOnB77qPuwmj3CyZXoWFH/Gs9kcaEuC2wkbLRHndLpA77zcg=="
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "XpO62cnn84vGZUubF1CJ4GrsxUujwwdrv26T9uqsLLhzSWnxujNclrunZXcmJGGykufUWNT5SaDhd3UiMH17hw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -194,7 +194,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "speckle.connectors.dui": {
@@ -216,7 +216,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "speckle.converters.plant3d2027": {
@@ -242,9 +242,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-beta.4, )",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "qdHMddzoXCFv8dFe6FrwnLlSzlZNvZ1cv1842zO6HArROE1NOHK50zT8OtrPJJCwZSbBCaogyVxQTXWffDPl4A==",
+        "requested": "[2026.9.0-beta.5, )",
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "24tOTnFe3D8q0SWVCRGdhmDSuvZSicPK0RhzzjQBuT2MfR8goQxsKFcT7ogLWxFGsim5CTqKRidKhf13Wx+vjg==",
         "dependencies": {
           "GraphQL.Client": "6.1.0",
           "Microsoft.Data.Sqlite": "10.0.0",
@@ -252,8 +252,8 @@
           "Microsoft.Extensions.ObjectPool": "10.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-beta.4",
-          "Speckle.Sdk.Parquet": "2026.9.0-beta.4"
+          "Speckle.Sdk.Dependencies": "2026.9.0-beta.5",
+          "Speckle.Sdk.Parquet": "2026.9.0-beta.5"
         }
       }
     },

--- a/Connectors/CSi/Speckle.Connectors.ETABS21/packages.lock.json
+++ b/Connectors/CSi/Speckle.Connectors.ETABS21/packages.lock.json
@@ -218,16 +218,16 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "o+u1sRKl+KUmxvGHoNhBu+JJtGseDDxevu0khtPrZ6A15AMQ8+jRK7n9C2HkOXlNexVUwKiC8WnAa6/LUo6JHQ==",
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "yM8ZPViRCYZyVoyB2aRXAnQ8HuLA7E9pAjQSk01Rys5EUSBHHQCVMOeOY/maZRUeXVVfqu+/DyV8ST4kjZyYBg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.10"
         }
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "l2Oa6SC8hq8f48mdWIXfnVbaUTlhKlrRVsGVUJSOnB77qPuwmj3CyZXoWFH/Gs9kcaEuC2wkbLRHndLpA77zcg=="
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "XpO62cnn84vGZUubF1CJ4GrsxUujwwdrv26T9uqsLLhzSWnxujNclrunZXcmJGGykufUWNT5SaDhd3UiMH17hw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -343,7 +343,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "speckle.connectors.dui": {
@@ -365,7 +365,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "speckle.converters.etabs21": {
@@ -388,9 +388,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-beta.4, )",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "qdHMddzoXCFv8dFe6FrwnLlSzlZNvZ1cv1842zO6HArROE1NOHK50zT8OtrPJJCwZSbBCaogyVxQTXWffDPl4A==",
+        "requested": "[2026.9.0-beta.5, )",
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "24tOTnFe3D8q0SWVCRGdhmDSuvZSicPK0RhzzjQBuT2MfR8goQxsKFcT7ogLWxFGsim5CTqKRidKhf13Wx+vjg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -400,8 +400,8 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-beta.4",
-          "Speckle.Sdk.Parquet": "2026.9.0-beta.4",
+          "Speckle.Sdk.Dependencies": "2026.9.0-beta.5",
+          "Speckle.Sdk.Parquet": "2026.9.0-beta.5",
           "System.Memory": "4.5.5",
           "System.Text.Json": "5.0.2"
         }

--- a/Connectors/CSi/Speckle.Connectors.ETABS22/packages.lock.json
+++ b/Connectors/CSi/Speckle.Connectors.ETABS22/packages.lock.json
@@ -139,13 +139,13 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "o+u1sRKl+KUmxvGHoNhBu+JJtGseDDxevu0khtPrZ6A15AMQ8+jRK7n9C2HkOXlNexVUwKiC8WnAa6/LUo6JHQ=="
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "yM8ZPViRCYZyVoyB2aRXAnQ8HuLA7E9pAjQSk01Rys5EUSBHHQCVMOeOY/maZRUeXVVfqu+/DyV8ST4kjZyYBg=="
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "l2Oa6SC8hq8f48mdWIXfnVbaUTlhKlrRVsGVUJSOnB77qPuwmj3CyZXoWFH/Gs9kcaEuC2wkbLRHndLpA77zcg=="
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "XpO62cnn84vGZUubF1CJ4GrsxUujwwdrv26T9uqsLLhzSWnxujNclrunZXcmJGGykufUWNT5SaDhd3UiMH17hw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -192,7 +192,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "speckle.connectors.dui": {
@@ -214,7 +214,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "speckle.converters.etabs22": {
@@ -237,9 +237,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-beta.4, )",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "qdHMddzoXCFv8dFe6FrwnLlSzlZNvZ1cv1842zO6HArROE1NOHK50zT8OtrPJJCwZSbBCaogyVxQTXWffDPl4A==",
+        "requested": "[2026.9.0-beta.5, )",
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "24tOTnFe3D8q0SWVCRGdhmDSuvZSicPK0RhzzjQBuT2MfR8goQxsKFcT7ogLWxFGsim5CTqKRidKhf13Wx+vjg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -247,8 +247,8 @@
           "Microsoft.Extensions.ObjectPool": "8.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-beta.4",
-          "Speckle.Sdk.Parquet": "2026.9.0-beta.4"
+          "Speckle.Sdk.Dependencies": "2026.9.0-beta.5",
+          "Speckle.Sdk.Parquet": "2026.9.0-beta.5"
         }
       }
     }

--- a/Connectors/CSi/Speckle.Connectors.ETABS23/packages.lock.json
+++ b/Connectors/CSi/Speckle.Connectors.ETABS23/packages.lock.json
@@ -139,13 +139,13 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "o+u1sRKl+KUmxvGHoNhBu+JJtGseDDxevu0khtPrZ6A15AMQ8+jRK7n9C2HkOXlNexVUwKiC8WnAa6/LUo6JHQ=="
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "yM8ZPViRCYZyVoyB2aRXAnQ8HuLA7E9pAjQSk01Rys5EUSBHHQCVMOeOY/maZRUeXVVfqu+/DyV8ST4kjZyYBg=="
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "l2Oa6SC8hq8f48mdWIXfnVbaUTlhKlrRVsGVUJSOnB77qPuwmj3CyZXoWFH/Gs9kcaEuC2wkbLRHndLpA77zcg=="
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "XpO62cnn84vGZUubF1CJ4GrsxUujwwdrv26T9uqsLLhzSWnxujNclrunZXcmJGGykufUWNT5SaDhd3UiMH17hw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -192,7 +192,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "speckle.connectors.dui": {
@@ -214,7 +214,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "speckle.converters.etabs23": {
@@ -237,9 +237,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-beta.4, )",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "qdHMddzoXCFv8dFe6FrwnLlSzlZNvZ1cv1842zO6HArROE1NOHK50zT8OtrPJJCwZSbBCaogyVxQTXWffDPl4A==",
+        "requested": "[2026.9.0-beta.5, )",
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "24tOTnFe3D8q0SWVCRGdhmDSuvZSicPK0RhzzjQBuT2MfR8goQxsKFcT7ogLWxFGsim5CTqKRidKhf13Wx+vjg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -247,8 +247,8 @@
           "Microsoft.Extensions.ObjectPool": "8.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-beta.4",
-          "Speckle.Sdk.Parquet": "2026.9.0-beta.4"
+          "Speckle.Sdk.Dependencies": "2026.9.0-beta.5",
+          "Speckle.Sdk.Parquet": "2026.9.0-beta.5"
         }
       }
     }

--- a/Connectors/Revit/Speckle.Connectors.Revit2023/packages.lock.json
+++ b/Connectors/Revit/Speckle.Connectors.Revit2023/packages.lock.json
@@ -225,16 +225,16 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "o+u1sRKl+KUmxvGHoNhBu+JJtGseDDxevu0khtPrZ6A15AMQ8+jRK7n9C2HkOXlNexVUwKiC8WnAa6/LUo6JHQ==",
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "yM8ZPViRCYZyVoyB2aRXAnQ8HuLA7E9pAjQSk01Rys5EUSBHHQCVMOeOY/maZRUeXVVfqu+/DyV8ST4kjZyYBg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.10"
         }
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "l2Oa6SC8hq8f48mdWIXfnVbaUTlhKlrRVsGVUJSOnB77qPuwmj3CyZXoWFH/Gs9kcaEuC2wkbLRHndLpA77zcg=="
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "XpO62cnn84vGZUubF1CJ4GrsxUujwwdrv26T9uqsLLhzSWnxujNclrunZXcmJGGykufUWNT5SaDhd3UiMH17hw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -356,7 +356,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "speckle.connectors.dui": {
@@ -377,7 +377,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "speckle.converters.revit2023": {
@@ -408,9 +408,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-beta.4, )",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "qdHMddzoXCFv8dFe6FrwnLlSzlZNvZ1cv1842zO6HArROE1NOHK50zT8OtrPJJCwZSbBCaogyVxQTXWffDPl4A==",
+        "requested": "[2026.9.0-beta.5, )",
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "24tOTnFe3D8q0SWVCRGdhmDSuvZSicPK0RhzzjQBuT2MfR8goQxsKFcT7ogLWxFGsim5CTqKRidKhf13Wx+vjg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -420,8 +420,8 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-beta.4",
-          "Speckle.Sdk.Parquet": "2026.9.0-beta.4",
+          "Speckle.Sdk.Dependencies": "2026.9.0-beta.5",
+          "Speckle.Sdk.Parquet": "2026.9.0-beta.5",
           "System.Memory": "4.5.5",
           "System.Text.Json": "5.0.2"
         }

--- a/Connectors/Revit/Speckle.Connectors.Revit2024/packages.lock.json
+++ b/Connectors/Revit/Speckle.Connectors.Revit2024/packages.lock.json
@@ -225,16 +225,16 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "o+u1sRKl+KUmxvGHoNhBu+JJtGseDDxevu0khtPrZ6A15AMQ8+jRK7n9C2HkOXlNexVUwKiC8WnAa6/LUo6JHQ==",
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "yM8ZPViRCYZyVoyB2aRXAnQ8HuLA7E9pAjQSk01Rys5EUSBHHQCVMOeOY/maZRUeXVVfqu+/DyV8ST4kjZyYBg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.10"
         }
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "l2Oa6SC8hq8f48mdWIXfnVbaUTlhKlrRVsGVUJSOnB77qPuwmj3CyZXoWFH/Gs9kcaEuC2wkbLRHndLpA77zcg=="
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "XpO62cnn84vGZUubF1CJ4GrsxUujwwdrv26T9uqsLLhzSWnxujNclrunZXcmJGGykufUWNT5SaDhd3UiMH17hw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -356,7 +356,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "speckle.connectors.dui": {
@@ -377,7 +377,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "speckle.converters.revit2024": {
@@ -408,9 +408,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-beta.4, )",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "qdHMddzoXCFv8dFe6FrwnLlSzlZNvZ1cv1842zO6HArROE1NOHK50zT8OtrPJJCwZSbBCaogyVxQTXWffDPl4A==",
+        "requested": "[2026.9.0-beta.5, )",
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "24tOTnFe3D8q0SWVCRGdhmDSuvZSicPK0RhzzjQBuT2MfR8goQxsKFcT7ogLWxFGsim5CTqKRidKhf13Wx+vjg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -420,8 +420,8 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-beta.4",
-          "Speckle.Sdk.Parquet": "2026.9.0-beta.4",
+          "Speckle.Sdk.Dependencies": "2026.9.0-beta.5",
+          "Speckle.Sdk.Parquet": "2026.9.0-beta.5",
           "System.Memory": "4.5.5",
           "System.Text.Json": "5.0.2"
         }

--- a/Connectors/Revit/Speckle.Connectors.Revit2025/packages.lock.json
+++ b/Connectors/Revit/Speckle.Connectors.Revit2025/packages.lock.json
@@ -155,13 +155,13 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "o+u1sRKl+KUmxvGHoNhBu+JJtGseDDxevu0khtPrZ6A15AMQ8+jRK7n9C2HkOXlNexVUwKiC8WnAa6/LUo6JHQ=="
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "yM8ZPViRCYZyVoyB2aRXAnQ8HuLA7E9pAjQSk01Rys5EUSBHHQCVMOeOY/maZRUeXVVfqu+/DyV8ST4kjZyYBg=="
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "l2Oa6SC8hq8f48mdWIXfnVbaUTlhKlrRVsGVUJSOnB77qPuwmj3CyZXoWFH/Gs9kcaEuC2wkbLRHndLpA77zcg=="
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "XpO62cnn84vGZUubF1CJ4GrsxUujwwdrv26T9uqsLLhzSWnxujNclrunZXcmJGGykufUWNT5SaDhd3UiMH17hw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -215,7 +215,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "speckle.connectors.dui": {
@@ -236,7 +236,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "speckle.converters.revit2025": {
@@ -267,9 +267,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-beta.4, )",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "qdHMddzoXCFv8dFe6FrwnLlSzlZNvZ1cv1842zO6HArROE1NOHK50zT8OtrPJJCwZSbBCaogyVxQTXWffDPl4A==",
+        "requested": "[2026.9.0-beta.5, )",
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "24tOTnFe3D8q0SWVCRGdhmDSuvZSicPK0RhzzjQBuT2MfR8goQxsKFcT7ogLWxFGsim5CTqKRidKhf13Wx+vjg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -277,8 +277,8 @@
           "Microsoft.Extensions.ObjectPool": "8.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-beta.4",
-          "Speckle.Sdk.Parquet": "2026.9.0-beta.4"
+          "Speckle.Sdk.Dependencies": "2026.9.0-beta.5",
+          "Speckle.Sdk.Parquet": "2026.9.0-beta.5"
         }
       }
     },

--- a/Connectors/Revit/Speckle.Connectors.Revit2026/packages.lock.json
+++ b/Connectors/Revit/Speckle.Connectors.Revit2026/packages.lock.json
@@ -140,13 +140,13 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "o+u1sRKl+KUmxvGHoNhBu+JJtGseDDxevu0khtPrZ6A15AMQ8+jRK7n9C2HkOXlNexVUwKiC8WnAa6/LUo6JHQ=="
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "yM8ZPViRCYZyVoyB2aRXAnQ8HuLA7E9pAjQSk01Rys5EUSBHHQCVMOeOY/maZRUeXVVfqu+/DyV8ST4kjZyYBg=="
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "l2Oa6SC8hq8f48mdWIXfnVbaUTlhKlrRVsGVUJSOnB77qPuwmj3CyZXoWFH/Gs9kcaEuC2wkbLRHndLpA77zcg=="
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "XpO62cnn84vGZUubF1CJ4GrsxUujwwdrv26T9uqsLLhzSWnxujNclrunZXcmJGGykufUWNT5SaDhd3UiMH17hw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -200,7 +200,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "speckle.connectors.dui": {
@@ -221,7 +221,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "speckle.converters.revit2026": {
@@ -252,9 +252,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-beta.4, )",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "qdHMddzoXCFv8dFe6FrwnLlSzlZNvZ1cv1842zO6HArROE1NOHK50zT8OtrPJJCwZSbBCaogyVxQTXWffDPl4A==",
+        "requested": "[2026.9.0-beta.5, )",
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "24tOTnFe3D8q0SWVCRGdhmDSuvZSicPK0RhzzjQBuT2MfR8goQxsKFcT7ogLWxFGsim5CTqKRidKhf13Wx+vjg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -262,8 +262,8 @@
           "Microsoft.Extensions.ObjectPool": "8.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-beta.4",
-          "Speckle.Sdk.Parquet": "2026.9.0-beta.4"
+          "Speckle.Sdk.Dependencies": "2026.9.0-beta.5",
+          "Speckle.Sdk.Parquet": "2026.9.0-beta.5"
         }
       }
     },

--- a/Connectors/Revit/Speckle.Connectors.Revit2027/packages.lock.json
+++ b/Connectors/Revit/Speckle.Connectors.Revit2027/packages.lock.json
@@ -140,13 +140,13 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "o+u1sRKl+KUmxvGHoNhBu+JJtGseDDxevu0khtPrZ6A15AMQ8+jRK7n9C2HkOXlNexVUwKiC8WnAa6/LUo6JHQ=="
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "yM8ZPViRCYZyVoyB2aRXAnQ8HuLA7E9pAjQSk01Rys5EUSBHHQCVMOeOY/maZRUeXVVfqu+/DyV8ST4kjZyYBg=="
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "l2Oa6SC8hq8f48mdWIXfnVbaUTlhKlrRVsGVUJSOnB77qPuwmj3CyZXoWFH/Gs9kcaEuC2wkbLRHndLpA77zcg=="
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "XpO62cnn84vGZUubF1CJ4GrsxUujwwdrv26T9uqsLLhzSWnxujNclrunZXcmJGGykufUWNT5SaDhd3UiMH17hw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -192,7 +192,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "speckle.connectors.dui": {
@@ -213,7 +213,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "speckle.converters.revit2027": {
@@ -244,9 +244,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-beta.4, )",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "qdHMddzoXCFv8dFe6FrwnLlSzlZNvZ1cv1842zO6HArROE1NOHK50zT8OtrPJJCwZSbBCaogyVxQTXWffDPl4A==",
+        "requested": "[2026.9.0-beta.5, )",
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "24tOTnFe3D8q0SWVCRGdhmDSuvZSicPK0RhzzjQBuT2MfR8goQxsKFcT7ogLWxFGsim5CTqKRidKhf13Wx+vjg==",
         "dependencies": {
           "GraphQL.Client": "6.1.0",
           "Microsoft.Data.Sqlite": "10.0.0",
@@ -254,8 +254,8 @@
           "Microsoft.Extensions.ObjectPool": "10.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-beta.4",
-          "Speckle.Sdk.Parquet": "2026.9.0-beta.4"
+          "Speckle.Sdk.Dependencies": "2026.9.0-beta.5",
+          "Speckle.Sdk.Parquet": "2026.9.0-beta.5"
         }
       }
     },

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/DependencyInjection/RevitConnectorModule.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/DependencyInjection/RevitConnectorModule.cs
@@ -65,6 +65,7 @@ public static class ServiceRegistration
     serviceCollection.AddScoped<ElementUnpacker>();
     serviceCollection.AddScoped<LevelUnpacker>();
     serviceCollection.AddScoped<ViewUnpacker>();
+    serviceCollection.AddScoped<MepCenterlineExtractor>();
     serviceCollection.AddScoped<SendCollectionManager>();
     serviceCollection.AddScoped<IRootObjectBuilder<DocumentToConvert>, RevitRootObjectBuilder>();
     serviceCollection.AddScoped<IRootContinuousTraversalBuilder<DocumentToConvert>, RevitContinuousTraversalBuilder>();

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/CenterlineScope.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/CenterlineScope.cs
@@ -8,19 +8,27 @@ namespace Speckle.Connectors.Revit.HostApp;
 /// </summary>
 /// <remarks>
 /// <para>A curated list, not "anything with a location curve". Every element that qualifies adds a geometry blob and
-/// a relation row to every Revit send, so the set is opened deliberately rather than by default. MEP was the ask;
-/// structural framing came with it.</para>
+/// a relation row to every Revit send, so the set is opened deliberately: MEP runs and the structural frame, where an
+/// axis is the element's defining datum. Walls and railings are excluded.</para>
 /// <para>Gated on type and <see cref="BuiltInCategory"/>, never on category NAME — those are localised, so a
 /// name-based list silently matches nothing on a German or French model.</para>
 /// <para>Does NOT gate MEP fittings: those have no location curve and reach
-/// <see cref="MepCenterlineExtractor"/> instead, which scopes itself by connector domain.</para>
+/// <see cref="MepCenterlineExtractor"/> instead, which scopes itself by connector domain. That also covers
+/// fabrication parts, which are not <see cref="MEPCurve"/> but do carry flow connectors.</para>
 /// </remarks>
 public static class CenterlineScope
 {
   /// <summary>Whether <paramref name="element"/>'s location curve should ship as a centerline.</summary>
+  /// <remarks>
+  /// A category listed here that turns out to be point-placed simply emits nothing — a vertical column or an
+  /// isolated footing has no location curve — so listing it costs a type check, not a blob.
+  /// </remarks>
   public static bool Includes(Element element) =>
     // Ducts, pipes, conduits and cable trays — plus their flex and placeholder variants, all MEPCurve subclasses.
     element is MEPCurve
-    // Beams, braces and girders. A category rather than a type, because that is how Revit models framing.
-    || element.Category?.GetBuiltInCategory() is BuiltInCategory.OST_StructuralFraming;
+    || element.Category?.GetBuiltInCategory()
+      is BuiltInCategory.OST_StructuralFraming // beams, braces, joists, girders
+        or BuiltInCategory.OST_StructuralColumns // slanted columns; vertical ones are point-placed
+        or BuiltInCategory.OST_StructuralTruss // truss chords follow the authored curve
+        or BuiltInCategory.OST_StructuralFoundation; // continuous/wall footings; isolated ones are point-placed
 }

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/CenterlineScope.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/CenterlineScope.cs
@@ -1,0 +1,26 @@
+using Autodesk.Revit.DB;
+using Speckle.Converters.RevitShared.Extensions;
+
+namespace Speckle.Connectors.Revit.HostApp;
+
+/// <summary>
+/// Which elements publish a <c>CENTERLINE</c> from their location curve [ENG-9510].
+/// </summary>
+/// <remarks>
+/// <para>A curated list, not "anything with a location curve". Every element that qualifies adds a geometry blob and
+/// a relation row to every Revit send, so the set is opened deliberately rather than by default. MEP was the ask;
+/// structural framing came with it.</para>
+/// <para>Gated on type and <see cref="BuiltInCategory"/>, never on category NAME — those are localised, so a
+/// name-based list silently matches nothing on a German or French model.</para>
+/// <para>Does NOT gate MEP fittings: those have no location curve and reach
+/// <see cref="MepCenterlineExtractor"/> instead, which scopes itself by connector domain.</para>
+/// </remarks>
+public static class CenterlineScope
+{
+  /// <summary>Whether <paramref name="element"/>'s location curve should ship as a centerline.</summary>
+  public static bool Includes(Element element) =>
+    // Ducts, pipes, conduits and cable trays — plus their flex and placeholder variants, all MEPCurve subclasses.
+    element is MEPCurve
+    // Beams, braces and girders. A category rather than a type, because that is how Revit models framing.
+    || element.Category?.GetBuiltInCategory() is BuiltInCategory.OST_StructuralFraming;
+}

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/MepCenterlineExtractor.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/MepCenterlineExtractor.cs
@@ -1,0 +1,101 @@
+using Autodesk.Revit.DB;
+using Speckle.Converters.Common;
+using Speckle.Converters.Common.Objects;
+using Speckle.Converters.RevitShared.Settings;
+using SOG = Speckle.Objects.Geometry;
+
+namespace Speckle.Connectors.Revit.HostApp;
+
+/// <summary>
+/// Derives the centerline of a point-placed MEP fitting from its connectors [ENG-9510].
+/// </summary>
+/// <remarks>
+/// <para>A duct or pipe IS its location curve, so its centerline is free. A fitting — elbow, tee, cross, transition —
+/// is placed at a point and has no location curve at all, which left a gap in every run downstream. The geometry that
+/// closes the gap is still authored, just not as a curve: each connector reports where the run enters or leaves the
+/// fitting, and the fitting's insertion point is the node those branches meet at.</para>
+/// <para><b>One segment per connector</b>, rather than one curve across the fitting. That is what a single-line
+/// drawing draws, and it is the only shape that stays correct for a tee or a cross — no single curve can express a
+/// branch. Consumers weld duct and fitting segments into continuous runs (Join Curves in Grasshopper).</para>
+/// <para>Its own class rather than another method on the send builder: this is a self-contained host-API read, it is
+/// the same shape as <see cref="ElementUnpacker"/> and friends, and folding the connector vocabulary into the builder
+/// pushed that class past its class-coupling budget.</para>
+/// </remarks>
+public class MepCenterlineExtractor(
+  ITypedConverter<XYZ, SOG.Point> pointConverter,
+  IConverterSettingsStore<RevitConversionSettings> converterSettings
+)
+{
+  /// <summary>
+  /// The fitting's centerline branches, one per flow connector, ordered as Revit reports them. Empty for anything
+  /// that is not a connector-bearing family instance, and for a fitting whose connectors cannot be read.
+  /// </summary>
+  /// <remarks>
+  /// Points go through the same <see cref="ITypedConverter{XYZ, Point}"/> the location curves use, so scaling and the
+  /// reference-point transform match the display meshes by construction — including in a linked model, provided the
+  /// caller is inside that document's converter-settings push.
+  /// </remarks>
+  public IReadOnlyList<SOG.Line> GetCenterlineBranches(Element element)
+  {
+    if (element is not FamilyInstance { MEPModel.ConnectorManager: { } connectorManager })
+    {
+      return [];
+    }
+
+    var origins = new List<XYZ>();
+    foreach (Connector connector in connectorManager.Connectors)
+    {
+      // A logical connector carries no geometry at all (CoordinateSystem throws on one), and a non-flow domain
+      // (electrical, structural analytical) is not a run whose centerline anyone asked for.
+      if (connector.ConnectorType == ConnectorType.Logical || !IsFlowDomain(connector.Domain))
+      {
+        continue;
+      }
+      // CoordinateSystem.Origin, NOT Connector.Origin: the latter is documented to throw for a connector that is
+      // part of a family instance, which is every fitting. Both name the same point.
+      origins.Add(connector.CoordinateSystem.Origin);
+    }
+
+    if (origins.Count == 0)
+    {
+      return [];
+    }
+
+    // The node the branches meet at. A placed fitting's insertion point IS that node; averaging the connector
+    // origins is the last resort for a family that reports no location, and degrades to the chord rather than to
+    // nothing.
+    XYZ node = element.Location is LocationPoint locationPoint
+      ? locationPoint.Point
+      : origins.Aggregate(XYZ.Zero, (sum, origin) => sum.Add(origin)).Divide(origins.Count);
+
+    string units = converterSettings.Current.SpeckleUnits;
+    SOG.Point nodePoint = pointConverter.Convert(node);
+    var branches = new List<SOG.Line>(origins.Count);
+    foreach (XYZ origin in origins)
+    {
+      var branch = new SOG.Line
+      {
+        start = pointConverter.Convert(origin),
+        end = nodePoint,
+        units = units,
+      };
+      // A connector sitting on the node contributes no branch — emitting it would put a degenerate, zero-length
+      // curve on the port for every consumer to filter out.
+      if (branch.length > BRANCH_TOLERANCE)
+      {
+        branches.Add(branch);
+      }
+    }
+
+    return branches;
+  }
+
+  // The domains where a connector marks a flow run. Electrical and structural-analytical connectors are a different
+  // kind of statement and carry no run geometry.
+  private static bool IsFlowDomain(Domain domain) =>
+    domain is Domain.DomainHvac or Domain.DomainPiping or Domain.DomainCableTrayConduit;
+
+  // The shortest branch worth shipping, in the send's own units — small enough that a real fitting branch never trips
+  // it, large enough to drop a connector that coincides with the insertion point.
+  private const double BRANCH_TOLERANCE = 1e-6;
+}

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/MepCenterlineExtractor.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/MepCenterlineExtractor.cs
@@ -10,16 +10,10 @@ namespace Speckle.Connectors.Revit.HostApp;
 /// Derives the centerline of a point-placed MEP fitting from its connectors [ENG-9510].
 /// </summary>
 /// <remarks>
-/// <para>A duct or pipe IS its location curve, so its centerline is free. A fitting — elbow, tee, cross, transition —
-/// is placed at a point and has no location curve at all, which left a gap in every run downstream. The geometry that
-/// closes the gap is still authored, just not as a curve: each connector reports where the run enters or leaves the
-/// fitting, and the fitting's insertion point is the node those branches meet at.</para>
-/// <para><b>One segment per connector</b>, rather than one curve across the fitting. That is what a single-line
-/// drawing draws, and it is the only shape that stays correct for a tee or a cross — no single curve can express a
-/// branch. Consumers weld duct and fitting segments into continuous runs (Join Curves in Grasshopper).</para>
-/// <para>Its own class rather than another method on the send builder: this is a self-contained host-API read, it is
-/// the same shape as <see cref="ElementUnpacker"/> and friends, and folding the connector vocabulary into the builder
-/// pushed that class past its class-coupling budget.</para>
+/// A duct IS its location curve, so its centerline is free. A fitting is placed at a point and has none, which left a
+/// gap in every run. Each connector says where the run meets the fitting, so the fitting ships ONE SEGMENT PER
+/// CONNECTOR to its insertion point — what a single-line drawing draws, and the only shape that survives a tee, where
+/// no single curve can express the branch.
 /// </remarks>
 public class MepCenterlineExtractor(
   ITypedConverter<XYZ, SOG.Point> pointConverter,
@@ -27,13 +21,12 @@ public class MepCenterlineExtractor(
 )
 {
   /// <summary>
-  /// The fitting's centerline branches, one per flow connector, ordered as Revit reports them. Empty for anything
-  /// that is not a connector-bearing family instance, and for a fitting whose connectors cannot be read.
+  /// The fitting's centerline branches, one per end connector, in Revit's order. Empty for anything that is not a
+  /// connector-bearing family instance.
   /// </summary>
   /// <remarks>
-  /// Points go through the same <see cref="ITypedConverter{XYZ, Point}"/> the location curves use, so scaling and the
-  /// reference-point transform match the display meshes by construction — including in a linked model, provided the
-  /// caller is inside that document's converter-settings push.
+  /// Points go through the same converter the location curves use, so scaling and the reference-point transform match
+  /// the display meshes by construction — provided the caller is inside the owning document's settings push.
   /// </remarks>
   public IReadOnlyList<SOG.Line> GetCenterlineBranches(Element element)
   {
@@ -45,15 +38,15 @@ public class MepCenterlineExtractor(
     var origins = new List<XYZ>();
     foreach (Connector connector in connectorManager.Connectors)
     {
-      // A logical connector carries no geometry at all (CoordinateSystem throws on one), and a non-flow domain
-      // (electrical, structural analytical) is not a run whose centerline anyone asked for.
-      if (connector.ConnectorType == ConnectorType.Logical || !IsFlowDomain(connector.Domain))
+      // End is the atomic type a run's endpoint reports; this enum's composite members (Physical = End|Curve|Surface,
+      // …) are query masks no connector ever equals. Testing for it positively also excludes the logical connectors
+      // whose CoordinateSystem throws.
+      if (connector.ConnectorType == ConnectorType.End && IsFlowDomain(connector.Domain))
       {
-        continue;
+        // CoordinateSystem.Origin, not Connector.Origin: the latter is documented to throw for a connector belonging
+        // to a family instance, i.e. every fitting. Both name the same point.
+        origins.Add(connector.CoordinateSystem.Origin);
       }
-      // CoordinateSystem.Origin, NOT Connector.Origin: the latter is documented to throw for a connector that is
-      // part of a family instance, which is every fitting. Both name the same point.
-      origins.Add(connector.CoordinateSystem.Origin);
     }
 
     if (origins.Count == 0)
@@ -61,9 +54,8 @@ public class MepCenterlineExtractor(
       return [];
     }
 
-    // The node the branches meet at. A placed fitting's insertion point IS that node; averaging the connector
-    // origins is the last resort for a family that reports no location, and degrades to the chord rather than to
-    // nothing.
+    // A placed fitting's insertion point IS the node its branches meet at; averaging the origins is the last resort
+    // for a family reporting no location, and degrades to the chord rather than to nothing.
     XYZ node = element.Location is LocationPoint locationPoint
       ? locationPoint.Point
       : origins.Aggregate(XYZ.Zero, (sum, origin) => sum.Add(origin)).Divide(origins.Count);
@@ -79,8 +71,7 @@ public class MepCenterlineExtractor(
         end = nodePoint,
         units = units,
       };
-      // A connector sitting on the node contributes no branch — emitting it would put a degenerate, zero-length
-      // curve on the port for every consumer to filter out.
+      // A connector sitting on the node would only put a degenerate curve on the port.
       if (branch.length > BRANCH_TOLERANCE)
       {
         branches.Add(branch);
@@ -90,12 +81,10 @@ public class MepCenterlineExtractor(
     return branches;
   }
 
-  // The domains where a connector marks a flow run. Electrical and structural-analytical connectors are a different
-  // kind of statement and carry no run geometry.
+  /// <summary>Domains where a connector marks a flow run; electrical and analytical ones carry no run geometry.</summary>
   private static bool IsFlowDomain(Domain domain) =>
     domain is Domain.DomainHvac or Domain.DomainPiping or Domain.DomainCableTrayConduit;
 
-  // The shortest branch worth shipping, in the send's own units — small enough that a real fitting branch never trips
-  // it, large enough to drop a connector that coincides with the insertion point.
+  // Shortest branch worth shipping, in the send's own units.
   private const double BRANCH_TOLERANCE = 1e-6;
 }

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/RevitArtifactRootObjectBuilder.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/RevitArtifactRootObjectBuilder.cs
@@ -18,6 +18,7 @@ using Speckle.Converters.RevitShared.Helpers;
 using Speckle.Converters.RevitShared.Services;
 using Speckle.Converters.RevitShared.Settings;
 using Speckle.DoubleNumerics;
+using Speckle.Objects;
 using Speckle.Objects.Data;
 using Speckle.Objects.Utils;
 using Speckle.Sdk;
@@ -452,7 +453,8 @@ public class RevitArtifactRootObjectBuilder(
   }
 
   // Emits one atomic object: its eav labels + IN_MODEL edge + per-fragment DISPLAY (→ geometry) /
-  // DISPLAY_INSTANCE (→ INSTANCE node). Instance definitions + materials + levels are wired post-loop.
+  // DISPLAY_INSTANCE (→ INSTANCE node) + its location curve as CENTERLINE (→ geometry). Instance definitions +
+  // materials + levels are wired post-loop.
   // Returns the interned object K so the caller can wire per-document topology (groups) to this exact placement.
   private int EmitObject(
     ObjectsArtifactPipeline pipeline,
@@ -487,6 +489,7 @@ public class RevitArtifactRootObjectBuilder(
     );
 
     EmitDisplayValue(pipeline, objK, applicationId, dataObject.displayValue);
+    EmitCenterline(pipeline, objK, applicationId, revitObject);
 
     // Recurse into hosted/nested children (RevitObject.elements) — curtain wall → mullions/panels, railing → top
     // rail, stacked wall → members. RemoveKnownChildElementsWhenParentPresent strips these from the atomic list when
@@ -742,6 +745,41 @@ public class RevitArtifactRootObjectBuilder(
     }
   }
 
+  // Emits the element's authored location curve as CENTERLINE geometry [ENG-9510] — the axis, kept apart from the
+  // shell that DISPLAY carries. Costs no Revit API call: the converter already produced this curve
+  // (RevitObject.location) through the SAME scaling + reference-point conversion as the display meshes, and both run
+  // inside the caller's converterSettings push, so the axis lands aligned with its own geometry even for a linked
+  // model placed away from the host origin.
+  //
+  // Emitted for EVERY element whose location is a curve, not only MEP: a duct/pipe/conduit IS its centerline, and a
+  // framing member's axis is the same datum and the same ask. Point-located elements — duct fittings, furniture,
+  // most family instances — emit nothing, because a point is not a centerline and deriving a fitting's axis from its
+  // connectors is a separate job. What lands is the element's LOCATION curve faithfully: for a wall that follows the
+  // Location Line type parameter and may be a core or finish face rather than the centre, which is why the rel is
+  // named for what it is used for and documented for what it holds.
+  private void EmitCenterline(ObjectsArtifactPipeline pipeline, int objK, string appId, RevitObject? revitObject)
+  {
+    // A point location — duct fittings, furniture, most family instances — is not a centerline.
+    if (revitObject?.location is not { } location || location is not ICurve)
+    {
+      return;
+    }
+
+    try
+    {
+      // Deterministic key, not location.applicationId: the converter never stamps one, and a key shared with a
+      // display fragment would collapse the two edges onto one blob.
+      int geometryK = pipeline.AddGeometry($"{appId}:cl", location);
+      pipeline.Centerline(objK, geometryK, 0);
+    }
+    catch (Exception ex) when (!ex.IsFatal())
+    {
+      // A curve the SGEO encoder doesn't cover is skipped without failing the object — its display geometry,
+      // properties and topology still land (same tolerance as EmitDisplayValue's curve path).
+      logger.LogWarning(ex, "Skipped unsupported centerline geometry {Type} on {AppId}", location.speckle_type, appId);
+    }
+  }
+
   // A hosted/nested child RevitObject: its own interned object (geometry + properties), a SUBELEMENT edge to its
   // owner, and recursion into its own children. Children are NOT in the atomic loop (stripped when the parent is
   // present), so they get no separate ON_LEVEL/type-key resolution here — geometry + hierarchy + materials suffice.
@@ -786,6 +824,7 @@ public class RevitArtifactRootObjectBuilder(
     pipeline.AddProperties(childAppId, child.properties, RootScalars(child, child));
 
     EmitDisplayValue(pipeline, childK, childAppId, child.displayValue);
+    EmitCenterline(pipeline, childK, childAppId, child);
 
     int grandOrd = 0;
     foreach (RevitObject grandChild in child.elements)

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/RevitArtifactRootObjectBuilder.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/RevitArtifactRootObjectBuilder.cs
@@ -48,6 +48,11 @@ namespace Speckle.Connectors.Revit.Operations.Send;
 /// every object emits an <c>IN_MODEL</c> relation to its owning model; a federated (&gt;1 document) send
 /// prepends the <c>IN_MODEL</c> tier to the default scene view.</para>
 /// </remarks>
+[SuppressMessage(
+  "Maintainability",
+  "CA1506:Avoid excessive class coupling",
+  Justification = "Top-level artefact send orchestrator; coupling to converters, unpackers, host API and the pipeline façade is inherent."
+)]
 public class RevitArtifactRootObjectBuilder(
   IRootToSpeckleConverter converter,
   IConverterSettingsStore<RevitConversionSettings> converterSettings,
@@ -59,6 +64,7 @@ public class RevitArtifactRootObjectBuilder(
   IArtifactPipelineFactory artifactPipelineFactory,
   IScalingServiceToSpeckle scalingService,
   IReferencePointConverter referencePointConverter,
+  MepCenterlineExtractor mepCenterlineExtractor,
   ISpeckleApplication speckleApplication,
   ILogger<RevitArtifactRootObjectBuilder> logger
 ) : IArtifactRootObjectBuilder<DocumentToConvert>
@@ -489,7 +495,7 @@ public class RevitArtifactRootObjectBuilder(
     );
 
     EmitDisplayValue(pipeline, objK, applicationId, dataObject.displayValue);
-    EmitCenterline(pipeline, objK, applicationId, revitObject);
+    EmitCenterline(pipeline, objK, applicationId, revitElement, revitObject);
 
     // Recurse into hosted/nested children (RevitObject.elements) — curtain wall → mullions/panels, railing → top
     // rail, stacked wall → members. RemoveKnownChildElementsWhenParentPresent strips these from the atomic list when
@@ -745,38 +751,80 @@ public class RevitArtifactRootObjectBuilder(
     }
   }
 
-  // Emits the element's authored location curve as CENTERLINE geometry [ENG-9510] — the axis, kept apart from the
-  // shell that DISPLAY carries. Costs no Revit API call: the converter already produced this curve
-  // (RevitObject.location) through the SAME scaling + reference-point conversion as the display meshes, and both run
-  // inside the caller's converterSettings push, so the axis lands aligned with its own geometry even for a linked
-  // model placed away from the host origin.
+  // Emits an element's centerline as CENTERLINE geometry [ENG-9510] — the axis, kept apart from the shell that
+  // DISPLAY carries. Two shapes, in precedence order:
   //
-  // Emitted for EVERY element whose location is a curve, not only MEP: a duct/pipe/conduit IS its centerline, and a
-  // framing member's axis is the same datum and the same ask. Point-located elements — duct fittings, furniture,
-  // most family instances — emit nothing, because a point is not a centerline and deriving a fitting's axis from its
-  // connectors is a separate job. What lands is the element's LOCATION curve faithfully: for a wall that follows the
-  // Location Line type parameter and may be a core or finish face rather than the centre, which is why the rel is
-  // named for what it is used for and documented for what it holds.
-  private void EmitCenterline(ObjectsArtifactPipeline pipeline, int objK, string appId, RevitObject? revitObject)
+  //   1. AUTHORED LOCATION CURVE, for anything Revit placed along a curve. Costs no Revit API call: the converter
+  //      already produced it (RevitObject.location) through the SAME scaling + reference-point conversion as the
+  //      display meshes, inside the caller's converterSettings push, so the axis lands aligned with its own
+  //      geometry even for a linked model placed away from the host origin. Emitted for EVERY such element, not
+  //      only MEP: a duct/pipe/conduit IS its centerline, and a framing member's axis is the same datum and the
+  //      same ask. What lands is the element's LOCATION curve faithfully — for a wall that follows the Location
+  //      Line type parameter and may be a core or finish face rather than the centre.
+  //   2. CONNECTOR BRANCHES, for a point-placed MEP fitting (see EmitFittingCenterline), which has no location
+  //      curve at all and so left a gap in every run.
+  //
+  // Precedence, not union: an element with a location curve already has its axis, and its connectors would only
+  // restate the ends of it.
+  private void EmitCenterline(
+    ObjectsArtifactPipeline pipeline,
+    int objK,
+    string appId,
+    Element? revitElement,
+    RevitObject? revitObject
+  )
   {
-    // A point location — duct fittings, furniture, most family instances — is not a centerline.
-    if (revitObject?.location is not { } location || location is not ICurve)
+    if (revitObject?.location is { } location && location is ICurve)
     {
+      try
+      {
+        // Deterministic key, not location.applicationId: the converter never stamps one, and a key shared with a
+        // display fragment would collapse the two edges onto one blob.
+        int geometryK = pipeline.AddGeometry($"{appId}:cl", location);
+        pipeline.Centerline(objK, geometryK, 0);
+      }
+      catch (Exception ex) when (!ex.IsFatal())
+      {
+        // A curve the SGEO encoder doesn't cover is skipped without failing the object — its display geometry,
+        // properties and topology still land (same tolerance as EmitDisplayValue's curve path).
+        logger.LogWarning(
+          ex,
+          "Skipped unsupported centerline geometry {Type} on {AppId}",
+          location.speckle_type,
+          appId
+        );
+      }
       return;
     }
 
+    if (revitElement is not null)
+    {
+      EmitFittingCenterline(pipeline, objK, appId, revitElement);
+    }
+  }
+
+  // A point-placed MEP fitting has no location curve, so its centerline is derived from its connectors instead
+  // — see MepCenterlineExtractor for what that means and why it is one segment per connector. The ord is the
+  // branch index, so a tee's three branches stay distinguishable and ordered.
+  private void EmitFittingCenterline(ObjectsArtifactPipeline pipeline, int objK, string appId, Element revitElement)
+  {
+    IReadOnlyList<SOG.Line> branches;
     try
     {
-      // Deterministic key, not location.applicationId: the converter never stamps one, and a key shared with a
-      // display fragment would collapse the two edges onto one blob.
-      int geometryK = pipeline.AddGeometry($"{appId}:cl", location);
-      pipeline.Centerline(objK, geometryK, 0);
+      branches = mepCenterlineExtractor.GetCenterlineBranches(revitElement);
     }
     catch (Exception ex) when (!ex.IsFatal())
     {
-      // A curve the SGEO encoder doesn't cover is skipped without failing the object — its display geometry,
-      // properties and topology still land (same tolerance as EmitDisplayValue's curve path).
-      logger.LogWarning(ex, "Skipped unsupported centerline geometry {Type} on {AppId}", location.speckle_type, appId);
+      // An unreadable connector set costs this fitting its centerline and nothing else — geometry, properties
+      // and topology still land (same tolerance as the rest of this builder's host-API reads).
+      logger.LogWarning(ex, "Could not read MEP connectors on {AppId}", appId);
+      return;
+    }
+
+    for (int ord = 0; ord < branches.Count; ord++)
+    {
+      int geometryK = pipeline.AddGeometry($"{appId}:cl{ord}", branches[ord]);
+      pipeline.Centerline(objK, geometryK, ord);
     }
   }
 
@@ -824,7 +872,9 @@ public class RevitArtifactRootObjectBuilder(
     pipeline.AddProperties(childAppId, child.properties, RootScalars(child, child));
 
     EmitDisplayValue(pipeline, childK, childAppId, child.displayValue);
-    EmitCenterline(pipeline, childK, childAppId, child);
+    // Children are curtain panels, mullions, top rails and stacked-wall members — never MEP
+    // fittings, so the connector fallback has nothing to offer and the element is not threaded down here.
+    EmitCenterline(pipeline, childK, childAppId, null, child);
 
     int grandOrd = 0;
     foreach (RevitObject grandChild in child.elements)

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/RevitArtifactRootObjectBuilder.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/RevitArtifactRootObjectBuilder.cs
@@ -751,21 +751,12 @@ public class RevitArtifactRootObjectBuilder(
     }
   }
 
-  // Emits an element's centerline as CENTERLINE geometry [ENG-9510] — the axis, kept apart from the shell that
-  // DISPLAY carries. Two shapes, in precedence order:
-  //
-  //   1. AUTHORED LOCATION CURVE, for anything Revit placed along a curve. Costs no Revit API call: the converter
-  //      already produced it (RevitObject.location) through the SAME scaling + reference-point conversion as the
-  //      display meshes, inside the caller's converterSettings push, so the axis lands aligned with its own
-  //      geometry even for a linked model placed away from the host origin. Emitted for EVERY such element, not
-  //      only MEP: a duct/pipe/conduit IS its centerline, and a framing member's axis is the same datum and the
-  //      same ask. What lands is the element's LOCATION curve faithfully — for a wall that follows the Location
-  //      Line type parameter and may be a core or finish face rather than the centre.
-  //   2. CONNECTOR BRANCHES, for a point-placed MEP fitting (see EmitFittingCenterline), which has no location
-  //      curve at all and so left a gap in every run.
-  //
-  // Precedence, not union: an element with a location curve already has its axis, and its connectors would only
-  // restate the ends of it.
+  // Emits an element's centerline as CENTERLINE geometry [ENG-9510] — the axis, kept apart from the shell
+  // DISPLAY carries. Precedence, not union: the authored location curve where there is one (free — the converter
+  // already produced it as RevitObject.location, through the same scaling + reference-point path as the meshes),
+  // else a point-placed MEP fitting's connector branches (see MepCenterlineExtractor). Emitted for EVERY
+  // curve-located element, not only MEP; what lands is the LOCATION curve faithfully, so for a wall it follows
+  // the Location Line type parameter and may be a face rather than the centre.
   private void EmitCenterline(
     ObjectsArtifactPipeline pipeline,
     int objK,
@@ -803,9 +794,8 @@ public class RevitArtifactRootObjectBuilder(
     }
   }
 
-  // A point-placed MEP fitting has no location curve, so its centerline is derived from its connectors instead
-  // — see MepCenterlineExtractor for what that means and why it is one segment per connector. The ord is the
-  // branch index, so a tee's three branches stay distinguishable and ordered.
+  // Connector-derived branches for a fitting, ord = branch index so a tee's three stay ordered. See
+  // MepCenterlineExtractor for why it is one segment per connector.
   private void EmitFittingCenterline(ObjectsArtifactPipeline pipeline, int objK, string appId, Element revitElement)
   {
     IReadOnlyList<SOG.Line> branches;
@@ -872,8 +862,7 @@ public class RevitArtifactRootObjectBuilder(
     pipeline.AddProperties(childAppId, child.properties, RootScalars(child, child));
 
     EmitDisplayValue(pipeline, childK, childAppId, child.displayValue);
-    // Children are curtain panels, mullions, top rails and stacked-wall members — never MEP
-    // fittings, so the connector fallback has nothing to offer and the element is not threaded down here.
+    // Children are panels, mullions and rails — never MEP fittings, so no element is threaded down.
     EmitCenterline(pipeline, childK, childAppId, null, child);
 
     int grandOrd = 0;

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/RevitArtifactRootObjectBuilder.cs
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/RevitArtifactRootObjectBuilder.cs
@@ -752,21 +752,28 @@ public class RevitArtifactRootObjectBuilder(
   }
 
   // Emits an element's centerline as CENTERLINE geometry [ENG-9510] — the axis, kept apart from the shell
-  // DISPLAY carries. Precedence, not union: the authored location curve where there is one (free — the converter
-  // already produced it as RevitObject.location, through the same scaling + reference-point path as the meshes),
-  // else a point-placed MEP fitting's connector branches (see MepCenterlineExtractor). Emitted for EVERY
-  // curve-located element, not only MEP; what lands is the LOCATION curve faithfully, so for a wall it follows
-  // the Location Line type parameter and may be a face rather than the centre.
+  // DISPLAY carries. Two sources: the authored location curve of an in-scope element, else a point-placed MEP
+  // fitting's connector branches. An element with a location curve never needs the fitting path — its connectors
+  // would only restate the ends of a curve it already has.
+  //
+  // The curve itself is free (the converter already produced it as RevitObject.location, through the same scaling +
+  // reference-point path as the display meshes), but each one still costs a geometry blob and a relation row on
+  // EVERY Revit send — hence CenterlineScope rather than "anything with a location curve".
   private void EmitCenterline(
     ObjectsArtifactPipeline pipeline,
     int objK,
     string appId,
-    Element? revitElement,
+    Element revitElement,
     RevitObject? revitObject
   )
   {
     if (revitObject?.location is { } location && location is ICurve)
     {
+      if (!CenterlineScope.Includes(revitElement))
+      {
+        return;
+      }
+
       try
       {
         // Deterministic key, not location.applicationId: the converter never stamps one, and a key shared with a
@@ -788,10 +795,7 @@ public class RevitArtifactRootObjectBuilder(
       return;
     }
 
-    if (revitElement is not null)
-    {
-      EmitFittingCenterline(pipeline, objK, appId, revitElement);
-    }
+    EmitFittingCenterline(pipeline, objK, appId, revitElement);
   }
 
   // Connector-derived branches for a fitting, ord = branch index so a tee's three stay ordered. See
@@ -862,8 +866,6 @@ public class RevitArtifactRootObjectBuilder(
     pipeline.AddProperties(childAppId, child.properties, RootScalars(child, child));
 
     EmitDisplayValue(pipeline, childK, childAppId, child.displayValue);
-    // Children are panels, mullions and rails — never MEP fittings, so no element is threaded down.
-    EmitCenterline(pipeline, childK, childAppId, null, child);
 
     int grandOrd = 0;
     foreach (RevitObject grandChild in child.elements)

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Speckle.Connectors.RevitShared.projitems
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Speckle.Connectors.RevitShared.projitems
@@ -23,6 +23,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)HostApp\DocumentToConvert.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HostApp\Elements.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HostApp\FamilyCategoryUtils.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)HostApp\MepCenterlineExtractor.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HostApp\FamilyGeometryBaker.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HostApp\FamilyMaterialManager.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HostApp\FamilyTransformUtils.cs" />

--- a/Connectors/Revit/Speckle.Connectors.RevitShared/Speckle.Connectors.RevitShared.projitems
+++ b/Connectors/Revit/Speckle.Connectors.RevitShared/Speckle.Connectors.RevitShared.projitems
@@ -23,6 +23,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)HostApp\DocumentToConvert.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HostApp\Elements.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HostApp\FamilyCategoryUtils.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)HostApp\CenterlineScope.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HostApp\MepCenterlineExtractor.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HostApp\FamilyGeometryBaker.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HostApp\FamilyMaterialManager.cs" />

--- a/Connectors/Rhino/Speckle.Connectors.Grasshopper7/packages.lock.json
+++ b/Connectors/Rhino/Speckle.Connectors.Grasshopper7/packages.lock.json
@@ -235,16 +235,16 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "o+u1sRKl+KUmxvGHoNhBu+JJtGseDDxevu0khtPrZ6A15AMQ8+jRK7n9C2HkOXlNexVUwKiC8WnAa6/LUo6JHQ==",
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "yM8ZPViRCYZyVoyB2aRXAnQ8HuLA7E9pAjQSk01Rys5EUSBHHQCVMOeOY/maZRUeXVVfqu+/DyV8ST4kjZyYBg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.10"
         }
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "l2Oa6SC8hq8f48mdWIXfnVbaUTlhKlrRVsGVUJSOnB77qPuwmj3CyZXoWFH/Gs9kcaEuC2wkbLRHndLpA77zcg=="
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "XpO62cnn84vGZUubF1CJ4GrsxUujwwdrv26T9uqsLLhzSWnxujNclrunZXcmJGGykufUWNT5SaDhd3UiMH17hw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -387,7 +387,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "speckle.connectors.logging": {
@@ -396,7 +396,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "speckle.converters.rhino7": {
@@ -414,9 +414,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-beta.4, )",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "qdHMddzoXCFv8dFe6FrwnLlSzlZNvZ1cv1842zO6HArROE1NOHK50zT8OtrPJJCwZSbBCaogyVxQTXWffDPl4A==",
+        "requested": "[2026.9.0-beta.5, )",
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "24tOTnFe3D8q0SWVCRGdhmDSuvZSicPK0RhzzjQBuT2MfR8goQxsKFcT7ogLWxFGsim5CTqKRidKhf13Wx+vjg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -426,8 +426,8 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-beta.4",
-          "Speckle.Sdk.Parquet": "2026.9.0-beta.4",
+          "Speckle.Sdk.Dependencies": "2026.9.0-beta.5",
+          "Speckle.Sdk.Parquet": "2026.9.0-beta.5",
           "System.Memory": "4.5.5",
           "System.Text.Json": "5.0.2"
         }

--- a/Connectors/Rhino/Speckle.Connectors.Grasshopper8/packages.lock.json
+++ b/Connectors/Rhino/Speckle.Connectors.Grasshopper8/packages.lock.json
@@ -235,16 +235,16 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "o+u1sRKl+KUmxvGHoNhBu+JJtGseDDxevu0khtPrZ6A15AMQ8+jRK7n9C2HkOXlNexVUwKiC8WnAa6/LUo6JHQ==",
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "yM8ZPViRCYZyVoyB2aRXAnQ8HuLA7E9pAjQSk01Rys5EUSBHHQCVMOeOY/maZRUeXVVfqu+/DyV8ST4kjZyYBg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.10"
         }
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "l2Oa6SC8hq8f48mdWIXfnVbaUTlhKlrRVsGVUJSOnB77qPuwmj3CyZXoWFH/Gs9kcaEuC2wkbLRHndLpA77zcg=="
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "XpO62cnn84vGZUubF1CJ4GrsxUujwwdrv26T9uqsLLhzSWnxujNclrunZXcmJGGykufUWNT5SaDhd3UiMH17hw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -387,7 +387,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "speckle.connectors.logging": {
@@ -396,7 +396,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "speckle.converters.rhino8": {
@@ -413,9 +413,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-beta.4, )",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "qdHMddzoXCFv8dFe6FrwnLlSzlZNvZ1cv1842zO6HArROE1NOHK50zT8OtrPJJCwZSbBCaogyVxQTXWffDPl4A==",
+        "requested": "[2026.9.0-beta.5, )",
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "24tOTnFe3D8q0SWVCRGdhmDSuvZSicPK0RhzzjQBuT2MfR8goQxsKFcT7ogLWxFGsim5CTqKRidKhf13Wx+vjg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -425,8 +425,8 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-beta.4",
-          "Speckle.Sdk.Parquet": "2026.9.0-beta.4",
+          "Speckle.Sdk.Dependencies": "2026.9.0-beta.5",
+          "Speckle.Sdk.Parquet": "2026.9.0-beta.5",
           "System.Memory": "4.5.5",
           "System.Text.Json": "5.0.2"
         }

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Objects/ExploreComponent.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Objects/ExploreComponent.cs
@@ -219,9 +219,8 @@ public class ExploreComponent : GH_Component, IGH_VariableParameterComponent
     // supplies the name and which namespace each end lives in, so a relation added to the spec appears by itself.
     foreach (var type in graph.RelationTypes)
     {
-      // A relation pointing AT geometry comes out as the geometry itself - a centerline is a curve you plug into
-      // Curve components, not an id you look up. Only the relations receive leaves unbaked reach here at all
-      // (ArtefactGraphCache.IsSurfacedGeometryRel), and Describe could only render their targets as bare indices.
+      // A relation pointing AT geometry comes out as the geometry itself — a centerline is a curve you plug
+      // into Curve components, not an id. Describe could only render its targets as bare indices.
       if (ArtefactGraphCache.IsGeometryNamespace(type.TargetNamespace))
       {
         Add(values, Humanise(type.Name), Decode(graph, type.Rel, objK));
@@ -340,16 +339,9 @@ public class ExploreComponent : GH_Component, IGH_VariableParameterComponent
     : bundle.ObjectAppIds.TryGetValue(k, out var appId) ? appId
     : null;
 
-  /// <summary>
-  /// The geometry a relation points at, decoded into the active document's units - the same decode path the receive
-  /// itself uses, so a centerline lands exactly on the object it belongs to.
-  /// </summary>
-  /// <remarks>
-  /// Failures are swallowed rather than surfaced: an unreadable blob means one empty branch, and Explore is a
-  /// read-only inspection component - failing the solve over it would be worse than showing nothing. The decoder
-  /// already absorbs SGEO problems into its warning list; the catch covers the raw-blob path, which no relation
-  /// surfaced today reaches but a future one could.
-  /// </remarks>
+  /// <summary>The geometry a relation points at, on the same decode path receive uses — so a centerline lands
+  /// exactly on the object it belongs to. Failures give one empty branch: Explore is read-only inspection, and
+  /// failing the solve over an unreadable blob would be worse than showing nothing.</summary>
   private static List<RG.GeometryBase> Decode(ArtefactGraph graph, byte rel, int objK)
   {
     var warnings = new List<string>();

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Objects/ExploreComponent.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Objects/ExploreComponent.cs
@@ -219,6 +219,15 @@ public class ExploreComponent : GH_Component, IGH_VariableParameterComponent
     // supplies the name and which namespace each end lives in, so a relation added to the spec appears by itself.
     foreach (var type in graph.RelationTypes)
     {
+      // A relation pointing AT geometry comes out as the geometry itself - a centerline is a curve you plug into
+      // Curve components, not an id you look up. Only the relations receive leaves unbaked reach here at all
+      // (ArtefactGraphCache.IsSurfacedGeometryRel), and Describe could only render their targets as bare indices.
+      if (ArtefactGraphCache.IsGeometryNamespace(type.TargetNamespace))
+      {
+        Add(values, Humanise(type.Name), Decode(graph, type.Rel, objK));
+        continue;
+      }
+
       if (ArtefactGraphCache.IsObjectNamespace(type.SourceNamespace))
       {
         Add(values, Humanise(type.Name), Describe(graph.Targets(type.Rel, objK), type.TargetNamespace, bundle));
@@ -330,6 +339,36 @@ public class ExploreComponent : GH_Component, IGH_VariableParameterComponent
     bundle.Nodes.TryGetValue(k, out var node) && node.Name is { Length: > 0 } name ? name
     : bundle.ObjectAppIds.TryGetValue(k, out var appId) ? appId
     : null;
+
+  /// <summary>
+  /// The geometry a relation points at, decoded into the active document's units - the same decode path the receive
+  /// itself uses, so a centerline lands exactly on the object it belongs to.
+  /// </summary>
+  /// <remarks>
+  /// Failures are swallowed rather than surfaced: an unreadable blob means one empty branch, and Explore is a
+  /// read-only inspection component - failing the solve over it would be worse than showing nothing. The decoder
+  /// already absorbs SGEO problems into its warning list; the catch covers the raw-blob path, which no relation
+  /// surfaced today reaches but a future one could.
+  /// </remarks>
+  private static List<RG.GeometryBase> Decode(ArtefactGraph graph, byte rel, int objK)
+  {
+    var warnings = new List<string>();
+    var result = new List<RG.GeometryBase>();
+    foreach (int geomK in graph.Targets(rel, objK))
+    {
+      try
+      {
+        result.AddRange(
+          ArtefactGeometryDecoder.DecodeGeometryIndex(geomK, graph.Bundle, graph.Bundle.Units, null, warnings)
+        );
+      }
+      catch (Exception ex) when (!ex.IsFatal())
+      {
+        // one unreadable fragment, not the whole port
+      }
+    }
+    return result;
+  }
 
   /// <summary>
   /// Turns dense ids into something readable, using the namespace the catalog declared for that end. Object and node

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Objects/ExploreComponent.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Objects/ExploreComponent.cs
@@ -64,27 +64,24 @@ public class ExploreComponent : GH_Component, IGH_VariableParameterComponent
     // applicable". Mirrors ExpandSpeckleProperties.
     if (da.Iteration == 0)
     {
-      // Gate on there being input at all, not on it resolving. With no input the data simply hasn't arrived yet (file
-      // load) and dropping ports would break wires - but input that resolves to nothing SHOULD clear them, otherwise
-      // swapping to an object the graph doesn't know leaves the previous object's ports sitting there.
-      if (Params.Input[0].VolatileData.DataCount > 0)
+      var resolved = Params
+        .Input[0]
+        .VolatileData.AllData(true)
+        .Select(Resolve)
+        .Where(r => r is not null)
+        .Cast<Dictionary<string, object?>>()
+        .ToList();
+
+      // NOTE: ports come from what resolved, never from nothing resolving - a graph that can't be read yet would
+      // otherwise unwire a reopened script
+      if (resolved.Count == 0)
       {
-        var resolved = Params
-          .Input[0]
-          .VolatileData.AllData(true)
-          .Select(Resolve)
-          .Where(r => r is not null)
-          .Cast<Dictionary<string, object?>>()
-          .ToList();
-
-        if (resolved.Count == 0)
-        {
-          // input arrived but none of it resolved - name what turned up, so an unhandled type is obvious rather
-          // than looking like the component is broken
-          var types = Params.Input[0].VolatileData.AllData(true).Select(g => g.GetType().Name).Distinct().ToList();
-          AddRuntimeMessage(GH_RuntimeMessageLevel.Remark, $"Nothing resolved from: {string.Join(", ", types)}.");
-        }
-
+        // name what turned up, so an unhandled type is obvious rather than looking like the component is broken
+        var types = Params.Input[0].VolatileData.AllData(true).Select(g => g.GetType().Name).Distinct().ToList();
+        AddRuntimeMessage(GH_RuntimeMessageLevel.Remark, $"Nothing resolved from: {string.Join(", ", types)}.");
+      }
+      else
+      {
         var names = new List<string>();
         foreach (var name in resolved.SelectMany(r => r.Keys))
         {
@@ -196,7 +193,8 @@ public class ExploreComponent : GH_Component, IGH_VariableParameterComponent
 
     if (values is { Count: 0 })
     {
-      return Explain("Nothing is recorded against this object.");
+      // empty, not absent - the caller clears ports on this, but not on null
+      AddRuntimeMessage(GH_RuntimeMessageLevel.Remark, "Nothing is recorded against this object.");
     }
 
     return values;

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Operations/Receive/ArtefactGeometryDecoder.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Operations/Receive/ArtefactGeometryDecoder.cs
@@ -1,0 +1,175 @@
+using Rhino;
+using Speckle.Connectors.GrasshopperShared.HostApp;
+using Speckle.Converters.Rhino.ToHost.Helpers;
+using Speckle.Objects.Other;
+using Speckle.Objects.Utils;
+using Speckle.Sdk;
+using Speckle.Sdk.Common;
+using Speckle.Sdk.Models;
+using Speckle.Sdk.Pipelines.Receive.Artifacts;
+using RG = Rhino.Geometry;
+using SOG = Speckle.Objects.Geometry;
+
+namespace Speckle.Connectors.GrasshopperShared.Operations.Receive;
+
+/// <summary>
+/// Turns one geometry index of an artefact <see cref="ArtefactBundle"/> into Rhino geometry, in the active document's
+/// units.
+/// </summary>
+/// <remarks>
+/// Extracted from <see cref="GrasshopperArtefactObjectBuilder"/> so the Explore component can decode the geometry the
+/// receive deliberately does NOT bake onto the canvas - a <c>CENTERLINE</c> curve - through the exact same path the
+/// receive uses for display geometry, rather than a second half-equivalent copy of it.
+/// </remarks>
+internal static class ArtefactGeometryDecoder
+{
+  // Decodes one geometry index to Rhino geometry, scaled from its source units to DocUnits (SGEO carries its own
+  // units; 3dm uses the caller-supplied fallback) — mirrors RhinoHostObjectArtefactBuilder.DecodeGeometryIndex.
+  // ConvertToSpeckle (below) stamps the *active document's* units onto the converted Base without rescaling the
+  // numeric values, so mesh/3dm geometry must already be in DocUnits by the time it gets there.
+  internal static List<RG.GeometryBase> DecodeGeometryIndex(
+    int geomK,
+    ArtefactBundle bundle,
+    string fallbackUnits,
+    string? sourceType,
+    List<string> warnings
+  )
+  {
+    if (!bundle.Geometries.TryGetValue(geomK, out var g))
+    {
+      return new List<RG.GeometryBase>();
+    }
+    if (g.Type == RawEncodingFormats.RHINO_3DM)
+    {
+      var geoms = RawEncodingToHost.Convert3dm(g.Content);
+      ApplyUnits(geoms, fallbackUnits);
+      return geoms;
+    }
+    if (g.IsSgeo)
+    {
+      // Meshes take the fast hand-rolled path (no Base allocation), scaled here.
+      if (SgeoDecoder.TryDecodeMesh(g.Content, out var sm))
+      {
+        var list = new List<RG.GeometryBase> { BuildMesh(sm) };
+        ApplyUnits(list, sm.Units);
+        return list;
+      }
+      // Curves, points, and point clouds: decode to a Speckle geometry object and convert via the shared Rhino ToHost
+      // converter (ConvertSpeckleGeometry below), which already scales from the decoded Base's own `units` to
+      // DocUnits (SpeckleToHostGeometryBaseTopLevelConverter) — so no extra ApplyUnits here, unlike mesh/3dm above.
+      // An unsupported/undecodable primitive degrades to nothing (with a warning) rather than aborting the receive.
+      Base? decoded = null;
+      try
+      {
+        decoded = AsSourceType(SgeoDecoder.Decode(g.Content), sourceType);
+        var converted = ConvertSpeckleGeometry(decoded);
+        if (converted.Count == 0)
+        {
+          warnings.Add($"Geometry {geomK} ({decoded.speckle_type}) did not convert to any native geometry.");
+        }
+        return converted;
+      }
+      catch (Exception ex) when (!ex.IsFatal())
+      {
+        string stage = decoded is null ? "decode" : $"convert of {decoded.speckle_type}";
+        warnings.Add($"Geometry {geomK} ({g.Type}) failed to {stage}: {ex.Message}");
+      }
+    }
+    return new List<RG.GeometryBase>();
+  }
+
+  // Speckle geometry object (from SgeoDecoder.Decode) → Rhino geometry via the shared Rhino ToHost converter (the
+  // same one Rhino's own artefact receive uses, ENG-8781). Mirrors RhinoHostObjectArtefactBuilder.ConvertSpeckleGeometry.
+  private static List<RG.GeometryBase> ConvertSpeckleGeometry(Base decoded) =>
+    SpeckleConversionContext
+      .Current.ConvertToHost(decoded)
+      .Select(pair => pair.Item1)
+      .OfType<RG.GeometryBase>()
+      .ToList();
+
+  private static void ApplyUnits(List<RG.GeometryBase> geoms, string? units)
+  {
+    if (units is not { Length: > 0 } u)
+    {
+      return;
+    }
+    var docUnits = DocUnits();
+    if (string.Equals(u, docUnits, StringComparison.OrdinalIgnoreCase))
+    {
+      return;
+    }
+    var t = RG.Transform.Scale(RG.Point3d.Origin, Units.GetConversionFactor(u, docUnits));
+    foreach (var geom in geoms)
+    {
+      geom.Transform(t);
+    }
+  }
+
+  // The active Rhino/GH document's units — what ConvertToSpeckle's converters (e.g. MeshToSpeckleConverter) stamp
+  // as the converted Base's "units" without rescaling, so all decoded geometry must land here before conversion.
+  internal static string DocUnits() => RhinoDoc.ActiveDoc?.ModelUnitSystem.ToSpeckleString() ?? Units.Meters;
+
+  // SGEO neutral mesh → Rhino mesh (Speckle count-prefixed face format; mirrors RhinoHostObjectArtefactBuilder).
+  private static RG.Mesh BuildMesh(SgeoMesh sm)
+  {
+    var mesh = new RG.Mesh();
+    var v = sm.Vertices;
+    for (int i = 0; i + 2 < v.Length; i += 3)
+    {
+      mesh.Vertices.Add(v[i], v[i + 1], v[i + 2]);
+    }
+
+    var f = sm.Faces;
+    int p = 0;
+    while (p < f.Length)
+    {
+      int n = f[p];
+      if (n < 3)
+      {
+        n += 3; // legacy 0 -> triangle, 1 -> quad
+      }
+      if (n == 3 && p + 3 < f.Length)
+      {
+        mesh.Faces.AddFace(f[p + 1], f[p + 2], f[p + 3]);
+      }
+      else if (n == 4 && p + 4 < f.Length)
+      {
+        mesh.Faces.AddFace(f[p + 1], f[p + 2], f[p + 3], f[p + 4]);
+      }
+      else if (n > 4 && p + n < f.Length)
+      {
+        for (int k = 1; k < n - 1; k++)
+        {
+          mesh.Faces.AddFace(f[p + 1], f[p + 1 + k], f[p + 2 + k]);
+        }
+      }
+      else
+      {
+        break;
+      }
+      p += n + 1;
+    }
+
+    if (sm.Colors.Length == mesh.Vertices.Count && sm.Colors.Length > 0)
+    {
+      foreach (var argb in sm.Colors)
+      {
+        mesh.VertexColors.Add(System.Drawing.Color.FromArgb(argb));
+      }
+    }
+    mesh.Normals.ComputeNormals();
+    mesh.Compact();
+    return mesh;
+  }
+
+  // SGEO encodes a single point and a whole point cloud under the same Points primitive, so Decode can only ever hand
+  // back a Pointcloud - and a Speckle Point came back as a one-point cloud, a different type to everything downstream
+  // [ENG-9162]. The object's source type is the discriminator the blob lacks. Mirrors RhinoHostObjectArtefactBuilder,
+  // which keys on Rhino's own ObjectType; here the send stamps the Speckle type instead.
+  private static Base AsSourceType(Base decoded, string? sourceType) =>
+    sourceType is not null
+    && sourceType.EndsWith(".Point", StringComparison.Ordinal)
+    && decoded is SOG.Pointcloud { points.Count: 3 } cloud
+      ? new SOG.Point(cloud.points[0], cloud.points[1], cloud.points[2], cloud.units)
+      : decoded;
+}

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Operations/Receive/ArtefactGeometryDecoder.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Operations/Receive/ArtefactGeometryDecoder.cs
@@ -13,13 +13,11 @@ using SOG = Speckle.Objects.Geometry;
 namespace Speckle.Connectors.GrasshopperShared.Operations.Receive;
 
 /// <summary>
-/// Turns one geometry index of an artefact <see cref="ArtefactBundle"/> into Rhino geometry, in the active document's
-/// units.
+/// Turns one geometry index of an artefact bundle into Rhino geometry, in the active document's units.
 /// </summary>
 /// <remarks>
-/// Extracted from <see cref="GrasshopperArtefactObjectBuilder"/> so the Explore component can decode the geometry the
-/// receive deliberately does NOT bake onto the canvas - a <c>CENTERLINE</c> curve - through the exact same path the
-/// receive uses for display geometry, rather than a second half-equivalent copy of it.
+/// Shared with <see cref="GrasshopperArtefactObjectBuilder"/> so Explore decodes the geometry receive does NOT
+/// bake — a CENTERLINE curve — through the same path, not a second half-equivalent copy of it.
 /// </remarks>
 internal static class ArtefactGeometryDecoder
 {

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Operations/Receive/ArtefactGraph.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Operations/Receive/ArtefactGraph.cs
@@ -1,3 +1,4 @@
+using Speckle.Sdk.Pipelines;
 using Speckle.Sdk.Pipelines.Receive.Artifacts;
 
 namespace Speckle.Connectors.GrasshopperShared.Operations.Receive;
@@ -103,6 +104,21 @@ internal static class ArtefactGraphCache
   public static bool IsGeometryNamespace(string? ns) =>
     ns is not null && ns.IndexOf(GEOMETRY_NS, StringComparison.OrdinalIgnoreCase) >= 0;
 
+  /// <summary>
+  /// The exceptions to <see cref="IsGeometryNamespace"/>: geometry relations receive does NOT resolve onto the canvas,
+  /// so Explore is the only route to them and dropping them would strand the geometry in the bundle.
+  /// </summary>
+  /// <remarks>
+  /// CENTERLINE is the whole membership today. The rule above holds for every other geometry relation precisely
+  /// because receive consumes it; a duct's axis is deliberately never baked (it would draw a line through the duct),
+  /// which is what puts it here instead. Kept as an explicit set rather than an inverted rule so a geometry relation
+  /// added to the spec stays hidden until someone decides what it should look like on the canvas.
+  /// </remarks>
+  private static readonly HashSet<byte> s_surfacedGeometryRels = [RelKind.Centerline];
+
+  /// <summary>Whether <paramref name="rel"/> is a geometry relation Explore surfaces as decoded native geometry.</summary>
+  public static bool IsSurfacedGeometryRel(byte rel) => s_surfacedGeometryRels.Contains(rel);
+
   public static bool IsNodeNamespace(string? ns) =>
     ns is not null && ns.IndexOf(NODE_NS, StringComparison.OrdinalIgnoreCase) >= 0;
 
@@ -204,7 +220,7 @@ internal static class ArtefactGraphCache
       {
         continue;
       }
-      if (IsGeometryNamespace(srcNs[i]) || IsGeometryNamespace(dstNs[i]))
+      if ((IsGeometryNamespace(srcNs[i]) || IsGeometryNamespace(dstNs[i])) && !IsSurfacedGeometryRel((byte)rel[i]))
       {
         continue;
       }

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Operations/Receive/ArtefactGraph.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Operations/Receive/ArtefactGraph.cs
@@ -105,19 +105,12 @@ internal static class ArtefactGraphCache
     ns is not null && ns.IndexOf(GEOMETRY_NS, StringComparison.OrdinalIgnoreCase) >= 0;
 
   /// <summary>
-  /// The exceptions to <see cref="IsGeometryNamespace"/>: geometry relations receive does NOT resolve onto the canvas,
-  /// so Explore is the only route to them and dropping them would strand the geometry in the bundle.
+  /// The exception to <see cref="IsGeometryNamespace"/>: a geometry relation receive does NOT bake, so Explore is
+  /// its only route out. CENTERLINE is the whole membership — the rule above holds for the others precisely
+  /// because receive consumes them. Kept a positive test, so a new geometry relation stays hidden until someone
+  /// decides what it should look like on the canvas.
   /// </summary>
-  /// <remarks>
-  /// CENTERLINE is the whole membership today. The rule above holds for every other geometry relation precisely
-  /// because receive consumes it; a duct's axis is deliberately never baked (it would draw a line through the duct),
-  /// which is what puts it here instead. Kept as an explicit set rather than an inverted rule so a geometry relation
-  /// added to the spec stays hidden until someone decides what it should look like on the canvas.
-  /// </remarks>
-  private static readonly HashSet<byte> s_surfacedGeometryRels = [RelKind.Centerline];
-
-  /// <summary>Whether <paramref name="rel"/> is a geometry relation Explore surfaces as decoded native geometry.</summary>
-  public static bool IsSurfacedGeometryRel(byte rel) => s_surfacedGeometryRels.Contains(rel);
+  private static bool IsSurfacedGeometryRel(byte rel) => rel == RelKind.Centerline;
 
   public static bool IsNodeNamespace(string? ns) =>
     ns is not null && ns.IndexOf(NODE_NS, StringComparison.OrdinalIgnoreCase) >= 0;

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Operations/Receive/GrasshopperArtefactObjectBuilder.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Operations/Receive/GrasshopperArtefactObjectBuilder.cs
@@ -1,5 +1,4 @@
 using System.Globalization;
-using Rhino;
 using Speckle.Connectors.Common.Operations;
 using Speckle.Connectors.GrasshopperShared.HostApp;
 using Speckle.Connectors.GrasshopperShared.Parameters;
@@ -16,7 +15,6 @@ using Speckle.Sdk.Pipelines;
 using Speckle.Sdk.Pipelines.Receive.Artifacts;
 using DataObject = Speckle.Objects.Data.DataObject;
 using RG = Rhino.Geometry;
-using SOG = Speckle.Objects.Geometry;
 using SpeckleRenderMaterial = Speckle.Objects.Other.RenderMaterial;
 
 namespace Speckle.Connectors.GrasshopperShared.Operations.Receive;
@@ -361,13 +359,16 @@ internal sealed class GrasshopperArtefactObjectBuilder
       var instNode = bundle.Nodes[e.Dst];
       int defNodeK = instNode.DefRef!.Value;
       var definition = definitions[defNodeK];
-      var xf = BuildTransform(instNode.Transform, instNode.Units is { Length: > 0 } u ? u : DocUnits());
+      var xf = BuildTransform(
+        instNode.Transform,
+        instNode.Units is { Length: > 0 } u ? u : ArtefactGeometryDecoder.DocUnits()
+      );
 
       var proxy = new InstanceProxy
       {
         definitionId = definition.ApplicationId!,
         transform = Matrix4x4.Identity,
-        units = DocUnits(),
+        units = ArtefactGeometryDecoder.DocUnits(),
         maxDepth = 0,
       };
       var instanceWrapper = new SpeckleBlockInstanceWrapper
@@ -419,7 +420,9 @@ internal sealed class GrasshopperArtefactObjectBuilder
     {
       foreach (var solidK in solidKs)
       {
-        foreach (var g in DecodeGeometryIndex(solidK, bundle, fallbackUnits, sourceType, warnings))
+        foreach (
+          var g in ArtefactGeometryDecoder.DecodeGeometryIndex(solidK, bundle, fallbackUnits, sourceType, warnings)
+        )
         {
           result.Add((solidK, g));
         }
@@ -429,7 +432,9 @@ internal sealed class GrasshopperArtefactObjectBuilder
     {
       foreach (var e in displayEdges.OrderBy(x => x.Ord))
       {
-        foreach (var g in DecodeGeometryIndex(e.Dst, bundle, fallbackUnits, sourceType, warnings))
+        foreach (
+          var g in ArtefactGeometryDecoder.DecodeGeometryIndex(e.Dst, bundle, fallbackUnits, sourceType, warnings)
+        )
         {
           result.Add((e.Dst, g));
         }
@@ -438,20 +443,10 @@ internal sealed class GrasshopperArtefactObjectBuilder
     return result;
   }
 
-  /// <summary>The owning object's source type, where the SGEO primitive alone is ambiguous - see <see cref="AsSourceType"/>.</summary>
+  /// <summary>The owning object's source type, where the SGEO primitive alone is ambiguous - see
+  /// <see cref="ArtefactGeometryDecoder"/>.</summary>
   private static string? ObjectSourceType(ArtefactBundle bundle, int objK) =>
     bundle.ObjectProperties(objK).GetString("type") is { Length: > 0 } s ? s : null;
-
-  // SGEO encodes a single point and a whole point cloud under the same Points primitive, so Decode can only ever hand
-  // back a Pointcloud - and a Speckle Point came back as a one-point cloud, a different type to everything downstream
-  // [ENG-9162]. The object's source type is the discriminator the blob lacks. Mirrors RhinoHostObjectArtefactBuilder,
-  // which keys on Rhino's own ObjectType; here the send stamps the Speckle type instead.
-  private static Base AsSourceType(Base decoded, string? sourceType) =>
-    sourceType is not null
-    && sourceType.EndsWith(".Point", StringComparison.Ordinal)
-    && decoded is SOG.Pointcloud { points.Count: 3 } cloud
-      ? new SOG.Point(cloud.points[0], cloud.points[1], cloud.points[2], cloud.units)
-      : decoded;
 
   // The send side stores "units" per object as an EAV property, falling back to the bundle's overall units when absent
   // (mirrors RhinoHostObjectArtefactBuilder.ObjectUnits).
@@ -653,7 +648,7 @@ internal sealed class GrasshopperArtefactObjectBuilder
             // DocUnits — otherwise a 3dm member isn't rescaled and a block sent from a metre model lands 1000x too
             // small in a millimetre GH doc (mirrors RhinoHostObjectArtefactBuilder.BuildDefinitions).
             // no owning object row for a definition member, so no source type to disambiguate points with
-            foreach (var g in DecodeGeometryIndex(geomK, bundle, bundle.Units, null, warnings))
+            foreach (var g in ArtefactGeometryDecoder.DecodeGeometryIndex(geomK, bundle, bundle.Units, null, warnings))
             {
               Base? converted;
               try
@@ -705,7 +700,7 @@ internal sealed class GrasshopperArtefactObjectBuilder
           {
             definitionId = childDef.ApplicationId!,
             transform = Matrix4x4.Identity,
-            units = DocUnits(),
+            units = ArtefactGeometryDecoder.DocUnits(),
             maxDepth = 0,
           };
           members.Add(
@@ -801,7 +796,7 @@ internal sealed class GrasshopperArtefactObjectBuilder
       d[0] = d[5] = d[10] = d[15] = 1.0;
     }
 
-    double scale = Units.GetConversionFactor(units, DocUnits());
+    double scale = Units.GetConversionFactor(units, ArtefactGeometryDecoder.DocUnits());
     var t = RG.Transform.Identity;
     t.M00 = d[0];
     t.M01 = d[1];
@@ -820,145 +815,6 @@ internal sealed class GrasshopperArtefactObjectBuilder
     t.M32 = d[14];
     t.M33 = d[15];
     return t;
-  }
-
-  // Decodes one geometry index to Rhino geometry, scaled from its source units to DocUnits (SGEO carries its own
-  // units; 3dm uses the caller-supplied fallback) — mirrors RhinoHostObjectArtefactBuilder.DecodeGeometryIndex.
-  // ConvertToSpeckle (below) stamps the *active document's* units onto the converted Base without rescaling the
-  // numeric values, so mesh/3dm geometry must already be in DocUnits by the time it gets there.
-  private static List<RG.GeometryBase> DecodeGeometryIndex(
-    int geomK,
-    ArtefactBundle bundle,
-    string fallbackUnits,
-    string? sourceType,
-    List<string> warnings
-  )
-  {
-    if (!bundle.Geometries.TryGetValue(geomK, out var g))
-    {
-      return new List<RG.GeometryBase>();
-    }
-    if (g.Type == RawEncodingFormats.RHINO_3DM)
-    {
-      var geoms = RawEncodingToHost.Convert3dm(g.Content);
-      ApplyUnits(geoms, fallbackUnits);
-      return geoms;
-    }
-    if (g.IsSgeo)
-    {
-      // Meshes take the fast hand-rolled path (no Base allocation), scaled here.
-      if (SgeoDecoder.TryDecodeMesh(g.Content, out var sm))
-      {
-        var list = new List<RG.GeometryBase> { BuildMesh(sm) };
-        ApplyUnits(list, sm.Units);
-        return list;
-      }
-      // Curves, points, and point clouds: decode to a Speckle geometry object and convert via the shared Rhino ToHost
-      // converter (ConvertSpeckleGeometry below), which already scales from the decoded Base's own `units` to
-      // DocUnits (SpeckleToHostGeometryBaseTopLevelConverter) — so no extra ApplyUnits here, unlike mesh/3dm above.
-      // An unsupported/undecodable primitive degrades to nothing (with a warning) rather than aborting the receive.
-      Base? decoded = null;
-      try
-      {
-        decoded = AsSourceType(SgeoDecoder.Decode(g.Content), sourceType);
-        var converted = ConvertSpeckleGeometry(decoded);
-        if (converted.Count == 0)
-        {
-          warnings.Add($"Geometry {geomK} ({decoded.speckle_type}) did not convert to any native geometry.");
-        }
-        return converted;
-      }
-      catch (Exception ex) when (!ex.IsFatal())
-      {
-        string stage = decoded is null ? "decode" : $"convert of {decoded.speckle_type}";
-        warnings.Add($"Geometry {geomK} ({g.Type}) failed to {stage}: {ex.Message}");
-      }
-    }
-    return new List<RG.GeometryBase>();
-  }
-
-  // Speckle geometry object (from SgeoDecoder.Decode) → Rhino geometry via the shared Rhino ToHost converter (the
-  // same one Rhino's own artefact receive uses, ENG-8781). Mirrors RhinoHostObjectArtefactBuilder.ConvertSpeckleGeometry.
-  private static List<RG.GeometryBase> ConvertSpeckleGeometry(Base decoded) =>
-    SpeckleConversionContext
-      .Current.ConvertToHost(decoded)
-      .Select(pair => pair.Item1)
-      .OfType<RG.GeometryBase>()
-      .ToList();
-
-  private static void ApplyUnits(List<RG.GeometryBase> geoms, string? units)
-  {
-    if (units is not { Length: > 0 } u)
-    {
-      return;
-    }
-    var docUnits = DocUnits();
-    if (string.Equals(u, docUnits, StringComparison.OrdinalIgnoreCase))
-    {
-      return;
-    }
-    var t = RG.Transform.Scale(RG.Point3d.Origin, Units.GetConversionFactor(u, docUnits));
-    foreach (var geom in geoms)
-    {
-      geom.Transform(t);
-    }
-  }
-
-  // The active Rhino/GH document's units — what ConvertToSpeckle's converters (e.g. MeshToSpeckleConverter) stamp
-  // as the converted Base's "units" without rescaling, so all decoded geometry must land here before conversion.
-  private static string DocUnits() => RhinoDoc.ActiveDoc?.ModelUnitSystem.ToSpeckleString() ?? Units.Meters;
-
-  // SGEO neutral mesh → Rhino mesh (Speckle count-prefixed face format; mirrors RhinoHostObjectArtefactBuilder).
-  private static RG.Mesh BuildMesh(SgeoMesh sm)
-  {
-    var mesh = new RG.Mesh();
-    var v = sm.Vertices;
-    for (int i = 0; i + 2 < v.Length; i += 3)
-    {
-      mesh.Vertices.Add(v[i], v[i + 1], v[i + 2]);
-    }
-
-    var f = sm.Faces;
-    int p = 0;
-    while (p < f.Length)
-    {
-      int n = f[p];
-      if (n < 3)
-      {
-        n += 3; // legacy 0 -> triangle, 1 -> quad
-      }
-      if (n == 3 && p + 3 < f.Length)
-      {
-        mesh.Faces.AddFace(f[p + 1], f[p + 2], f[p + 3]);
-      }
-      else if (n == 4 && p + 4 < f.Length)
-      {
-        mesh.Faces.AddFace(f[p + 1], f[p + 2], f[p + 3], f[p + 4]);
-      }
-      else if (n > 4 && p + n < f.Length)
-      {
-        for (int k = 1; k < n - 1; k++)
-        {
-          mesh.Faces.AddFace(f[p + 1], f[p + 1 + k], f[p + 2 + k]);
-        }
-      }
-      else
-      {
-        break;
-      }
-      p += n + 1;
-    }
-
-    if (sm.Colors.Length == mesh.Vertices.Count && sm.Colors.Length > 0)
-    {
-      foreach (var argb in sm.Colors)
-      {
-        mesh.VertexColors.Add(System.Drawing.Color.FromArgb(argb));
-      }
-    }
-    mesh.Normals.ComputeNormals();
-    mesh.Compact();
-    return mesh;
   }
 
   // Resolves (and creates once) the nested collection-wrapper chain for the given scene-view segments under the root.

--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Speckle.Connectors.GrasshopperShared.projitems
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Speckle.Connectors.GrasshopperShared.projitems
@@ -56,6 +56,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Operations\Receive\LocalToGlobalMapHandler.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Operations\Receive\GrasshopperColorUnpacker.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Operations\Receive\ArtefactGraph.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Operations\Receive\ArtefactGeometryDecoder.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Operations\Receive\GrasshopperArtefactObjectBuilder.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Operations\Receive\GrasshopperCollectionRebuilder.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Components\Operations\Receive\ReceiveComponentBase.cs" />

--- a/Connectors/Rhino/Speckle.Connectors.Rhino7/packages.lock.json
+++ b/Connectors/Rhino/Speckle.Connectors.Rhino7/packages.lock.json
@@ -194,16 +194,16 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "o+u1sRKl+KUmxvGHoNhBu+JJtGseDDxevu0khtPrZ6A15AMQ8+jRK7n9C2HkOXlNexVUwKiC8WnAa6/LUo6JHQ==",
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "yM8ZPViRCYZyVoyB2aRXAnQ8HuLA7E9pAjQSk01Rys5EUSBHHQCVMOeOY/maZRUeXVVfqu+/DyV8ST4kjZyYBg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.10"
         }
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "l2Oa6SC8hq8f48mdWIXfnVbaUTlhKlrRVsGVUJSOnB77qPuwmj3CyZXoWFH/Gs9kcaEuC2wkbLRHndLpA77zcg=="
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "XpO62cnn84vGZUubF1CJ4GrsxUujwwdrv26T9uqsLLhzSWnxujNclrunZXcmJGGykufUWNT5SaDhd3UiMH17hw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -337,7 +337,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "speckle.connectors.dui": {
@@ -368,7 +368,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "speckle.converters.rhino7": {
@@ -401,9 +401,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-beta.4, )",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "qdHMddzoXCFv8dFe6FrwnLlSzlZNvZ1cv1842zO6HArROE1NOHK50zT8OtrPJJCwZSbBCaogyVxQTXWffDPl4A==",
+        "requested": "[2026.9.0-beta.5, )",
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "24tOTnFe3D8q0SWVCRGdhmDSuvZSicPK0RhzzjQBuT2MfR8goQxsKFcT7ogLWxFGsim5CTqKRidKhf13Wx+vjg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -413,8 +413,8 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-beta.4",
-          "Speckle.Sdk.Parquet": "2026.9.0-beta.4",
+          "Speckle.Sdk.Dependencies": "2026.9.0-beta.5",
+          "Speckle.Sdk.Parquet": "2026.9.0-beta.5",
           "System.Memory": "4.5.5",
           "System.Text.Json": "5.0.2"
         }

--- a/Connectors/Rhino/Speckle.Connectors.Rhino8/packages.lock.json
+++ b/Connectors/Rhino/Speckle.Connectors.Rhino8/packages.lock.json
@@ -232,16 +232,16 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "o+u1sRKl+KUmxvGHoNhBu+JJtGseDDxevu0khtPrZ6A15AMQ8+jRK7n9C2HkOXlNexVUwKiC8WnAa6/LUo6JHQ==",
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "yM8ZPViRCYZyVoyB2aRXAnQ8HuLA7E9pAjQSk01Rys5EUSBHHQCVMOeOY/maZRUeXVVfqu+/DyV8ST4kjZyYBg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.10"
         }
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "l2Oa6SC8hq8f48mdWIXfnVbaUTlhKlrRVsGVUJSOnB77qPuwmj3CyZXoWFH/Gs9kcaEuC2wkbLRHndLpA77zcg=="
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "XpO62cnn84vGZUubF1CJ4GrsxUujwwdrv26T9uqsLLhzSWnxujNclrunZXcmJGGykufUWNT5SaDhd3UiMH17hw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -385,7 +385,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "speckle.connectors.dui": {
@@ -416,7 +416,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "speckle.converters.rhino8": {
@@ -448,9 +448,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-beta.4, )",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "qdHMddzoXCFv8dFe6FrwnLlSzlZNvZ1cv1842zO6HArROE1NOHK50zT8OtrPJJCwZSbBCaogyVxQTXWffDPl4A==",
+        "requested": "[2026.9.0-beta.5, )",
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "24tOTnFe3D8q0SWVCRGdhmDSuvZSicPK0RhzzjQBuT2MfR8goQxsKFcT7ogLWxFGsim5CTqKRidKhf13Wx+vjg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -460,8 +460,8 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-beta.4",
-          "Speckle.Sdk.Parquet": "2026.9.0-beta.4",
+          "Speckle.Sdk.Dependencies": "2026.9.0-beta.5",
+          "Speckle.Sdk.Parquet": "2026.9.0-beta.5",
           "System.Memory": "4.5.5",
           "System.Text.Json": "5.0.2"
         }

--- a/Connectors/Rhino/Speckle.Connectors.RhinoHeadless/packages.lock.json
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoHeadless/packages.lock.json
@@ -148,13 +148,13 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "o+u1sRKl+KUmxvGHoNhBu+JJtGseDDxevu0khtPrZ6A15AMQ8+jRK7n9C2HkOXlNexVUwKiC8WnAa6/LUo6JHQ=="
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "yM8ZPViRCYZyVoyB2aRXAnQ8HuLA7E9pAjQSk01Rys5EUSBHHQCVMOeOY/maZRUeXVVfqu+/DyV8ST4kjZyYBg=="
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "l2Oa6SC8hq8f48mdWIXfnVbaUTlhKlrRVsGVUJSOnB77qPuwmj3CyZXoWFH/Gs9kcaEuC2wkbLRHndLpA77zcg=="
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "XpO62cnn84vGZUubF1CJ4GrsxUujwwdrv26T9uqsLLhzSWnxujNclrunZXcmJGGykufUWNT5SaDhd3UiMH17hw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -201,7 +201,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "speckle.connectors.logging": {
@@ -210,7 +210,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "speckle.converters.rhino9": {
@@ -238,9 +238,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-beta.4, )",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "qdHMddzoXCFv8dFe6FrwnLlSzlZNvZ1cv1842zO6HArROE1NOHK50zT8OtrPJJCwZSbBCaogyVxQTXWffDPl4A==",
+        "requested": "[2026.9.0-beta.5, )",
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "24tOTnFe3D8q0SWVCRGdhmDSuvZSicPK0RhzzjQBuT2MfR8goQxsKFcT7ogLWxFGsim5CTqKRidKhf13Wx+vjg==",
         "dependencies": {
           "GraphQL.Client": "6.1.0",
           "Microsoft.Data.Sqlite": "10.0.0",
@@ -248,8 +248,8 @@
           "Microsoft.Extensions.ObjectPool": "10.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-beta.4",
-          "Speckle.Sdk.Parquet": "2026.9.0-beta.4"
+          "Speckle.Sdk.Dependencies": "2026.9.0-beta.5",
+          "Speckle.Sdk.Parquet": "2026.9.0-beta.5"
         }
       }
     }

--- a/Connectors/Rhino/Speckle.Connectors.RhinoImporter/packages.lock.json
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoImporter/packages.lock.json
@@ -156,13 +156,13 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "o+u1sRKl+KUmxvGHoNhBu+JJtGseDDxevu0khtPrZ6A15AMQ8+jRK7n9C2HkOXlNexVUwKiC8WnAa6/LUo6JHQ=="
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "yM8ZPViRCYZyVoyB2aRXAnQ8HuLA7E9pAjQSk01Rys5EUSBHHQCVMOeOY/maZRUeXVVfqu+/DyV8ST4kjZyYBg=="
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "l2Oa6SC8hq8f48mdWIXfnVbaUTlhKlrRVsGVUJSOnB77qPuwmj3CyZXoWFH/Gs9kcaEuC2wkbLRHndLpA77zcg=="
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "XpO62cnn84vGZUubF1CJ4GrsxUujwwdrv26T9uqsLLhzSWnxujNclrunZXcmJGGykufUWNT5SaDhd3UiMH17hw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -217,7 +217,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "speckle.connectors.dui": {
@@ -239,7 +239,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "speckle.converters.rhino8": {
@@ -262,9 +262,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-beta.4, )",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "qdHMddzoXCFv8dFe6FrwnLlSzlZNvZ1cv1842zO6HArROE1NOHK50zT8OtrPJJCwZSbBCaogyVxQTXWffDPl4A==",
+        "requested": "[2026.9.0-beta.5, )",
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "24tOTnFe3D8q0SWVCRGdhmDSuvZSicPK0RhzzjQBuT2MfR8goQxsKFcT7ogLWxFGsim5CTqKRidKhf13Wx+vjg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -272,8 +272,8 @@
           "Microsoft.Extensions.ObjectPool": "8.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-beta.4",
-          "Speckle.Sdk.Parquet": "2026.9.0-beta.4"
+          "Speckle.Sdk.Dependencies": "2026.9.0-beta.5",
+          "Speckle.Sdk.Parquet": "2026.9.0-beta.5"
         }
       }
     },

--- a/Connectors/TSD/Speckle.Connectors.TSD2027/packages.lock.json
+++ b/Connectors/TSD/Speckle.Connectors.TSD2027/packages.lock.json
@@ -171,13 +171,13 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "o+u1sRKl+KUmxvGHoNhBu+JJtGseDDxevu0khtPrZ6A15AMQ8+jRK7n9C2HkOXlNexVUwKiC8WnAa6/LUo6JHQ=="
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "yM8ZPViRCYZyVoyB2aRXAnQ8HuLA7E9pAjQSk01Rys5EUSBHHQCVMOeOY/maZRUeXVVfqu+/DyV8ST4kjZyYBg=="
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "l2Oa6SC8hq8f48mdWIXfnVbaUTlhKlrRVsGVUJSOnB77qPuwmj3CyZXoWFH/Gs9kcaEuC2wkbLRHndLpA77zcg=="
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "XpO62cnn84vGZUubF1CJ4GrsxUujwwdrv26T9uqsLLhzSWnxujNclrunZXcmJGGykufUWNT5SaDhd3UiMH17hw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -223,7 +223,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "speckle.connectors.dui": {
@@ -245,7 +245,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "speckle.converters.tsd2027": {
@@ -275,9 +275,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-beta.4, )",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "qdHMddzoXCFv8dFe6FrwnLlSzlZNvZ1cv1842zO6HArROE1NOHK50zT8OtrPJJCwZSbBCaogyVxQTXWffDPl4A==",
+        "requested": "[2026.9.0-beta.5, )",
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "24tOTnFe3D8q0SWVCRGdhmDSuvZSicPK0RhzzjQBuT2MfR8goQxsKFcT7ogLWxFGsim5CTqKRidKhf13Wx+vjg==",
         "dependencies": {
           "GraphQL.Client": "6.1.0",
           "Microsoft.Data.Sqlite": "10.0.0",
@@ -285,8 +285,8 @@
           "Microsoft.Extensions.ObjectPool": "10.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-beta.4",
-          "Speckle.Sdk.Parquet": "2026.9.0-beta.4"
+          "Speckle.Sdk.Dependencies": "2026.9.0-beta.5",
+          "Speckle.Sdk.Parquet": "2026.9.0-beta.5"
         }
       }
     }

--- a/Connectors/Tekla/Speckle.Connector.Tekla2023/packages.lock.json
+++ b/Connectors/Tekla/Speckle.Connector.Tekla2023/packages.lock.json
@@ -256,16 +256,16 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "o+u1sRKl+KUmxvGHoNhBu+JJtGseDDxevu0khtPrZ6A15AMQ8+jRK7n9C2HkOXlNexVUwKiC8WnAa6/LUo6JHQ==",
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "yM8ZPViRCYZyVoyB2aRXAnQ8HuLA7E9pAjQSk01Rys5EUSBHHQCVMOeOY/maZRUeXVVfqu+/DyV8ST4kjZyYBg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.10"
         }
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "l2Oa6SC8hq8f48mdWIXfnVbaUTlhKlrRVsGVUJSOnB77qPuwmj3CyZXoWFH/Gs9kcaEuC2wkbLRHndLpA77zcg=="
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "XpO62cnn84vGZUubF1CJ4GrsxUujwwdrv26T9uqsLLhzSWnxujNclrunZXcmJGGykufUWNT5SaDhd3UiMH17hw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -408,7 +408,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "speckle.connectors.dui": {
@@ -439,7 +439,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "LibTessDotNet": {
@@ -462,9 +462,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-beta.4, )",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "qdHMddzoXCFv8dFe6FrwnLlSzlZNvZ1cv1842zO6HArROE1NOHK50zT8OtrPJJCwZSbBCaogyVxQTXWffDPl4A==",
+        "requested": "[2026.9.0-beta.5, )",
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "24tOTnFe3D8q0SWVCRGdhmDSuvZSicPK0RhzzjQBuT2MfR8goQxsKFcT7ogLWxFGsim5CTqKRidKhf13Wx+vjg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -474,8 +474,8 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-beta.4",
-          "Speckle.Sdk.Parquet": "2026.9.0-beta.4",
+          "Speckle.Sdk.Dependencies": "2026.9.0-beta.5",
+          "Speckle.Sdk.Parquet": "2026.9.0-beta.5",
           "System.Memory": "4.5.5",
           "System.Text.Json": "5.0.2"
         }

--- a/Connectors/Tekla/Speckle.Connector.Tekla2024/packages.lock.json
+++ b/Connectors/Tekla/Speckle.Connector.Tekla2024/packages.lock.json
@@ -275,16 +275,16 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "o+u1sRKl+KUmxvGHoNhBu+JJtGseDDxevu0khtPrZ6A15AMQ8+jRK7n9C2HkOXlNexVUwKiC8WnAa6/LUo6JHQ==",
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "yM8ZPViRCYZyVoyB2aRXAnQ8HuLA7E9pAjQSk01Rys5EUSBHHQCVMOeOY/maZRUeXVVfqu+/DyV8ST4kjZyYBg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.10"
         }
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "l2Oa6SC8hq8f48mdWIXfnVbaUTlhKlrRVsGVUJSOnB77qPuwmj3CyZXoWFH/Gs9kcaEuC2wkbLRHndLpA77zcg=="
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "XpO62cnn84vGZUubF1CJ4GrsxUujwwdrv26T9uqsLLhzSWnxujNclrunZXcmJGGykufUWNT5SaDhd3UiMH17hw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -489,7 +489,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "speckle.connectors.dui": {
@@ -520,7 +520,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "LibTessDotNet": {
@@ -543,9 +543,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-beta.4, )",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "qdHMddzoXCFv8dFe6FrwnLlSzlZNvZ1cv1842zO6HArROE1NOHK50zT8OtrPJJCwZSbBCaogyVxQTXWffDPl4A==",
+        "requested": "[2026.9.0-beta.5, )",
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "24tOTnFe3D8q0SWVCRGdhmDSuvZSicPK0RhzzjQBuT2MfR8goQxsKFcT7ogLWxFGsim5CTqKRidKhf13Wx+vjg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -555,8 +555,8 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-beta.4",
-          "Speckle.Sdk.Parquet": "2026.9.0-beta.4",
+          "Speckle.Sdk.Dependencies": "2026.9.0-beta.5",
+          "Speckle.Sdk.Parquet": "2026.9.0-beta.5",
           "System.Memory": "4.5.5",
           "System.Text.Json": "5.0.2"
         }

--- a/Connectors/Tekla/Speckle.Connector.Tekla2025/packages.lock.json
+++ b/Connectors/Tekla/Speckle.Connector.Tekla2025/packages.lock.json
@@ -275,16 +275,16 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "o+u1sRKl+KUmxvGHoNhBu+JJtGseDDxevu0khtPrZ6A15AMQ8+jRK7n9C2HkOXlNexVUwKiC8WnAa6/LUo6JHQ==",
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "yM8ZPViRCYZyVoyB2aRXAnQ8HuLA7E9pAjQSk01Rys5EUSBHHQCVMOeOY/maZRUeXVVfqu+/DyV8ST4kjZyYBg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.10"
         }
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "l2Oa6SC8hq8f48mdWIXfnVbaUTlhKlrRVsGVUJSOnB77qPuwmj3CyZXoWFH/Gs9kcaEuC2wkbLRHndLpA77zcg=="
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "XpO62cnn84vGZUubF1CJ4GrsxUujwwdrv26T9uqsLLhzSWnxujNclrunZXcmJGGykufUWNT5SaDhd3UiMH17hw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -489,7 +489,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "speckle.connectors.dui": {
@@ -520,7 +520,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "LibTessDotNet": {
@@ -543,9 +543,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-beta.4, )",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "qdHMddzoXCFv8dFe6FrwnLlSzlZNvZ1cv1842zO6HArROE1NOHK50zT8OtrPJJCwZSbBCaogyVxQTXWffDPl4A==",
+        "requested": "[2026.9.0-beta.5, )",
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "24tOTnFe3D8q0SWVCRGdhmDSuvZSicPK0RhzzjQBuT2MfR8goQxsKFcT7ogLWxFGsim5CTqKRidKhf13Wx+vjg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -555,8 +555,8 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-beta.4",
-          "Speckle.Sdk.Parquet": "2026.9.0-beta.4",
+          "Speckle.Sdk.Dependencies": "2026.9.0-beta.5",
+          "Speckle.Sdk.Parquet": "2026.9.0-beta.5",
           "System.Memory": "4.5.5",
           "System.Text.Json": "5.0.2"
         }

--- a/Converters/Autocad/Speckle.Converters.Autocad2023/packages.lock.json
+++ b/Converters/Autocad/Speckle.Converters.Autocad2023/packages.lock.json
@@ -180,16 +180,16 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "o+u1sRKl+KUmxvGHoNhBu+JJtGseDDxevu0khtPrZ6A15AMQ8+jRK7n9C2HkOXlNexVUwKiC8WnAa6/LUo6JHQ==",
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "yM8ZPViRCYZyVoyB2aRXAnQ8HuLA7E9pAjQSk01Rys5EUSBHHQCVMOeOY/maZRUeXVVfqu+/DyV8ST4kjZyYBg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.10"
         }
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "l2Oa6SC8hq8f48mdWIXfnVbaUTlhKlrRVsGVUJSOnB77qPuwmj3CyZXoWFH/Gs9kcaEuC2wkbLRHndLpA77zcg=="
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "XpO62cnn84vGZUubF1CJ4GrsxUujwwdrv26T9uqsLLhzSWnxujNclrunZXcmJGGykufUWNT5SaDhd3UiMH17hw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -293,7 +293,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "Speckle.DoubleNumerics": {
@@ -304,9 +304,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-beta.4, )",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "qdHMddzoXCFv8dFe6FrwnLlSzlZNvZ1cv1842zO6HArROE1NOHK50zT8OtrPJJCwZSbBCaogyVxQTXWffDPl4A==",
+        "requested": "[2026.9.0-beta.5, )",
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "24tOTnFe3D8q0SWVCRGdhmDSuvZSicPK0RhzzjQBuT2MfR8goQxsKFcT7ogLWxFGsim5CTqKRidKhf13Wx+vjg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -316,8 +316,8 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-beta.4",
-          "Speckle.Sdk.Parquet": "2026.9.0-beta.4",
+          "Speckle.Sdk.Dependencies": "2026.9.0-beta.5",
+          "Speckle.Sdk.Parquet": "2026.9.0-beta.5",
           "System.Memory": "4.5.5",
           "System.Text.Json": "5.0.2"
         }

--- a/Converters/Autocad/Speckle.Converters.Autocad2024/packages.lock.json
+++ b/Converters/Autocad/Speckle.Converters.Autocad2024/packages.lock.json
@@ -180,16 +180,16 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "o+u1sRKl+KUmxvGHoNhBu+JJtGseDDxevu0khtPrZ6A15AMQ8+jRK7n9C2HkOXlNexVUwKiC8WnAa6/LUo6JHQ==",
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "yM8ZPViRCYZyVoyB2aRXAnQ8HuLA7E9pAjQSk01Rys5EUSBHHQCVMOeOY/maZRUeXVVfqu+/DyV8ST4kjZyYBg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.10"
         }
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "l2Oa6SC8hq8f48mdWIXfnVbaUTlhKlrRVsGVUJSOnB77qPuwmj3CyZXoWFH/Gs9kcaEuC2wkbLRHndLpA77zcg=="
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "XpO62cnn84vGZUubF1CJ4GrsxUujwwdrv26T9uqsLLhzSWnxujNclrunZXcmJGGykufUWNT5SaDhd3UiMH17hw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -295,7 +295,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "speckle.connectors.dui": {
@@ -317,7 +317,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "Microsoft.Web.WebView2": {
@@ -334,9 +334,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-beta.4, )",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "qdHMddzoXCFv8dFe6FrwnLlSzlZNvZ1cv1842zO6HArROE1NOHK50zT8OtrPJJCwZSbBCaogyVxQTXWffDPl4A==",
+        "requested": "[2026.9.0-beta.5, )",
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "24tOTnFe3D8q0SWVCRGdhmDSuvZSicPK0RhzzjQBuT2MfR8goQxsKFcT7ogLWxFGsim5CTqKRidKhf13Wx+vjg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -346,8 +346,8 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-beta.4",
-          "Speckle.Sdk.Parquet": "2026.9.0-beta.4",
+          "Speckle.Sdk.Dependencies": "2026.9.0-beta.5",
+          "Speckle.Sdk.Parquet": "2026.9.0-beta.5",
           "System.Memory": "4.5.5",
           "System.Text.Json": "5.0.2"
         }

--- a/Converters/Autocad/Speckle.Converters.Autocad2025/packages.lock.json
+++ b/Converters/Autocad/Speckle.Converters.Autocad2025/packages.lock.json
@@ -139,13 +139,13 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "o+u1sRKl+KUmxvGHoNhBu+JJtGseDDxevu0khtPrZ6A15AMQ8+jRK7n9C2HkOXlNexVUwKiC8WnAa6/LUo6JHQ=="
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "yM8ZPViRCYZyVoyB2aRXAnQ8HuLA7E9pAjQSk01Rys5EUSBHHQCVMOeOY/maZRUeXVVfqu+/DyV8ST4kjZyYBg=="
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "l2Oa6SC8hq8f48mdWIXfnVbaUTlhKlrRVsGVUJSOnB77qPuwmj3CyZXoWFH/Gs9kcaEuC2wkbLRHndLpA77zcg=="
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "XpO62cnn84vGZUubF1CJ4GrsxUujwwdrv26T9uqsLLhzSWnxujNclrunZXcmJGGykufUWNT5SaDhd3UiMH17hw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -192,7 +192,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "speckle.connectors.dui": {
@@ -214,7 +214,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "Microsoft.Web.WebView2": {
@@ -231,9 +231,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-beta.4, )",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "qdHMddzoXCFv8dFe6FrwnLlSzlZNvZ1cv1842zO6HArROE1NOHK50zT8OtrPJJCwZSbBCaogyVxQTXWffDPl4A==",
+        "requested": "[2026.9.0-beta.5, )",
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "24tOTnFe3D8q0SWVCRGdhmDSuvZSicPK0RhzzjQBuT2MfR8goQxsKFcT7ogLWxFGsim5CTqKRidKhf13Wx+vjg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -241,8 +241,8 @@
           "Microsoft.Extensions.ObjectPool": "8.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-beta.4",
-          "Speckle.Sdk.Parquet": "2026.9.0-beta.4"
+          "Speckle.Sdk.Dependencies": "2026.9.0-beta.5",
+          "Speckle.Sdk.Parquet": "2026.9.0-beta.5"
         }
       }
     }

--- a/Converters/Autocad/Speckle.Converters.Autocad2026/packages.lock.json
+++ b/Converters/Autocad/Speckle.Converters.Autocad2026/packages.lock.json
@@ -139,13 +139,13 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "o+u1sRKl+KUmxvGHoNhBu+JJtGseDDxevu0khtPrZ6A15AMQ8+jRK7n9C2HkOXlNexVUwKiC8WnAa6/LUo6JHQ=="
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "yM8ZPViRCYZyVoyB2aRXAnQ8HuLA7E9pAjQSk01Rys5EUSBHHQCVMOeOY/maZRUeXVVfqu+/DyV8ST4kjZyYBg=="
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "l2Oa6SC8hq8f48mdWIXfnVbaUTlhKlrRVsGVUJSOnB77qPuwmj3CyZXoWFH/Gs9kcaEuC2wkbLRHndLpA77zcg=="
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "XpO62cnn84vGZUubF1CJ4GrsxUujwwdrv26T9uqsLLhzSWnxujNclrunZXcmJGGykufUWNT5SaDhd3UiMH17hw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -192,7 +192,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "speckle.connectors.dui": {
@@ -214,7 +214,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "Microsoft.Web.WebView2": {
@@ -231,9 +231,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-beta.4, )",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "qdHMddzoXCFv8dFe6FrwnLlSzlZNvZ1cv1842zO6HArROE1NOHK50zT8OtrPJJCwZSbBCaogyVxQTXWffDPl4A==",
+        "requested": "[2026.9.0-beta.5, )",
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "24tOTnFe3D8q0SWVCRGdhmDSuvZSicPK0RhzzjQBuT2MfR8goQxsKFcT7ogLWxFGsim5CTqKRidKhf13Wx+vjg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -241,8 +241,8 @@
           "Microsoft.Extensions.ObjectPool": "8.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-beta.4",
-          "Speckle.Sdk.Parquet": "2026.9.0-beta.4"
+          "Speckle.Sdk.Dependencies": "2026.9.0-beta.5",
+          "Speckle.Sdk.Parquet": "2026.9.0-beta.5"
         }
       }
     }

--- a/Converters/Autocad/Speckle.Converters.Autocad2027/packages.lock.json
+++ b/Converters/Autocad/Speckle.Converters.Autocad2027/packages.lock.json
@@ -140,13 +140,13 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "o+u1sRKl+KUmxvGHoNhBu+JJtGseDDxevu0khtPrZ6A15AMQ8+jRK7n9C2HkOXlNexVUwKiC8WnAa6/LUo6JHQ=="
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "yM8ZPViRCYZyVoyB2aRXAnQ8HuLA7E9pAjQSk01Rys5EUSBHHQCVMOeOY/maZRUeXVVfqu+/DyV8ST4kjZyYBg=="
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "l2Oa6SC8hq8f48mdWIXfnVbaUTlhKlrRVsGVUJSOnB77qPuwmj3CyZXoWFH/Gs9kcaEuC2wkbLRHndLpA77zcg=="
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "XpO62cnn84vGZUubF1CJ4GrsxUujwwdrv26T9uqsLLhzSWnxujNclrunZXcmJGGykufUWNT5SaDhd3UiMH17hw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -185,7 +185,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "speckle.connectors.dui": {
@@ -207,7 +207,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "Microsoft.Web.WebView2": {
@@ -224,9 +224,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-beta.4, )",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "qdHMddzoXCFv8dFe6FrwnLlSzlZNvZ1cv1842zO6HArROE1NOHK50zT8OtrPJJCwZSbBCaogyVxQTXWffDPl4A==",
+        "requested": "[2026.9.0-beta.5, )",
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "24tOTnFe3D8q0SWVCRGdhmDSuvZSicPK0RhzzjQBuT2MfR8goQxsKFcT7ogLWxFGsim5CTqKRidKhf13Wx+vjg==",
         "dependencies": {
           "GraphQL.Client": "6.1.0",
           "Microsoft.Data.Sqlite": "10.0.0",
@@ -234,8 +234,8 @@
           "Microsoft.Extensions.ObjectPool": "10.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-beta.4",
-          "Speckle.Sdk.Parquet": "2026.9.0-beta.4"
+          "Speckle.Sdk.Dependencies": "2026.9.0-beta.5",
+          "Speckle.Sdk.Parquet": "2026.9.0-beta.5"
         }
       }
     }

--- a/Converters/CSi/Speckle.Converters.ETABS21/packages.lock.json
+++ b/Converters/CSi/Speckle.Converters.ETABS21/packages.lock.json
@@ -180,16 +180,16 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "o+u1sRKl+KUmxvGHoNhBu+JJtGseDDxevu0khtPrZ6A15AMQ8+jRK7n9C2HkOXlNexVUwKiC8WnAa6/LUo6JHQ==",
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "yM8ZPViRCYZyVoyB2aRXAnQ8HuLA7E9pAjQSk01Rys5EUSBHHQCVMOeOY/maZRUeXVVfqu+/DyV8ST4kjZyYBg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.10"
         }
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "l2Oa6SC8hq8f48mdWIXfnVbaUTlhKlrRVsGVUJSOnB77qPuwmj3CyZXoWFH/Gs9kcaEuC2wkbLRHndLpA77zcg=="
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "XpO62cnn84vGZUubF1CJ4GrsxUujwwdrv26T9uqsLLhzSWnxujNclrunZXcmJGGykufUWNT5SaDhd3UiMH17hw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -293,7 +293,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "Speckle.DoubleNumerics": {
@@ -304,9 +304,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-beta.4, )",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "qdHMddzoXCFv8dFe6FrwnLlSzlZNvZ1cv1842zO6HArROE1NOHK50zT8OtrPJJCwZSbBCaogyVxQTXWffDPl4A==",
+        "requested": "[2026.9.0-beta.5, )",
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "24tOTnFe3D8q0SWVCRGdhmDSuvZSicPK0RhzzjQBuT2MfR8goQxsKFcT7ogLWxFGsim5CTqKRidKhf13Wx+vjg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -316,8 +316,8 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-beta.4",
-          "Speckle.Sdk.Parquet": "2026.9.0-beta.4",
+          "Speckle.Sdk.Dependencies": "2026.9.0-beta.5",
+          "Speckle.Sdk.Parquet": "2026.9.0-beta.5",
           "System.Memory": "4.5.5",
           "System.Text.Json": "5.0.2"
         }

--- a/Converters/CSi/Speckle.Converters.ETABS22/packages.lock.json
+++ b/Converters/CSi/Speckle.Converters.ETABS22/packages.lock.json
@@ -139,13 +139,13 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "o+u1sRKl+KUmxvGHoNhBu+JJtGseDDxevu0khtPrZ6A15AMQ8+jRK7n9C2HkOXlNexVUwKiC8WnAa6/LUo6JHQ=="
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "yM8ZPViRCYZyVoyB2aRXAnQ8HuLA7E9pAjQSk01Rys5EUSBHHQCVMOeOY/maZRUeXVVfqu+/DyV8ST4kjZyYBg=="
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "l2Oa6SC8hq8f48mdWIXfnVbaUTlhKlrRVsGVUJSOnB77qPuwmj3CyZXoWFH/Gs9kcaEuC2wkbLRHndLpA77zcg=="
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "XpO62cnn84vGZUubF1CJ4GrsxUujwwdrv26T9uqsLLhzSWnxujNclrunZXcmJGGykufUWNT5SaDhd3UiMH17hw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -190,7 +190,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "Speckle.DoubleNumerics": {
@@ -201,9 +201,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-beta.4, )",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "qdHMddzoXCFv8dFe6FrwnLlSzlZNvZ1cv1842zO6HArROE1NOHK50zT8OtrPJJCwZSbBCaogyVxQTXWffDPl4A==",
+        "requested": "[2026.9.0-beta.5, )",
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "24tOTnFe3D8q0SWVCRGdhmDSuvZSicPK0RhzzjQBuT2MfR8goQxsKFcT7ogLWxFGsim5CTqKRidKhf13Wx+vjg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -211,8 +211,8 @@
           "Microsoft.Extensions.ObjectPool": "8.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-beta.4",
-          "Speckle.Sdk.Parquet": "2026.9.0-beta.4"
+          "Speckle.Sdk.Dependencies": "2026.9.0-beta.5",
+          "Speckle.Sdk.Parquet": "2026.9.0-beta.5"
         }
       }
     }

--- a/Converters/CSi/Speckle.Converters.ETABS23/packages.lock.json
+++ b/Converters/CSi/Speckle.Converters.ETABS23/packages.lock.json
@@ -139,13 +139,13 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "o+u1sRKl+KUmxvGHoNhBu+JJtGseDDxevu0khtPrZ6A15AMQ8+jRK7n9C2HkOXlNexVUwKiC8WnAa6/LUo6JHQ=="
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "yM8ZPViRCYZyVoyB2aRXAnQ8HuLA7E9pAjQSk01Rys5EUSBHHQCVMOeOY/maZRUeXVVfqu+/DyV8ST4kjZyYBg=="
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "l2Oa6SC8hq8f48mdWIXfnVbaUTlhKlrRVsGVUJSOnB77qPuwmj3CyZXoWFH/Gs9kcaEuC2wkbLRHndLpA77zcg=="
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "XpO62cnn84vGZUubF1CJ4GrsxUujwwdrv26T9uqsLLhzSWnxujNclrunZXcmJGGykufUWNT5SaDhd3UiMH17hw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -190,7 +190,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "Speckle.DoubleNumerics": {
@@ -201,9 +201,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-beta.4, )",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "qdHMddzoXCFv8dFe6FrwnLlSzlZNvZ1cv1842zO6HArROE1NOHK50zT8OtrPJJCwZSbBCaogyVxQTXWffDPl4A==",
+        "requested": "[2026.9.0-beta.5, )",
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "24tOTnFe3D8q0SWVCRGdhmDSuvZSicPK0RhzzjQBuT2MfR8goQxsKFcT7ogLWxFGsim5CTqKRidKhf13Wx+vjg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -211,8 +211,8 @@
           "Microsoft.Extensions.ObjectPool": "8.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-beta.4",
-          "Speckle.Sdk.Parquet": "2026.9.0-beta.4"
+          "Speckle.Sdk.Dependencies": "2026.9.0-beta.5",
+          "Speckle.Sdk.Parquet": "2026.9.0-beta.5"
         }
       }
     }

--- a/Converters/Civil3d/Speckle.Converters.Civil3d2023/packages.lock.json
+++ b/Converters/Civil3d/Speckle.Converters.Civil3d2023/packages.lock.json
@@ -189,16 +189,16 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "o+u1sRKl+KUmxvGHoNhBu+JJtGseDDxevu0khtPrZ6A15AMQ8+jRK7n9C2HkOXlNexVUwKiC8WnAa6/LUo6JHQ==",
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "yM8ZPViRCYZyVoyB2aRXAnQ8HuLA7E9pAjQSk01Rys5EUSBHHQCVMOeOY/maZRUeXVVfqu+/DyV8ST4kjZyYBg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.10"
         }
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "l2Oa6SC8hq8f48mdWIXfnVbaUTlhKlrRVsGVUJSOnB77qPuwmj3CyZXoWFH/Gs9kcaEuC2wkbLRHndLpA77zcg=="
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "XpO62cnn84vGZUubF1CJ4GrsxUujwwdrv26T9uqsLLhzSWnxujNclrunZXcmJGGykufUWNT5SaDhd3UiMH17hw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -302,7 +302,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "Speckle.DoubleNumerics": {
@@ -313,9 +313,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-beta.4, )",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "qdHMddzoXCFv8dFe6FrwnLlSzlZNvZ1cv1842zO6HArROE1NOHK50zT8OtrPJJCwZSbBCaogyVxQTXWffDPl4A==",
+        "requested": "[2026.9.0-beta.5, )",
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "24tOTnFe3D8q0SWVCRGdhmDSuvZSicPK0RhzzjQBuT2MfR8goQxsKFcT7ogLWxFGsim5CTqKRidKhf13Wx+vjg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -325,8 +325,8 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-beta.4",
-          "Speckle.Sdk.Parquet": "2026.9.0-beta.4",
+          "Speckle.Sdk.Dependencies": "2026.9.0-beta.5",
+          "Speckle.Sdk.Parquet": "2026.9.0-beta.5",
           "System.Memory": "4.5.5",
           "System.Text.Json": "5.0.2"
         }

--- a/Converters/Civil3d/Speckle.Converters.Civil3d2024/packages.lock.json
+++ b/Converters/Civil3d/Speckle.Converters.Civil3d2024/packages.lock.json
@@ -189,16 +189,16 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "o+u1sRKl+KUmxvGHoNhBu+JJtGseDDxevu0khtPrZ6A15AMQ8+jRK7n9C2HkOXlNexVUwKiC8WnAa6/LUo6JHQ==",
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "yM8ZPViRCYZyVoyB2aRXAnQ8HuLA7E9pAjQSk01Rys5EUSBHHQCVMOeOY/maZRUeXVVfqu+/DyV8ST4kjZyYBg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.10"
         }
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "l2Oa6SC8hq8f48mdWIXfnVbaUTlhKlrRVsGVUJSOnB77qPuwmj3CyZXoWFH/Gs9kcaEuC2wkbLRHndLpA77zcg=="
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "XpO62cnn84vGZUubF1CJ4GrsxUujwwdrv26T9uqsLLhzSWnxujNclrunZXcmJGGykufUWNT5SaDhd3UiMH17hw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -302,7 +302,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "Speckle.DoubleNumerics": {
@@ -313,9 +313,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-beta.4, )",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "qdHMddzoXCFv8dFe6FrwnLlSzlZNvZ1cv1842zO6HArROE1NOHK50zT8OtrPJJCwZSbBCaogyVxQTXWffDPl4A==",
+        "requested": "[2026.9.0-beta.5, )",
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "24tOTnFe3D8q0SWVCRGdhmDSuvZSicPK0RhzzjQBuT2MfR8goQxsKFcT7ogLWxFGsim5CTqKRidKhf13Wx+vjg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -325,8 +325,8 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-beta.4",
-          "Speckle.Sdk.Parquet": "2026.9.0-beta.4",
+          "Speckle.Sdk.Dependencies": "2026.9.0-beta.5",
+          "Speckle.Sdk.Parquet": "2026.9.0-beta.5",
           "System.Memory": "4.5.5",
           "System.Text.Json": "5.0.2"
         }

--- a/Converters/Civil3d/Speckle.Converters.Civil3d2025/packages.lock.json
+++ b/Converters/Civil3d/Speckle.Converters.Civil3d2025/packages.lock.json
@@ -148,13 +148,13 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "o+u1sRKl+KUmxvGHoNhBu+JJtGseDDxevu0khtPrZ6A15AMQ8+jRK7n9C2HkOXlNexVUwKiC8WnAa6/LUo6JHQ=="
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "yM8ZPViRCYZyVoyB2aRXAnQ8HuLA7E9pAjQSk01Rys5EUSBHHQCVMOeOY/maZRUeXVVfqu+/DyV8ST4kjZyYBg=="
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "l2Oa6SC8hq8f48mdWIXfnVbaUTlhKlrRVsGVUJSOnB77qPuwmj3CyZXoWFH/Gs9kcaEuC2wkbLRHndLpA77zcg=="
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "XpO62cnn84vGZUubF1CJ4GrsxUujwwdrv26T9uqsLLhzSWnxujNclrunZXcmJGGykufUWNT5SaDhd3UiMH17hw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -201,7 +201,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "speckle.connectors.dui": {
@@ -223,7 +223,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "Microsoft.Web.WebView2": {
@@ -240,9 +240,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-beta.4, )",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "qdHMddzoXCFv8dFe6FrwnLlSzlZNvZ1cv1842zO6HArROE1NOHK50zT8OtrPJJCwZSbBCaogyVxQTXWffDPl4A==",
+        "requested": "[2026.9.0-beta.5, )",
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "24tOTnFe3D8q0SWVCRGdhmDSuvZSicPK0RhzzjQBuT2MfR8goQxsKFcT7ogLWxFGsim5CTqKRidKhf13Wx+vjg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -250,8 +250,8 @@
           "Microsoft.Extensions.ObjectPool": "8.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-beta.4",
-          "Speckle.Sdk.Parquet": "2026.9.0-beta.4"
+          "Speckle.Sdk.Dependencies": "2026.9.0-beta.5",
+          "Speckle.Sdk.Parquet": "2026.9.0-beta.5"
         }
       }
     }

--- a/Converters/Civil3d/Speckle.Converters.Civil3d2026/packages.lock.json
+++ b/Converters/Civil3d/Speckle.Converters.Civil3d2026/packages.lock.json
@@ -148,13 +148,13 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "o+u1sRKl+KUmxvGHoNhBu+JJtGseDDxevu0khtPrZ6A15AMQ8+jRK7n9C2HkOXlNexVUwKiC8WnAa6/LUo6JHQ=="
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "yM8ZPViRCYZyVoyB2aRXAnQ8HuLA7E9pAjQSk01Rys5EUSBHHQCVMOeOY/maZRUeXVVfqu+/DyV8ST4kjZyYBg=="
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "l2Oa6SC8hq8f48mdWIXfnVbaUTlhKlrRVsGVUJSOnB77qPuwmj3CyZXoWFH/Gs9kcaEuC2wkbLRHndLpA77zcg=="
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "XpO62cnn84vGZUubF1CJ4GrsxUujwwdrv26T9uqsLLhzSWnxujNclrunZXcmJGGykufUWNT5SaDhd3UiMH17hw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -201,7 +201,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "speckle.connectors.dui": {
@@ -223,7 +223,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "Microsoft.Web.WebView2": {
@@ -240,9 +240,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-beta.4, )",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "qdHMddzoXCFv8dFe6FrwnLlSzlZNvZ1cv1842zO6HArROE1NOHK50zT8OtrPJJCwZSbBCaogyVxQTXWffDPl4A==",
+        "requested": "[2026.9.0-beta.5, )",
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "24tOTnFe3D8q0SWVCRGdhmDSuvZSicPK0RhzzjQBuT2MfR8goQxsKFcT7ogLWxFGsim5CTqKRidKhf13Wx+vjg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -250,8 +250,8 @@
           "Microsoft.Extensions.ObjectPool": "8.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-beta.4",
-          "Speckle.Sdk.Parquet": "2026.9.0-beta.4"
+          "Speckle.Sdk.Dependencies": "2026.9.0-beta.5",
+          "Speckle.Sdk.Parquet": "2026.9.0-beta.5"
         }
       }
     }

--- a/Converters/Civil3d/Speckle.Converters.Civil3d2027/packages.lock.json
+++ b/Converters/Civil3d/Speckle.Converters.Civil3d2027/packages.lock.json
@@ -149,13 +149,13 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "o+u1sRKl+KUmxvGHoNhBu+JJtGseDDxevu0khtPrZ6A15AMQ8+jRK7n9C2HkOXlNexVUwKiC8WnAa6/LUo6JHQ=="
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "yM8ZPViRCYZyVoyB2aRXAnQ8HuLA7E9pAjQSk01Rys5EUSBHHQCVMOeOY/maZRUeXVVfqu+/DyV8ST4kjZyYBg=="
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "l2Oa6SC8hq8f48mdWIXfnVbaUTlhKlrRVsGVUJSOnB77qPuwmj3CyZXoWFH/Gs9kcaEuC2wkbLRHndLpA77zcg=="
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "XpO62cnn84vGZUubF1CJ4GrsxUujwwdrv26T9uqsLLhzSWnxujNclrunZXcmJGGykufUWNT5SaDhd3UiMH17hw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -194,7 +194,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "speckle.connectors.dui": {
@@ -216,7 +216,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "Microsoft.Web.WebView2": {
@@ -233,9 +233,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-beta.4, )",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "qdHMddzoXCFv8dFe6FrwnLlSzlZNvZ1cv1842zO6HArROE1NOHK50zT8OtrPJJCwZSbBCaogyVxQTXWffDPl4A==",
+        "requested": "[2026.9.0-beta.5, )",
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "24tOTnFe3D8q0SWVCRGdhmDSuvZSicPK0RhzzjQBuT2MfR8goQxsKFcT7ogLWxFGsim5CTqKRidKhf13Wx+vjg==",
         "dependencies": {
           "GraphQL.Client": "6.1.0",
           "Microsoft.Data.Sqlite": "10.0.0",
@@ -243,8 +243,8 @@
           "Microsoft.Extensions.ObjectPool": "10.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-beta.4",
-          "Speckle.Sdk.Parquet": "2026.9.0-beta.4"
+          "Speckle.Sdk.Dependencies": "2026.9.0-beta.5",
+          "Speckle.Sdk.Parquet": "2026.9.0-beta.5"
         }
       }
     }

--- a/Converters/Plant3d/Speckle.Converters.Plant3d2026/packages.lock.json
+++ b/Converters/Plant3d/Speckle.Converters.Plant3d2026/packages.lock.json
@@ -148,13 +148,13 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "o+u1sRKl+KUmxvGHoNhBu+JJtGseDDxevu0khtPrZ6A15AMQ8+jRK7n9C2HkOXlNexVUwKiC8WnAa6/LUo6JHQ=="
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "yM8ZPViRCYZyVoyB2aRXAnQ8HuLA7E9pAjQSk01Rys5EUSBHHQCVMOeOY/maZRUeXVVfqu+/DyV8ST4kjZyYBg=="
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "l2Oa6SC8hq8f48mdWIXfnVbaUTlhKlrRVsGVUJSOnB77qPuwmj3CyZXoWFH/Gs9kcaEuC2wkbLRHndLpA77zcg=="
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "XpO62cnn84vGZUubF1CJ4GrsxUujwwdrv26T9uqsLLhzSWnxujNclrunZXcmJGGykufUWNT5SaDhd3UiMH17hw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -201,7 +201,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "speckle.connectors.dui": {
@@ -223,7 +223,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "Microsoft.Web.WebView2": {
@@ -240,9 +240,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-beta.4, )",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "qdHMddzoXCFv8dFe6FrwnLlSzlZNvZ1cv1842zO6HArROE1NOHK50zT8OtrPJJCwZSbBCaogyVxQTXWffDPl4A==",
+        "requested": "[2026.9.0-beta.5, )",
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "24tOTnFe3D8q0SWVCRGdhmDSuvZSicPK0RhzzjQBuT2MfR8goQxsKFcT7ogLWxFGsim5CTqKRidKhf13Wx+vjg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -250,8 +250,8 @@
           "Microsoft.Extensions.ObjectPool": "8.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-beta.4",
-          "Speckle.Sdk.Parquet": "2026.9.0-beta.4"
+          "Speckle.Sdk.Dependencies": "2026.9.0-beta.5",
+          "Speckle.Sdk.Parquet": "2026.9.0-beta.5"
         }
       }
     }

--- a/Converters/Plant3d/Speckle.Converters.Plant3d2027/packages.lock.json
+++ b/Converters/Plant3d/Speckle.Converters.Plant3d2027/packages.lock.json
@@ -149,13 +149,13 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "o+u1sRKl+KUmxvGHoNhBu+JJtGseDDxevu0khtPrZ6A15AMQ8+jRK7n9C2HkOXlNexVUwKiC8WnAa6/LUo6JHQ=="
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "yM8ZPViRCYZyVoyB2aRXAnQ8HuLA7E9pAjQSk01Rys5EUSBHHQCVMOeOY/maZRUeXVVfqu+/DyV8ST4kjZyYBg=="
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "l2Oa6SC8hq8f48mdWIXfnVbaUTlhKlrRVsGVUJSOnB77qPuwmj3CyZXoWFH/Gs9kcaEuC2wkbLRHndLpA77zcg=="
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "XpO62cnn84vGZUubF1CJ4GrsxUujwwdrv26T9uqsLLhzSWnxujNclrunZXcmJGGykufUWNT5SaDhd3UiMH17hw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -194,7 +194,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "speckle.connectors.dui": {
@@ -216,7 +216,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "Microsoft.Web.WebView2": {
@@ -233,9 +233,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-beta.4, )",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "qdHMddzoXCFv8dFe6FrwnLlSzlZNvZ1cv1842zO6HArROE1NOHK50zT8OtrPJJCwZSbBCaogyVxQTXWffDPl4A==",
+        "requested": "[2026.9.0-beta.5, )",
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "24tOTnFe3D8q0SWVCRGdhmDSuvZSicPK0RhzzjQBuT2MfR8goQxsKFcT7ogLWxFGsim5CTqKRidKhf13Wx+vjg==",
         "dependencies": {
           "GraphQL.Client": "6.1.0",
           "Microsoft.Data.Sqlite": "10.0.0",
@@ -243,8 +243,8 @@
           "Microsoft.Extensions.ObjectPool": "10.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-beta.4",
-          "Speckle.Sdk.Parquet": "2026.9.0-beta.4"
+          "Speckle.Sdk.Dependencies": "2026.9.0-beta.5",
+          "Speckle.Sdk.Parquet": "2026.9.0-beta.5"
         }
       }
     }

--- a/Converters/Revit/Speckle.Converters.Revit2023/packages.lock.json
+++ b/Converters/Revit/Speckle.Converters.Revit2023/packages.lock.json
@@ -180,16 +180,16 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "o+u1sRKl+KUmxvGHoNhBu+JJtGseDDxevu0khtPrZ6A15AMQ8+jRK7n9C2HkOXlNexVUwKiC8WnAa6/LUo6JHQ==",
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "yM8ZPViRCYZyVoyB2aRXAnQ8HuLA7E9pAjQSk01Rys5EUSBHHQCVMOeOY/maZRUeXVVfqu+/DyV8ST4kjZyYBg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.10"
         }
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "l2Oa6SC8hq8f48mdWIXfnVbaUTlhKlrRVsGVUJSOnB77qPuwmj3CyZXoWFH/Gs9kcaEuC2wkbLRHndLpA77zcg=="
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "XpO62cnn84vGZUubF1CJ4GrsxUujwwdrv26T9uqsLLhzSWnxujNclrunZXcmJGGykufUWNT5SaDhd3UiMH17hw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -300,7 +300,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "LibTessDotNet": {
@@ -317,9 +317,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-beta.4, )",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "qdHMddzoXCFv8dFe6FrwnLlSzlZNvZ1cv1842zO6HArROE1NOHK50zT8OtrPJJCwZSbBCaogyVxQTXWffDPl4A==",
+        "requested": "[2026.9.0-beta.5, )",
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "24tOTnFe3D8q0SWVCRGdhmDSuvZSicPK0RhzzjQBuT2MfR8goQxsKFcT7ogLWxFGsim5CTqKRidKhf13Wx+vjg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -329,8 +329,8 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-beta.4",
-          "Speckle.Sdk.Parquet": "2026.9.0-beta.4",
+          "Speckle.Sdk.Dependencies": "2026.9.0-beta.5",
+          "Speckle.Sdk.Parquet": "2026.9.0-beta.5",
           "System.Memory": "4.5.5",
           "System.Text.Json": "5.0.2"
         }

--- a/Converters/Revit/Speckle.Converters.Revit2024/packages.lock.json
+++ b/Converters/Revit/Speckle.Converters.Revit2024/packages.lock.json
@@ -180,16 +180,16 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "o+u1sRKl+KUmxvGHoNhBu+JJtGseDDxevu0khtPrZ6A15AMQ8+jRK7n9C2HkOXlNexVUwKiC8WnAa6/LUo6JHQ==",
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "yM8ZPViRCYZyVoyB2aRXAnQ8HuLA7E9pAjQSk01Rys5EUSBHHQCVMOeOY/maZRUeXVVfqu+/DyV8ST4kjZyYBg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.10"
         }
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "l2Oa6SC8hq8f48mdWIXfnVbaUTlhKlrRVsGVUJSOnB77qPuwmj3CyZXoWFH/Gs9kcaEuC2wkbLRHndLpA77zcg=="
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "XpO62cnn84vGZUubF1CJ4GrsxUujwwdrv26T9uqsLLhzSWnxujNclrunZXcmJGGykufUWNT5SaDhd3UiMH17hw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -300,7 +300,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "LibTessDotNet": {
@@ -317,9 +317,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-beta.4, )",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "qdHMddzoXCFv8dFe6FrwnLlSzlZNvZ1cv1842zO6HArROE1NOHK50zT8OtrPJJCwZSbBCaogyVxQTXWffDPl4A==",
+        "requested": "[2026.9.0-beta.5, )",
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "24tOTnFe3D8q0SWVCRGdhmDSuvZSicPK0RhzzjQBuT2MfR8goQxsKFcT7ogLWxFGsim5CTqKRidKhf13Wx+vjg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -329,8 +329,8 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-beta.4",
-          "Speckle.Sdk.Parquet": "2026.9.0-beta.4",
+          "Speckle.Sdk.Dependencies": "2026.9.0-beta.5",
+          "Speckle.Sdk.Parquet": "2026.9.0-beta.5",
           "System.Memory": "4.5.5",
           "System.Text.Json": "5.0.2"
         }

--- a/Converters/Revit/Speckle.Converters.Revit2025/packages.lock.json
+++ b/Converters/Revit/Speckle.Converters.Revit2025/packages.lock.json
@@ -139,13 +139,13 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "o+u1sRKl+KUmxvGHoNhBu+JJtGseDDxevu0khtPrZ6A15AMQ8+jRK7n9C2HkOXlNexVUwKiC8WnAa6/LUo6JHQ=="
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "yM8ZPViRCYZyVoyB2aRXAnQ8HuLA7E9pAjQSk01Rys5EUSBHHQCVMOeOY/maZRUeXVVfqu+/DyV8ST4kjZyYBg=="
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "l2Oa6SC8hq8f48mdWIXfnVbaUTlhKlrRVsGVUJSOnB77qPuwmj3CyZXoWFH/Gs9kcaEuC2wkbLRHndLpA77zcg=="
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "XpO62cnn84vGZUubF1CJ4GrsxUujwwdrv26T9uqsLLhzSWnxujNclrunZXcmJGGykufUWNT5SaDhd3UiMH17hw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -197,7 +197,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "LibTessDotNet": {
@@ -214,9 +214,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-beta.4, )",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "qdHMddzoXCFv8dFe6FrwnLlSzlZNvZ1cv1842zO6HArROE1NOHK50zT8OtrPJJCwZSbBCaogyVxQTXWffDPl4A==",
+        "requested": "[2026.9.0-beta.5, )",
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "24tOTnFe3D8q0SWVCRGdhmDSuvZSicPK0RhzzjQBuT2MfR8goQxsKFcT7ogLWxFGsim5CTqKRidKhf13Wx+vjg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -224,8 +224,8 @@
           "Microsoft.Extensions.ObjectPool": "8.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-beta.4",
-          "Speckle.Sdk.Parquet": "2026.9.0-beta.4"
+          "Speckle.Sdk.Dependencies": "2026.9.0-beta.5",
+          "Speckle.Sdk.Parquet": "2026.9.0-beta.5"
         }
       }
     }

--- a/Converters/Revit/Speckle.Converters.Revit2026/packages.lock.json
+++ b/Converters/Revit/Speckle.Converters.Revit2026/packages.lock.json
@@ -139,13 +139,13 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "o+u1sRKl+KUmxvGHoNhBu+JJtGseDDxevu0khtPrZ6A15AMQ8+jRK7n9C2HkOXlNexVUwKiC8WnAa6/LUo6JHQ=="
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "yM8ZPViRCYZyVoyB2aRXAnQ8HuLA7E9pAjQSk01Rys5EUSBHHQCVMOeOY/maZRUeXVVfqu+/DyV8ST4kjZyYBg=="
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "l2Oa6SC8hq8f48mdWIXfnVbaUTlhKlrRVsGVUJSOnB77qPuwmj3CyZXoWFH/Gs9kcaEuC2wkbLRHndLpA77zcg=="
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "XpO62cnn84vGZUubF1CJ4GrsxUujwwdrv26T9uqsLLhzSWnxujNclrunZXcmJGGykufUWNT5SaDhd3UiMH17hw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -197,7 +197,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "LibTessDotNet": {
@@ -214,9 +214,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-beta.4, )",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "qdHMddzoXCFv8dFe6FrwnLlSzlZNvZ1cv1842zO6HArROE1NOHK50zT8OtrPJJCwZSbBCaogyVxQTXWffDPl4A==",
+        "requested": "[2026.9.0-beta.5, )",
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "24tOTnFe3D8q0SWVCRGdhmDSuvZSicPK0RhzzjQBuT2MfR8goQxsKFcT7ogLWxFGsim5CTqKRidKhf13Wx+vjg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -224,8 +224,8 @@
           "Microsoft.Extensions.ObjectPool": "8.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-beta.4",
-          "Speckle.Sdk.Parquet": "2026.9.0-beta.4"
+          "Speckle.Sdk.Dependencies": "2026.9.0-beta.5",
+          "Speckle.Sdk.Parquet": "2026.9.0-beta.5"
         }
       }
     }

--- a/Converters/Revit/Speckle.Converters.Revit2027/packages.lock.json
+++ b/Converters/Revit/Speckle.Converters.Revit2027/packages.lock.json
@@ -140,13 +140,13 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "o+u1sRKl+KUmxvGHoNhBu+JJtGseDDxevu0khtPrZ6A15AMQ8+jRK7n9C2HkOXlNexVUwKiC8WnAa6/LUo6JHQ=="
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "yM8ZPViRCYZyVoyB2aRXAnQ8HuLA7E9pAjQSk01Rys5EUSBHHQCVMOeOY/maZRUeXVVfqu+/DyV8ST4kjZyYBg=="
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "l2Oa6SC8hq8f48mdWIXfnVbaUTlhKlrRVsGVUJSOnB77qPuwmj3CyZXoWFH/Gs9kcaEuC2wkbLRHndLpA77zcg=="
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "XpO62cnn84vGZUubF1CJ4GrsxUujwwdrv26T9uqsLLhzSWnxujNclrunZXcmJGGykufUWNT5SaDhd3UiMH17hw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -190,7 +190,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "LibTessDotNet": {
@@ -207,9 +207,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-beta.4, )",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "qdHMddzoXCFv8dFe6FrwnLlSzlZNvZ1cv1842zO6HArROE1NOHK50zT8OtrPJJCwZSbBCaogyVxQTXWffDPl4A==",
+        "requested": "[2026.9.0-beta.5, )",
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "24tOTnFe3D8q0SWVCRGdhmDSuvZSicPK0RhzzjQBuT2MfR8goQxsKFcT7ogLWxFGsim5CTqKRidKhf13Wx+vjg==",
         "dependencies": {
           "GraphQL.Client": "6.1.0",
           "Microsoft.Data.Sqlite": "10.0.0",
@@ -217,8 +217,8 @@
           "Microsoft.Extensions.ObjectPool": "10.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-beta.4",
-          "Speckle.Sdk.Parquet": "2026.9.0-beta.4"
+          "Speckle.Sdk.Dependencies": "2026.9.0-beta.5",
+          "Speckle.Sdk.Parquet": "2026.9.0-beta.5"
         }
       }
     }

--- a/Converters/Rhino/Speckle.Converters.Rhino7/packages.lock.json
+++ b/Converters/Rhino/Speckle.Converters.Rhino7/packages.lock.json
@@ -180,16 +180,16 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "o+u1sRKl+KUmxvGHoNhBu+JJtGseDDxevu0khtPrZ6A15AMQ8+jRK7n9C2HkOXlNexVUwKiC8WnAa6/LUo6JHQ==",
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "yM8ZPViRCYZyVoyB2aRXAnQ8HuLA7E9pAjQSk01Rys5EUSBHHQCVMOeOY/maZRUeXVVfqu+/DyV8ST4kjZyYBg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.10"
         }
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "l2Oa6SC8hq8f48mdWIXfnVbaUTlhKlrRVsGVUJSOnB77qPuwmj3CyZXoWFH/Gs9kcaEuC2wkbLRHndLpA77zcg=="
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "XpO62cnn84vGZUubF1CJ4GrsxUujwwdrv26T9uqsLLhzSWnxujNclrunZXcmJGGykufUWNT5SaDhd3UiMH17hw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -293,7 +293,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "Speckle.DoubleNumerics": {
@@ -304,9 +304,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-beta.4, )",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "qdHMddzoXCFv8dFe6FrwnLlSzlZNvZ1cv1842zO6HArROE1NOHK50zT8OtrPJJCwZSbBCaogyVxQTXWffDPl4A==",
+        "requested": "[2026.9.0-beta.5, )",
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "24tOTnFe3D8q0SWVCRGdhmDSuvZSicPK0RhzzjQBuT2MfR8goQxsKFcT7ogLWxFGsim5CTqKRidKhf13Wx+vjg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -316,8 +316,8 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-beta.4",
-          "Speckle.Sdk.Parquet": "2026.9.0-beta.4",
+          "Speckle.Sdk.Dependencies": "2026.9.0-beta.5",
+          "Speckle.Sdk.Parquet": "2026.9.0-beta.5",
           "System.Memory": "4.5.5",
           "System.Text.Json": "5.0.2"
         }

--- a/Converters/Rhino/Speckle.Converters.Rhino8/packages.lock.json
+++ b/Converters/Rhino/Speckle.Converters.Rhino8/packages.lock.json
@@ -180,16 +180,16 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "o+u1sRKl+KUmxvGHoNhBu+JJtGseDDxevu0khtPrZ6A15AMQ8+jRK7n9C2HkOXlNexVUwKiC8WnAa6/LUo6JHQ==",
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "yM8ZPViRCYZyVoyB2aRXAnQ8HuLA7E9pAjQSk01Rys5EUSBHHQCVMOeOY/maZRUeXVVfqu+/DyV8ST4kjZyYBg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.10"
         }
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "l2Oa6SC8hq8f48mdWIXfnVbaUTlhKlrRVsGVUJSOnB77qPuwmj3CyZXoWFH/Gs9kcaEuC2wkbLRHndLpA77zcg=="
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "XpO62cnn84vGZUubF1CJ4GrsxUujwwdrv26T9uqsLLhzSWnxujNclrunZXcmJGGykufUWNT5SaDhd3UiMH17hw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -293,7 +293,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "Speckle.DoubleNumerics": {
@@ -304,9 +304,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-beta.4, )",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "qdHMddzoXCFv8dFe6FrwnLlSzlZNvZ1cv1842zO6HArROE1NOHK50zT8OtrPJJCwZSbBCaogyVxQTXWffDPl4A==",
+        "requested": "[2026.9.0-beta.5, )",
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "24tOTnFe3D8q0SWVCRGdhmDSuvZSicPK0RhzzjQBuT2MfR8goQxsKFcT7ogLWxFGsim5CTqKRidKhf13Wx+vjg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -316,8 +316,8 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-beta.4",
-          "Speckle.Sdk.Parquet": "2026.9.0-beta.4",
+          "Speckle.Sdk.Dependencies": "2026.9.0-beta.5",
+          "Speckle.Sdk.Parquet": "2026.9.0-beta.5",
           "System.Memory": "4.5.5",
           "System.Text.Json": "5.0.2"
         }
@@ -485,13 +485,13 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "o+u1sRKl+KUmxvGHoNhBu+JJtGseDDxevu0khtPrZ6A15AMQ8+jRK7n9C2HkOXlNexVUwKiC8WnAa6/LUo6JHQ=="
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "yM8ZPViRCYZyVoyB2aRXAnQ8HuLA7E9pAjQSk01Rys5EUSBHHQCVMOeOY/maZRUeXVVfqu+/DyV8ST4kjZyYBg=="
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "l2Oa6SC8hq8f48mdWIXfnVbaUTlhKlrRVsGVUJSOnB77qPuwmj3CyZXoWFH/Gs9kcaEuC2wkbLRHndLpA77zcg=="
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "XpO62cnn84vGZUubF1CJ4GrsxUujwwdrv26T9uqsLLhzSWnxujNclrunZXcmJGGykufUWNT5SaDhd3UiMH17hw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -544,7 +544,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "Speckle.DoubleNumerics": {
@@ -555,9 +555,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-beta.4, )",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "qdHMddzoXCFv8dFe6FrwnLlSzlZNvZ1cv1842zO6HArROE1NOHK50zT8OtrPJJCwZSbBCaogyVxQTXWffDPl4A==",
+        "requested": "[2026.9.0-beta.5, )",
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "24tOTnFe3D8q0SWVCRGdhmDSuvZSicPK0RhzzjQBuT2MfR8goQxsKFcT7ogLWxFGsim5CTqKRidKhf13Wx+vjg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -565,8 +565,8 @@
           "Microsoft.Extensions.ObjectPool": "8.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-beta.4",
-          "Speckle.Sdk.Parquet": "2026.9.0-beta.4"
+          "Speckle.Sdk.Dependencies": "2026.9.0-beta.5",
+          "Speckle.Sdk.Parquet": "2026.9.0-beta.5"
         }
       }
     }

--- a/Converters/Rhino/Speckle.Converters.Rhino9/packages.lock.json
+++ b/Converters/Rhino/Speckle.Converters.Rhino9/packages.lock.json
@@ -167,13 +167,13 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "o+u1sRKl+KUmxvGHoNhBu+JJtGseDDxevu0khtPrZ6A15AMQ8+jRK7n9C2HkOXlNexVUwKiC8WnAa6/LUo6JHQ=="
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "yM8ZPViRCYZyVoyB2aRXAnQ8HuLA7E9pAjQSk01Rys5EUSBHHQCVMOeOY/maZRUeXVVfqu+/DyV8ST4kjZyYBg=="
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "l2Oa6SC8hq8f48mdWIXfnVbaUTlhKlrRVsGVUJSOnB77qPuwmj3CyZXoWFH/Gs9kcaEuC2wkbLRHndLpA77zcg=="
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "XpO62cnn84vGZUubF1CJ4GrsxUujwwdrv26T9uqsLLhzSWnxujNclrunZXcmJGGykufUWNT5SaDhd3UiMH17hw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -218,7 +218,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "Speckle.DoubleNumerics": {
@@ -229,9 +229,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-beta.4, )",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "qdHMddzoXCFv8dFe6FrwnLlSzlZNvZ1cv1842zO6HArROE1NOHK50zT8OtrPJJCwZSbBCaogyVxQTXWffDPl4A==",
+        "requested": "[2026.9.0-beta.5, )",
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "24tOTnFe3D8q0SWVCRGdhmDSuvZSicPK0RhzzjQBuT2MfR8goQxsKFcT7ogLWxFGsim5CTqKRidKhf13Wx+vjg==",
         "dependencies": {
           "GraphQL.Client": "6.1.0",
           "Microsoft.Data.Sqlite": "10.0.0",
@@ -239,8 +239,8 @@
           "Microsoft.Extensions.ObjectPool": "10.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-beta.4",
-          "Speckle.Sdk.Parquet": "2026.9.0-beta.4"
+          "Speckle.Sdk.Dependencies": "2026.9.0-beta.5",
+          "Speckle.Sdk.Parquet": "2026.9.0-beta.5"
         }
       }
     }

--- a/Converters/TSD/Speckle.Converters.TSD2027/packages.lock.json
+++ b/Converters/TSD/Speckle.Converters.TSD2027/packages.lock.json
@@ -171,13 +171,13 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "o+u1sRKl+KUmxvGHoNhBu+JJtGseDDxevu0khtPrZ6A15AMQ8+jRK7n9C2HkOXlNexVUwKiC8WnAa6/LUo6JHQ=="
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "yM8ZPViRCYZyVoyB2aRXAnQ8HuLA7E9pAjQSk01Rys5EUSBHHQCVMOeOY/maZRUeXVVfqu+/DyV8ST4kjZyYBg=="
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "l2Oa6SC8hq8f48mdWIXfnVbaUTlhKlrRVsGVUJSOnB77qPuwmj3CyZXoWFH/Gs9kcaEuC2wkbLRHndLpA77zcg=="
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "XpO62cnn84vGZUubF1CJ4GrsxUujwwdrv26T9uqsLLhzSWnxujNclrunZXcmJGGykufUWNT5SaDhd3UiMH17hw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -221,7 +221,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "LibTessDotNet": {
@@ -238,9 +238,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-beta.4, )",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "qdHMddzoXCFv8dFe6FrwnLlSzlZNvZ1cv1842zO6HArROE1NOHK50zT8OtrPJJCwZSbBCaogyVxQTXWffDPl4A==",
+        "requested": "[2026.9.0-beta.5, )",
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "24tOTnFe3D8q0SWVCRGdhmDSuvZSicPK0RhzzjQBuT2MfR8goQxsKFcT7ogLWxFGsim5CTqKRidKhf13Wx+vjg==",
         "dependencies": {
           "GraphQL.Client": "6.1.0",
           "Microsoft.Data.Sqlite": "10.0.0",
@@ -248,8 +248,8 @@
           "Microsoft.Extensions.ObjectPool": "10.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-beta.4",
-          "Speckle.Sdk.Parquet": "2026.9.0-beta.4"
+          "Speckle.Sdk.Dependencies": "2026.9.0-beta.5",
+          "Speckle.Sdk.Parquet": "2026.9.0-beta.5"
         }
       }
     }

--- a/Converters/Tekla/Speckle.Converter.Tekla2023/packages.lock.json
+++ b/Converters/Tekla/Speckle.Converter.Tekla2023/packages.lock.json
@@ -197,16 +197,16 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "o+u1sRKl+KUmxvGHoNhBu+JJtGseDDxevu0khtPrZ6A15AMQ8+jRK7n9C2HkOXlNexVUwKiC8WnAa6/LUo6JHQ==",
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "yM8ZPViRCYZyVoyB2aRXAnQ8HuLA7E9pAjQSk01Rys5EUSBHHQCVMOeOY/maZRUeXVVfqu+/DyV8ST4kjZyYBg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.10"
         }
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "l2Oa6SC8hq8f48mdWIXfnVbaUTlhKlrRVsGVUJSOnB77qPuwmj3CyZXoWFH/Gs9kcaEuC2wkbLRHndLpA77zcg=="
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "XpO62cnn84vGZUubF1CJ4GrsxUujwwdrv26T9uqsLLhzSWnxujNclrunZXcmJGGykufUWNT5SaDhd3UiMH17hw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -337,7 +337,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "LibTessDotNet": {
@@ -354,9 +354,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-beta.4, )",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "qdHMddzoXCFv8dFe6FrwnLlSzlZNvZ1cv1842zO6HArROE1NOHK50zT8OtrPJJCwZSbBCaogyVxQTXWffDPl4A==",
+        "requested": "[2026.9.0-beta.5, )",
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "24tOTnFe3D8q0SWVCRGdhmDSuvZSicPK0RhzzjQBuT2MfR8goQxsKFcT7ogLWxFGsim5CTqKRidKhf13Wx+vjg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -366,8 +366,8 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-beta.4",
-          "Speckle.Sdk.Parquet": "2026.9.0-beta.4",
+          "Speckle.Sdk.Dependencies": "2026.9.0-beta.5",
+          "Speckle.Sdk.Parquet": "2026.9.0-beta.5",
           "System.Memory": "4.5.5",
           "System.Text.Json": "5.0.2"
         }

--- a/Converters/Tekla/Speckle.Converter.Tekla2024/packages.lock.json
+++ b/Converters/Tekla/Speckle.Converter.Tekla2024/packages.lock.json
@@ -207,16 +207,16 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "o+u1sRKl+KUmxvGHoNhBu+JJtGseDDxevu0khtPrZ6A15AMQ8+jRK7n9C2HkOXlNexVUwKiC8WnAa6/LUo6JHQ==",
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "yM8ZPViRCYZyVoyB2aRXAnQ8HuLA7E9pAjQSk01Rys5EUSBHHQCVMOeOY/maZRUeXVVfqu+/DyV8ST4kjZyYBg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.10"
         }
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "l2Oa6SC8hq8f48mdWIXfnVbaUTlhKlrRVsGVUJSOnB77qPuwmj3CyZXoWFH/Gs9kcaEuC2wkbLRHndLpA77zcg=="
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "XpO62cnn84vGZUubF1CJ4GrsxUujwwdrv26T9uqsLLhzSWnxujNclrunZXcmJGGykufUWNT5SaDhd3UiMH17hw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -378,7 +378,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "LibTessDotNet": {
@@ -395,9 +395,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-beta.4, )",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "qdHMddzoXCFv8dFe6FrwnLlSzlZNvZ1cv1842zO6HArROE1NOHK50zT8OtrPJJCwZSbBCaogyVxQTXWffDPl4A==",
+        "requested": "[2026.9.0-beta.5, )",
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "24tOTnFe3D8q0SWVCRGdhmDSuvZSicPK0RhzzjQBuT2MfR8goQxsKFcT7ogLWxFGsim5CTqKRidKhf13Wx+vjg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -407,8 +407,8 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-beta.4",
-          "Speckle.Sdk.Parquet": "2026.9.0-beta.4",
+          "Speckle.Sdk.Dependencies": "2026.9.0-beta.5",
+          "Speckle.Sdk.Parquet": "2026.9.0-beta.5",
           "System.Memory": "4.5.5",
           "System.Text.Json": "5.0.2"
         }

--- a/Converters/Tekla/Speckle.Converter.Tekla2025/packages.lock.json
+++ b/Converters/Tekla/Speckle.Converter.Tekla2025/packages.lock.json
@@ -207,16 +207,16 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "o+u1sRKl+KUmxvGHoNhBu+JJtGseDDxevu0khtPrZ6A15AMQ8+jRK7n9C2HkOXlNexVUwKiC8WnAa6/LUo6JHQ==",
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "yM8ZPViRCYZyVoyB2aRXAnQ8HuLA7E9pAjQSk01Rys5EUSBHHQCVMOeOY/maZRUeXVVfqu+/DyV8ST4kjZyYBg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.10"
         }
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "l2Oa6SC8hq8f48mdWIXfnVbaUTlhKlrRVsGVUJSOnB77qPuwmj3CyZXoWFH/Gs9kcaEuC2wkbLRHndLpA77zcg=="
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "XpO62cnn84vGZUubF1CJ4GrsxUujwwdrv26T9uqsLLhzSWnxujNclrunZXcmJGGykufUWNT5SaDhd3UiMH17hw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -378,7 +378,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "LibTessDotNet": {
@@ -395,9 +395,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-beta.4, )",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "qdHMddzoXCFv8dFe6FrwnLlSzlZNvZ1cv1842zO6HArROE1NOHK50zT8OtrPJJCwZSbBCaogyVxQTXWffDPl4A==",
+        "requested": "[2026.9.0-beta.5, )",
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "24tOTnFe3D8q0SWVCRGdhmDSuvZSicPK0RhzzjQBuT2MfR8goQxsKFcT7ogLWxFGsim5CTqKRidKhf13Wx+vjg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -407,8 +407,8 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-beta.4",
-          "Speckle.Sdk.Parquet": "2026.9.0-beta.4",
+          "Speckle.Sdk.Dependencies": "2026.9.0-beta.5",
+          "Speckle.Sdk.Parquet": "2026.9.0-beta.5",
           "System.Memory": "4.5.5",
           "System.Text.Json": "5.0.2"
         }

--- a/DUI3/Speckle.Connectors.DUI.Tests/packages.lock.json
+++ b/DUI3/Speckle.Connectors.DUI.Tests/packages.lock.json
@@ -271,13 +271,13 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "o+u1sRKl+KUmxvGHoNhBu+JJtGseDDxevu0khtPrZ6A15AMQ8+jRK7n9C2HkOXlNexVUwKiC8WnAa6/LUo6JHQ=="
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "yM8ZPViRCYZyVoyB2aRXAnQ8HuLA7E9pAjQSk01Rys5EUSBHHQCVMOeOY/maZRUeXVVfqu+/DyV8ST4kjZyYBg=="
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "l2Oa6SC8hq8f48mdWIXfnVbaUTlhKlrRVsGVUJSOnB77qPuwmj3CyZXoWFH/Gs9kcaEuC2wkbLRHndLpA77zcg=="
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "XpO62cnn84vGZUubF1CJ4GrsxUujwwdrv26T9uqsLLhzSWnxujNclrunZXcmJGGykufUWNT5SaDhd3UiMH17hw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -321,7 +321,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "speckle.connectors.dui": {
@@ -336,7 +336,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "speckle.testing": {
@@ -344,7 +344,7 @@
         "dependencies": {
           "Moq": "[4.20.70, )",
           "NUnit": "[4.5.1, )",
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "Speckle.DoubleNumerics": {
@@ -355,9 +355,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-beta.4, )",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "qdHMddzoXCFv8dFe6FrwnLlSzlZNvZ1cv1842zO6HArROE1NOHK50zT8OtrPJJCwZSbBCaogyVxQTXWffDPl4A==",
+        "requested": "[2026.9.0-beta.5, )",
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "24tOTnFe3D8q0SWVCRGdhmDSuvZSicPK0RhzzjQBuT2MfR8goQxsKFcT7ogLWxFGsim5CTqKRidKhf13Wx+vjg==",
         "dependencies": {
           "GraphQL.Client": "6.1.0",
           "Microsoft.Data.Sqlite": "10.0.0",
@@ -365,8 +365,8 @@
           "Microsoft.Extensions.ObjectPool": "10.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-beta.4",
-          "Speckle.Sdk.Parquet": "2026.9.0-beta.4"
+          "Speckle.Sdk.Dependencies": "2026.9.0-beta.5",
+          "Speckle.Sdk.Parquet": "2026.9.0-beta.5"
         }
       }
     }

--- a/DUI3/Speckle.Connectors.DUI.WebView/packages.lock.json
+++ b/DUI3/Speckle.Connectors.DUI.WebView/packages.lock.json
@@ -180,16 +180,16 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "o+u1sRKl+KUmxvGHoNhBu+JJtGseDDxevu0khtPrZ6A15AMQ8+jRK7n9C2HkOXlNexVUwKiC8WnAa6/LUo6JHQ==",
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "yM8ZPViRCYZyVoyB2aRXAnQ8HuLA7E9pAjQSk01Rys5EUSBHHQCVMOeOY/maZRUeXVVfqu+/DyV8ST4kjZyYBg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.10"
         }
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "l2Oa6SC8hq8f48mdWIXfnVbaUTlhKlrRVsGVUJSOnB77qPuwmj3CyZXoWFH/Gs9kcaEuC2wkbLRHndLpA77zcg=="
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "XpO62cnn84vGZUubF1CJ4GrsxUujwwdrv26T9uqsLLhzSWnxujNclrunZXcmJGGykufUWNT5SaDhd3UiMH17hw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -295,7 +295,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "speckle.connectors.dui": {
@@ -310,7 +310,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "Speckle.DoubleNumerics": {
@@ -321,9 +321,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-beta.4, )",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "qdHMddzoXCFv8dFe6FrwnLlSzlZNvZ1cv1842zO6HArROE1NOHK50zT8OtrPJJCwZSbBCaogyVxQTXWffDPl4A==",
+        "requested": "[2026.9.0-beta.5, )",
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "24tOTnFe3D8q0SWVCRGdhmDSuvZSicPK0RhzzjQBuT2MfR8goQxsKFcT7ogLWxFGsim5CTqKRidKhf13Wx+vjg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -333,8 +333,8 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-beta.4",
-          "Speckle.Sdk.Parquet": "2026.9.0-beta.4",
+          "Speckle.Sdk.Dependencies": "2026.9.0-beta.5",
+          "Speckle.Sdk.Parquet": "2026.9.0-beta.5",
           "System.Memory": "4.5.5",
           "System.Text.Json": "5.0.2"
         }
@@ -495,13 +495,13 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "o+u1sRKl+KUmxvGHoNhBu+JJtGseDDxevu0khtPrZ6A15AMQ8+jRK7n9C2HkOXlNexVUwKiC8WnAa6/LUo6JHQ=="
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "yM8ZPViRCYZyVoyB2aRXAnQ8HuLA7E9pAjQSk01Rys5EUSBHHQCVMOeOY/maZRUeXVVfqu+/DyV8ST4kjZyYBg=="
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "l2Oa6SC8hq8f48mdWIXfnVbaUTlhKlrRVsGVUJSOnB77qPuwmj3CyZXoWFH/Gs9kcaEuC2wkbLRHndLpA77zcg=="
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "XpO62cnn84vGZUubF1CJ4GrsxUujwwdrv26T9uqsLLhzSWnxujNclrunZXcmJGGykufUWNT5SaDhd3UiMH17hw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -540,7 +540,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "speckle.connectors.dui": {
@@ -555,7 +555,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "Speckle.DoubleNumerics": {
@@ -566,9 +566,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-beta.4, )",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "qdHMddzoXCFv8dFe6FrwnLlSzlZNvZ1cv1842zO6HArROE1NOHK50zT8OtrPJJCwZSbBCaogyVxQTXWffDPl4A==",
+        "requested": "[2026.9.0-beta.5, )",
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "24tOTnFe3D8q0SWVCRGdhmDSuvZSicPK0RhzzjQBuT2MfR8goQxsKFcT7ogLWxFGsim5CTqKRidKhf13Wx+vjg==",
         "dependencies": {
           "GraphQL.Client": "6.1.0",
           "Microsoft.Data.Sqlite": "10.0.0",
@@ -576,8 +576,8 @@
           "Microsoft.Extensions.ObjectPool": "10.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-beta.4",
-          "Speckle.Sdk.Parquet": "2026.9.0-beta.4"
+          "Speckle.Sdk.Dependencies": "2026.9.0-beta.5",
+          "Speckle.Sdk.Parquet": "2026.9.0-beta.5"
         }
       }
     },
@@ -719,13 +719,13 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "o+u1sRKl+KUmxvGHoNhBu+JJtGseDDxevu0khtPrZ6A15AMQ8+jRK7n9C2HkOXlNexVUwKiC8WnAa6/LUo6JHQ=="
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "yM8ZPViRCYZyVoyB2aRXAnQ8HuLA7E9pAjQSk01Rys5EUSBHHQCVMOeOY/maZRUeXVVfqu+/DyV8ST4kjZyYBg=="
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "l2Oa6SC8hq8f48mdWIXfnVbaUTlhKlrRVsGVUJSOnB77qPuwmj3CyZXoWFH/Gs9kcaEuC2wkbLRHndLpA77zcg=="
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "XpO62cnn84vGZUubF1CJ4GrsxUujwwdrv26T9uqsLLhzSWnxujNclrunZXcmJGGykufUWNT5SaDhd3UiMH17hw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -764,7 +764,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "speckle.connectors.dui": {
@@ -779,7 +779,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "Speckle.DoubleNumerics": {
@@ -790,9 +790,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-beta.4, )",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "qdHMddzoXCFv8dFe6FrwnLlSzlZNvZ1cv1842zO6HArROE1NOHK50zT8OtrPJJCwZSbBCaogyVxQTXWffDPl4A==",
+        "requested": "[2026.9.0-beta.5, )",
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "24tOTnFe3D8q0SWVCRGdhmDSuvZSicPK0RhzzjQBuT2MfR8goQxsKFcT7ogLWxFGsim5CTqKRidKhf13Wx+vjg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -800,8 +800,8 @@
           "Microsoft.Extensions.ObjectPool": "8.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-beta.4",
-          "Speckle.Sdk.Parquet": "2026.9.0-beta.4"
+          "Speckle.Sdk.Dependencies": "2026.9.0-beta.5",
+          "Speckle.Sdk.Parquet": "2026.9.0-beta.5"
         }
       }
     }

--- a/DUI3/Speckle.Connectors.DUI/packages.lock.json
+++ b/DUI3/Speckle.Connectors.DUI/packages.lock.json
@@ -174,16 +174,16 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "o+u1sRKl+KUmxvGHoNhBu+JJtGseDDxevu0khtPrZ6A15AMQ8+jRK7n9C2HkOXlNexVUwKiC8WnAa6/LUo6JHQ==",
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "yM8ZPViRCYZyVoyB2aRXAnQ8HuLA7E9pAjQSk01Rys5EUSBHHQCVMOeOY/maZRUeXVVfqu+/DyV8ST4kjZyYBg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.10"
         }
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "l2Oa6SC8hq8f48mdWIXfnVbaUTlhKlrRVsGVUJSOnB77qPuwmj3CyZXoWFH/Gs9kcaEuC2wkbLRHndLpA77zcg=="
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "XpO62cnn84vGZUubF1CJ4GrsxUujwwdrv26T9uqsLLhzSWnxujNclrunZXcmJGGykufUWNT5SaDhd3UiMH17hw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -289,7 +289,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "speckle.connectors.logging": {
@@ -298,7 +298,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "Speckle.DoubleNumerics": {
@@ -309,9 +309,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-beta.4, )",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "qdHMddzoXCFv8dFe6FrwnLlSzlZNvZ1cv1842zO6HArROE1NOHK50zT8OtrPJJCwZSbBCaogyVxQTXWffDPl4A==",
+        "requested": "[2026.9.0-beta.5, )",
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "24tOTnFe3D8q0SWVCRGdhmDSuvZSicPK0RhzzjQBuT2MfR8goQxsKFcT7ogLWxFGsim5CTqKRidKhf13Wx+vjg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -321,8 +321,8 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-beta.4",
-          "Speckle.Sdk.Parquet": "2026.9.0-beta.4",
+          "Speckle.Sdk.Dependencies": "2026.9.0-beta.5",
+          "Speckle.Sdk.Parquet": "2026.9.0-beta.5",
           "System.Memory": "4.5.5",
           "System.Text.Json": "5.0.2"
         }
@@ -477,13 +477,13 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "o+u1sRKl+KUmxvGHoNhBu+JJtGseDDxevu0khtPrZ6A15AMQ8+jRK7n9C2HkOXlNexVUwKiC8WnAa6/LUo6JHQ=="
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "yM8ZPViRCYZyVoyB2aRXAnQ8HuLA7E9pAjQSk01Rys5EUSBHHQCVMOeOY/maZRUeXVVfqu+/DyV8ST4kjZyYBg=="
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "l2Oa6SC8hq8f48mdWIXfnVbaUTlhKlrRVsGVUJSOnB77qPuwmj3CyZXoWFH/Gs9kcaEuC2wkbLRHndLpA77zcg=="
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "XpO62cnn84vGZUubF1CJ4GrsxUujwwdrv26T9uqsLLhzSWnxujNclrunZXcmJGGykufUWNT5SaDhd3UiMH17hw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -522,7 +522,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "speckle.connectors.logging": {
@@ -531,7 +531,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "Speckle.DoubleNumerics": {
@@ -542,9 +542,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-beta.4, )",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "qdHMddzoXCFv8dFe6FrwnLlSzlZNvZ1cv1842zO6HArROE1NOHK50zT8OtrPJJCwZSbBCaogyVxQTXWffDPl4A==",
+        "requested": "[2026.9.0-beta.5, )",
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "24tOTnFe3D8q0SWVCRGdhmDSuvZSicPK0RhzzjQBuT2MfR8goQxsKFcT7ogLWxFGsim5CTqKRidKhf13Wx+vjg==",
         "dependencies": {
           "GraphQL.Client": "6.1.0",
           "Microsoft.Data.Sqlite": "10.0.0",
@@ -552,8 +552,8 @@
           "Microsoft.Extensions.ObjectPool": "10.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-beta.4",
-          "Speckle.Sdk.Parquet": "2026.9.0-beta.4"
+          "Speckle.Sdk.Dependencies": "2026.9.0-beta.5",
+          "Speckle.Sdk.Parquet": "2026.9.0-beta.5"
         }
       }
     },
@@ -689,13 +689,13 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "o+u1sRKl+KUmxvGHoNhBu+JJtGseDDxevu0khtPrZ6A15AMQ8+jRK7n9C2HkOXlNexVUwKiC8WnAa6/LUo6JHQ=="
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "yM8ZPViRCYZyVoyB2aRXAnQ8HuLA7E9pAjQSk01Rys5EUSBHHQCVMOeOY/maZRUeXVVfqu+/DyV8ST4kjZyYBg=="
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "l2Oa6SC8hq8f48mdWIXfnVbaUTlhKlrRVsGVUJSOnB77qPuwmj3CyZXoWFH/Gs9kcaEuC2wkbLRHndLpA77zcg=="
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "XpO62cnn84vGZUubF1CJ4GrsxUujwwdrv26T9uqsLLhzSWnxujNclrunZXcmJGGykufUWNT5SaDhd3UiMH17hw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -734,7 +734,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "speckle.connectors.logging": {
@@ -743,7 +743,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "Speckle.DoubleNumerics": {
@@ -754,9 +754,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-beta.4, )",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "qdHMddzoXCFv8dFe6FrwnLlSzlZNvZ1cv1842zO6HArROE1NOHK50zT8OtrPJJCwZSbBCaogyVxQTXWffDPl4A==",
+        "requested": "[2026.9.0-beta.5, )",
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "24tOTnFe3D8q0SWVCRGdhmDSuvZSicPK0RhzzjQBuT2MfR8goQxsKFcT7ogLWxFGsim5CTqKRidKhf13Wx+vjg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -764,8 +764,8 @@
           "Microsoft.Extensions.ObjectPool": "8.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-beta.4",
-          "Speckle.Sdk.Parquet": "2026.9.0-beta.4"
+          "Speckle.Sdk.Dependencies": "2026.9.0-beta.5",
+          "Speckle.Sdk.Parquet": "2026.9.0-beta.5"
         }
       }
     }

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -53,7 +53,7 @@
     <PackageVersion Include="Speckle.Civil3D.API" Version="2022.0.2" />
     <PackageVersion Include="Speckle.Revit.API" Version="2023.0.0" />
     <PackageVersion Include="Speckle.Navisworks.API" Version="2024.0.0" />
-    <PackageVersion Include="Speckle.Sdk" Version="2026.9.0-beta.4" />
+    <PackageVersion Include="Speckle.Sdk" Version="2026.9.0-beta.5" />
     <PackageVersion Include="SimpleExec" Version="12.0.0" />
     <GlobalPackageReference Include="PolySharp" Version="1.15.0" />
     <GlobalPackageReference Include="Speckle.InterfaceGenerator" Version="0.9.6" />

--- a/Importers/Rhino/Speckle.Importers.JobProcessor/packages.lock.json
+++ b/Importers/Rhino/Speckle.Importers.JobProcessor/packages.lock.json
@@ -425,13 +425,13 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "o+u1sRKl+KUmxvGHoNhBu+JJtGseDDxevu0khtPrZ6A15AMQ8+jRK7n9C2HkOXlNexVUwKiC8WnAa6/LUo6JHQ=="
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "yM8ZPViRCYZyVoyB2aRXAnQ8HuLA7E9pAjQSk01Rys5EUSBHHQCVMOeOY/maZRUeXVVfqu+/DyV8ST4kjZyYBg=="
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "l2Oa6SC8hq8f48mdWIXfnVbaUTlhKlrRVsGVUJSOnB77qPuwmj3CyZXoWFH/Gs9kcaEuC2wkbLRHndLpA77zcg=="
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "XpO62cnn84vGZUubF1CJ4GrsxUujwwdrv26T9uqsLLhzSWnxujNclrunZXcmJGGykufUWNT5SaDhd3UiMH17hw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -506,7 +506,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "speckle.connectors.dui": {
@@ -536,7 +536,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "speckle.converters.rhino8": {
@@ -583,9 +583,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-beta.4, )",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "qdHMddzoXCFv8dFe6FrwnLlSzlZNvZ1cv1842zO6HArROE1NOHK50zT8OtrPJJCwZSbBCaogyVxQTXWffDPl4A==",
+        "requested": "[2026.9.0-beta.5, )",
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "24tOTnFe3D8q0SWVCRGdhmDSuvZSicPK0RhzzjQBuT2MfR8goQxsKFcT7ogLWxFGsim5CTqKRidKhf13Wx+vjg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -593,8 +593,8 @@
           "Microsoft.Extensions.ObjectPool": "8.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-beta.4",
-          "Speckle.Sdk.Parquet": "2026.9.0-beta.4"
+          "Speckle.Sdk.Dependencies": "2026.9.0-beta.5",
+          "Speckle.Sdk.Parquet": "2026.9.0-beta.5"
         }
       },
       "System.Text.Json": {

--- a/Importers/Rhino/Speckle.Importers.Rhino/packages.lock.json
+++ b/Importers/Rhino/Speckle.Importers.Rhino/packages.lock.json
@@ -175,13 +175,13 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "o+u1sRKl+KUmxvGHoNhBu+JJtGseDDxevu0khtPrZ6A15AMQ8+jRK7n9C2HkOXlNexVUwKiC8WnAa6/LUo6JHQ=="
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "yM8ZPViRCYZyVoyB2aRXAnQ8HuLA7E9pAjQSk01Rys5EUSBHHQCVMOeOY/maZRUeXVVfqu+/DyV8ST4kjZyYBg=="
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "l2Oa6SC8hq8f48mdWIXfnVbaUTlhKlrRVsGVUJSOnB77qPuwmj3CyZXoWFH/Gs9kcaEuC2wkbLRHndLpA77zcg=="
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "XpO62cnn84vGZUubF1CJ4GrsxUujwwdrv26T9uqsLLhzSWnxujNclrunZXcmJGGykufUWNT5SaDhd3UiMH17hw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -236,7 +236,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "speckle.connectors.dui": {
@@ -266,7 +266,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "speckle.converters.rhino8": {
@@ -289,9 +289,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-beta.4, )",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "qdHMddzoXCFv8dFe6FrwnLlSzlZNvZ1cv1842zO6HArROE1NOHK50zT8OtrPJJCwZSbBCaogyVxQTXWffDPl4A==",
+        "requested": "[2026.9.0-beta.5, )",
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "24tOTnFe3D8q0SWVCRGdhmDSuvZSicPK0RhzzjQBuT2MfR8goQxsKFcT7ogLWxFGsim5CTqKRidKhf13Wx+vjg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -299,8 +299,8 @@
           "Microsoft.Extensions.ObjectPool": "8.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-beta.4",
-          "Speckle.Sdk.Parquet": "2026.9.0-beta.4"
+          "Speckle.Sdk.Dependencies": "2026.9.0-beta.5",
+          "Speckle.Sdk.Parquet": "2026.9.0-beta.5"
         }
       }
     }

--- a/Sdk/Speckle.Connectors.Common.Tests/packages.lock.json
+++ b/Sdk/Speckle.Connectors.Common.Tests/packages.lock.json
@@ -256,13 +256,13 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "o+u1sRKl+KUmxvGHoNhBu+JJtGseDDxevu0khtPrZ6A15AMQ8+jRK7n9C2HkOXlNexVUwKiC8WnAa6/LUo6JHQ=="
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "yM8ZPViRCYZyVoyB2aRXAnQ8HuLA7E9pAjQSk01Rys5EUSBHHQCVMOeOY/maZRUeXVVfqu+/DyV8ST4kjZyYBg=="
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "l2Oa6SC8hq8f48mdWIXfnVbaUTlhKlrRVsGVUJSOnB77qPuwmj3CyZXoWFH/Gs9kcaEuC2wkbLRHndLpA77zcg=="
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "XpO62cnn84vGZUubF1CJ4GrsxUujwwdrv26T9uqsLLhzSWnxujNclrunZXcmJGGykufUWNT5SaDhd3UiMH17hw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -306,7 +306,7 @@
         "dependencies": {
           "Speckle.Connectors.Logging": "[1.0.0, )",
           "Speckle.Converters.Common": "[1.0.0, )",
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "speckle.connectors.logging": {
@@ -315,7 +315,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "speckle.testing": {
@@ -323,7 +323,7 @@
         "dependencies": {
           "Moq": "[4.20.70, )",
           "NUnit": "[4.5.1, )",
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "Moq": {
@@ -349,9 +349,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-beta.4, )",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "qdHMddzoXCFv8dFe6FrwnLlSzlZNvZ1cv1842zO6HArROE1NOHK50zT8OtrPJJCwZSbBCaogyVxQTXWffDPl4A==",
+        "requested": "[2026.9.0-beta.5, )",
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "24tOTnFe3D8q0SWVCRGdhmDSuvZSicPK0RhzzjQBuT2MfR8goQxsKFcT7ogLWxFGsim5CTqKRidKhf13Wx+vjg==",
         "dependencies": {
           "GraphQL.Client": "6.1.0",
           "Microsoft.Data.Sqlite": "10.0.0",
@@ -359,8 +359,8 @@
           "Microsoft.Extensions.ObjectPool": "10.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-beta.4",
-          "Speckle.Sdk.Parquet": "2026.9.0-beta.4"
+          "Speckle.Sdk.Dependencies": "2026.9.0-beta.5",
+          "Speckle.Sdk.Parquet": "2026.9.0-beta.5"
         }
       }
     }

--- a/Sdk/Speckle.Connectors.Common/packages.lock.json
+++ b/Sdk/Speckle.Connectors.Common/packages.lock.json
@@ -25,9 +25,9 @@
       },
       "Speckle.Sdk": {
         "type": "Direct",
-        "requested": "[2026.9.0-beta.4, )",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "qdHMddzoXCFv8dFe6FrwnLlSzlZNvZ1cv1842zO6HArROE1NOHK50zT8OtrPJJCwZSbBCaogyVxQTXWffDPl4A==",
+        "requested": "[2026.9.0-beta.5, )",
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "24tOTnFe3D8q0SWVCRGdhmDSuvZSicPK0RhzzjQBuT2MfR8goQxsKFcT7ogLWxFGsim5CTqKRidKhf13Wx+vjg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -37,8 +37,8 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-beta.4",
-          "Speckle.Sdk.Parquet": "2026.9.0-beta.4",
+          "Speckle.Sdk.Dependencies": "2026.9.0-beta.5",
+          "Speckle.Sdk.Parquet": "2026.9.0-beta.5",
           "System.Memory": "4.5.5",
           "System.Text.Json": "5.0.2"
         }
@@ -194,16 +194,16 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "o+u1sRKl+KUmxvGHoNhBu+JJtGseDDxevu0khtPrZ6A15AMQ8+jRK7n9C2HkOXlNexVUwKiC8WnAa6/LUo6JHQ==",
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "yM8ZPViRCYZyVoyB2aRXAnQ8HuLA7E9pAjQSk01Rys5EUSBHHQCVMOeOY/maZRUeXVVfqu+/DyV8ST4kjZyYBg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.10"
         }
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "l2Oa6SC8hq8f48mdWIXfnVbaUTlhKlrRVsGVUJSOnB77qPuwmj3CyZXoWFH/Gs9kcaEuC2wkbLRHndLpA77zcg=="
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "XpO62cnn84vGZUubF1CJ4GrsxUujwwdrv26T9uqsLLhzSWnxujNclrunZXcmJGGykufUWNT5SaDhd3UiMH17hw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -310,7 +310,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "Speckle.DoubleNumerics": {
@@ -360,9 +360,9 @@
       },
       "Speckle.Sdk": {
         "type": "Direct",
-        "requested": "[2026.9.0-beta.4, )",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "qdHMddzoXCFv8dFe6FrwnLlSzlZNvZ1cv1842zO6HArROE1NOHK50zT8OtrPJJCwZSbBCaogyVxQTXWffDPl4A==",
+        "requested": "[2026.9.0-beta.5, )",
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "24tOTnFe3D8q0SWVCRGdhmDSuvZSicPK0RhzzjQBuT2MfR8goQxsKFcT7ogLWxFGsim5CTqKRidKhf13Wx+vjg==",
         "dependencies": {
           "GraphQL.Client": "6.1.0",
           "Microsoft.Data.Sqlite": "10.0.0",
@@ -370,8 +370,8 @@
           "Microsoft.Extensions.ObjectPool": "10.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-beta.4",
-          "Speckle.Sdk.Parquet": "2026.9.0-beta.4"
+          "Speckle.Sdk.Dependencies": "2026.9.0-beta.5",
+          "Speckle.Sdk.Parquet": "2026.9.0-beta.5"
         }
       },
       "GraphQL.Client": {
@@ -485,13 +485,13 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "o+u1sRKl+KUmxvGHoNhBu+JJtGseDDxevu0khtPrZ6A15AMQ8+jRK7n9C2HkOXlNexVUwKiC8WnAa6/LUo6JHQ=="
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "yM8ZPViRCYZyVoyB2aRXAnQ8HuLA7E9pAjQSk01Rys5EUSBHHQCVMOeOY/maZRUeXVVfqu+/DyV8ST4kjZyYBg=="
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "l2Oa6SC8hq8f48mdWIXfnVbaUTlhKlrRVsGVUJSOnB77qPuwmj3CyZXoWFH/Gs9kcaEuC2wkbLRHndLpA77zcg=="
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "XpO62cnn84vGZUubF1CJ4GrsxUujwwdrv26T9uqsLLhzSWnxujNclrunZXcmJGGykufUWNT5SaDhd3UiMH17hw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -531,7 +531,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "Speckle.DoubleNumerics": {
@@ -565,9 +565,9 @@
       },
       "Speckle.Sdk": {
         "type": "Direct",
-        "requested": "[2026.9.0-beta.4, )",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "qdHMddzoXCFv8dFe6FrwnLlSzlZNvZ1cv1842zO6HArROE1NOHK50zT8OtrPJJCwZSbBCaogyVxQTXWffDPl4A==",
+        "requested": "[2026.9.0-beta.5, )",
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "24tOTnFe3D8q0SWVCRGdhmDSuvZSicPK0RhzzjQBuT2MfR8goQxsKFcT7ogLWxFGsim5CTqKRidKhf13Wx+vjg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -575,8 +575,8 @@
           "Microsoft.Extensions.ObjectPool": "8.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-beta.4",
-          "Speckle.Sdk.Parquet": "2026.9.0-beta.4"
+          "Speckle.Sdk.Dependencies": "2026.9.0-beta.5",
+          "Speckle.Sdk.Parquet": "2026.9.0-beta.5"
         }
       },
       "GraphQL.Client": {
@@ -689,13 +689,13 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "o+u1sRKl+KUmxvGHoNhBu+JJtGseDDxevu0khtPrZ6A15AMQ8+jRK7n9C2HkOXlNexVUwKiC8WnAa6/LUo6JHQ=="
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "yM8ZPViRCYZyVoyB2aRXAnQ8HuLA7E9pAjQSk01Rys5EUSBHHQCVMOeOY/maZRUeXVVfqu+/DyV8ST4kjZyYBg=="
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "l2Oa6SC8hq8f48mdWIXfnVbaUTlhKlrRVsGVUJSOnB77qPuwmj3CyZXoWFH/Gs9kcaEuC2wkbLRHndLpA77zcg=="
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "XpO62cnn84vGZUubF1CJ4GrsxUujwwdrv26T9uqsLLhzSWnxujNclrunZXcmJGGykufUWNT5SaDhd3UiMH17hw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -735,7 +735,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "Speckle.DoubleNumerics": {

--- a/Sdk/Speckle.Converters.Common.Tests/packages.lock.json
+++ b/Sdk/Speckle.Converters.Common.Tests/packages.lock.json
@@ -271,13 +271,13 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "o+u1sRKl+KUmxvGHoNhBu+JJtGseDDxevu0khtPrZ6A15AMQ8+jRK7n9C2HkOXlNexVUwKiC8WnAa6/LUo6JHQ=="
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "yM8ZPViRCYZyVoyB2aRXAnQ8HuLA7E9pAjQSk01Rys5EUSBHHQCVMOeOY/maZRUeXVVfqu+/DyV8ST4kjZyYBg=="
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "l2Oa6SC8hq8f48mdWIXfnVbaUTlhKlrRVsGVUJSOnB77qPuwmj3CyZXoWFH/Gs9kcaEuC2wkbLRHndLpA77zcg=="
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "XpO62cnn84vGZUubF1CJ4GrsxUujwwdrv26T9uqsLLhzSWnxujNclrunZXcmJGGykufUWNT5SaDhd3UiMH17hw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -319,7 +319,7 @@
       "speckle.converters.common": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "speckle.testing": {
@@ -327,7 +327,7 @@
         "dependencies": {
           "Moq": "[4.20.70, )",
           "NUnit": "[4.5.1, )",
-          "Speckle.Sdk": "[2026.9.0-beta.4, )"
+          "Speckle.Sdk": "[2026.9.0-beta.5, )"
         }
       },
       "Speckle.DoubleNumerics": {
@@ -338,9 +338,9 @@
       },
       "Speckle.Sdk": {
         "type": "CentralTransitive",
-        "requested": "[2026.9.0-beta.4, )",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "qdHMddzoXCFv8dFe6FrwnLlSzlZNvZ1cv1842zO6HArROE1NOHK50zT8OtrPJJCwZSbBCaogyVxQTXWffDPl4A==",
+        "requested": "[2026.9.0-beta.5, )",
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "24tOTnFe3D8q0SWVCRGdhmDSuvZSicPK0RhzzjQBuT2MfR8goQxsKFcT7ogLWxFGsim5CTqKRidKhf13Wx+vjg==",
         "dependencies": {
           "GraphQL.Client": "6.1.0",
           "Microsoft.Data.Sqlite": "10.0.0",
@@ -348,8 +348,8 @@
           "Microsoft.Extensions.ObjectPool": "10.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-beta.4",
-          "Speckle.Sdk.Parquet": "2026.9.0-beta.4"
+          "Speckle.Sdk.Dependencies": "2026.9.0-beta.5",
+          "Speckle.Sdk.Parquet": "2026.9.0-beta.5"
         }
       }
     }

--- a/Sdk/Speckle.Converters.Common/packages.lock.json
+++ b/Sdk/Speckle.Converters.Common/packages.lock.json
@@ -25,9 +25,9 @@
       },
       "Speckle.Sdk": {
         "type": "Direct",
-        "requested": "[2026.9.0-beta.4, )",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "qdHMddzoXCFv8dFe6FrwnLlSzlZNvZ1cv1842zO6HArROE1NOHK50zT8OtrPJJCwZSbBCaogyVxQTXWffDPl4A==",
+        "requested": "[2026.9.0-beta.5, )",
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "24tOTnFe3D8q0SWVCRGdhmDSuvZSicPK0RhzzjQBuT2MfR8goQxsKFcT7ogLWxFGsim5CTqKRidKhf13Wx+vjg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.CSharp": "4.7.0",
@@ -37,8 +37,8 @@
           "Microsoft.Extensions.ObjectPool": "6.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-beta.4",
-          "Speckle.Sdk.Parquet": "2026.9.0-beta.4",
+          "Speckle.Sdk.Dependencies": "2026.9.0-beta.5",
+          "Speckle.Sdk.Parquet": "2026.9.0-beta.5",
           "System.Memory": "4.5.5",
           "System.Text.Json": "5.0.2"
         }
@@ -194,16 +194,16 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "o+u1sRKl+KUmxvGHoNhBu+JJtGseDDxevu0khtPrZ6A15AMQ8+jRK7n9C2HkOXlNexVUwKiC8WnAa6/LUo6JHQ==",
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "yM8ZPViRCYZyVoyB2aRXAnQ8HuLA7E9pAjQSk01Rys5EUSBHHQCVMOeOY/maZRUeXVVfqu+/DyV8ST4kjZyYBg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "9.0.10"
         }
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "l2Oa6SC8hq8f48mdWIXfnVbaUTlhKlrRVsGVUJSOnB77qPuwmj3CyZXoWFH/Gs9kcaEuC2wkbLRHndLpA77zcg=="
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "XpO62cnn84vGZUubF1CJ4GrsxUujwwdrv26T9uqsLLhzSWnxujNclrunZXcmJGGykufUWNT5SaDhd3UiMH17hw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -351,9 +351,9 @@
       },
       "Speckle.Sdk": {
         "type": "Direct",
-        "requested": "[2026.9.0-beta.4, )",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "qdHMddzoXCFv8dFe6FrwnLlSzlZNvZ1cv1842zO6HArROE1NOHK50zT8OtrPJJCwZSbBCaogyVxQTXWffDPl4A==",
+        "requested": "[2026.9.0-beta.5, )",
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "24tOTnFe3D8q0SWVCRGdhmDSuvZSicPK0RhzzjQBuT2MfR8goQxsKFcT7ogLWxFGsim5CTqKRidKhf13Wx+vjg==",
         "dependencies": {
           "GraphQL.Client": "6.1.0",
           "Microsoft.Data.Sqlite": "10.0.0",
@@ -361,8 +361,8 @@
           "Microsoft.Extensions.ObjectPool": "10.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-beta.4",
-          "Speckle.Sdk.Parquet": "2026.9.0-beta.4"
+          "Speckle.Sdk.Dependencies": "2026.9.0-beta.5",
+          "Speckle.Sdk.Parquet": "2026.9.0-beta.5"
         }
       },
       "GraphQL.Client": {
@@ -476,13 +476,13 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "o+u1sRKl+KUmxvGHoNhBu+JJtGseDDxevu0khtPrZ6A15AMQ8+jRK7n9C2HkOXlNexVUwKiC8WnAa6/LUo6JHQ=="
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "yM8ZPViRCYZyVoyB2aRXAnQ8HuLA7E9pAjQSk01Rys5EUSBHHQCVMOeOY/maZRUeXVVfqu+/DyV8ST4kjZyYBg=="
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "l2Oa6SC8hq8f48mdWIXfnVbaUTlhKlrRVsGVUJSOnB77qPuwmj3CyZXoWFH/Gs9kcaEuC2wkbLRHndLpA77zcg=="
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "XpO62cnn84vGZUubF1CJ4GrsxUujwwdrv26T9uqsLLhzSWnxujNclrunZXcmJGGykufUWNT5SaDhd3UiMH17hw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -547,9 +547,9 @@
       },
       "Speckle.Sdk": {
         "type": "Direct",
-        "requested": "[2026.9.0-beta.4, )",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "qdHMddzoXCFv8dFe6FrwnLlSzlZNvZ1cv1842zO6HArROE1NOHK50zT8OtrPJJCwZSbBCaogyVxQTXWffDPl4A==",
+        "requested": "[2026.9.0-beta.5, )",
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "24tOTnFe3D8q0SWVCRGdhmDSuvZSicPK0RhzzjQBuT2MfR8goQxsKFcT7ogLWxFGsim5CTqKRidKhf13Wx+vjg==",
         "dependencies": {
           "GraphQL.Client": "6.0.0",
           "Microsoft.Data.Sqlite": "7.0.5",
@@ -557,8 +557,8 @@
           "Microsoft.Extensions.ObjectPool": "8.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-beta.4",
-          "Speckle.Sdk.Parquet": "2026.9.0-beta.4"
+          "Speckle.Sdk.Dependencies": "2026.9.0-beta.5",
+          "Speckle.Sdk.Parquet": "2026.9.0-beta.5"
         }
       },
       "GraphQL.Client": {
@@ -671,13 +671,13 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "o+u1sRKl+KUmxvGHoNhBu+JJtGseDDxevu0khtPrZ6A15AMQ8+jRK7n9C2HkOXlNexVUwKiC8WnAa6/LUo6JHQ=="
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "yM8ZPViRCYZyVoyB2aRXAnQ8HuLA7E9pAjQSk01Rys5EUSBHHQCVMOeOY/maZRUeXVVfqu+/DyV8ST4kjZyYBg=="
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "l2Oa6SC8hq8f48mdWIXfnVbaUTlhKlrRVsGVUJSOnB77qPuwmj3CyZXoWFH/Gs9kcaEuC2wkbLRHndLpA77zcg=="
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "XpO62cnn84vGZUubF1CJ4GrsxUujwwdrv26T9uqsLLhzSWnxujNclrunZXcmJGGykufUWNT5SaDhd3UiMH17hw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",

--- a/Sdk/Speckle.Testing/packages.lock.json
+++ b/Sdk/Speckle.Testing/packages.lock.json
@@ -40,9 +40,9 @@
       },
       "Speckle.Sdk": {
         "type": "Direct",
-        "requested": "[2026.9.0-beta.4, )",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "qdHMddzoXCFv8dFe6FrwnLlSzlZNvZ1cv1842zO6HArROE1NOHK50zT8OtrPJJCwZSbBCaogyVxQTXWffDPl4A==",
+        "requested": "[2026.9.0-beta.5, )",
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "24tOTnFe3D8q0SWVCRGdhmDSuvZSicPK0RhzzjQBuT2MfR8goQxsKFcT7ogLWxFGsim5CTqKRidKhf13Wx+vjg==",
         "dependencies": {
           "GraphQL.Client": "6.1.0",
           "Microsoft.Data.Sqlite": "10.0.0",
@@ -50,8 +50,8 @@
           "Microsoft.Extensions.ObjectPool": "10.0.0",
           "Speckle.DoubleNumerics": "4.1.0",
           "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Dependencies": "2026.9.0-beta.4",
-          "Speckle.Sdk.Parquet": "2026.9.0-beta.4"
+          "Speckle.Sdk.Dependencies": "2026.9.0-beta.5",
+          "Speckle.Sdk.Parquet": "2026.9.0-beta.5"
         }
       },
       "Castle.Core": {
@@ -173,13 +173,13 @@
       },
       "Speckle.Sdk.Dependencies": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "o+u1sRKl+KUmxvGHoNhBu+JJtGseDDxevu0khtPrZ6A15AMQ8+jRK7n9C2HkOXlNexVUwKiC8WnAa6/LUo6JHQ=="
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "yM8ZPViRCYZyVoyB2aRXAnQ8HuLA7E9pAjQSk01Rys5EUSBHHQCVMOeOY/maZRUeXVVfqu+/DyV8ST4kjZyYBg=="
       },
       "Speckle.Sdk.Parquet": {
         "type": "Transitive",
-        "resolved": "2026.9.0-beta.4",
-        "contentHash": "l2Oa6SC8hq8f48mdWIXfnVbaUTlhKlrRVsGVUJSOnB77qPuwmj3CyZXoWFH/Gs9kcaEuC2wkbLRHndLpA77zcg=="
+        "resolved": "2026.9.0-beta.5",
+        "contentHash": "XpO62cnn84vGZUubF1CJ4GrsxUujwwdrv26T9uqsLLhzSWnxujNclrunZXcmJGGykufUWNT5SaDhd3UiMH17hw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",

--- a/docs/connector-relations.md
+++ b/docs/connector-relations.md
@@ -2,7 +2,7 @@
 
 _Speckle 4.0 artifact bundle · schema_version 5 · verified against connector send builders on `big-truck` + the SketchUp Ruby producer._
 
-The [bundle spec](https://github.com/specklesystems/speckle-bundle-spec) defines **17 live relations**, but no connector emits all of them. Each host maps its own concepts (layers, levels, blocks, systems, results) onto the subset that fits. This doc pins down, with diagrams and code evidence, exactly what **every connector** produces and consumes.
+The [bundle spec](https://github.com/specklesystems/speckle-bundle-spec) defines the live relations, but no connector emits all of them. Each host maps its own concepts (layers, levels, blocks, systems, results) onto the subset that fits. This doc pins down, with diagrams and code evidence, exactly what **every connector** produces and consumes.
 
 > Companion: [the artifact object model field guide](./artifact-object-model.md) — worked examples of each relation in the abstract.
 
@@ -18,7 +18,10 @@ A bundle is a graph of flat parquet rows across **three ID spaces**. A bare numb
 | **geometry** | `geometries` · `geometryIndex` | one blob — display mesh (SGEO) or lossless raw body (3dm / SAT) |
 | **node** | `envelope.nodes` · `id` | a synthetic value — material, color, level, definition, instance, container |
 
-### The 17 live relations
+### The live relations
+
+> This table lags the spec: rels 18 and 24-29 landed after it was written and are not listed. `docs/reference.md`
+> in speckle-bundle-spec is generated from the spec itself and is always current.
 
 | id | relation | src → dst | meaning |
 |---:|---|---|---|
@@ -39,6 +42,7 @@ A bundle is a graph of flat parquet rows across **three ID spaces**. A bare numb
 | 21 | `CONNECTS_TO` | object → object | directed connectivity (frame→joint, pipe→structure, room adjacency) |
 | 22 | `HOSTED_ON` | object → object | hosted element **placed on** host (door→wall) · distinct from ownership |
 | 23 | `BOUNDS` | object → object | bounding wall → room |
+| 30 | `CENTERLINE` | object → geometry | element's authored location curve (duct/pipe axis) · **not** a render edge |
 
 Plus four **value / sidecar files** outside the relation graph: `camera_views` (named viewpoints), `structural_results` (analysis rows), `reference_point` (meta columns), and the Civil3D **property-set definitions carrier**.
 
@@ -69,6 +73,7 @@ What each connector actually emits, verified in the send builders. `●` emitted
 | **21 CONNECTS_TO** | · | · | · | · | ● | · | ● | · | ● | · |
 | **22 HOSTED_ON** | · | · | · | · | · | · | ● | · | · | · |
 | **23 BOUNDS** | · | · | · | · | · | · | ◐² | · | · | · |
+| **30 CENTERLINE** | · | · | · | · | · | · | ● | · | · | · |
 | _camera_views_ | ● | · | · | · | · | ● | ● | · | · | · |
 | _structural_results_ | · | · | · | · | · | · | · | · | ● | ● |
 | _reference_point (meta)_ | · | · | · | · | · | · | ● | · | · | · |
@@ -183,6 +188,9 @@ graph LR
 Every GH branch maps to one CONTAINER; the exact path array rides a sidecar eav object (`__collection_topology_{k}`) so receivers rebuild the tree with no schema change. GH reuses Rhino's geometry/material/color/block packers verbatim — no layer or level concept.
 
 - **Nodes:** CONTAINER `"Collection"` (nested, one per branch) · DEFINITION/INSTANCE · MATERIAL · COLOR
+- **Consumes:** the Explore component reads the envelope graph catalog, so every relation surfaces without a code
+  change — as application ids for object/node ends, and as native geometry for `CENTERLINE` (the one geometry rel it
+  keeps, because receive never bakes it; see the Revit section)
 - **Receive:** send-only (data connector)
 
 ---
@@ -317,7 +325,7 @@ A SketchUp group emits DISPLAY_INSTANCE like a component — so **IN_GROUP is ne
 
 ---
 
-### Revit — BIM · emits 11
+### Revit — BIM · emits 12
 
 The richest BIM producer: display geometry + instances/materials/levels, per-document model containers for federation, and a best-effort host-API topology layer (sub-elements, rooms, room-adjacency, model groups).
 
@@ -397,6 +405,28 @@ graph LR
 ```
 
 `ElementUnpacker` explodes every placed group into its members before conversion, so the group instance is never an object — membership is recovered from each member's `Element.GroupId`, and because that unpacking recurses, `GroupId` always names the **innermost** group (one `IN_GROUP` edge per element). Nesting is the CONTAINER parent chain (`def_ref`), walked from each group's own `GroupId`. Containers are keyed per model container, so a linked file placed twice gets one group tier per placement. Attached detail groups are excluded (annotation, not model topology). The container name is the group TYPE name — the same string that ships as the `groupName` property.
+
+**Centerlines** — `CENTERLINE` (ENG-9510)
+
+```mermaid
+graph LR
+  DU([obj · Duct]):::obj
+  SH[geo · tube mesh]:::geo
+  AX[geo · axis curve]:::geo
+  DU -->|DISPLAY| SH
+  DU -->|CENTERLINE| AX
+  classDef obj fill:#eac36a,stroke:#9a5f0c,color:#2a1c04;
+  classDef geo fill:#5fc7b8,stroke:#0a7369,color:#052723;
+```
+
+Every element whose `Location` is a `LocationCurve` ships that curve alongside its display geometry — a duct, pipe,
+conduit or tray IS its centerline, and a framing member's axis is the same datum. Free: the converter already
+produced the curve as `RevitObject.location`, through the same scaling + reference-point path as the meshes and inside
+the same settings push, so the axis lands aligned with its own shell in a linked model too. Point-located elements
+(duct fittings, furniture) emit nothing — a point is not a centerline. **Not a render edge**: no receiver bakes it, so
+Grasshopper's Explore component is the route to it (it is the one geometry rel `ArtefactGraphCache` deliberately does
+not drop). Caveat: it is the element's LOCATION curve, so for a wall it follows the Location Line type parameter and
+may be a face rather than the centre.
 
 - **Nodes:** CONTAINER `"Model"` (per source doc) · CONTAINER `"Group"` (per placed model group) · LEVEL (name+elev) · DEFINITION/INSTANCE · MATERIAL
 - **Sidecar:** `camera_views` ← 3D views (ENG-8802) · `reference_point` meta (ENG-8808)

--- a/docs/connector-relations.md
+++ b/docs/connector-relations.md
@@ -415,18 +415,38 @@ graph LR
   AX[geo · axis curve]:::geo
   DU -->|DISPLAY| SH
   DU -->|CENTERLINE| AX
+  EL([obj · Elbow fitting]):::obj
+  B0[geo · branch 0]:::geo
+  B1[geo · branch 1]:::geo
+  EL -->|CENTERLINE ord 0| B0
+  EL -->|CENTERLINE ord 1| B1
   classDef obj fill:#eac36a,stroke:#9a5f0c,color:#2a1c04;
   classDef geo fill:#5fc7b8,stroke:#0a7369,color:#052723;
 ```
 
-Every element whose `Location` is a `LocationCurve` ships that curve alongside its display geometry — a duct, pipe,
-conduit or tray IS its centerline, and a framing member's axis is the same datum. Free: the converter already
-produced the curve as `RevitObject.location`, through the same scaling + reference-point path as the meshes and inside
-the same settings push, so the axis lands aligned with its own shell in a linked model too. Point-located elements
-(duct fittings, furniture) emit nothing — a point is not a centerline. **Not a render edge**: no receiver bakes it, so
-Grasshopper's Explore component is the route to it (it is the one geometry rel `ArtefactGraphCache` deliberately does
-not drop). Caveat: it is the element's LOCATION curve, so for a wall it follows the Location Line type parameter and
-may be a face rather than the centre.
+Two shapes, one rel, because a consumer asking "where is the axis" does not care which.
+
+**(a) The authored location curve**, for every element whose `Location` is a `LocationCurve` — a duct,
+pipe, conduit or tray IS its centerline, and a framing member’s axis is the same datum. Free: the converter
+already produced the curve as `RevitObject.location`, through the same scaling + reference-point path as the
+meshes and inside the same settings push, so the axis lands aligned with its own shell in a linked model too.
+*Caveat*: it is the element’s LOCATION curve, so for a wall it follows the Location Line type parameter and may
+be a face rather than the centre.
+
+**(b) Connector branches**, for a point-placed MEP fitting — elbow, tee, cross, transition — which has no
+location curve at all and so left a gap in every run. Each connector reports where the run enters or leaves the
+fitting and the insertion point is the node they meet at, so the fitting ships **one segment per connector**
+(`MepCenterlineExtractor`), `ord` = branch index. That is what a single-line drawing draws, and the only shape
+that survives a branch — no single curve can express a tee. Consumers weld duct and fitting segments into
+continuous runs (Join Curves). Origins come from `Connector.CoordinateSystem.Origin`, **not** `Connector.Origin`,
+which is documented to throw for a connector belonging to a family instance — i.e. every fitting. Also fires
+for connector-bearing equipment and air terminals: a stub per connector to the unit’s insertion point.
+
+Elements placed by a point with no flow connectors (furniture, isolated foundations, vertical structural columns)
+emit nothing — a point is not a centerline.
+
+**Not a render edge**: no receiver bakes it, so Grasshopper’s Explore component is the route to it (it is the one
+geometry rel `ArtefactGraphCache` deliberately does not drop).
 
 - **Nodes:** CONTAINER `"Model"` (per source doc) · CONTAINER `"Group"` (per placed model group) · LEVEL (name+elev) · DEFINITION/INSTANCE · MATERIAL
 - **Sidecar:** `camera_views` ← 3D views (ENG-8802) · `reference_point` meta (ENG-8808)

--- a/docs/connector-relations.md
+++ b/docs/connector-relations.md
@@ -427,8 +427,9 @@ graph LR
 Two shapes, one rel, because a consumer asking "where is the axis" does not care which.
 
 **(a) The authored location curve**, for elements in a **curated scope** (`CenterlineScope`) — MEP curves
-(ducts, pipes, conduits, cable trays, incl. flex and placeholders) and structural framing (beams, braces,
-girders). Free: the converter already produced the curve as `RevitObject.location`, through the same scaling +
+(ducts, pipes, conduits, cable trays, incl. flex and placeholders) and the structural frame (framing, columns,
+trusses, foundations). Free: the converter already produced the curve as `RevitObject.location`, through the
+same scaling +
 reference-point path as the meshes and inside the same settings push, so the axis lands aligned with its own
 shell in a linked model too. **Deliberately not "anything with a location curve"**: every qualifying element adds
 a geometry blob and a relation row to *every* Revit send, so the set is opened on request rather than by default.

--- a/docs/connector-relations.md
+++ b/docs/connector-relations.md
@@ -426,12 +426,15 @@ graph LR
 
 Two shapes, one rel, because a consumer asking "where is the axis" does not care which.
 
-**(a) The authored location curve**, for every element whose `Location` is a `LocationCurve` — a duct,
-pipe, conduit or tray IS its centerline, and a framing member’s axis is the same datum. Free: the converter
-already produced the curve as `RevitObject.location`, through the same scaling + reference-point path as the
-meshes and inside the same settings push, so the axis lands aligned with its own shell in a linked model too.
-*Caveat*: it is the element’s LOCATION curve, so for a wall it follows the Location Line type parameter and may
-be a face rather than the centre.
+**(a) The authored location curve**, for elements in a **curated scope** (`CenterlineScope`) — MEP curves
+(ducts, pipes, conduits, cable trays, incl. flex and placeholders) and structural framing (beams, braces,
+girders). Free: the converter already produced the curve as `RevitObject.location`, through the same scaling +
+reference-point path as the meshes and inside the same settings push, so the axis lands aligned with its own
+shell in a linked model too. **Deliberately not "anything with a location curve"**: every qualifying element adds
+a geometry blob and a relation row to *every* Revit send, so the set is opened on request rather than by default.
+Walls are therefore excluded, which also sidesteps their location line being a core or finish face rather than
+the centre. Gated on type and `BuiltInCategory`, **never on category name** — those are localised, so a
+name-based list matches nothing on a German or French model.
 
 **(b) Connector branches**, for a point-placed MEP fitting — elbow, tee, cross, transition — which has no
 location curve at all and so left a gap in every run. Each connector reports where the run enters or leaves the
@@ -439,11 +442,11 @@ fitting and the insertion point is the node they meet at, so the fitting ships *
 (`MepCenterlineExtractor`), `ord` = branch index. That is what a single-line drawing draws, and the only shape
 that survives a branch — no single curve can express a tee. Consumers weld duct and fitting segments into
 continuous runs (Join Curves). Origins come from `Connector.CoordinateSystem.Origin`, **not** `Connector.Origin`,
-which is documented to throw for a connector belonging to a family instance — i.e. every fitting. Also fires
-for connector-bearing equipment and air terminals: a stub per connector to the unit’s insertion point.
+which is documented to throw for a connector belonging to a family instance — i.e. every fitting. Scoped by
+connector **domain** (HVAC, piping, cable tray); electrical and structural-analytical connectors are excluded.
 
-Elements placed by a point with no flow connectors (furniture, isolated foundations, vertical structural columns)
-emit nothing — a point is not a centerline.
+Everything else emits nothing — walls, floors, railings, nested mullions and panels, furniture, and any
+point-placed element with no flow connectors.
 
 **Not a render edge**: no receiver bakes it, so Grasshopper’s Explore component is the route to it (it is the one
 geometry rel `ArtefactGraphCache` deliberately does not drop).


### PR DESCRIPTION
## Description

Revit already computes every element's location curve, and the 4.0 send threw it away — there was nowhere in a bundle to put it. This adds `CENTERLINE` (rel 30, object → geometry) and wires it up Revit → Grasshopper.

Needs the spec and SDK PRs first.

## User Value

Consume duct and pipe centrelines (and beam axes) in Grasshopper.

## Changes:

- new rel 30 `CENTERLINE`, `object → geometry`, `schema_version` → 1.1.0 (bundle-spec)
- SDK read + write: `RelKind.Centerline`, `pipeline.Centerline()`, `BundleObject.AddCenterline()`,
  `ArtefactRelations.Centerline`, `ModelObject.Centerlines`
- Revit send: location curve for every curve-located element, not just MEP (beam and wall axes come
  for free); connector branches for fittings via new `MepCenterlineExtractor`
- Grasshopper: Explore surfaces it as native curves; `ArtefactGraphCache` stops dropping it as a
  geometry rel — it's the one receive never bakes
- extracted the SGEO→Rhino decode out of `GrasshopperArtefactObjectBuilder` into
  `ArtefactGeometryDecoder`, so Explore and receive share one decode path
- `docs/connector-relations.md`

## To-do before merge:

- [x] merge speckle-bundle-spec [#31](https://github.com/specklesystems/speckle-bundle-spec/pull/31)
- [x] merge speckle-sharp-sdk [#574](https://github.com/specklesystems/speckle-sharp-sdk/pull/574)
- [x] bump `Speckle.Sdk` in `Directory.Packages.props` + relock

## Screenshots:

<img width="1920" height="1044" alt="Screenshot 2026-09-03 164718" src="https://github.com/user-attachments/assets/4eff62ff-ce75-4469-8567-0c4893564684" />
<img width="1919" height="1044" alt="Screenshot 2026-09-03 172308" src="https://github.com/user-attachments/assets/d94e5951-eed5-4e7b-a590-beddc819099c" />
<img width="1919" height="1043" alt="Screenshot 2026-09-03 153253" src="https://github.com/user-attachments/assets/e1d3e844-228d-41f2-a8fd-f52147f5f5b3" />