### PR TITLE
fix(grasshopper): cast Speckle Block Instances to native geometry types

### DIFF
--- a/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/Wrappers/SpeckleBlockInstanceWrapperGoo.cs
+++ b/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Parameters/Wrappers/SpeckleBlockInstanceWrapperGoo.cs
@@ -106,8 +106,47 @@ public partial class SpeckleBlockInstanceWrapperGoo : GH_Goo<SpeckleBlockInstanc
         target = (T)(object)Value.Transform;
         return true;
       default:
-        return CastToModelObject(ref target);
+        if (CastToModelObject(ref target))
+        {
+          return true;
+        }
+
+        // Instances have no native geometry of their own (their GeometryBase is a placeholder
+        // InstanceReferenceGeometry - see GrasshopperBlockUnpacker). Standard downstream components
+        // (Mesh, Brep, Curve, ...) can't consume that, so wiring an instance straight into one used to
+        // silently produce nothing (FEA-694). Fall back to the single defining object's geometry,
+        // transformed into world space, and let SpeckleGeometryWrapperGoo's existing GH_Convert-based
+        // casts take it from there. Ambiguous for multi-object or nested-instance definitions - those
+        // still need to go through the Speckle Block Instance / Block Definition components.
+        return TryGetSingleTransformedGeometryGoo() is SpeckleGeometryWrapperGoo geometryGoo
+          && geometryGoo.CastTo(ref target);
     }
+  }
+
+  /// <summary>
+  /// Resolves this instance to its single defining geometry object, transformed into world space.
+  /// </summary>
+  /// <returns>
+  /// Null when the definition is missing or empty, has more than one object, or its sole object is
+  /// itself a nested instance or has no geometry - all ambiguous cases where the caller should use the
+  /// Speckle Block Instance / Block Definition components to deconstruct explicitly instead.
+  /// </returns>
+  private SpeckleGeometryWrapperGoo? TryGetSingleTransformedGeometryGoo()
+  {
+    if (Value?.Definition?.Objects is not { Count: 1 } objects || objects[0] is SpeckleBlockInstanceWrapper)
+    {
+      return null;
+    }
+
+    SpeckleGeometryWrapper singleObject = objects[0];
+    if (singleObject.GeometryBase == null)
+    {
+      return null;
+    }
+
+    SpeckleGeometryWrapper transformed = singleObject.DeepCopy();
+    transformed.GeometryBase!.Transform(Value.Transform);
+    return new SpeckleGeometryWrapperGoo(transformed);
   }
 
 #if !RHINO8_OR_GREATER


### PR DESCRIPTION
Fixes FEA-694.

## Problem

Speckle Block Instance objects queried into Grasshopper (e.g. via "Query Speckle Objects" on a Revit-derived model) couldn't be used by standard downstream components — wiring one directly into a native geometry input (Mesh, Brep, Curve, ...) silently produced no output, with no deconstructable path that didn't require the user to already know about the dedicated Speckle Block Instance / Speckle Block Definition components.

## Root cause

`SpeckleBlockInstanceWrapperGoo.CastTo` only handled casting to `SpeckleGeometryWrapperGoo`, `Transform`, and (on Rhino 8+) a couple of model-object types. Unlike its sibling `SpeckleGeometryWrapperGoo`, it never
delegated to `GH_Convert` for native GH types — reasonably, since an instance's own `GeometryBase` is just a placeholder `InstanceReferenceGeometry` (see `GrasshopperBlockUnpacker`), not real geometry. Grasshopper's automatic type coercion calls `CastTo<T>` when a wire's source type doesn't match the downstream parameter, so this fell straight through to `false` for every native geometry type.

## Fix

For the common case of a definition with exactly one defining object, resolve that object's geometry transformed into world space and hand casting off to `SpeckleGeometryWrapperGoo`, which already has full `GH_Convert`-based casts to `GH_Mesh`/`GH_Brep`/`GH_Curve`/etc. This mirrors the existing single-geometry convention `SpeckleGeometryWrapperGoo.CastFromDataObject` already uses for `SpeckleDataObjectWrapper`.

Multi-object and nested-instance definitions are left as-is (ambiguous — no single geometry to collapse to) and still require the Speckle Block Instance / Speckle Block Definition components to deconstruct explicitly.

No behavior change for existing model-object casts (`GH_InstanceReference`, `InstanceReferenceGeometry`) — those are still tried first via `CastToModelObject`.

## Testing

— needs a real build + manual check in Grasshopper before merge:
1. Receive a model containing Speckle Block Instances (single-object definition, e.g. a repeated Revit family instance)
2. Query the instances via "Query Speckle Objects"
3. Wire an instance directly into a native Mesh/Brep param and confirm it now resolves geometry in world space (no console link, no intermediate Speckle Block Instance / Block Definition components)
4. Confirm multi-object definitions still behave as before (existing deconstruct path unaffected)