### PR TITLE
Plant3d converter resolution

### DIFF
--- a/Converters/Plant3d/Speckle.Converters.Plant3dShared/Speckle.Converters.Plant3dShared.projitems
+++ b/Converters/Plant3d/Speckle.Converters.Plant3dShared/Speckle.Converters.Plant3dShared.projitems
@@ -16,6 +16,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)GlobalUsings.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Helpers\PropertyHandler.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ServiceRegistration.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)ToSpeckle\Geometry\Solid3dToSpeckleConverter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ToSpeckle\Properties\PropertiesExtractor.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ToSpeckle\Properties\ExtensionDictionaryExtractor.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ToSpeckle\Properties\Plant3dDataExtractor.cs" />

--- a/Converters/Plant3d/Speckle.Converters.Plant3dShared/ToSpeckle/Geometry/Plant3dEntityToSpeckleConverter.cs
+++ b/Converters/Plant3d/Speckle.Converters.Plant3dShared/ToSpeckle/Geometry/Plant3dEntityToSpeckleConverter.cs
@@ -81,11 +81,14 @@ public abstract class Plant3dEntityToSpeckleConverter : IToSpeckleTopLevelConver
     {
       try
       {
-        var converter = _converterManager.ResolveConverter(entity.GetType(), false);
-
-        var converted = converter.Convert(entity);
-        results.Add(converted);
-        return;
+        var converter = _converterManager.ResolveConverter(entity.GetType());
+        // Guard against infinite recursion and fall through to the explode path instead.
+        if (converter is not Plant3dEntityToSpeckleConverter)
+        {
+          var converted = converter.Convert(entity);
+          results.Add(converted);
+          return;
+        }
       }
       catch (System.Exception)
       {

--- a/Converters/Plant3d/Speckle.Converters.Plant3dShared/ToSpeckle/Geometry/Solid3dToSpeckleConverter.cs
+++ b/Converters/Plant3d/Speckle.Converters.Plant3dShared/ToSpeckle/Geometry/Solid3dToSpeckleConverter.cs
@@ -1,0 +1,19 @@
+using Speckle.Converters.Common;
+using Speckle.Converters.Common.Objects;
+using Speckle.Sdk.Models;
+
+namespace Speckle.Converters.Plant3dShared.ToSpeckle.Geometry;
+
+/// <summary>
+/// Converts AutoCAD Solid3d entities to SolidX with SAT encoding for lossless round-trip.
+/// </summary>
+[NameAndRankValue(typeof(ADB.Solid3d), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK + 2)]
+public class Solid3dToSpeckleConverter(ITypedConverter<ADB.Solid3d, SOG.Mesh> meshConverter)
+  : IToSpeckleTopLevelConverter
+{
+  private readonly ITypedConverter<ADB.Solid3d, SOG.Mesh> _meshConverter = meshConverter;
+
+  public Base Convert(object target) => RawConvert((ADB.Solid3d)target);
+
+  public SOG.Mesh RawConvert(ADB.Solid3d target) => _meshConverter.Convert(target);
+}


### PR DESCRIPTION
## Description
Resolves stack overflow exception on publishing 3D models from Plant 3D (2D models are already working and unaffected).
This is caused by infinite recursion of calls to Plant3dEntityToSpeckleConverter.Convert.
Resolution:
1. Guard against recursive calls to Plant3dEntityToSpeckleConverter.Convert and allow execution to fall through to the explode path instead.
2. Calls ResolveConverter with default recursive parameter.
3. Render 3D objects (Solid3D) as a mesh.

## Screenshots:

### Stack overflow exception (before)

<img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/7ec6d045-8bfe-4189-a3f8-17c751d74429" />

### 3D model published from Plant 3D (after)

<img width="1914" height="1024" alt="image" src="https://github.com/user-attachments/assets/25e41824-c679-4c88-8819-540d7edfc203" />

<!---

Include a screenshot the before and after.  This can be a screenshot of a plugin, web frontend, or output in a terminal.

-->

## Validation of changes:

3D models now published and rendering in Speckle viewer.

## Checklist:

<!---

This checklist is a useful reminder of related tasks to uphold our repo quality. Amend this list as needed for the pr.

-->
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.

