### PR TITLE
Resolve "Forgot to call Dispose?" messages in the debugger on publish

### DIFF
--- a/Converters/Autocad/Speckle.Converters.AutocadShared/ToSpeckle/Geometry/HatchToSpeckleConverter.cs
+++ b/Converters/Autocad/Speckle.Converters.AutocadShared/ToSpeckle/Geometry/HatchToSpeckleConverter.cs
@@ -75,6 +75,8 @@ public class HatchToSpeckleConverter : IToSpeckleTopLevelConverter, ITypedConver
           }
         }
       }
+
+      polyline.ForEach(curve => curve.Dispose());
     }
 
     if (regionToConvert == null)
@@ -89,6 +91,8 @@ public class HatchToSpeckleConverter : IToSpeckleTopLevelConverter, ITypedConver
     // convert and store Regions
     SOG.Region convertedRegion = _regionConverter.Convert(regionToConvert);
     convertedRegion.hasHatchPattern = true;
+
+    regionToConvert.Dispose();
 
     return convertedRegion;
   }

--- a/Converters/Autocad/Speckle.Converters.AutocadShared/ToSpeckle/Geometry/Polyline2dToSpeckleConverter.cs
+++ b/Converters/Autocad/Speckle.Converters.AutocadShared/ToSpeckle/Geometry/Polyline2dToSpeckleConverter.cs
@@ -158,6 +158,11 @@ public class Polyline2dToSpeckleConverter
       }
     }
 
+    foreach (ADB.DBObject obj in exploded)
+    {
+      obj.Dispose();
+    }
+
     // for splines, convert the spline curve and display value and add to the segments list
     if (isSpline)
     {

--- a/Converters/Autocad/Speckle.Converters.AutocadShared/ToSpeckle/Geometry/RegionToSpeckleConverter.cs
+++ b/Converters/Autocad/Speckle.Converters.AutocadShared/ToSpeckle/Geometry/RegionToSpeckleConverter.cs
@@ -115,22 +115,11 @@ public class RegionToSpeckleConverter : IToSpeckleTopLevelConverter, ITypedConve
     switch (segment)
     {
       case AG.CircularArc3d arc: // expected to be closed
-        return arc.StartPoint == arc.EndPoint
-          ? _circleConverter.Convert(new ADB.Circle(arc.Center, arc.Normal, arc.Radius))
-          : _arcConverter.Convert(arc);
+        return arc.StartPoint == arc.EndPoint ? ConvertCircle(arc) : _arcConverter.Convert(arc);
       case AG.EllipticalArc3d ellipse:
-        return _ellipseConverter.Convert(
-          new ADB.Ellipse(
-            ellipse.Center,
-            ellipse.Normal,
-            ellipse.MajorRadius * ellipse.MajorAxis,
-            ellipse.MinorRadius / ellipse.MajorRadius,
-            ellipse.StartAngle,
-            ellipse.EndAngle
-          )
-        );
+        return ConvertEllipse(ellipse);
       case AG.NurbCurve3d nurbs:
-        return _nurbConverter.Convert(ADB.Curve.CreateFromGeCurve(nurbs));
+        return ConvertCurve(nurbs);
       default:
         throw new ConversionException($"Unsupported curve type for Region conversion: {segment}");
     }
@@ -146,13 +135,39 @@ public class RegionToSpeckleConverter : IToSpeckleTopLevelConverter, ITypedConve
     };
   }
 
