### PR TITLE
feat(otel): Send to collector

### DIFF
--- a/DUI3/Speckle.Connectors.DUI.Tests/Bridge/BrowserBridgeTests.cs
+++ b/DUI3/Speckle.Connectors.DUI.Tests/Bridge/BrowserBridgeTests.cs
@@ -1,0 +1,105 @@
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using NUnit.Framework;
+using Speckle.Connectors.Common;
+using Speckle.Connectors.Common.Threading;
+using Speckle.Connectors.DUI.Bindings;
+using Speckle.Connectors.DUI.Bridge;
+using Speckle.Connectors.DUI.Utils;
+using Speckle.Testing;
+
+namespace Speckle.Connectors.DUI.Tests.Bridge;
+
+public class BrowserBridgeTests : MoqTest
+{
+  private const string VALID_TRACE_CONTEXT =
+    """{"traceparent":"00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"}""";
+
+  [Test]
+  public void GetBridgeCapabilities_AdvertisesOtelTraceContext()
+  {
+    var sut = new BrowserBridge(
+      Create<IThreadContext>().Object,
+      Create<IJsonSerializer>().Object,
+      NullLogger<BrowserBridge>.Instance,
+      Create<IBrowserScriptExecutor>().Object,
+      new TopLevelExceptionHandler(NullLogger<TopLevelExceptionHandler>.Instance),
+      new ConnectorActivityFactory()
+    );
+
+    sut.GetBridgeCapabilities().Should().Contain("otelTraceContext");
+  }
+
+  [Test]
+  public void RunMethod_WithoutTraceContext_StillExecutesTheBinding()
+  {
+    var (sut, binding) = CreateBridge();
+
+    sut.RunMethod(nameof(TestBinding.Echo), "req", """["\"hi\""]""");
+
+    binding.Calls.Should().Be(1);
+  }
+
+  // A frontend that cannot produce a trace context, or produces a broken one, must still get
+  // its binding call run - the span is the expendable part, not the user's action.
+  [TestCase(null)]
+  [TestCase("")]
+  [TestCase("not json")]
+  [TestCase("{}")]
+  [TestCase("""{"traceparent":"garbage"}""")]
+  [TestCase(VALID_TRACE_CONTEXT)]
+  public void RunMethodTraced_WithAnyTraceContext_StillExecutesTheBinding(string? otelTraceContext)
+  {
+    var (sut, binding) = CreateBridge();
+
+    sut.RunMethodTraced(nameof(TestBinding.Echo), "req", """["\"hi\""]""", otelTraceContext);
+
+    binding.Calls.Should().Be(1);
+  }
+
+  private (BrowserBridge Bridge, TestBinding Binding) CreateBridge()
+  {
+    var threadContext = Create<IThreadContext>();
+    threadContext
+      .Setup(x => x.RunOnThreadAsync(It.IsAny<Func<Task>>(), false))
+      .Returns((Func<Task> action, bool _) => action());
+
+    var scriptExecutor = Create<IBrowserScriptExecutor>();
+    scriptExecutor.Setup(x => x.ExecuteScript(It.IsAny<string>(), It.IsAny<CancellationToken>()));
+
+    var serializer = new JsonSerializer(
+      new JsonSerializerSettingsFactory(new ServiceCollection().BuildServiceProvider())
+    );
+
+    var bridge = new BrowserBridge(
+      threadContext.Object,
+      serializer,
+      NullLogger<BrowserBridge>.Instance,
+      scriptExecutor.Object,
+      new TopLevelExceptionHandler(NullLogger<TopLevelExceptionHandler>.Instance),
+      new ConnectorActivityFactory()
+    );
+
+    var binding = new TestBinding { Parent = bridge };
+    bridge.AssociateWithBinding(binding);
+
+    return (bridge, binding);
+  }
+
+  private sealed class TestBinding : IBinding
+  {
+    public string Name => "testBinding";
+
+    public IBrowserBridge Parent { get; init; } = null!;
+
+    public int Calls { get; private set; }
+
+    public string Echo(string value)
+    {
+      Calls++;
+      return value;
+    }
+  }
+}

