### PR TITLE
chore(rhino): drop the Linux instance-API fallback in RhinoInstanceUnpacker (ENG-9569)

### DIFF
--- a/Connectors/Rhino/Speckle.Connectors.RhinoShared/HostApp/RhinoInstanceUnpacker.cs
+++ b/Connectors/Rhino/Speckle.Connectors.RhinoShared/HostApp/RhinoInstanceUnpacker.cs
@@ -1,7 +1,6 @@
 ﻿using Microsoft.Extensions.Logging;
 using Rhino;
 using Rhino.DocObjects;
-using Rhino.FileIO;
 using Rhino.Geometry;
 using Speckle.Connectors.Common.Instances;
 using Speckle.Connectors.Rhino.Extensions;
@@ -16,17 +15,6 @@ public class RhinoInstanceUnpacker : IInstanceUnpacker<RhinoObject>
   private readonly IInstanceObjectsManager<RhinoObject, List<string>> _instanceObjectsManager;
   private readonly RhinoLayerHelper _rhinoLayerHelper;
   private readonly ILogger<RhinoInstanceUnpacker> _logger;
-
-  // ENG-9047: the Linux Rhino WIP native (librhcommon_c.so) ships none of the doc-level
-  // instance C-API (CRhinoInstanceObject_*, CRhinoInstanceDefinition*, and the definition
-  // table), so InstanceObject.InstanceDefinition throws EntryPointNotFoundException there.
-  // Once observed, definitions are resolved from the doc's source 3dm via the opennurbs
-  // surface (ON_InstanceRef/ON_InstanceDefinition/ONX_Model), which that native does
-  // implement.
-  private static bool s_docInstanceApiMissing;
-  private Dictionary<Guid, InstanceDefinitionInfo>? _fileDefinitions;
-
-  private sealed record InstanceDefinitionInfo(string Name, string Description, IReadOnlyList<RhinoObject> Objects);
 
   public RhinoInstanceUnpacker(
     IInstanceObjectsManager<RhinoObject, List<string>> instanceObjectsManager,
@@ -57,19 +45,14 @@ public class RhinoInstanceUnpacker : IInstanceUnpacker<RhinoObject>
     try
     {
       var instanceId = instance.Id.ToString();
-      // Read the definition id and transform off the ON_InstanceRef geometry rather than
-      // InstanceObject.InstanceDefinition/.InstanceXform: same underlying data, but the
-      // geometry route also exists on the Linux WIP native (ENG-9047).
-      var instanceGeometry = (InstanceReferenceGeometry)instance.Geometry;
-      var definitionGuid = instanceGeometry.ParentIdefId;
-      var instanceDefinitionId = definitionGuid.ToString();
+      var instanceDefinitionId = instance.InstanceDefinition.Id.ToString();
       var currentDoc = RhinoDoc.ActiveDoc; // POC: too much right now to interface around
 
       InstanceProxy instanceProxy = new()
       {
         applicationId = instanceId,
-        definitionId = instanceDefinitionId,
-        transform = XFormToMatrix(instanceGeometry.Xform),
+        definitionId = instance.InstanceDefinition.Id.ToString(),
+        transform = XFormToMatrix(instance.InstanceXform),
         maxDepth = depth,
         units = currentDoc.ModelUnitSystem.ToSpeckleString(),
       };
@@ -117,23 +100,22 @@ public class RhinoInstanceUnpacker : IInstanceUnpacker<RhinoObject>
         return;
       }
 
-      var definitionInfo = GetDefinition(instance, definitionGuid);
-
       var definition = new InstanceDefinitionProxy
       {
         applicationId = instanceDefinitionId,
         objects = new List<string>(),
         maxDepth = depth,
-        name = definitionInfo.Name,
-        ["description"] = definitionInfo.Description,
+        name = instance.InstanceDefinition.Name,
+        ["description"] = instance.InstanceDefinition.Description,
       };
 
-      _instanceObjectsManager.AddDefinitionProxy(instanceDefinitionId, definition);
+      _instanceObjectsManager.AddDefinitionProxy(instance.InstanceDefinition.Id.ToString(), definition);
 
       // NOTE: InstanceDefinition.GetObjects() returns all constituent objects of a block, but those constituent
       // objects can be on layers, that are not visible. The publish should respect that.
       // See request: [CNX-2254](https://linear.app/speckle/issue/CNX-2254/rhino-publish-blocks-with-hidden-objects)
-      var visibleDefinitionObjects = _rhinoLayerHelper.FilterByLayerVisibility(definitionInfo.Objects);
+      var allDefinitionObjects = instance.InstanceDefinition.GetObjects();
+      var visibleDefinitionObjects = _rhinoLayerHelper.FilterByLayerVisibility(allDefinitionObjects);
       foreach (var obj in visibleDefinitionObjects)
       {
         definition.objects.Add(obj.Id.ToString());
@@ -149,61 +131,6 @@ public class RhinoInstanceUnpacker : IInstanceUnpacker<RhinoObject>
     {
       _logger.LogError(ex, "Failed unpacking Rhino instance");
     }
-  }
-
-  private InstanceDefinitionInfo GetDefinition(InstanceObject instance, Guid definitionId)
-  {
-    if (!s_docInstanceApiMissing)
-    {
-      try
-      {
-        var definition = instance.InstanceDefinition;
-        return new InstanceDefinitionInfo(definition.Name, definition.Description, definition.GetObjects());
-      }
-      catch (EntryPointNotFoundException)
-      {
-        s_docInstanceApiMissing = true;
-      }
-    }
-
-    _fileDefinitions ??= ReadDefinitionsFromSourceFile(instance.Document);
-    if (!_fileDefinitions.TryGetValue(definitionId, out var info))
-    {
-      throw new SpeckleException($"Instance definition {definitionId} not found in the doc's source 3dm");
-    }
-    return info;
-  }
-
-  private static Dictionary<Guid, InstanceDefinitionInfo> ReadDefinitionsFromSourceFile(RhinoDoc doc)
-  {
-    if (string.IsNullOrEmpty(doc.Path))
-    {
-      throw new SpeckleException(
-        "Cannot resolve instance definitions: the doc-level instance API is unavailable on this platform and the doc has no source 3dm to read them from"
-      );
-    }
-
-    // Known limit (ENG-9047): a linked (non-embedded) definition's file table entry carries
-    // the link path, not member ids, so it resolves to an empty definition here — where the
-    // doc-level GetObjects() would return the loaded linked geometry.
-    using var file = File3dm.Read(doc.Path, File3dm.TableTypeFilter.InstanceDefinition, File3dm.ObjectTypeFilter.None);
-    var definitions = new Dictionary<Guid, InstanceDefinitionInfo>();
-    foreach (InstanceDefinitionGeometry definition in file.AllInstanceDefinitions)
-    {
-      var objects = new List<RhinoObject>();
-      foreach (Guid objectId in definition.GetObjectIds())
-      {
-        // 3dm object ids survive the headless open, so the file's member list resolves
-        // against the live doc; a miss (e.g. an id the doc dropped on open) is skipped the
-        // same way the doc-level GetObjects() would simply not return it.
-        if (doc.Objects.FindId(objectId) is RhinoObject obj)
-        {
-          objects.Add(obj);
-        }
-      }
-      definitions[definition.Id] = new InstanceDefinitionInfo(definition.Name, definition.Description, objects);
-    }
-    return definitions;
   }
 
   private Matrix4x4 XFormToMatrix(Transform t) =>


### PR DESCRIPTION
## Description

Reverts #1492 (ENG-9047). McNeel fixed the Linux Rhino 9 WIP native gap: deb `rhino3d=9.0.26252.7009` (built 2026-09-09) now exports the doc-level instance C-API that RhinoCommon binds, so the `RhinoInstanceUnpacker` fallback (static `s_docInstanceApiMissing` flag plus a File3dm read of the doc's source 3dm) is dead code on that build and later. Thread: https://discourse.mcneel.com/t/rhino-9-beta-on-linux-missing-doc-level-block-instance-api/221404

Linear: [ENG-9569](https://linear.app/speckle/issue/ENG-9569). Converters follow-up (gitlink bump after merge): [ENG-9570](https://linear.app/speckle/issue/ENG-9570).

## User Value

Block instances on the Linux rhino leg go through the same doc-level path as desktop Rhino, which also fixes the fallback's known limit where linked (non-embedded) block definitions resolved to empty member lists.

## Changes:

- `RhinoInstanceUnpacker` is back to `InstanceObject.InstanceDefinition` / `.InstanceXform` / `InstanceDefinition.GetObjects()`; the `GetDefinition` / `ReadDefinitionsFromSourceFile` fallback and the `Rhino.FileIO` dependency are gone. One file, net minus 73 lines.

## To-do before merge:

- [ ] Nothing in this repo. On the converters side the deb pin is already `9.0.26252.7009` (specklesystems/speckle-converters#142); a deb older than that would throw `EntryPointNotFoundException` on block instances again once this lands, which is the loud failure we want instead of a silent fallback.

## Validation of changes:

Windows/Mac never tripped the fallback, so desktop behaviour is unchanged. Linux was verified in the converters checkout on 2026-09-09:

- Symbol diff of `librhcommon_c.so`: deb 26243 exports 0 of the `CRhinoInstance*` C wrappers, deb 26252 exports 54 of the 59 names `RhinoCommon.dll` P/Invokes. Still missing and unused by us: `CRhinoInstanceDefinitionTable_CreateFromFile`, `_Export`, `_RefreshLinkedBlock`, `CRhinoInstanceDefinition_GetPreviewBitmap`, `_GetPreviewBitmap2`.
- The ENG-9047 minimal repro rebuilt on 26252 prints OK for all four calls that threw on 26211.
- A converter image built with this exact revert (`speckle-converters:nofallback-26252`, shipped assembly contains no `s_docInstanceApiMissing`) passes the full Rhino tripwire: exit 0, census identical to the committed goldens, `blocks-nested` 8/8 objects, all 34 instance references in `objects.3dm` converted. The remaining failures in that corpus are annotation types without a converter and are pre-existing.

## Checklist:

- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [ ] I have added appropriate tests. (Covered by the converters full-tier tripwire fixtures; no connectors-side test exercised the fallback.)
- [ ] I have updated or added relevant documentation. (None references the fallback.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TrZX97hCkaEBeKDDUF1qfR