+  private ICurve ConvertCurve(AG.NurbCurve3d nurb)
+  {
+    using var curve = ADB.Curve.CreateFromGeCurve(nurb);
+    return _nurbConverter.Convert(curve);
+  }
+
+  private SOG.Circle ConvertCircle(AG.CircularArc3d arc)
+  {
+    using var circle = new ADB.Circle(arc.Center, arc.Normal, arc.Radius);
+    return _circleConverter.Convert(circle);
+  }
+
+  private SOG.Ellipse ConvertEllipse(AG.EllipticalArc3d arc)
+  {
+    using var ellipse = new ADB.Ellipse(
+      arc.Center,
+      arc.Normal,
+      arc.MajorRadius * arc.MajorAxis,
+      arc.MinorRadius / arc.MajorRadius,
+      arc.StartAngle,
+      arc.EndAngle
+    );
+    return _ellipseConverter.Convert(ellipse);
+  }
+
   private ICurve ConvertSegment(AG.Curve3d curve)
   {
     return curve switch
     {
       AG.LineSegment3d line => _lineConverter.Convert(line),
       AG.CircularArc3d arc => _arcConverter.Convert(arc),
-      AG.NurbCurve3d nurb => _nurbConverter.Convert(ADB.Curve.CreateFromGeCurve(nurb)),
+      AG.NurbCurve3d nurb => ConvertCurve(nurb),
+      AG.EllipticalArc3d ellipse => ConvertEllipse(ellipse),
       _ => throw new ConversionException($"Unsupported curve type for Region conversion: {curve}"),
     };
   }

--- a/Converters/Autocad/Speckle.Converters.AutocadShared/ToSpeckle/Raw/DBSplineToSpeckleRawConverter.cs
+++ b/Converters/Autocad/Speckle.Converters.AutocadShared/ToSpeckle/Raw/DBSplineToSpeckleRawConverter.cs
@@ -37,7 +37,8 @@ public class DBSplineToSpeckleRawConverter : ITypedConverter<ADB.Spline, SOG.Cur
     bool periodicClosed = false;
     double length = 0;
     SOP.Interval domain = SOP.Interval.UnitInterval;
-    if (target.GetGeCurve() is NurbCurve3d nurbs)
+    using AG.Curve3d curve3d = target.GetGeCurve();
+    if (curve3d is NurbCurve3d nurbs)
     {
       length = nurbs.GetLength(nurbs.StartParameter, nurbs.EndParameter, 0.001);
       domain = _intervalConverter.Convert(nurbs.GetInterval());
@@ -124,7 +125,7 @@ public class DBSplineToSpeckleRawConverter : ITypedConverter<ADB.Spline, SOG.Cur
   // POC: we might have DisplayValue converter/mapper?
   private SOG.Polyline GetDisplayValue(ADB.Spline spline)
   {
-    ADB.Curve polySpline = spline.ToPolylineWithPrecision(10, false, false);
+    using ADB.Curve polySpline = spline.ToPolylineWithPrecision(10, false, false);
     List<double> verticesList = new();
     switch (polySpline)
     {

--- a/Converters/Plant3d/Speckle.Converters.Plant3dShared/ToSpeckle/Geometry/Plant3dEntityToSpeckleConverter.cs
+++ b/Converters/Plant3d/Speckle.Converters.Plant3dShared/ToSpeckle/Geometry/Plant3dEntityToSpeckleConverter.cs
@@ -132,9 +132,12 @@ public abstract class Plant3dEntityToSpeckleConverter : IToSpeckleTopLevelConver
       entity.Explode(exploded);
       foreach (ADB.DBObject obj in exploded)
       {
-        if (obj is ADB.Entity subEntity)
+        using (obj)
         {
-          CollectDisplayObjects(subEntity, results, depth + 1);
+          if (obj is ADB.Entity subEntity)
+          {
+            CollectDisplayObjects(subEntity, results, depth + 1);
+          }
         }
       }
     }


### PR DESCRIPTION
## Issue
Missing using/Dispose in AutocadShared converters causing delayed clean up and debugger warnings

## Symptom
"Forgot to call Dispose?" messages in the debugger on publish (Plant 3D)

## Fix
Added using" statements and Dispose calls in the AutocadShared converters and 1 Plant 3D converter

## Screenshot
<img width="589" height="534" alt="image" src="https://github.com/user-attachments/assets/e3d30f6a-a0b8-46b5-b83c-18f4f49fef4e" />