--- a/DUI3/Speckle.Connectors.DUI/Bridge/BrowserBridge.cs
+++ b/DUI3/Speckle.Connectors.DUI/Bridge/BrowserBridge.cs
@@ -7,8 +7,11 @@ using Microsoft.Extensions.Logging;
 using Speckle.Connectors.Common.Threading;
 using Speckle.Connectors.DUI.Bindings;
 using Speckle.Connectors.DUI.Utils;
+using Speckle.Connectors.Logging;
 using Speckle.Newtonsoft.Json;
+using Speckle.Sdk;
 using Speckle.Sdk.Common;
+using Speckle.Sdk.Logging;
 using Speckle.Sdk.Models.Extensions;
 
 namespace Speckle.Connectors.DUI.Bridge;
@@ -23,6 +26,8 @@ namespace Speckle.Connectors.DUI.Bridge;
 [ComVisible(true)]
 public sealed class BrowserBridge : IBrowserBridge
 {
+  private const string OTEL_TRACE_CONTEXT_CAPABILITY = "otelTraceContext";
+
   /// <summary>
   /// The name under which we expect the frontend to hoist this bindings class to the global scope.
   /// e.g., `receiveBindings` should be available as `window.receiveBindings`.
@@ -30,6 +35,7 @@ public sealed class BrowserBridge : IBrowserBridge
   private readonly ConcurrentDictionary<string, string?> _resultsStore = new();
 
   private readonly ITopLevelExceptionHandler _topLevelExceptionHandler;
+  private readonly ISdkActivityFactory _activityFactory;
   private readonly IThreadContext _threadContext;
 
   private readonly IBrowserScriptExecutor _browserScriptExecutor;
@@ -62,7 +68,8 @@ public sealed class BrowserBridge : IBrowserBridge
     IJsonSerializer jsonSerializer,
     ILogger<BrowserBridge> logger,
     IBrowserScriptExecutor browserScriptExecutor,
-    ITopLevelExceptionHandler topLevelExceptionHandler
+    ITopLevelExceptionHandler topLevelExceptionHandler,
+    ISdkActivityFactory activityFactory
   )
   {
     _threadContext = threadContext;
@@ -70,6 +77,7 @@ public sealed class BrowserBridge : IBrowserBridge
     _logger = logger;
     _browserScriptExecutor = browserScriptExecutor;
     _topLevelExceptionHandler = topLevelExceptionHandler;
+    _activityFactory = activityFactory;
   }
 
   public void AssociateWithBinding(IBinding binding)
@@ -102,17 +110,44 @@ public sealed class BrowserBridge : IBrowserBridge
     return bindingNames;
   }
 
-  //don't wait for browser runs on purpose
+  /// <summary>
+  /// Optional bridge features the frontend may use. Connectors predating a feature simply
+  /// omit it, so the frontend can degrade instead of guessing from a version number.
+  /// </summary>
+  public string[] GetBridgeCapabilities() => [OTEL_TRACE_CONTEXT_CAPABILITY];
+
+  /// <summary>
+  /// Kept at three arguments forever: the frontend is served as a single hosted bundle to
+  /// every installed connector, and older bundles only know this signature.
+  /// </summary>
+  [Obsolete("Replaced by RunMethodTraced")]
   public void RunMethod(string methodName, string requestId, string methodArgs) =>
+    RunMethodTraced(methodName, requestId, methodArgs, null);
+
+  //don't wait for browser runs on purpose
+  public void RunMethodTraced(string methodName, string requestId, string methodArgs, string? otelTraceContext) =>
     _threadContext
       .RunOnWorkerAsync(async () =>
       {
         var task = await _topLevelExceptionHandler
           .CatchUnhandledAsync(async () =>
           {
-            var result = await ExecuteMethod(methodName, methodArgs).ConfigureAwait(false);
-            string resultJson = _jsonSerializer.Serialize(result);
-            NotifyUIMethodCallResultReady(requestId, resultJson);
+            using ISdkActivity? activity = StartRunMethodActivity(methodName, requestId, otelTraceContext);
+
+            try
+            {
+              object? result = await ExecuteMethod(methodName, methodArgs).ConfigureAwait(false);
+              string resultJson = _jsonSerializer.Serialize(result);
+              NotifyUIMethodCallResultReady(requestId, resultJson);
+            }
+            catch (Exception ex) when (!ex.IsFatal())
+            {
+              // Recorded here because the activity is disposed before the top level handler
+              // sees this, which would otherwise leave the span looking successful.
+              activity?.RecordException(ex);
+              activity?.SetStatus(SdkActivityStatusCode.Error);
+              throw;
+            }
           })
           .ConfigureAwait(false);
         if (task.Exception is not null)
@@ -122,6 +157,49 @@ public sealed class BrowserBridge : IBrowserBridge
         }
       })
       .FireAndForget();
+
+  /// <summary>
+  /// Never throws. This runs before <see cref="ExecuteMethod"/>, so letting a malformed trace
+  /// context from a mismatched frontend escape would fail the user's action rather than a span.
+  /// </summary>
+  private ISdkActivity? StartRunMethodActivity(string methodName, string requestId, string? otelTraceContext)
+  {
+    // methodArgs is deliberately not tagged as methodArgs can carry auth tokens and emails.
+    var tags = new Dictionary<string, object?> { { "methodName", methodName }, { "requestId", requestId } };
+
+    try
+    {
+      OtelTraceContext? traceContext = string.IsNullOrWhiteSpace(otelTraceContext)
+        ? null
+        : _jsonSerializer.Deserialize<OtelTraceContext>(otelTraceContext!);
+
+      return _activityFactory.StartRemote(
+        traceContext?.TraceParent,
+        traceContext?.TraceState,
+        SdkActivityKind.Server,
+        nameof(RunMethod),
+        tags
+      );
+    }
+    catch (Exception ex) when (!ex.IsFatal())
+    {
+      _logger.LogDebug(ex, "Discarding unusable otel trace context from the frontend");
+      return _activityFactory.Start(nameof(RunMethod), SdkActivityKind.Server, tags);
+    }
+  }
+
+  /// <summary>
+  /// The W3C carrier as the frontend sends it. Property names are pinned explicitly because
+  /// <see cref="IJsonSerializer"/> camel-cases by convention, which would not match these.
+  /// </summary>
+  private sealed class OtelTraceContext
+  {
+    [JsonProperty("traceparent")]
+    public string? TraceParent { get; init; }
+
+    [JsonProperty("tracestate")]
+    public string? TraceState { get; init; }
+  }
 
   /// <summary>
   /// Used by the action block to invoke the actual method called by the UI.

--- a/DUI3/Speckle.Connectors.DUI/Bridge/BrowserBridge.cs
+++ b/DUI3/Speckle.Connectors.DUI/Bridge/BrowserBridge.cs
@@ -139,6 +139,8 @@ public sealed class BrowserBridge : IBrowserBridge
               object? result = await ExecuteMethod(methodName, methodArgs).ConfigureAwait(false);
               string resultJson = _jsonSerializer.Serialize(result);
               NotifyUIMethodCallResultReady(requestId, resultJson);
+
+              activity?.SetStatus(SdkActivityStatusCode.Ok);
             }
             catch (Exception ex) when (!ex.IsFatal())
             {
@@ -188,10 +190,6 @@ public sealed class BrowserBridge : IBrowserBridge
     }
   }
 
-  /// <summary>
-  /// The W3C carrier as the frontend sends it. Property names are pinned explicitly because
-  /// <see cref="IJsonSerializer"/> camel-cases by convention, which would not match these.
-  /// </summary>
   private sealed class OtelTraceContext
   {
     [JsonProperty("traceparent")]

--- a/DUI3/Speckle.Connectors.DUI/Bridge/IBrowserBridge.cs
+++ b/DUI3/Speckle.Connectors.DUI/Bridge/IBrowserBridge.cs
@@ -21,6 +21,12 @@ public interface IBrowserBridge
   public string[] GetBindingsMethodNames();
 
   /// <summary>
+  /// This method is called by the Frontend bridge to discover optional bridge features, so that it can
+  /// degrade gracefully when running against a connector that predates them.
+  /// </summary>
+  public string[] GetBridgeCapabilities();
+
+  /// <summary>
   /// This method is called by the Frontend bridge when invoking any of the wrapped binding's methods.
   /// </summary>
   /// <param name="methodName"></param>
@@ -28,6 +34,10 @@ public interface IBrowserBridge
   /// <param name="args"></param>
   /// <returns></returns>
   public void RunMethod(string methodName, string requestId, string args);
+
+  /// <inheritdoc cref="RunMethod(string, string, string)"/>
+  /// <param name="otelTraceContext">W3C trace context as <c>{"traceparent":..,"tracestate":..}</c>, or null.</param>
+  public void RunMethodTraced(string methodName, string requestId, string args, string? otelTraceContext);
 
   /// <param name="eventName"></param>
   /// <exception cref="InvalidOperationException">Bridge was not initialized with a binding</exception>

--- a/Importers/Rhino/Speckle.Importers.JobProcessor/ServiceRegistration.cs
+++ b/Importers/Rhino/Speckle.Importers.JobProcessor/ServiceRegistration.cs
@@ -54,16 +54,6 @@ internal static class ServiceRegistration
         Otel:
         [
           new(
-            Endpoint: new Uri("https://seq.speckle.systems/ingest/otlp/v1/logs"),
-            Headers: new()
-            {
-              // We're using a different token than connectors for seq because we want to beable to
-              // trust the client's timestamps (rather than use the server's timestamps) for better tracing
-              // This setting has more opportunity for abuse, so we're keeping it secret, unlike the connectors token.
-              { "X-Seq-ApiKey", Environment.GetEnvironmentVariable("SEQ_API_KEY").NotNullOrWhiteSpace() },
-            }
-          ),
-          new(
             Endpoint: new Uri("https://collector.speckle.dev/v1/logs"),
             Headers: new()
             {
@@ -80,13 +70,6 @@ internal static class ServiceRegistration
         Console: false,
         Otel:
         [
-          new(
-            Endpoint: new Uri("https://seq.speckle.systems/ingest/otlp/v1/traces"),
-            Headers: new()
-            {
-              { "X-Seq-ApiKey", Environment.GetEnvironmentVariable("SEQ_API_KEY").NotNullOrWhiteSpace() },
-            }
-          ),
           new(
             Endpoint: new Uri("https://collector.speckle.dev/v1/traces"),
             Headers: new()

--- a/Importers/Rhino/Speckle.Importers.Rhino/Internal/ServiceRegistration.cs
+++ b/Importers/Rhino/Speckle.Importers.Rhino/Internal/ServiceRegistration.cs
@@ -68,16 +68,6 @@ internal static class ServiceRegistration
         Otel:
         [
           new(
-            Endpoint: new Uri("https://seq.speckle.systems/ingest/otlp/v1/logs"),
-            Headers: new()
-            {
-              // We're using a different token than connectors for seq because we want to beable to
-              // trust the client's timestamps (rather than use the server's timestamps) for better tracing
-              // This setting has more opportunity for abuse, so we're keeping it secret, unlike the connectors token.
-              { "X-Seq-ApiKey", Environment.GetEnvironmentVariable("SEQ_API_KEY").NotNullOrWhiteSpace() },
-            }
-          ),
-          new(
             Endpoint: new Uri("https://collector.speckle.dev/v1/logs"),
             Headers: new()
             {
@@ -94,13 +84,6 @@ internal static class ServiceRegistration
         Console: false,
         Otel:
         [
-          new(
-            Endpoint: new Uri("https://seq.speckle.systems/ingest/otlp/v1/traces"),
-            Headers: new()
-            {
-              { "X-Seq-ApiKey", Environment.GetEnvironmentVariable("SEQ_API_KEY").NotNullOrWhiteSpace() },
-            }
-          ),
           new(
             Endpoint: new Uri("https://collector.speckle.dev/v1/traces"),
             Headers: new()

--- a/Sdk/Speckle.Connectors.Common.Tests/Logging/ConnectorActivityFactoryTests.cs
+++ b/Sdk/Speckle.Connectors.Common.Tests/Logging/ConnectorActivityFactoryTests.cs
@@ -1,0 +1,40 @@
+using FluentAssertions;
+using NUnit.Framework;
+using Speckle.Connectors.Logging;
+
+namespace Speckle.Connectors.Common.Tests.Logging;
+
+public class ConnectorActivityFactoryTests
+{
+  private const string VALID_TRACE_PARENT = "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01";
+
+  [Test]
+  public void StartRemote_WithoutTraceParent_DoesNotThrow()
+  {
+    using var sut = new ConnectorActivityFactory();
+
+    Action start = () => sut.StartRemote(null, null, SdkActivityKind.Server, "test");
+
+    start.Should().NotThrow();
+  }
+
+  [Test]
+  public void StartRemote_WithValidTraceParent_DoesNotThrow()
+  {
+    using var sut = new ConnectorActivityFactory();
+
+    Action start = () => sut.StartRemote(VALID_TRACE_PARENT, null, SdkActivityKind.Server, "test");
+
+    start.Should().NotThrow();
+  }
+
+  [Test]
+  public void StartRemote_WithMalformedTraceParent_Throws()
+  {
+    using var sut = new ConnectorActivityFactory();
+
+    Action start = () => sut.StartRemote("not-a-traceparent", null, SdkActivityKind.Server, "test");
+
+    start.Should().Throw<ArgumentException>();
+  }
+}

--- a/Sdk/Speckle.Connectors.Common/Connector.cs
+++ b/Sdk/Speckle.Connectors.Common/Connector.cs
@@ -20,6 +20,7 @@ public static class Connector
     }
   }
 
+  private const string CONNECTOR_GATEWAY_TOKEN = "7a6754bf-a883-49a7-afc4-f74ddd25e9c1";
   public static readonly string TabName = "Speckle";
   public static readonly string TabTitle = "Speckle";
 
@@ -41,19 +42,14 @@ public static class Connector
       "Connector",
       application,
       version,
-#if DEBUG || LOCAL
-      new SpeckleLogging(Console: true, File: new(), MinimumLevel: SpeckleLogLevel.Debug),
-      new SpeckleTracing(Console: false),
-      new SpeckleMetrics(Console: false)
-#else
       new SpeckleLogging(
         Console: true,
         File: new(),
         Otel:
         [
           new(
-            Endpoint: new Uri("https://seq.speckle.systems/ingest/otlp/v1/logs"),
-            Headers: new() { { "X-Seq-ApiKey", "Y0Ya2CFVt1tCSgrbY07c" } }
+            Endpoint: new Uri("https://connectors.collector.speckle.dev/v1/logs"),
+            Headers: new() { { "authorization", CONNECTOR_GATEWAY_TOKEN } }
           ),
         ],
         MinimumLevel: SpeckleLogLevel.Information
@@ -63,13 +59,12 @@ public static class Connector
         Otel:
         [
           new(
-            Endpoint: new Uri("https://seq.speckle.systems/ingest/otlp/v1/traces"),
-            Headers: new() { { "X-Seq-ApiKey", "Y0Ya2CFVt1tCSgrbY07c" } }
+            Endpoint: new Uri("https://connectors.collector.speckle.dev/v1/traces"),
+            Headers: new() { { "authorization", CONNECTOR_GATEWAY_TOKEN } }
           ),
         ]
       ),
       null
-#endif
     );
   }
 

--- a/Sdk/Speckle.Connectors.Logging/Consts.cs
+++ b/Sdk/Speckle.Connectors.Logging/Consts.cs
@@ -4,15 +4,30 @@ namespace Speckle.Connectors.Logging;
 
 public static class Consts
 {
-  public const string DEPLOYMENT_ENVIRONMENT = "deployment.environment.name";
+  public const string DEPLOYMENT_ENVIRONMENT = "deployment.environment.name"; // Semantic conventions 1.44.0
   public const string SERVICE_NAME = "connector.name";
   public const string SERVICE_SLUG = "connector.slug";
-  public const string OS_NAME = "os.name";
-  public const string OS_TYPE = "os.type";
-  public const string OS_SLUG = "os.slug";
-  public const string RUNTIME_NAME = "process.runtime.name";
-  public const string RUNTIME_VERSION = "process.runtime.version";
-  public const string USER_ID = "user.id";
+
+  public const string OS_NAME = "os.name"; // Semantic conventions 1.44.0
+  public const string OS_VERSION = "os.version"; // Semantic conventions 1.44.0
+  public const string OS_TYPE = "os.type"; // Semantic conventions 1.44.0
+  public const string OS_DESCRIPTION = "os.description"; // Semantic conventions 1.44.0
+
+  public const string HOST_ARCH = "host.arch"; // Semantic conventions 1.44.0
+  public const string HOST_ID = "host.id"; // Semantic conventions 1.44.0
+
+  public const string SESSION_ID = "session.id"; // Semantic conventions 1.44.0
+
+  public const string PROCESS_CREATION_TIME = "process.creation.time"; // Semantic conventions 1.44.0
+  public const string PROCESS_PID = "process.pid"; // Semantic conventions 1.44.0
+
+  public const string RUNTIME_NAME = "process.runtime.name"; // Semantic conventions 1.44.0
+  public const string RUNTIME_VERSION = "process.runtime.version"; // Semantic conventions 1.44.0
+
+  public const string CPU_COUNT = "dotnet.process.cpu.count"; // Semantic conventions 1.44.0
+  public const string MEMORY_WORKING_SET = "dotnet.process.memory.working_set"; // Semantic conventions 1.44.0
+
+  public const string USER_ID = "user.id"; // Semantic conventions 1.44.0
   public const string USER_DISTINCT_ID = "user.distinctId";
   public const string USER_SERVER_URL = "user.server_url";
   public const string TRACING_SOURCE = "connector";

--- a/Sdk/Speckle.Connectors.Logging/Internal/ResourceCreator.cs
+++ b/Sdk/Speckle.Connectors.Logging/Internal/ResourceCreator.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.InteropServices;
+﻿using System.Diagnostics;
+using System.Runtime.InteropServices;
 using OpenTelemetry.Resources;
 
 namespace Speckle.Connectors.Logging.Internal;
@@ -12,42 +13,112 @@ internal static class ResourceCreator
     string connectorVersion
   )
   {
-    string deploymentEnvironment =
-      Environment.GetEnvironmentVariable("DOTNET_ENVIRONMENT")
-      ?? Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT")
-      ?? "Development";
+    Dictionary<string, object> resourceAttributes = new()
+    {
+      { Consts.DEPLOYMENT_ENVIRONMENT, GetDeploymentEnvironment().ToLowerInvariant() },
+      { Consts.SERVICE_NAME, applicationAndVersion },
+      { Consts.SERVICE_SLUG, slug },
+      { Consts.OS_NAME, Environment.OSVersion.ToString() },
+      { Consts.OS_VERSION, Environment.OSVersion.VersionString },
+      { Consts.OS_TYPE, GetOsType() },
+      { Consts.OS_DESCRIPTION, RuntimeInformation.OSDescription },
+      { Consts.HOST_ARCH, GetHostArch() },
+      { Consts.HOST_ID, GetOrCreateMachineGuid().ToString("D") },
+#if NET5_0_OR_GREATER
+      { Consts.PROCESS_PID, Environment.ProcessId.ToString() },
+#endif
+      { Consts.PROCESS_CREATION_TIME, Process.GetCurrentProcess().StartTime.ToString("O") },
+      { Consts.RUNTIME_NAME, ".NET" },
+      { Consts.RUNTIME_VERSION, RuntimeInformation.FrameworkDescription },
+#if NET9_0_OR_GREATER
+      { Consts.MEMORY_WORKING_SET, Environment.WorkingSet },
+#endif
+      { Consts.CPU_COUNT, Environment.ProcessorCount },
+      { Consts.SESSION_ID, Consts.StaticSessionId },
+    };
     return ResourceBuilder
       .CreateEmpty()
+      .AddTelemetrySdk()
       .AddService(serviceName: serviceName, serviceVersion: connectorVersion, serviceInstanceId: Consts.StaticSessionId)
-      .AddAttributes([
-        new(Consts.DEPLOYMENT_ENVIRONMENT, deploymentEnvironment.ToLowerInvariant()),
-        new(Consts.SERVICE_NAME, applicationAndVersion),
-        new(Consts.SERVICE_SLUG, slug),
-        new(Consts.OS_NAME, Environment.OSVersion.ToString()),
-        new(Consts.OS_TYPE, RuntimeInformation.ProcessArchitecture.ToString()),
-        new(Consts.OS_SLUG, DetermineHostOsSlug()),
-        new(Consts.RUNTIME_NAME, ".NET"),
-        new(Consts.RUNTIME_VERSION, RuntimeInformation.FrameworkDescription),
-      ]);
+      .AddAttributes(resourceAttributes);
   }
 
-  private static string DetermineHostOsSlug()
+  private static string GetDeploymentEnvironment()
   {
+#if DEBUG || LOCAL
+    return "Development";
+#else
+    return Environment.GetEnvironmentVariable("SPECKLE_DOTNET_ENVIRONMENT")
+      ?? Environment.GetEnvironmentVariable("DOTNET_ENVIRONMENT")
+      ?? Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT")
+      ?? "Production";
+#endif
+  }
+
+  private static string GetHostArch()
+  {
+    // Following Semantic conventions 1.44.0
+    return RuntimeInformation.OSArchitecture switch
+    {
+      Architecture.X86 => "x86",
+      Architecture.X64 => "amd64",
+      Architecture.Arm => "arm32",
+      Architecture.Arm64 => "arm64",
+#if NET5_0_OR_GREATER
+      Architecture.Ppc64le => "ppc64",
+      Architecture.S390x => "s390x",
+#endif
+      _ => RuntimeInformation.OSArchitecture.ToString().ToLowerInvariant(),
+    };
+  }
+
+  private static string GetOsType()
+  {
+    // Following Semantic conventions 1.44.0
     if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
     {
-      return "Windows";
+      return "windows";
     }
 
     if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
     {
-      return "MacOS";
+      return "darwin";
     }
 
     if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
     {
-      return "Linux";
+      return "linux";
     }
 
+#if NET5_0_OR_GREATER
+    if (RuntimeInformation.IsOSPlatform(OSPlatform.FreeBSD))
+    {
+      return "freebsd";
+    }
+#endif
     return RuntimeInformation.OSDescription;
+  }
+
+  public static Guid GetOrCreateMachineGuid()
+  {
+    string filePath = Path.Combine(SpecklePathProvider.UserSpeckleFolderPath, "MachineGUID");
+    if (File.Exists(filePath))
+    {
+      var existing = File.ReadAllText(filePath).Trim();
+      if (Guid.TryParse(existing, out var guid))
+      {
+        return guid;
+      }
+    }
+    var newGuid = Guid.NewGuid();
+
+    var directory = Path.GetDirectoryName(filePath);
+    if (!string.IsNullOrEmpty(directory))
+    {
+      Directory.CreateDirectory(directory);
+    }
+
+    File.WriteAllText(filePath, newGuid.ToString("D"));
+    return newGuid;
   }
 }

--- a/Sdk/Speckle.Connectors.Logging/LoggingActivityFactory.cs
+++ b/Sdk/Speckle.Connectors.Logging/LoggingActivityFactory.cs
@@ -21,10 +21,15 @@ public sealed class LoggingActivityFactory : IDisposable
   {
     if (!ActivityContext.TryParse(traceParent, traceState, true, out ActivityContext context))
     {
-      throw new ArgumentException(
-        "traceContext was not parsable to a valid W3C traceParent or traceState Header",
-        nameof(traceParent)
-      );
+      if (traceParent is not null)
+      {
+        throw new ArgumentException(
+          "traceContext was not parsable to a valid W3C traceParent or traceState Header",
+          nameof(traceParent)
+        );
+      }
+
+      return Start(name, kind, tags, startTime);
     }
 
     //If you get a MissingManifestResourceException, Likely source or name is empty string, which is no good.


### PR DESCRIPTION

Paired with https://github.com/specklesystems/speckle-connectors-dui/pull/129

---

Send OTEL trace context from DUI bridge to C#'s `RunMethodTraced`, enabled via new `GetBridgeCapabilities` function.
DUI kept is backwards compatible with bridges that only have `RunMethod`.

This allows tracing from DUI -> Connectors -> server

see [example trace](https://clickstack.speckle.dev/search?source=699c85711e4d53f7d98fb889&where=&select=&whereLanguage=lucene&filters=%5B%7B%22type%22%3A%22sql%22%2C%22condition%22%3A%22ServiceName%20IN%20(%27Connector%27)%22%7D%5D&orderBy=&isLive=false&eventRowWhere=%7B%22id%22%3A%22SpanName%3D%27Uploading%20artefact%20bundle%20(v2)%27%20AND%20Timestamp%3DparseDateTime64BestEffort(%272026-09-11T10%3A49%3A08.927747700Z%27%2C%209)%20AND%20SpanId%3D%27cad509d1d21e221d%27%20AND%20ServiceName%3D%27Connector%27%20AND%20ResourceAttributes%5B%27deployment.environment.name%27%5D%3D%27development%27%20AND%20ResourceAttributes%5B%27k8s.namespace.name%27%5D%3D%27%27%20AND%20(Duration)%2F1e9%3D0.0045115%20AND%20ParentSpanId%3D%276c1d92a4b73789d0%27%20AND%20StatusCode%3D%27Unset%27%22%2C%22type%22%3A%22trace%22%2C%22aliasWith%22%3A%5B%5D%2C%22traceId%22%3A%225d0cb34ba8068864cca736d8e9d5c5a1%22%7D&from=1789123796401&to=1789124096401&rowWhere=Timestamp%3DparseDateTime64BestEffort(%272026-09-11T10%3A54%3A40.442469000Z%27%2C%209)%20AND%20ResourceAttributes%5B%27deployment.environment.name%27%5D%3D%27development%27%20AND%20ServiceName%3D%27Connector%27%20AND%20StatusCode%3D%27Unset%27%20AND%20round(divide(Duration%2C%201000000.))%3D6%20AND%20SpanName%3D%27Uploading%20artefact%20bundle%20(v2)%27%20AND%20toDate(Timestamp)%3DparseDateTime64BestEffort(%272026-09-11%27%2C%209)%20AND%20toDateTime(Timestamp)%3DparseDateTime64BestEffort(%272026-09-11T10%3A54%3A40Z%27%2C%209)&rowSource=699c85711e4d53f7d98fb889)

---

Limitations:
 - Only continuing context for DUI -> C# comms, C# -> dui unchanged.

Other changes:
- Send to new collector gateway
- Remove sending to seq
- Align resource context with OTEL conventions
